### PR TITLE
Werkzeug: Hoch-/Tiefstellung + Proof-Renderer für v2.4.1

### DIFF
--- a/tools/goetheanum-fontfix/proof_v241.py
+++ b/tools/goetheanum-fontfix/proof_v241.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Proof render for v2.4.1 calibration — Klar cut.
+# Kurzziffern: Hoehe 515 / Gewicht 540 / Laufweite 0
+# Kapitaelchen: Hoehe 505 / Gewicht 550 / Laufweite +30
+# Weight via interpolation between family cuts (Klar 440 <-> Laut 680);
+# height via uniform scale H/690 (same model as werkzeug.html).
+import os, sys, glob
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+from fontfix import grec, blend, sig
+from fontTools.ttLib import TTFont
+import cairosvg
+
+KLAR = glob.glob(os.path.join(HERE, "input", "*-Klar.otf"))[0]
+LAUT = glob.glob(os.path.join(HERE, "input", "*-Laut.otf"))[0]
+fK, fL = TTFont(KLAR), TTFont(LAUT)
+W_KLAR, W_LAUT, CAP = 440.0, 680.0, 690.0
+
+FIG_H, FIG_W, FIG_T = 515, 540, 0
+CAP_H, CAP_W, CAP_T = 505, 550, 30
+
+def interp(uni, target_w):
+    rA, aA = grec(fK, uni)
+    rB, aB = grec(fL, uni)
+    if rA is None: return None, 0
+    if rB is None or sig(rA) != sig(rB):
+        return rA, aA                                  # not compatible -> Klar as-is
+    t = (target_w - W_KLAR) / (W_LAUT - W_KLAR)
+    return blend(rA, aA, rB, aB, t)
+
+def xform(recv, s, dx):
+    return [(c, tuple((x * s + dx, y * s) for x, y in p)) for c, p in recv]
+
+def to_path(recv):
+    d = []
+    for c, p in recv:
+        if c == "moveTo":   d.append("M%.1f %.1f" % p[0])
+        elif c == "lineTo": d.append("L%.1f %.1f" % p[0])
+        elif c == "curveTo":d.append("C%.1f %.1f %.1f %.1f %.1f %.1f" % (p[0]+p[1]+p[2]))
+        elif c == "qCurveTo":
+            pts = p
+            for i in range(len(pts) - 1):
+                d.append("Q%.1f %.1f %.1f %.1f" % (pts[i] + pts[i+1]))
+        elif c == "closePath": d.append("Z")
+    return "".join(d)
+
+def glyph(ch, mode):
+    """mode: 'n' normal Klar, 'd' onum digit, 'k' smcp cap. returns (recv_klarframe, advance)."""
+    uni = ord(ch)
+    if mode == "d":
+        rec, adv = interp(uni, FIG_W); s = FIG_H / CAP
+        rec = xform(rec, s, 0); return rec, adv * s + FIG_T
+    if mode == "k":
+        rec, adv = interp(ord(ch.upper()), CAP_W); s = CAP_H / CAP
+        rec = xform(rec, s, 0); return rec, adv * s + CAP_T
+    rec, adv = grec(fK, uni)
+    if rec is None: rec = []
+    return rec, adv
+
+def layout(tokens, baseline_y):
+    """tokens: list of (text, mode). returns (svg_paths, width)."""
+    x = 0.0; paths = []
+    for text, mode in tokens:
+        for ch in text:
+            if ch == " ":
+                _, adv = grec(fK, 0x20); x += adv if adv else 250; continue
+            rec, adv = glyph(ch, mode)
+            rec = [(c, tuple((px + x, py) for px, py in p)) for c, p in rec]
+            paths.append(to_path(rec)); x += adv
+    return paths, x
+
+def parse(s):
+    """digits -> 'd', {..} -> 'k', else 'n'."""
+    toks = []; i = 0
+    while i < len(s):
+        ch = s[i]
+        if ch == "{":
+            j = s.index("}", i); toks.append((s[i+1:j], "k")); i = j + 1
+        elif ch.isdigit():
+            j = i
+            while j < len(s) and s[j].isdigit(): j += 1
+            toks.append((s[i:j], "d")); i = j
+        else:
+            toks.append((ch, "n")); i += 1
+    return toks
+
+SAMPLE = "Am 24. Juni 1923 bestaetigte die {UNESCO} das {GOETHEANUM}; vgl. {Bd}. II, S. 36 - von 1922 auf 1487 Mitglieder."
+def parse_ref(s):
+    """reference line: digits default-lining, caps as full caps (drop braces)."""
+    return [(s.replace("{", "").replace("}", ""), "n")]
+
+EM = 1000; LH = 1500; PAD = 120; FS_LABEL = 150
+lines = [
+    ("v2.4.1  –  Kurzziffern 515/540  +  Kapitaelchen 505/550 +30", parse_ref, "lab"),
+    (SAMPLE, parse, "main"),
+    ("Referenz: Versalziffern + volle Versalien", parse_ref, "lab"),
+    (SAMPLE, parse_ref, "ref"),
+]
+rows = []
+maxw = 0
+for text, fn, kind in lines:
+    toks = fn(text) if fn is parse else fn(text)
+    paths, w = layout(toks, 0)
+    rows.append((paths, w, kind)); maxw = max(maxw, w)
+
+W = maxw + 2 * PAD
+H = PAD + len(rows) * LH + PAD
+svg = ['<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" viewBox="0 0 %d %d">' % (W//2, H//2, W, H)]
+svg.append('<rect width="%d" height="%d" fill="#ffffff"/>' % (W, H))
+y = PAD + EM
+for paths, w, kind in rows:
+    color = "#23272b" if kind in ("main",) else ("#a07a33" if kind == "ref" else "#9aa0a6")
+    g = '<g transform="translate(%d,%d) scale(1,-1)" fill="%s">' % (PAD, y, color)
+    g += '<path d="%s"/>' % "".join(paths)
+    g += "</g>"
+    svg.append(g)
+    y += LH
+svg.append("</svg>")
+svg = "\n".join(svg)
+out_png = "/tmp/v241_proof_klar.png"
+cairosvg.svg2png(bytestring=svg.encode("utf-8"), write_to=out_png, output_width=1800)
+print("wrote", out_png)

--- a/werkzeug.html
+++ b/werkzeug.html
@@ -91,6 +91,48 @@
     </div>
   </section>
 
+  <section class="panel" id="sup">
+    <h2>Hochstellung</h2>
+    <div class="hint">Fussnotenzeichen, Einheiten, Exponenten.</div>
+    <div class="stage">
+      <p class="line">Goethe<span class="sp su">1</span> mass am 28.<span class="sp su">8</span>. die Fläche 12 m<span class="sp su">2</span> und x<span class="sp su">3</span>.</p>
+      <p class="big">a<span class="sp su">2</span> + b<span class="sp su">2</span> = c<span class="sp su">2</span></p>
+      <p class="cmp">Grundziffern zum Vergleich: 1&nbsp;&nbsp;8&nbsp;&nbsp;2&nbsp;&nbsp;3</p>
+    </div>
+    <div class="ctrls">
+      <div class="ctrl"><label>Höhe <b><span id="supH-v">430</span></b></label><input type="range" id="supH" min="300" max="690" value="430"></div>
+      <div class="ctrl"><label>Gewicht (Dicke) <b><span id="supW-v">530</span></b></label><input type="range" id="supW" min="190" max="725" value="530"></div>
+      <div class="ctrl"><label>Versatz (über Grundlinie) <b><span id="supO-v">+300</span></b></label><input type="range" id="supO" min="0" max="430" value="300"></div>
+      <div class="ctrl"><label>Laufweite <b><span id="supT-v">0</span></b></label><input type="range" id="supT" min="-30" max="160" value="0"></div>
+    </div>
+    <div class="readout">
+      <span class="code" id="supCode"></span>
+      <button class="btn" data-copy="supCode">Werte kopieren</button>
+      <button class="reset" data-reset="sup">zurücksetzen</button>
+    </div>
+  </section>
+
+  <section class="panel" id="sub">
+    <h2>Tiefstellung</h2>
+    <div class="hint">Indizes in Formeln (H₂O, CO₂).</div>
+    <div class="stage">
+      <p class="line">Wasser H<span class="sp sb">2</span>O, Kohlendioxid CO<span class="sp sb">2</span>, Reihe a<span class="sp sb">1</span> + a<span class="sp sb">2</span>.</p>
+      <p class="big">H<span class="sp sb">2</span>SO<span class="sp sb">4</span></p>
+      <p class="cmp">Grundziffern zum Vergleich: 2&nbsp;&nbsp;4&nbsp;&nbsp;1</p>
+    </div>
+    <div class="ctrls">
+      <div class="ctrl"><label>Höhe <b><span id="subH-v">430</span></b></label><input type="range" id="subH" min="300" max="690" value="430"></div>
+      <div class="ctrl"><label>Gewicht (Dicke) <b><span id="subW-v">530</span></b></label><input type="range" id="subW" min="190" max="725" value="530"></div>
+      <div class="ctrl"><label>Versatz (unter Grundlinie) <b><span id="subO-v">-110</span></b></label><input type="range" id="subO" min="-300" max="60" value="-110"></div>
+      <div class="ctrl"><label>Laufweite <b><span id="subT-v">0</span></b></label><input type="range" id="subT" min="-30" max="160" value="0"></div>
+    </div>
+    <div class="readout">
+      <span class="code" id="subCode"></span>
+      <button class="btn" data-copy="subCode">Werte kopieren</button>
+      <button class="reset" data-reset="sub">zurücksetzen</button>
+    </div>
+  </section>
+
   <section class="panel" id="mix">
     <h2>Mischsatz</h2>
     <div class="hint">Freier Text – prüfe, wie Kurzziffern und Kapitälchen zusammen sitzen. <b>Ziffern</b> werden automatisch zu Kurzziffern; Text in <b>{geschweiften&nbsp;Klammern}</b> wird zu Kapitälchen. Beide folgen live den Reglern oben.</div>
@@ -104,31 +146,37 @@
 
 <script>
   var CAP = 690; // Versalhöhe in Fonteinheiten
+  function setTxt(id,t){ var e=document.getElementById(id); if(e) e.textContent=t; }
+  function sign(n){ return (n>0?"+":"")+n; }
   function apply(prefix, sel){
     var H = +document.getElementById(prefix+"H").value;
     var W = +document.getElementById(prefix+"W").value;
     var T = +document.getElementById(prefix+"T").value;
-    document.getElementById(prefix+"H-v").textContent = H;
-    document.getElementById(prefix+"W-v").textContent = W;
-    document.getElementById(prefix+"T-v").textContent = (T>0?"+":"")+T;
+    var Oel = document.getElementById(prefix+"O"), O = Oel ? +Oel.value : null;
+    setTxt(prefix+"H-v", H); setTxt(prefix+"W-v", W); setTxt(prefix+"T-v", sign(T));
+    if(Oel) setTxt(prefix+"O-v", sign(O));
     document.querySelectorAll(sel).forEach(function(el){
       var line = el.closest(".line, .big");
       var B = parseFloat(getComputedStyle(line).fontSize);
       el.style.fontSize = (B * H / CAP) + "px";
       el.style.letterSpacing = (B * T / 1000) + "px";
       el.style.fontVariationSettings = "'wght' " + W;
+      if(Oel){ el.style.display = "inline-block"; el.style.transform = "translateY(" + (-B * O / 1000) + "px)"; }
     });
-    var code = "Höhe " + H + " · Gewicht " + W + " · Laufweite " + (T>0?"+":"") + T;
-    document.getElementById(prefix+"Code").textContent = code;
+    var code = "Höhe " + H + " · Gewicht " + W + (Oel ? (" · Versatz " + sign(O)) : "") + " · Laufweite " + sign(T);
+    setTxt(prefix+"Code", code);
   }
   function bind(prefix, sel){
-    ["H","W","T"].forEach(function(k){
-      document.getElementById(prefix+k).addEventListener("input", function(){ apply(prefix, sel); });
+    ["H","W","T","O"].forEach(function(k){
+      var e = document.getElementById(prefix+k);
+      if(e) e.addEventListener("input", function(){ apply(prefix, sel); });
     });
     apply(prefix, sel);
   }
-  var defaults = {figH:580,figW:518,figT:0,capH:545,capW:548,capT:25};
-  bind("fig",".d"); bind("cap",".k");
+  var SEL = {fig:".d", cap:".k", sup:".su", sub:".sb"};
+  var defaults = {figH:580,figW:518,figT:0, capH:545,capW:548,capT:25,
+                  supH:430,supW:530,supO:300,supT:0, subH:430,subW:530,subO:-110,subT:0};
+  bind("fig",".d"); bind("cap",".k"); bind("sup",".su"); bind("sub",".sb");
   document.querySelectorAll("[data-copy]").forEach(function(b){
     b.addEventListener("click", function(){
       var t = document.getElementById(b.dataset.copy).textContent;
@@ -136,10 +184,11 @@
       var o=b.textContent; b.textContent="kopiert ✓"; setTimeout(function(){b.textContent=o;},1200);
     });
   });
+  var RMAP = {figs:"fig", caps:"cap", sup:"sup", sub:"sub"};
   document.querySelectorAll("[data-reset]").forEach(function(b){
     b.addEventListener("click", function(){
-      var p = b.dataset.reset==="figs"?"fig":"cap"; var sel=p==="fig"?".d":".k";
-      ["H","W","T"].forEach(function(k){ document.getElementById(p+k).value = defaults[p+k]; });
+      var p = RMAP[b.dataset.reset], sel = SEL[p];
+      ["H","W","T","O"].forEach(function(k){ var c=document.getElementById(p+k); if(c) c.value = defaults[p+k]; });
       apply(p, sel);
     });
   });
@@ -157,10 +206,11 @@
     mixOut.innerHTML = out.replace(/\n/g,"<br>");
     apply("fig",".d"); apply("cap",".k");
   }
+  function refreshAll(){ apply("sup",".su"); apply("sub",".sb"); renderMix(); }
   mixIn.addEventListener("input", renderMix);
-  renderMix();
-  window.addEventListener("resize", function(){ renderMix(); });
-  document.fonts && document.fonts.ready.then(function(){ renderMix(); });
+  refreshAll();
+  window.addEventListener("resize", refreshAll);
+  document.fonts && document.fonts.ready.then(refreshAll);
 </script>
 </body>
 </html>


### PR DESCRIPTION
Erweitert das Kalibrier-Werkzeug und legt den Proof-Renderer für den anstehenden Schnitt ab.

## Werkzeug (`werkzeug.html`)
- **Hoch- und Tiefstellung** als neue Panels, nach demselben Live-Modell wie Kapitälchen/Kurzziffern. Regler: **Höhe · Gewicht · Versatz · Laufweite**. `apply/bind/reset` wurden um einen optionalen Versatz-Regler generalisiert.

## Tooling
- `tools/goetheanum-fontfix/proof_v241.py`: rendert den Mischsatz mit **echt erzeugten Glyphen** (Gewicht zwischen den Familienschnitten interpoliert, Höhe per H/690 skaliert) zur visuellen Abnahme vor dem Schnitt.

Reine Frontend-/Tooling-Änderung; keine Schrift-Binaries berührt.

https://claude.ai/code/session_017aSpY9SVm7s2z5dMoG4Cy4

---
_Generated by [Claude Code](https://claude.ai/code/session_017aSpY9SVm7s2z5dMoG4Cy4)_