### PR TITLE
feat(gtv-naming): Sitzung in localStorage speichern

### DIFF
--- a/apps/gtv-naming/README.md
+++ b/apps/gtv-naming/README.md
@@ -40,6 +40,12 @@ Optional in der goeloggen-Übersicht/Startseite verlinken (neben Logo-Generator)
 - **▾-Knopf** (links in der Leiste): klappt die Presenter-Leiste auf eine
   schmale Zeile zusammen – nützlich auf dem iPhone, wo die volle Leiste
   sonst die halbe Sicht nimmt.
+- **Speichern**: eigene Vorschläge, ausgeschiedene Kandidaten, Auswahl und
+  Toggle-Zustände werden automatisch in `localStorage` gesichert und beim
+  Neuladen wiederhergestellt (pro Browser/Gerät). Einen eigenen Vorschlag
+  dauerhaft löschen: mit **×** ausscheiden und neu laden – ausgeschiedene
+  Vorschläge werden nicht mitgespeichert. **↺** holt nur die
+  Standard-Kandidaten der laufenden Sitzung zurück.
 
 ## Architektur-Notizen
 
@@ -66,6 +72,4 @@ Optional in der goeloggen-Übersicht/Startseite verlinken (neben Logo-Generator)
 1. Refactor: Logo-Konstanten mit logo-generator teilen (s.o.).
 2. TLD-Liste (`const TLDS`) gelegentlich gegen
    https://data.iana.org/TLD/tlds-alpha-by-domain.txt aktualisieren.
-3. Optional: Zustand (ausgeschiedene Kandidaten, neue Vorschläge) in
-   localStorage persistieren, damit eine Sitzung wiederaufgenommen werden kann.
-4. Optional: Export-Knopf „aktuelle Ansicht als PNG" (html2canvas o.ä.).
+3. Optional: Export-Knopf „aktuelle Ansicht als PNG" (html2canvas o.ä.).

--- a/apps/gtv-naming/index.html
+++ b/apps/gtv-naming/index.html
@@ -279,6 +279,30 @@ let cur=0, dot=false, sig=false, kurz=false;
 const chips=document.getElementById("chips");
 const elim=new Set();
 const EMBED=location.hash==="#embed";
+/* ---- Persistenz: Vorschlaege, Ausgeschiedene und Toggles in localStorage ---- */
+const STORE="gtvNamingState_v1";
+const BASE_N=CANDIDATES.length;
+let saved=null;
+if(!EMBED){try{saved=JSON.parse(localStorage.getItem(STORE)||"null");}catch(e){}}
+if(saved){
+  (saved.custom||[]).forEach(c=>{
+    if(c&&c.label&&!CANDIDATES.some(x=>x.label===c.label))CANDIDATES.push(c);
+  });
+  dot=!!saved.dot;sig=!!saved.sig;kurz=!!saved.kurz;
+}
+function saveState(){
+  if(EMBED)return;
+  try{
+    localStorage.setItem(STORE,JSON.stringify({
+      /* ausgeschiedene Vorschlaege werden nicht mitgespeichert:
+         × auf einem eigenen Vorschlag + Neuladen entfernt ihn dauerhaft */
+      custom:CANDIDATES.slice(BASE_N).filter((c,k)=>!elim.has(BASE_N+k)),
+      elim:[...elim].map(i=>CANDIDATES[i].label),
+      cur:CANDIDATES[cur]?CANDIDATES[cur].label:null,
+      dot:dot,sig:sig,kurz:kurz
+    }));
+  }catch(e){}
+}
 function addChip(c,i){
   const b=document.createElement("button");
   b.className="chip"+(i===cur?" on":"");
@@ -296,6 +320,15 @@ function addChip(c,i){
   chips.appendChild(b);
 }
 CANDIDATES.forEach(addChip);
+if(saved){
+  (saved.elim||[]).forEach(l=>{
+    const i=CANDIDATES.findIndex(x=>x.label===l);
+    if(i>=0&&elim.size<CANDIDATES.length-1){elim.add(i);}
+  });
+  const ci=CANDIDATES.findIndex(x=>x.label===saved.cur);
+  if(ci>=0&&!elim.has(ci))cur=ci;
+  else cur=Math.max(0,CANDIDATES.findIndex((_,j)=>!elim.has(j)));
+}
 /* IANA tlds-alpha-by-domain.txt, Version 2026061200 */
 const TLDS=new Set("aaa aarp abb abbott abbvie abc able abogado abudhabi ac academy accenture accountant accountants aco actor ad ads adult ae aeg aero aetna af afl africa ag agakhan agency ai aig airbus airforce airtel akdn al alibaba alipay allfinanz allstate ally alsace alstom am amazon americanexpress americanfamily amex amfam amica amsterdam analytics android anquan anz ao aol apartments app apple aq aquarelle ar arab aramco archi army arpa art arte as asda asia associates at athleta attorney au auction audi audible audio auspost author auto autos aw aws ax axa az azure ba baby baidu banamex band bank bar barcelona barclaycard barclays barefoot bargains baseball basketball bauhaus bayern bb bbc bbt bbva bcg bcn bd be beats beauty beer berlin best bestbuy bet bf bg bh bharti bi bible bid bike bing bingo bio biz bj black blackfriday blockbuster blog bloomberg blue bm bms bmw bn bnpparibas bo boats boehringer bofa bom bond boo book booking bosch bostik boston bot boutique box br bradesco bridgestone broadway broker brother brussels bs bt build builders business buy buzz bv bw by bz bzh ca cab cafe cal call calvinklein cam camera camp canon capetown capital capitalone car caravan cards care career careers cars casa case cash casino cat catering catholic cba cbn cbre cc cd center ceo cern cf cfa cfd cg ch chanel channel charity chase chat cheap chintai christmas chrome church ci cipriani circle cisco citadel citi citic city ck cl claims cleaning click clinic clinique clothing cloud club clubmed cm cn co coach codes coffee college cologne com commbank community company compare computer comsec condos construction consulting contact contractors cooking cool coop corsica country coupon coupons courses cpa cr credit creditcard creditunion cricket crown crs cruise cruises cu cuisinella cv cw cx cy cymru cyou cz dad dance data date dating datsun day dclk dds de deal dealer deals degree delivery dell deloitte delta democrat dental dentist desi design dev dhl diamonds diet digital direct directory discount discover dish diy dj dk dm dnp do docs doctor dog domains dot download drive dtv dubai dupont durban dvag dvr dz earth eat ec eco edeka edu education ee eg email emerck energy engineer engineering enterprises epson equipment er ericsson erni es esq estate et eu eurovision eus events exchange expert exposed express extraspace fage fail fairwinds faith family fan fans farm farmers fashion fast fedex feedback ferrari ferrero fi fidelity fido film final finance financial fire firestone firmdale fish fishing fit fitness fj fk flickr flights flir florist flowers fly fm fo foo food football ford forex forsale forum foundation fox fr free fresenius frl frogans frontier ftr fujitsu fun fund furniture futbol fyi ga gal gallery gallo gallup game games gap garden gay gb gbiz gd gdn ge gea gent genting george gf gg ggee gh gi gift gifts gives giving gl glass gle global globo gm gmail gmbh gmo gmx gn godaddy gold goldpoint golf goodyear goog google gop got gov gp gq gr grainger graphics gratis green gripe grocery group gs gt gu gucci guge guide guitars guru gw gy hair hamburg hangout haus hbo hdfc hdfcbank health healthcare help helsinki here hermes hiphop hisamitsu hitachi hiv hk hkt hm hn hockey holdings holiday homedepot homegoods homes homesense honda horse hospital host hosting hot hotels hotmail house how hr hsbc ht hu hughes hyatt hyundai ibm icbc ice icu id ie ieee ifm ikano il im imamat imdb immo immobilien in inc industries infiniti info ing ink institute insurance insure int international intuit investments io ipiranga iq ir irish is ismaili ist istanbul it itau itv jaguar java jcb je jeep jetzt jewelry jio jll jm jmp jnj jo jobs joburg jot joy jp jpmorgan jprs juegos juniper kaufen kddi ke kerryhotels kerryproperties kfh kg kh ki kia kids kim kindle kitchen kiwi km kn koeln komatsu kosher kp kpmg kpn kr krd kred kuokgroup kw ky kyoto kz la lacaixa lamborghini lamer land landrover lanxess lasalle lat latino latrobe law lawyer lb lc lds lease leclerc lefrak legal lego lexus lgbt li lidl life lifeinsurance lifestyle lighting like lilly limited limo lincoln link live living lk llc llp loan loans locker locus lol london lotte lotto love lpl lplfinancial lr ls lt ltd ltda lu lundbeck luxe luxury lv ly ma madrid maif maison makeup man management mango map market marketing markets marriott marshalls mattel mba mc mckinsey md me med media meet melbourne meme memorial men menu merck merckmsd mg mh miami microsoft mil mini mint mit mitsubishi mk ml mlb mls mm mma mn mo mobi mobile moda moe moi mom monash money monster mormon mortgage moscow moto motorcycles mov movie mp mq mr ms msd mt mtn mtr mu museum music mv mw mx my mz na nab nagoya name navy nba nc ne nec net netbank netflix network neustar new news next nextdirect nexus nf nfl ng ngo nhk ni nico nike nikon ninja nissan nissay nl no nokia norton now nowruz nowtv np nr nra nrw ntt nu nyc nz obi observer office okinawa olayan olayangroup ollo om omega one ong onl online ooo open oracle orange org organic origins osaka otsuka ott ovh pa page panasonic paris pars partners parts party pay pccw pe pet pf pfizer pg ph pharmacy phd philips phone photo photography photos physio pics pictet pictures pid pin ping pink pioneer pizza pk pl place play playstation plumbing plus pm pn pnc pohl poker politie porn post pr praxi press prime pro prod productions prof progressive promo properties property protection pru prudential ps pt pub pw pwc py qa qpon quebec quest racing radio re read realestate realtor realty recipes red redumbrella rehab reise reisen reit reliance ren rent rentals repair report republican rest restaurant review reviews rexroth rich richardli ricoh ril rio rip ro rocks rodeo rogers room rs rsvp ru rugby ruhr run rw rwe ryukyu sa saarland safe safety sakura sale salon samsclub samsung sandvik sandvikcoromant sanofi sap sarl sas save saxo sb sbi sbs sc scb schaeffler schmidt scholarships school schule schwarz science scot sd se search seat secure security seek select sener services seven sew sex sexy sfr sg sh shangrila sharp shell shia shiksha shoes shop shopping shouji show si silk sina singles site sj sk ski skin sky skype sl sling sm smart smile sn sncf so soccer social softbank software sohu solar solutions song sony soy spa space sport spot sr srl ss st stada staples star statebank statefarm stc stcgroup stockholm storage store stream studio study style su sucks supplies supply support surf surgery suzuki sv swatch swiss sx sy sydney systems sz tab taipei talk taobao target tatamotors tatar tattoo tax taxi tc tci td tdk team tech technology tel temasek tennis teva tf tg th thd theater theatre tiaa tickets tienda tips tires tirol tj tjmaxx tjx tk tkmaxx tl tm tmall tn to today tokyo tools top toray toshiba total tours town toyota toys tr trade trading training travel travelers travelersinsurance trust trv tt tube tui tunes tushu tv tvs tw tz ua ubank ubs ug uk unicom university uno uol ups us uy uz va vacations vana vanguard vc ve vegas ventures verisign versicherung vet vg vi viajes video vig viking villas vin vip virgin visa vision viva vivo vlaanderen vn vodka volvo vote voting voto voyage vu wales walmart walter wang wanggou watch watches weather weatherchannel webcam weber website wed wedding weibo weir wf whoswho wien wiki williamhill win windows wine winners wme woodside work works world wow ws wtc wtf xbox xerox xihuan xin xxx xyz yachts yahoo yamaxun yandex ye yodobashi yoga yokohama you youtube yt yun za zappos zara zero zip zm zone zuerich zw".split(" "));
 function slugify(w){return w.toLowerCase().replace(/\s+/g,"").replace(/ä/g,"ae").replace(/ö/g,"oe").replace(/ü/g,"ue").replace(/ß/g,"ss");}
@@ -472,6 +505,7 @@ render=function(){
   document.getElementById("pcollapsed").textContent=CANDIDATES[cur].label;
   postState();
   renderPhoneScreens();
+  saveState();
 };
 go(0);render();
 window.addEventListener("resize",render);


### PR DESCRIPTION
Eingaben werden jetzt gespeichert: Eigene Vorschläge, ausgeschiedene Kandidaten, die aktuelle Auswahl und alle Toggle-Zustände landen in `localStorage` und werden beim Neuladen wiederhergestellt (pro Browser/Gerät).

- Ausgeschiedene **eigene** Vorschläge werden nicht mitgespeichert — × + Neuladen entfernt einen Vorschlag dauerhaft (bewusst: so wird man Tippfehler wieder los)
- Der Embed-Modus (iPhone-iframe) liest/schreibt den Speicher nicht, er spiegelt weiterhin nur den Hauptzustand
- README: Bedienung ergänzt, offene Aufgabe 3 (Persistenz) erledigt

Tests: 4 neue Persistenz-Checks (Reload-Restore, dauerhaftes Löschen, frischer Kontext = Default) + Regression 12/12 + 5/5 — alle grün, keine JS-Fehler.

https://claude.ai/code/session_017oCB4YaMsFBXL1ZPVDjjEA

---
_Generated by [Claude Code](https://claude.ai/code/session_017oCB4YaMsFBXL1ZPVDjjEA)_