### PR TITLE
Tool: Ligaturen ineinanderschieben (live im Fliesstext)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -12,6 +12,7 @@ on:
       - "proof.html"
       - "zuordnen.html"
       - "kerning.html"
+      - "ineinander.html"
       - "tester.html"
       - "typografie.html"
       - "vorschau.html"
@@ -55,6 +56,7 @@ jobs:
           if [ -f proof.html ]; then cp proof.html _site/proof.html; fi
           if [ -f zuordnen.html ]; then cp zuordnen.html _site/zuordnen.html; fi
           if [ -f kerning.html ]; then cp kerning.html _site/kerning.html; fi
+          if [ -f ineinander.html ]; then cp ineinander.html _site/ineinander.html; fi
           if [ -f tester.html ]; then cp tester.html _site/tester.html; fi
           if [ -f typografie.html ]; then cp typografie.html _site/typografie.html; fi
           if [ -f vorschau.html ]; then cp vorschau.html _site/vorschau.html; fi

--- a/ineinander.html
+++ b/ineinander.html
@@ -1,0 +1,54 @@
+<!doctype html><html lang="de"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>Ligaturen ineinander</title>
+<style>
+@font-face{font-family:"G Klar";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.4.1-Klar.woff2") format("woff2");font-weight:400;font-display:swap}
+body{margin:0;background:#faf8f4;color:#23272b;font:15px/1.5 -apple-system,"Segoe UI",Helvetica,Arial,sans-serif}
+.wrap{max-width:1040px;margin:0 auto;padding:26px 22px 80px}
+h1{font-size:22px;margin:0 0 6px}.hint{color:#737a80;font-size:14px;margin:6px 0 16px}
+.stage{background:#fff;border:1px solid rgba(20,24,28,.12);border-radius:14px;padding:26px 28px;margin:14px 0}
+.sample{font-family:"G Klar";font-size:46px;line-height:1.55;color:#23272b}
+.lig{display:inline-block;vertical-align:-0.24em}
+.lig svg{height:1em;fill:currentColor}
+.ctrls{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:16px 26px;margin-top:16px}
+.ctrl label{display:flex;justify-content:space-between;font-size:13px;color:#3a3f44;margin-bottom:5px}
+.ctrl b{font-variant-numeric:tabular-nums}
+input[type=range]{width:100%}
+.readout{margin-top:16px;font-size:13px;color:#3a3f44;background:#f3efe7;border-radius:10px;padding:11px 13px}
+.code{font-family:ui-monospace,Menlo,monospace}
+.btn{font:inherit;font-size:13px;border:1px solid rgba(20,24,28,.18);background:#fff;border-radius:8px;padding:6px 11px;cursor:pointer;margin-right:8px}
+small{color:#9aa0a6}
+</style></head><body><div class="wrap">
+<h1>Ligaturen ineinanderschieben</h1>
+<div class="hint">Deine Ligaturen liegen <b>zerlegt</b> (f + Folgebuchstabe) inline im echten Klar‑Satz. Jeder Regler schiebt den Folgebuchstaben <b>unter den f‑Bogen</b>: negativ = enger, positiv = lockerer. Du justierst, während du die Ligatur <b>im Gebrauch</b> siehst. Werte in Fonteinheiten.</div>
+<div class="stage"><div class="sample" id="sample">Au<span class="lig" data-l="ff"></span>ällige, <span class="lig" data-l="fl"></span>ießende Schri<span class="lig" data-l="ft"></span>züge: der Sto<span class="lig" data-l="ff"></span>, das Schi<span class="lig" data-l="ff"></span>, ein P<span class="lig" data-l="fi"></span><span class="lig" data-l="ff"></span>, Ko<span class="lig" data-l="ff"></span>er, scha<span class="lig" data-l="ff"></span>en, tre<span class="lig" data-l="ff"></span>en, ö<span class="lig" data-l="ff"></span>nen, die Au<span class="lig" data-l="fl"></span>age, das P<span class="lig" data-l="fl"></span>aster, Gra<span class="lig" data-l="fi"></span>k, san<span class="lig" data-l="ft"></span>e Kra<span class="lig" data-l="ft"></span>, o<span class="lig" data-l="ft"></span> geprü<span class="lig" data-l="ft"></span>, fünf.</div></div>
+<div class="ctrls"><div class="ctrl"><label>ff · Überlappung <b><span id="v_ff">0</span></b></label><input type="range" id="s_ff" min="-220" max="120" value="0"></div><div class="ctrl"><label>fi · Überlappung <b><span id="v_fi">0</span></b></label><input type="range" id="s_fi" min="-220" max="120" value="0"></div><div class="ctrl"><label>fl · Überlappung <b><span id="v_fl">0</span></b></label><input type="range" id="s_fl" min="-220" max="120" value="0"></div><div class="ctrl"><label>ft · Überlappung <b><span id="v_ft">0</span></b></label><input type="range" id="s_ft" min="-220" max="120" value="0"></div><div class="ctrl"><label>fj · Überlappung <b><span id="v_fj">0</span></b></label><input type="range" id="s_fj" min="-220" max="120" value="0"></div><div class="ctrl"><label>fk · Überlappung <b><span id="v_fk">0</span></b></label><input type="range" id="s_fk" min="-220" max="120" value="0"></div></div>
+<div class="readout"><span class="code" id="code"></span>
+<div style="margin-top:9px"><button class="btn" id="copy">Werte kopieren</button><button class="btn" id="reset">zurücksetzen</button>
+<small>Diese Überlappung wird die Komponenten‑Position in der Ligatur.</small></div></div>
+</div>
+<script>
+var DATA={"ff": {"lead": "M139.0 332.0L266.0 332.0L266.0 260.0L139.0 260.0L139.0 221.0C139.0 145.0 150.0 106.0 200.0 106.0C250.0 106.0 273.0 113.0 273.0 113.0L274.0 44.0C274.0 44.0 216.0 34.0 184.0 34.0C94.0 34.0 55.0 86.0 55.0 220.0L55.0 260.0L0.0 260.0L0.0 332.0L55.0 332.0L55.0 980.0L131.0 980.0L138.0 760.0L139.0 332.0Z", "trail": "M386.5 332.0L513.5 332.0L513.5 260.0L386.5 260.0L386.5 221.0C386.5 145.0 397.5 106.0 447.5 106.0C497.5 106.0 520.5 113.0 520.5 113.0L521.5 44.0C521.5 44.0 463.5 34.0 431.5 34.0C341.5 34.0 302.5 86.0 302.5 220.0L302.5 260.0L247.5 260.0L247.5 332.0L302.5 332.0L302.5 980.0L378.5 980.0L385.5 760.0L386.5 332.0Z", "lx": 274.0, "tlo": 247.5, "thi": 521.5}, "fi": {"lead": "M139.0 335.4L266.0 335.4L266.0 263.4L139.0 263.4L139.0 224.4C139.0 148.4 150.0 109.4 200.0 109.4C250.0 109.4 273.0 116.4 273.0 116.4L274.0 47.4C274.0 47.4 216.0 37.4 184.0 37.4C94.0 37.4 55.0 89.4 55.0 223.4L55.0 263.4L0.0 263.4L0.0 335.4L55.0 335.4L55.0 983.4L131.0 983.4L138.0 763.4L139.0 335.4Z", "trail": "M257.0 763.4L340.0 763.4L340.0 263.4L257.0 263.4L257.0 763.4L257.0 763.4Z", "lx": 274.0, "tlo": 257.0, "thi": 340.0}, "fl": {"lead": "M139.0 332.0L207.1 332.0L207.1 260.0L139.0 260.0L139.0 221.0C139.0 145.0 150.0 106.0 200.0 106.0C250.0 106.0 273.0 113.0 273.0 113.0L274.0 44.0C274.0 44.0 216.0 34.0 184.0 34.0C94.0 34.0 55.0 86.0 55.0 220.0L55.0 260.0L0.0 260.0L0.0 332.0L55.0 332.0L55.0 980.0L131.0 980.0L138.0 760.0L139.0 332.0Z", "trail": "M261.0 760.0L345.0 760.0L345.0 45.0L261.0 45.0L261.0 760.0Z", "lx": 274.0, "tlo": 261.0, "thi": 345.0}, "ft": {"lead": "M139.0 332.0L235.2 332.0L235.2 260.0L139.0 260.0L139.0 221.0C139.0 145.0 150.0 106.0 200.0 106.0C250.0 106.0 362.9 119.0 362.9 119.0L364.0 50.0C364.0 50.0 216.0 34.0 184.0 34.0C94.0 34.0 55.0 86.0 55.0 220.0L55.0 260.0L0.0 260.0L0.0 332.0L55.0 332.0L55.0 980.0L131.0 980.0L138.0 760.0L139.0 332.0L139.0 332.0Z", "trail": "M499.0 332.0L499.0 260.0L363.0 260.0L363.0 115.0L280.0 110.0L280.0 617.0C280.0 714.0 308.0 770.0 412.0 770.0C516.0 770.0 505.0 757.0 505.0 757.0L501.0 692.0C501.0 692.0 454.0 698.0 423.0 698.0C378.0 698.0 363.0 665.0 363.0 612.0L363.0 331.0L499.0 332.0Z", "lx": 364.0, "tlo": 280.0, "thi": 516.0}, "fj": {"lead": "M139.0 330.7L266.0 330.7L266.0 258.7L139.0 258.7L139.0 219.7C139.0 143.7 150.0 104.7 200.0 104.7C250.0 104.7 273.0 111.7 273.0 111.7L274.0 42.7C274.0 42.7 216.0 32.7 184.0 32.7C94.0 32.7 55.0 84.7 55.0 218.7L55.0 258.7L0.0 258.7L0.0 330.7L55.0 330.7L55.0 978.7L131.0 978.7L138.0 758.7L139.0 330.7L139.0 330.7Z", "trail": "M257.0 758.7C257.0 849.7 253.0 863.7 147.0 928.7L179.0 992.7C328.0 914.7 341.0 889.7 341.0 758.7L341.0 258.7L258.0 258.7L257.0 758.7Z", "lx": 274.0, "tlo": 147.0, "thi": 341.0}, "fk": {"lead": "M139.0 351.0L215.4 351.0L215.4 279.0L139.0 279.0L139.0 240.0C139.0 164.0 150.0 125.0 200.0 125.0C250.0 125.0 273.0 132.0 273.0 132.0L274.0 63.0C274.0 63.0 216.0 53.0 184.0 53.0C94.0 53.0 55.0 105.0 55.0 239.0L55.0 279.0L0.0 279.0L0.0 351.0L55.0 351.0L55.0 999.0L131.0 999.0L138.0 779.0L139.0 351.0Z", "trail": "M341.0 779.0L341.0 556.0L402.0 551.0L539.0 779.0L632.0 779.0L471.0 510.0L629.0 279.0L536.0 279.0L401.0 480.0L341.0 484.0L341.0 64.0L258.0 64.0L258.0 779.0L341.0 779.0Z", "lx": 274.0, "tlo": 258.0, "thi": 632.0}};
+var OV={ff:0,fi:0,fl:0,ft:0,fj:0,fk:0};
+function svgFor(key){
+ var d=DATA[key], ov=OV[key];
+ var minx=Math.min(0, d.tlo+ov), maxx=Math.max(d.lx, d.thi+ov);
+ var w=maxx-minx;
+ return '<svg viewBox="'+minx.toFixed(1)+' 0 '+w.toFixed(1)+' 1000" style="width:'+(w/1000).toFixed(3)+'em">'
+  +'<path d="'+d.lead+'"/><g transform="translate('+ov+',0)"><path d="'+d.trail+'"/></g></svg>';
+}
+function renderAll(){
+ [].forEach.call(document.querySelectorAll(".lig"),function(s){s.innerHTML=svgFor(s.dataset.l);});
+ document.getElementById("code").textContent=
+  Object.keys(OV).map(function(k){return k+": "+(OV[k]>0?"+":"")+OV[k];}).join("   ·   ");
+}
+["ff","fi","fl","ft","fj","fk"].forEach(function(k){
+ var s=document.getElementById("s_"+k);
+ s.addEventListener("input",function(){OV[k]=+s.value;document.getElementById("v_"+k).textContent=(OV[k]>0?"+":"")+OV[k];renderAll();});
+});
+document.getElementById("reset").onclick=function(){["ff","fi","fl","ft","fj","fk"].forEach(function(k){
+ OV[k]=0;document.getElementById("s_"+k).value=0;document.getElementById("v_"+k).textContent="0";});renderAll();};
+document.getElementById("copy").onclick=function(){navigator.clipboard&&navigator.clipboard.writeText(document.getElementById("code").textContent);
+ var b=this;b.textContent="kopiert ✓";setTimeout(function(){b.textContent="Werte kopieren";},1200);};
+document.fonts&&document.fonts.ready.then(renderAll);
+renderAll();
+</script></body></html>

--- a/tools/goetheanum-fontfix/make_overlap_tool.py
+++ b/tools/goetheanum-fontfix/make_overlap_tool.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# Generate ineinander.html: each ligature decomposed into letter components;
+# live slider per ligature shifts the trailing letter(s) under the f-bow, shown in Klar text.
+import os, sys, json
+import xml.etree.ElementTree as ET
+HERE = "/home/user/goeloggen/tools/goetheanum-fontfix"; sys.path.insert(0, HERE)
+from fontTools.svgLib.path import parse_path
+from fontTools.pens.recordingPen import RecordingPen
+
+SVG = "/tmp/ph_lig/f-ligaturen_ph.svg"
+root = ET.parse(SVG).getroot()
+parent = {c: p for p in root.iter() for c in p}
+def find(g):
+    for e in root.iter():
+        if e.get('id') == g: return e
+def paths_of(el): return [e.get('d') for e in el.iter() if e.tag.split('}')[-1] == 'path' and e.get('d')]
+def baseline_for(y): return 1020 if y < 1400 else (2340 if y < 2900 else 3660)
+BASE = 760
+
+def path_pts(d):
+    rp = RecordingPen(); parse_path(d, rp); return rp
+
+def comp_emit(rp, minx, By):
+    out = []
+    for c, q in rp.value:
+        Q = [(x - minx, BASE - (By - y)) for x, y in q]
+        if c == "moveTo": out.append("M%.1f %.1f" % Q[0])
+        elif c == "lineTo": out.append("L%.1f %.1f" % Q[0])
+        elif c == "curveTo": out.append("C%.1f %.1f %.1f %.1f %.1f %.1f" % (Q[0]+Q[1]+Q[2]))
+        elif c == "qCurveTo":
+            for i in range(len(Q)-1): out.append("Q%.1f %.1f %.1f %.1f" % (Q[i]+Q[i+1]))
+        elif c == "closePath": out.append("Z")
+    return "".join(out)
+
+def decompose(gid):
+    el = find(gid); ps = paths_of(el)
+    if len(ps) < 2 and el in parent: ps = paths_of(parent[el])
+    rps = [path_pts(d) for d in ps]
+    allpts = [p for rp in rps for c, q in rp.value for p in q]
+    By = baseline_for(min(y for x, y in allpts)); minx = min(x for x, y in allpts)
+    # lead = leftmost path; trail = the rest (moved together)
+    def pmin(rp): return min(x for c, q in rp.value for x, y in q)
+    order = sorted(range(len(rps)), key=lambda i: pmin(rps[i]))
+    lead_i = order[0]
+    lead = comp_emit(rps[lead_i], minx, By)
+    trail = "".join(comp_emit(rps[i], minx, By) for i in order[1:])
+    xs_lead = [x - minx for c, q in rps[lead_i].value for x, y in q]
+    xs_trail = [x - minx for i in order[1:] for c, q in rps[i].value for x, y in q]
+    return {"lead": lead, "trail": trail,
+            "lx": round(max(xs_lead), 1),
+            "tlo": round(min(xs_trail), 1) if xs_trail else 0,
+            "thi": round(max(xs_trail), 1) if xs_trail else 0}
+
+MAP = {"ff": "ff", "fi": "fi", "fl": "fl", "ft": "ft", "fj": "fj", "fk": "fk"}
+DATA = {k: decompose(v) for k, v in MAP.items()}
+
+LIGSEQ = ["ff", "fi", "fl", "fj", "fk", "ft"]
+def esc(s): return s.replace("&", "&amp;").replace("<", "&lt;")
+def markup(text):
+    out = ""; i = 0
+    while i < len(text):
+        seq = next((s for s in LIGSEQ if text[i:i+len(s)] == s and s in DATA), None)
+        if seq:
+            out += '<span class="lig" data-l="%s"></span>' % seq; i += len(seq); continue
+        out += esc(text[i]); i += 1
+    return out
+
+SAMPLE = ("Auffällige, fließende Schriftzüge: der Stoff, das Schiff, ein Pfiff, "
+          "Koffer, schaffen, treffen, öffnen, die Auflage, das Pflaster, "
+          "Grafik, sanfte Kraft, oft geprüft, fünf.")
+BODY = markup(SAMPLE)
+
+ctrls = "".join(
+    '<div class="ctrl"><label>%s · Überlappung <b><span id="v_%s">0</span></b></label>'
+    '<input type="range" id="s_%s" min="-220" max="120" value="0"></div>' % (k, k, k)
+    for k in ["ff", "fi", "fl", "ft", "fj", "fk"])
+
+HTML = """<!doctype html><html lang="de"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>Ligaturen ineinander</title>
+<style>
+@font-face{font-family:"G Klar";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.4.1-Klar.woff2") format("woff2");font-weight:400;font-display:swap}
+body{margin:0;background:#faf8f4;color:#23272b;font:15px/1.5 -apple-system,"Segoe UI",Helvetica,Arial,sans-serif}
+.wrap{max-width:1040px;margin:0 auto;padding:26px 22px 80px}
+h1{font-size:22px;margin:0 0 6px}.hint{color:#737a80;font-size:14px;margin:6px 0 16px}
+.stage{background:#fff;border:1px solid rgba(20,24,28,.12);border-radius:14px;padding:26px 28px;margin:14px 0}
+.sample{font-family:"G Klar";font-size:46px;line-height:1.55;color:#23272b}
+.lig{display:inline-block;vertical-align:-0.24em}
+.lig svg{height:1em;fill:currentColor}
+.ctrls{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:16px 26px;margin-top:16px}
+.ctrl label{display:flex;justify-content:space-between;font-size:13px;color:#3a3f44;margin-bottom:5px}
+.ctrl b{font-variant-numeric:tabular-nums}
+input[type=range]{width:100%}
+.readout{margin-top:16px;font-size:13px;color:#3a3f44;background:#f3efe7;border-radius:10px;padding:11px 13px}
+.code{font-family:ui-monospace,Menlo,monospace}
+.btn{font:inherit;font-size:13px;border:1px solid rgba(20,24,28,.18);background:#fff;border-radius:8px;padding:6px 11px;cursor:pointer;margin-right:8px}
+small{color:#9aa0a6}
+</style></head><body><div class="wrap">
+<h1>Ligaturen ineinanderschieben</h1>
+<div class="hint">Deine Ligaturen liegen <b>zerlegt</b> (f + Folgebuchstabe) inline im echten Klar‑Satz. Jeder Regler schiebt den Folgebuchstaben <b>unter den f‑Bogen</b>: negativ = enger, positiv = lockerer. Du justierst, während du die Ligatur <b>im Gebrauch</b> siehst. Werte in Fonteinheiten.</div>
+<div class="stage"><div class="sample" id="sample">__BODY__</div></div>
+<div class="ctrls">__CTRLS__</div>
+<div class="readout"><span class="code" id="code"></span>
+<div style="margin-top:9px"><button class="btn" id="copy">Werte kopieren</button><button class="btn" id="reset">zurücksetzen</button>
+<small>Diese Überlappung wird die Komponenten‑Position in der Ligatur.</small></div></div>
+</div>
+<script>
+var DATA=__DATA__;
+var OV={ff:0,fi:0,fl:0,ft:0,fj:0,fk:0};
+function svgFor(key){
+ var d=DATA[key], ov=OV[key];
+ var minx=Math.min(0, d.tlo+ov), maxx=Math.max(d.lx, d.thi+ov);
+ var w=maxx-minx;
+ return '<svg viewBox="'+minx.toFixed(1)+' 0 '+w.toFixed(1)+' 1000" style="width:'+(w/1000).toFixed(3)+'em">'
+  +'<path d="'+d.lead+'"/><g transform="translate('+ov+',0)"><path d="'+d.trail+'"/></g></svg>';
+}
+function renderAll(){
+ [].forEach.call(document.querySelectorAll(".lig"),function(s){s.innerHTML=svgFor(s.dataset.l);});
+ document.getElementById("code").textContent=
+  Object.keys(OV).map(function(k){return k+": "+(OV[k]>0?"+":"")+OV[k];}).join("   ·   ");
+}
+["ff","fi","fl","ft","fj","fk"].forEach(function(k){
+ var s=document.getElementById("s_"+k);
+ s.addEventListener("input",function(){OV[k]=+s.value;document.getElementById("v_"+k).textContent=(OV[k]>0?"+":"")+OV[k];renderAll();});
+});
+document.getElementById("reset").onclick=function(){["ff","fi","fl","ft","fj","fk"].forEach(function(k){
+ OV[k]=0;document.getElementById("s_"+k).value=0;document.getElementById("v_"+k).textContent="0";});renderAll();};
+document.getElementById("copy").onclick=function(){navigator.clipboard&&navigator.clipboard.writeText(document.getElementById("code").textContent);
+ var b=this;b.textContent="kopiert ✓";setTimeout(function(){b.textContent="Werte kopieren";},1200);};
+document.fonts&&document.fonts.ready.then(renderAll);
+renderAll();
+</script></body></html>"""
+HTML = (HTML.replace("__BODY__", BODY).replace("__CTRLS__", ctrls)
+            .replace("__DATA__", json.dumps(DATA)))
+open("/home/user/goeloggen/ineinander.html", "w").write(HTML)
+print("wrote ineinander.html; components:", {k: (round(v["lx"]), round(v["thi"])) for k, v in DATA.items()})


### PR DESCRIPTION
Auf Philipps Bedarf: nicht das Spacing *um* die Ligatur, sondern das **Ineinanderschieben der Buchstaben** *in* der Ligatur justieren — live im Satz.

`ineinander.html` zerlegt jede Ligatur in **f + Folgebuchstabe** (Komponenten aus seiner SVG) und legt sie inline in echten Klar‑Webfont‑Satz. Ein Regler je Ligatur (ff/fi/fl/ft/fj/fk) schiebt die hintere Komponente unter den f‑Bogen: **negativ = enger, positiv = lockerer**. Werte kopierbar → werden die Komponenten‑Position der Ligatur-Glyphen.

In den Pages‑Build aufgenommen.

https://claude.ai/code/session_017aSpY9SVm7s2z5dMoG4Cy4

---
_Generated by [Claude Code](https://claude.ai/code/session_017aSpY9SVm7s2z5dMoG4Cy4)_