### PR TITLE
feat(gtv-naming): Kurzform-Toggle – Zusatzname ohne Goetheanum-Zeile

### DIFF
--- a/apps/gtv-naming/README.md
+++ b/apps/gtv-naming/README.md
@@ -29,6 +29,9 @@ Optional in der goeloggen-Übersicht/Startseite verlinken (neben Logo-Generator)
   TLD wirksam, z. B. tv, studio, online, media).
 - **Icon (offene Form)**: schaltet den Zweizeiler vom Kreis-Icon (Default)
   auf das offene Icon um.
+- **Kurzform**: zeigt nur den Zusatznamen neben dem Icon, ohne die
+  „Goetheanum"-Zeile (z. B. Icon + „Studio"). Hat Vorrang vor Zweizeiler
+  und Punkt-Sonderform; das gewählte Icon (Kreis/offen) gilt auch hier.
 - **iPhone**: schwebende Mobilvorschau unten rechts, synchron zum Hauptzustand
   (iframe derselben Datei mit `#embed`, Sync via postMessage).
 

--- a/apps/gtv-naming/index.html
+++ b/apps/gtv-naming/index.html
@@ -122,6 +122,10 @@
     <span class="track"></span>
     <span style="font-weight:600">Icon (offene Form)</span>
   </label>
+  <label class="ptoggle" id="kurztoggle" style="margin-left:0">
+    <span class="track"></span>
+    <span style="font-weight:600">Kurzform</span>
+  </label>
   <span id="domline">goetheanum.tv</span>
   <span id="tldflag" class="ok">.tv existiert</span>
 </div>
@@ -202,6 +206,19 @@ function logoZweizeiler(suffix,px,kreis){
   s+=tp(suffix,tx,20.05,fs,bc);
   return s+'</svg>';
 }
+function logoKurzform(suffix,px,kreis){
+  const fs=10.3,bc="#23323F";
+  const tx=kreis?26.1:19.5;
+  const W=Math.ceil(tx-19.5+tw(suffix,fs)+25),H=22.24;
+  let s='<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.8 '+(W+1)+' '+(H+1.6)+'" height="'+px+'" role="img" aria-label="'+suffix+'">';
+  if(kreis){
+    s+='<g transform="scale(0.78412)"><circle cx="14.2058" cy="14.1895" r="14.1733" fill="#ffffff"/><path fill="'+bc+'" d="'+POINT+'"/></g>';
+  }else{
+    SIGNET.forEach(d=>s+='<path d="'+d+'" fill="'+bc+'"/>');
+  }
+  s+=tp(suffix,tx,14.68,fs,bc);
+  return s+'</svg>';
+}
 function logoSonderform(word,dot,iconPx){
   return '<svg width="'+iconPx+'" height="'+iconPx+'" viewBox="0 0 28.379 28.3628" role="img" aria-label="Goetheanum '+word+'">'+
     '<circle cx="14.2058" cy="14.1895" r="14.1733" fill="#ffffff"/>'+
@@ -222,7 +239,7 @@ const CANDIDATES=[
   {label:"campus online",word:"campus online",l2:"Campus Online", tld:false, dom:"",                   sub:"campus.goetheanum.ch",   name:"Goetheanum Campus Online"},
   {label:"window",      word:"window",        l2:"Window",        tld:false, dom:"goetheanum.window",  sub:"window.goetheanum.ch",   name:"Goetheanum Window"}
 ];
-let cur=0, dot=false, sig=false;
+let cur=0, dot=false, sig=false, kurz=false;
 const chips=document.getElementById("chips");
 const elim=new Set();
 const EMBED=location.hash==="#embed";
@@ -281,12 +298,14 @@ document.getElementById("resetbtn").onclick=()=>{
 };
 document.getElementById("dottoggle").onclick=e=>{e.preventDefault();dot=!dot;render();};
 document.getElementById("kreistoggle").onclick=e=>{e.preventDefault();sig=!sig;render();};
+document.getElementById("kurztoggle").onclick=e=>{e.preventDefault();kurz=!kurz;render();};
 
 function render(){
   const c=CANDIDATES[cur];
   [...chips.children].forEach((b,i)=>{b.classList.toggle("on",i===cur);b.classList.toggle("gone",elim.has(i));});
   document.getElementById("dottoggle").classList.toggle("on",dot);
   document.getElementById("kreistoggle").classList.toggle("on",sig);
+  document.getElementById("kurztoggle").classList.toggle("on",kurz);
   const box=document.getElementById("logobox");
   const small=window.innerWidth<=520;
   const dl=document.getElementById("domline");
@@ -311,6 +330,7 @@ function render(){
       else{fl.className="neutral";fl.textContent="Subdomain";}
     }
   }
+  if(kurz)box.innerHTML=logoKurzform(c.l2,small?46:62,!sig);
   document.getElementById("footname").textContent="© 2026 "+c.name;
   document.title=c.name+" – Naming-Rendering";
 }
@@ -331,7 +351,7 @@ let phoneOn=false;
 function postState(){
   const f=document.getElementById("pframe");
   if(phoneOn&&f&&f.contentWindow){
-    f.contentWindow.postMessage({gtv:1,c:CANDIDATES[cur],dot:dot,sig:sig},"*");
+    f.contentWindow.postMessage({gtv:1,c:CANDIDATES[cur],dot:dot,sig:sig,kurz:kurz},"*");
   }
 }
 document.getElementById("phonetoggle").onclick=e=>{
@@ -350,7 +370,7 @@ if(EMBED){
     if(!m||m.gtv!==1)return;
     let idx=CANDIDATES.findIndex(x=>x.name===m.c.name);
     if(idx<0){CANDIDATES.push(m.c);idx=CANDIDATES.length-1;}
-    cur=idx;dot=m.dot;sig=m.sig;render();
+    cur=idx;dot=m.dot;sig=m.sig;kurz=!!m.kurz;render();
   });
 }
 const _render=render;


### PR DESCRIPTION
Neuer Presenter-Toggle **„Kurzform"**: rendert nur den Zusatznamen (z. B. „Studio") in der offiziellen Wortmarken-Glyphe neben dem Icon-Point — ohne die „Goetheanum"-Zeile.

- respektiert den Icon-Toggle (Kreis ↔ offene Form)
- hat Vorrang vor Zweizeiler, tv- und Punkt-Sonderform; Domainzeile/TLD-Flag bleiben unverändert
- Zustand synchronisiert in die iPhone-Vorschau (postMessage)
- App-README ergänzt

Headless-Smoke-Test: 12/12 bestanden (inkl. neuem Kurzform-Check: Goetheanum-Zeile weg, Zusatzname in Glyphe, offene Form greift, Vorrang bei „tv", Zurückschalten ok). Keine JS-Fehler.

https://claude.ai/code/session_017oCB4YaMsFBXL1ZPVDjjEA

---
_Generated by [Claude Code](https://claude.ai/code/session_017oCB4YaMsFBXL1ZPVDjjEA)_