### PR TITLE
Signatur-Generator: helles Layout (schriften.html), Adresse mit Land

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -1,622 +1,430 @@
 <!doctype html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Goetheanum E-Mail-Signatur-Generator</title>
-  <style>
-    @font-face {
-      font-family: "Goetheanum-Deutsch";
-      src: url("../../assets/fonts/goetheanum-titel-deutsch.otf") format("opentype");
-      font-weight: 400;
-      font-style: normal;
-      font-display: swap;
-    }
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Goetheanum E-Mail-Signatur</title>
+<meta name="description" content="E-Mail-Signatur-Generator – erzeugt table-basiertes HTML mit Inline-CSS nach der gemeinsamen Goetheanum-Vorlage." />
+<meta name="robots" content="noindex" />
+<style>
+  @font-face{font-family:"G Leise";src:url("../../assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Leise.woff2") format("woff2");font-weight:400;font-display:swap}
+  @font-face{font-family:"G Klar";src:url("../../assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Klar.woff2") format("woff2");font-weight:400;font-display:swap}
+  @font-face{font-family:"G Laut";src:url("../../assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Laut.woff2") format("woff2");font-weight:400;font-display:swap}
 
-    @font-face {
-      font-family: "Goetheanum-English";
-      src: url("../../assets/fonts/goetheanum-titel-english.otf") format("opentype");
-      font-weight: 400;
-      font-style: normal;
-      font-display: swap;
-    }
+  :root{
+    --ink:#23272b; --muted:#737a80; --line:rgba(20,24,28,.10); --line-soft:rgba(20,24,28,.055);
+    --gold:#d7ab68; --gold-deep:#a07a33; --paper:#fff; --soft:#faf8f4; --maxw:1080px;
+    /* Goetheanum-Rot fuer die Signatur selbst */
+    --sig-red:#9b1c20;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--paper);color:var(--ink);font-family:"G Klar","Helvetica Neue",Arial,sans-serif;
+       letter-spacing:normal;font-kerning:normal;text-rendering:optimizeLegibility;-webkit-font-smoothing:antialiased;line-height:1.5}
+  .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
+  a{color:inherit}
 
-    :root {
-      --bg: #1f2933;
-      --bg-deep: #172029;
-      --panel: #2c3844;
-      --panel-soft: #364452;
-      --line: rgba(219, 224, 228, 0.16);
-      --line-strong: rgba(219, 224, 228, 0.28);
-      --text: #edf1f4;
-      --muted: #afbcc8;
-      --accent: #d7ab68;
-      --venue: #df666a;
-      --shadow: rgba(0, 0, 0, 0.22);
-      /* Goetheanum-Rot fuer die Signatur selbst */
-      --sig-red: #9b1c20;
-    }
+  header{position:sticky;top:0;z-index:30;background:rgba(255,255,255,.9);backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--line)}
+  .bar{display:flex;align-items:center;justify-content:space-between;height:58px}
+  .brand{display:flex;align-items:center;gap:12px;text-decoration:none}
+  .brand img{height:34px}
+  nav.top{display:flex;gap:22px}
+  nav.top a{color:var(--muted);text-decoration:none;font-size:13.5px}
+  nav.top a:hover{color:var(--gold-deep)}
+  @media(max-width:720px){nav.top{display:none}}
 
-    * {
-      box-sizing: border-box;
-      margin: 0;
-      padding: 0;
-    }
+  .kick{color:var(--gold-deep);font-size:14px;letter-spacing:.01em;margin-bottom:16px;line-height:1.5}
+  h1{font-family:"G Laut";font-weight:400;font-size:clamp(40px,7vw,78px);line-height:1.08}
+  .hero{padding:60px 0 14px}
+  .lede{font-family:"G Leise";font-size:clamp(17px,2.1vw,21px);color:var(--muted);max-width:620px;margin-top:16px}
 
-    html,
-    body {
-      min-height: 100%;
-      background: var(--bg);
-      color: var(--text);
-      font-family: "Goetheanum-Deutsch", "Goetheanum-English", serif;
-    }
+  section{padding:46px 0;border-top:1px solid var(--line-soft)}
+  .shead{display:flex;align-items:baseline;justify-content:space-between;gap:18px;margin-bottom:22px;flex-wrap:wrap}
+  .shead h2{font-family:"G Laut";font-weight:400;font-size:clamp(23px,3.4vw,33px);line-height:1.05}
+  .shead p{color:var(--muted);font-size:14px;max-width:380px}
 
-    body::before {
-      content: "";
-      position: fixed;
-      inset: 0 0 auto 0;
-      height: 6px;
-      background: var(--accent);
-      z-index: 900;
-    }
+  /* Zwei-Spalten-Arbeitsbereich */
+  .work{display:grid;grid-template-columns:1fr;gap:22px;align-items:start}
+  @media(min-width:880px){.work{grid-template-columns:minmax(320px,420px) 1fr}}
 
-    .page-head {
-      margin-top: 6px;
-      background: var(--bg-deep);
-      border-bottom: 1px solid var(--line-strong);
-      position: sticky;
-      top: 6px;
-      z-index: 40;
-    }
+  .card{border:1px solid var(--line);border-radius:16px;padding:24px}
+  .card.soft{background:var(--soft)}
 
-    .page-head-inner {
-      padding: 18px 24px;
-      display: flex;
-      justify-content: space-between;
-      align-items: end;
-      gap: 16px;
-    }
+  /* Variante-Umschalter (Tabs-Stil) */
+  .tabs{display:flex;gap:8px;margin-bottom:22px}
+  .tabs button{font:inherit;font-size:13.5px;color:var(--muted);background:none;border:1px solid var(--line);border-radius:999px;padding:7px 16px;cursor:pointer;transition:.15s}
+  .tabs button.on{color:var(--gold-deep);border-color:var(--gold)}
 
-    .brand {
-      display: grid;
-      gap: 5px;
-    }
+  /* Formular – bewusst gut lesbar: normale Strichstaerke, ruhige Sans */
+  .fset{border:0;display:grid;gap:14px;margin-bottom:22px}
+  .fset > legend{font-family:"G Laut";font-weight:400;font-size:16px;color:var(--ink);margin-bottom:4px}
+  .field{display:grid;gap:6px}
+  .field > .lab{font-size:13px;color:var(--muted);letter-spacing:.01em}
+  .field input{
+    width:100%;
+    font-family:"Helvetica Neue",Arial,sans-serif;
+    font-size:15.5px;font-weight:400;line-height:1.4;color:var(--ink);
+    background:#fff;border:1px solid var(--line);border-radius:10px;
+    padding:11px 13px;outline:none;transition:border-color .15s,box-shadow .15s;
+  }
+  .field input::placeholder{color:#aeb4b9;font-weight:400}
+  .field input:focus{border-color:var(--gold-deep);box-shadow:0 0 0 3px rgba(215,171,104,.18)}
 
-    .brand-kicker {
-      font-size: 0.78rem;
-      color: var(--accent);
-      letter-spacing: 0.1em;
-      text-transform: uppercase;
-    }
+  .btnrow{display:flex;gap:10px;flex-wrap:wrap;margin-top:4px}
+  .btn{display:inline-block;text-decoration:none;font:inherit;font-size:13.5px;padding:9px 15px;border-radius:9px;border:1px solid var(--line);color:var(--ink);background:#fff;text-align:center;cursor:pointer;transition:.15s}
+  .btn:hover{border-color:var(--gold-deep)}
+  .btn.primary{background:var(--gold);border-color:var(--gold);color:#3a2d10}
+  .btn.primary:hover{background:#c59f56}
+  .btn.ok{background:#3f7d46;border-color:#3f7d46;color:#fff}
+  .hint{font-size:13px;color:var(--muted);line-height:1.5;margin-top:12px}
 
-    .brand-title {
-      font-size: clamp(1.8rem, 2.2vw, 2.5rem);
-      line-height: 0.96;
-    }
+  /* Vorschau im weissen "Mailfenster" */
+  .stage-lab{font-size:13px;color:var(--muted);margin-bottom:10px}
+  .mail-stage{background:#fff;border:1px solid var(--line);border-radius:14px;padding:26px 28px;box-shadow:0 10px 30px rgba(20,24,28,.06)}
+  .mail-body{font-family:Arial,Helvetica,sans-serif;font-size:10pt;color:#999;line-height:1.5}
+  .mail-greeting{margin-bottom:14px}
+  .sig-sep{color:#999;font-family:Arial,Helvetica,sans-serif;font-size:10pt;margin:6px 0 8px}
 
-    .brand-copy {
-      max-width: 820px;
-      color: var(--muted);
-      font-size: 0.92rem;
-      line-height: 1.35;
-    }
+  .code-wrap{position:relative;margin-top:22px}
+  pre.code{margin:0;background:#1f2428;color:#e8eef2;border-radius:14px;padding:18px;overflow:auto;
+    font:12.5px/1.55 ui-monospace,Menlo,Consolas,monospace;border:1px solid var(--line);white-space:pre-wrap;word-break:break-word;max-height:320px}
+  .copybtn{position:absolute;top:11px;right:11px;font:inherit;font-size:11.5px;border:1px solid #3a4148;background:#2b3137;color:#e8eef2;border-radius:8px;padding:5px 10px;cursor:pointer}
+  .copybtn:hover{background:#343b42}
 
-    .app {
-      display: grid;
-      grid-template-columns: minmax(320px, 420px) 1fr;
-      align-items: start;
-      gap: 0;
-      min-height: calc(100vh - 104px);
-    }
-
-    .controls {
-      padding: 18px;
-      border-right: 1px solid var(--line);
-      background: rgba(255, 255, 255, 0.02);
-      display: grid;
-      align-content: start;
-      gap: 12px;
-      overflow: auto;
-    }
-
-    fieldset {
-      border: 1px solid var(--line);
-      border-radius: 14px;
-      padding: 14px;
-      background: rgba(255, 255, 255, 0.035);
-      display: grid;
-      gap: 10px;
-    }
-
-    legend {
-      padding: 0 6px;
-      color: var(--accent);
-      font-size: 0.76rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-
-    label.field {
-      display: grid;
-      gap: 4px;
-      font-size: 0.82rem;
-      color: var(--muted);
-    }
-
-    button,
-    input,
-    select {
-      font: inherit;
-    }
-
-    input[type="text"],
-    input[type="email"],
-    input[type="url"],
-    input[type="tel"] {
-      width: 100%;
-      border: 1px solid var(--line);
-      border-radius: 12px;
-      background: rgba(255, 255, 255, 0.06);
-      color: var(--text);
-      padding: 9px 12px;
-      outline: none;
-      font-family: "Goetheanum-Deutsch", sans-serif;
-    }
-
-    input:focus {
-      border-color: rgba(215, 171, 104, 0.58);
-    }
-
-    .seg {
-      display: inline-flex;
-      border: 1px solid var(--line);
-      border-radius: 999px;
-      overflow: hidden;
-      background: rgba(255, 255, 255, 0.04);
-    }
-
-    .seg button {
-      border: 0;
-      background: transparent;
-      color: var(--muted);
-      padding: 8px 16px;
-      cursor: pointer;
-      transition: 0.16s ease;
-    }
-
-    .seg button.on {
-      background: var(--accent);
-      color: #1a2128;
-    }
-
-    .button-row {
-      display: flex;
-      gap: 8px;
-      flex-wrap: wrap;
-      align-items: center;
-    }
-
-    button.act {
-      border: 0;
-      border-radius: 999px;
-      padding: 10px 16px;
-      background: var(--panel-soft);
-      color: var(--text);
-      cursor: pointer;
-      transition: 0.16s ease;
-    }
-
-    button.act:hover {
-      background: #435468;
-    }
-
-    button.act.primary {
-      background: var(--accent);
-      color: #1a2128;
-    }
-
-    button.act.primary:hover {
-      background: #ecc185;
-    }
-
-    button.act.ok {
-      background: #6fa86f;
-      color: #122012;
-    }
-
-    .hint {
-      color: var(--muted);
-      font-size: 0.8rem;
-      line-height: 1.4;
-    }
-
-    .preview-shell {
-      padding: 22px;
-      display: grid;
-      align-content: start;
-      gap: 16px;
-      overflow: auto;
-    }
-
-    .preview-top {
-      display: flex;
-      justify-content: space-between;
-      gap: 10px;
-      flex-wrap: wrap;
-      align-items: center;
-    }
-
-    .preview-label {
-      color: var(--accent);
-      font-size: 0.76rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-
-    /* weisses "Mailfenster" damit die Signatur wie im Client wirkt */
-    .mail-stage {
-      background: #ffffff;
-      border-radius: 10px;
-      border: 1px solid rgba(0, 0, 0, 0.2);
-      box-shadow: 0 18px 40px var(--shadow);
-      padding: 26px 28px;
-      max-width: 760px;
-    }
-
-    .mail-body {
-      font-family: Arial, Helvetica, sans-serif;
-      font-size: 10pt;
-      color: #999;
-      line-height: 1.5;
-    }
-
-    .mail-greeting {
-      margin-bottom: 14px;
-    }
-
-    .sig-sep {
-      color: #999;
-      font-family: Arial, Helvetica, sans-serif;
-      font-size: 10pt;
-      margin: 6px 0 8px;
-    }
-
-    .code-card {
-      background: var(--bg-deep);
-      border: 1px solid var(--line);
-      border-radius: 12px;
-      padding: 14px;
-      display: grid;
-      gap: 10px;
-      max-width: 760px;
-    }
-
-    .code-card textarea {
-      width: 100%;
-      min-height: 180px;
-      resize: vertical;
-      border: 1px solid var(--line);
-      border-radius: 10px;
-      background: #0f161d;
-      color: #cdd8e2;
-      padding: 12px;
-      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-      font-size: 0.78rem;
-      line-height: 1.5;
-    }
-
-    @media (max-width: 920px) {
-      .app {
-        grid-template-columns: 1fr;
-      }
-      .controls {
-        border-right: 0;
-        border-bottom: 1px solid var(--line);
-      }
-    }
-  </style>
+  footer{border-top:1px solid var(--line);padding:34px 0 60px;color:var(--muted);font-size:12.5px}
+  .frow{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap}
+  .frow strong{color:var(--ink);font-weight:400}
+</style>
 </head>
 <body>
-  <header class="page-head">
-    <div class="page-head-inner">
-      <div class="brand">
-        <div class="brand-kicker">Goetheanum Grafik</div>
-        <h1 class="brand-title">E-Mail-Signatur-Generator</h1>
-        <p class="brand-copy">
-          Eigene Angaben eintragen, fertige Signatur kopieren. Erzeugt table-basiertes HTML mit
-          Inline-CSS nach der gemeinsamen Vorlage – funktioniert in Outlook, Apple Mail und Gmail.
-          Individuell gepflegt, einheitlich im Erscheinungsbild.
-        </p>
-      </div>
-    </div>
-  </header>
 
-  <main class="app">
-    <aside class="controls">
-      <fieldset>
-        <legend>Variante</legend>
-        <div class="seg" id="variant">
+<header><div class="wrap bar">
+  <a class="brand" href="https://grafik.goetheanum.ch" aria-label="Zur Grafikseite – grafik.goetheanum.ch">
+    <img src="../../assets/logos/am-goetheanum-dark.svg" alt="Am Goetheanum" />
+  </a>
+  <nav class="top">
+    <a href="../../schriften.html">Schriften</a>
+    <a href="../../typografie.html">Typografie</a>
+    <a href="https://grafik.goetheanum.ch/signatur">Signatur-Leitfaden</a>
+  </nav>
+</div></header>
+
+<main class="wrap">
+  <div class="hero">
+    <div class="kick">Goetheanum Grafik</div>
+    <h1>E-Mail-Signatur</h1>
+    <p class="lede">
+      Eigene Angaben eintragen, fertige Signatur kopieren. Erzeugt table-basiertes HTML
+      mit Inline-CSS nach der gemeinsamen Vorlage – individuell gepflegt, einheitlich im Bild.
+    </p>
+  </div>
+
+  <section>
+    <div class="shead">
+      <h2>Signatur erstellen</h2>
+      <p>Funktioniert in Outlook, Apple Mail und Gmail. Kein JavaScript, keine Web-Fonts.</p>
+    </div>
+
+    <div class="work">
+      <!-- Formular -->
+      <div class="card soft">
+        <div class="tabs" id="variant">
           <button type="button" data-variant="long" class="on">Lang</button>
           <button type="button" data-variant="short">Kurz (Antwort)</button>
         </div>
-        <div class="hint">Kurz = nur Name und Telefon, fuer Antworten innerhalb eines Verlaufs.</div>
-      </fieldset>
 
-      <fieldset>
-        <legend>Person</legend>
-        <label class="field">Name
-          <input type="text" id="name" placeholder="Oliver Pauletto" />
-        </label>
-        <label class="field">Funktion (Deutsch)
-          <input type="text" id="roleDe" placeholder="Leiter IT-Abteilung" />
-        </label>
-        <label class="field">Funktion (English, optional)
-          <input type="text" id="roleEn" placeholder="Head of IT Department" />
-        </label>
-      </fieldset>
+        <fieldset class="fset">
+          <legend>Person</legend>
+          <label class="field"><span class="lab">Name</span>
+            <input type="text" id="name" placeholder="Oliver Pauletto" />
+          </label>
+          <label class="field"><span class="lab">Funktion (Deutsch)</span>
+            <input type="text" id="roleDe" placeholder="Leiter IT-Abteilung" />
+          </label>
+          <label class="field"><span class="lab">Funktion (English, optional)</span>
+            <input type="text" id="roleEn" placeholder="Head of IT Department" />
+          </label>
+        </fieldset>
 
-      <fieldset>
-        <legend>Organisation</legend>
-        <label class="field">Zeile 1
-          <input type="text" id="org1" placeholder="Allgemeine Anthroposophische Gesellschaft" />
-        </label>
-        <label class="field">Zeile 2
-          <input type="text" id="org2" placeholder="Goetheanum" />
-        </label>
-      </fieldset>
+        <fieldset class="fset">
+          <legend>Organisation</legend>
+          <label class="field"><span class="lab">Zeile 1</span>
+            <input type="text" id="org1" placeholder="Allgemeine Anthroposophische Gesellschaft" />
+          </label>
+          <label class="field"><span class="lab">Zeile 2</span>
+            <input type="text" id="org2" placeholder="Goetheanum" />
+          </label>
+        </fieldset>
 
-      <fieldset>
-        <legend>Adresse</legend>
-        <label class="field">Strasse / Nr.
-          <input type="text" id="street" placeholder="Ruettiweg 45" />
-        </label>
-        <label class="field">PLZ / Ort
-          <input type="text" id="city" placeholder="CH-4143 Dornach" />
-        </label>
-      </fieldset>
+        <fieldset class="fset">
+          <legend>Adresse</legend>
+          <label class="field"><span class="lab">Strasse / Nr.</span>
+            <input type="text" id="street" placeholder="Rüttiweg 45" />
+          </label>
+          <label class="field"><span class="lab">PLZ / Ort</span>
+            <input type="text" id="city" placeholder="4143 Dornach" />
+          </label>
+          <label class="field"><span class="lab">Land</span>
+            <input type="text" id="country" placeholder="Schweiz" />
+          </label>
+        </fieldset>
 
-      <fieldset>
-        <legend>Kontakt</legend>
-        <label class="field">Telefon
-          <input type="tel" id="phone" placeholder="+41 61 706 44 94" />
-        </label>
-        <label class="field">E-Mail
-          <input type="email" id="email" placeholder="oliver.pauletto@goetheanum.ch" />
-        </label>
-        <label class="field">Website
-          <input type="url" id="web" placeholder="www.goetheanum.org" />
-        </label>
-      </fieldset>
+        <fieldset class="fset">
+          <legend>Kontakt</legend>
+          <label class="field"><span class="lab">Telefon</span>
+            <input type="tel" id="phone" placeholder="+41 61 706 44 94" />
+          </label>
+          <label class="field"><span class="lab">E-Mail</span>
+            <input type="email" id="email" placeholder="oliver.pauletto@goetheanum.ch" />
+          </label>
+          <label class="field"><span class="lab">Website</span>
+            <input type="url" id="web" placeholder="www.goetheanum.org" />
+          </label>
+        </fieldset>
 
-      <fieldset>
-        <legend>Ausgabe</legend>
-        <div class="button-row">
-          <button type="button" class="act primary" id="copyRich">Signatur kopieren</button>
-          <button type="button" class="act" id="copyCode">HTML-Code kopieren</button>
-          <button type="button" class="act" id="download">.htm laden</button>
-        </div>
-        <div class="hint" id="copyHint">
-          „Signatur kopieren“ legt die formatierte Signatur in die Zwischenablage – direkt in die
-          Signatur-Einstellung des Mailprogramms einfuegbar.
-        </div>
-      </fieldset>
-    </aside>
-
-    <section class="preview-shell">
-      <div class="preview-top">
-        <span class="preview-label">Vorschau</span>
+        <fieldset class="fset" style="margin-bottom:0">
+          <legend>Ausgabe</legend>
+          <div class="btnrow">
+            <button type="button" class="btn primary" id="copyRich">Signatur kopieren</button>
+            <button type="button" class="btn" id="copyCode">HTML-Code kopieren</button>
+            <button type="button" class="btn" id="download">.htm laden</button>
+          </div>
+          <div class="hint">
+            „Signatur kopieren“ legt die formatierte Signatur in die Zwischenablage – direkt in
+            die Signatur-Einstellung des Mailprogramms einfügbar.
+          </div>
+        </fieldset>
       </div>
 
-      <div class="mail-stage">
-        <div class="mail-body">
-          <div class="mail-greeting">Mit besten Gruessen<br />…</div>
-          <div class="sig-sep">--</div>
-          <div id="sigPreview"></div>
+      <!-- Vorschau + Code -->
+      <div>
+        <div class="card">
+          <div class="stage-lab">Vorschau</div>
+          <div class="mail-stage">
+            <div class="mail-body">
+              <div class="mail-greeting">Mit besten Grüssen<br />…</div>
+              <div class="sig-sep">--</div>
+              <div id="sigPreview"></div>
+            </div>
+          </div>
+
+          <div class="code-wrap">
+            <pre class="code" id="codeOut"></pre>
+            <button type="button" class="copybtn" id="copyCode2">Kopieren</button>
+          </div>
         </div>
       </div>
+    </div>
+  </section>
+</main>
 
-      <div class="code-card">
-        <span class="preview-label">HTML-Code (Inline-CSS, table-basiert)</span>
-        <textarea id="codeOut" readonly spellcheck="false"></textarea>
-      </div>
-    </section>
-  </main>
+<footer><div class="wrap frow">
+  <span><strong>Goetheanum Grafik</strong> · E-Mail-Signatur-Generator</span>
+  <span>Allgemeine Anthroposophische Gesellschaft</span>
+</div></footer>
 
-  <script>
-    var state = { variant: "long" };
+<script>
+  var state = { variant: "long" };
 
-    var els = {
-      name: document.getElementById("name"),
-      roleDe: document.getElementById("roleDe"),
-      roleEn: document.getElementById("roleEn"),
-      org1: document.getElementById("org1"),
-      org2: document.getElementById("org2"),
-      street: document.getElementById("street"),
-      city: document.getElementById("city"),
-      phone: document.getElementById("phone"),
-      email: document.getElementById("email"),
-      web: document.getElementById("web")
-    };
+  var els = {
+    name: document.getElementById("name"),
+    roleDe: document.getElementById("roleDe"),
+    roleEn: document.getElementById("roleEn"),
+    org1: document.getElementById("org1"),
+    org2: document.getElementById("org2"),
+    street: document.getElementById("street"),
+    city: document.getElementById("city"),
+    country: document.getElementById("country"),
+    phone: document.getElementById("phone"),
+    email: document.getElementById("email"),
+    web: document.getElementById("web")
+  };
 
-    // Vorbelegung = Vorlagenbeispiel aus dem Handout
-    var defaults = {
-      name: "Oliver Pauletto",
-      roleDe: "Leiter IT-Abteilung",
-      roleEn: "Head of IT Department",
-      org1: "Allgemeine Anthroposophische Gesellschaft",
-      org2: "Goetheanum",
-      street: "Ruettiweg 45",
-      city: "CH-4143 Dornach",
-      phone: "+41 61 706 44 94",
-      email: "oliver.pauletto@goetheanum.ch",
-      web: "www.goetheanum.org"
-    };
-    Object.keys(defaults).forEach(function (k) { els[k].value = defaults[k]; });
+  // Vorbelegung = Vorlagenbeispiel aus dem Handout
+  var defaults = {
+    name: "Oliver Pauletto",
+    roleDe: "Leiter IT-Abteilung",
+    roleEn: "Head of IT Department",
+    org1: "Allgemeine Anthroposophische Gesellschaft",
+    org2: "Goetheanum",
+    street: "Rüttiweg 45",
+    city: "4143 Dornach",
+    country: "Schweiz",
+    phone: "+41 61 706 44 94",
+    email: "oliver.pauletto@goetheanum.ch",
+    web: "www.goetheanum.org"
+  };
+  Object.keys(defaults).forEach(function (k) { els[k].value = defaults[k]; });
 
-    var RED = "#9b1c20";
-    var INK = "#333333";
-    var SUB = "#777777";
+  var RED = "#9b1c20";
+  var INK = "#333333";
+  var SUB = "#777777";
 
-    function esc(s) {
-      return String(s || "")
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;");
-    }
+  function esc(s) {
+    return String(s || "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
 
-    function val(k) { return els[k].value.trim(); }
+  function val(k) { return els[k].value.trim(); }
 
-    function webHref(w) {
-      if (!w) return "";
-      return /^https?:\/\//i.test(w) ? w : "https://" + w;
-    }
+  function webHref(w) {
+    if (!w) return "";
+    return /^https?:\/\//i.test(w) ? w : "https://" + w;
+  }
 
-    // Erzeugt das table-basierte Signatur-HTML mit Inline-CSS
-    function buildSignature() {
-      var name = val("name");
-      var phone = val("phone");
+  // Erzeugt das table-basierte Signatur-HTML mit Inline-CSS
+  function buildSignature() {
+    var name = val("name");
+    var phone = val("phone");
 
-      if (state.variant === "short") {
-        var lines = [];
-        if (name) lines.push('<span style="font-weight:bold;color:' + INK + ';">' + esc(name) + "</span>");
-        if (phone) lines.push("T&nbsp;&nbsp;" + esc(phone));
-        return (
-          '<table cellpadding="0" cellspacing="0" border="0" ' +
-          'style="border-collapse:collapse;font-family:Arial,Helvetica,sans-serif;' +
-          'font-size:10pt;line-height:1.45;color:' + INK + ';">' +
-          "<tr><td>" + lines.join("<br />") + "</td></tr></table>"
-        );
-      }
-
-      // Linke Spalte: Person + Organisation
-      var left = [];
-      if (name) left.push('<span style="font-size:11pt;font-weight:bold;color:#222222;">' + esc(name) + "</span>");
-      if (val("roleDe")) left.push('<span style="color:' + SUB + ';">' + esc(val("roleDe")) + "</span>");
-      if (val("roleEn")) left.push('<span style="color:' + SUB + ';">' + esc(val("roleEn")) + "</span>");
-      var orgBlock = [];
-      if (val("org1")) orgBlock.push(esc(val("org1")));
-      if (val("org2")) orgBlock.push(esc(val("org2")));
-      var leftHtml = left.join("<br />");
-      if (orgBlock.length) leftHtml += (left.length ? "<br /><br />" : "") + orgBlock.join("<br />");
-
-      // Rechte Spalte: Adresse + Kontakt, durch roten Balken getrennt
-      var right = [];
-      if (val("street")) right.push(esc(val("street")));
-      if (val("city")) right.push(esc(val("city")));
-      var addrCount = right.length;
-      var contact = [];
-      if (phone) contact.push('<span style="color:' + RED + ';">T</span>&nbsp;&nbsp;' + esc(phone));
-      if (val("email"))
-        contact.push(
-          '<span style="color:' + RED + ';">E</span>&nbsp;&nbsp;' +
-          '<a href="mailto:' + esc(val("email")) + '" style="color:' + RED + ';text-decoration:none;">' +
-          esc(val("email")) + "</a>"
-        );
-      if (val("web"))
-        contact.push(
-          '<span style="color:' + RED + ';">W</span>&nbsp;&nbsp;' +
-          '<a href="' + esc(webHref(val("web"))) + '" style="color:' + RED + ';text-decoration:none;">' +
-          esc(val("web")) + "</a>"
-        );
-      var rightHtml = right.join("<br />");
-      if (contact.length) rightHtml += (addrCount ? "<br /><br />" : "") + contact.join("<br />");
-
+    if (state.variant === "short") {
+      var lines = [];
+      if (name) lines.push('<span style="font-weight:bold;color:' + INK + ';">' + esc(name) + "</span>");
+      if (phone) lines.push("T&nbsp;&nbsp;" + esc(phone));
       return (
         '<table cellpadding="0" cellspacing="0" border="0" ' +
         'style="border-collapse:collapse;font-family:Arial,Helvetica,sans-serif;' +
-        'font-size:10pt;line-height:1.5;color:' + INK + ';">' +
-        "<tr>" +
-        '<td style="vertical-align:top;padding:0 26px 0 0;">' + leftHtml + "</td>" +
-        '<td style="vertical-align:top;border-left:2px solid ' + RED + ';padding:0 0 0 26px;">' +
-        rightHtml + "</td>" +
-        "</tr></table>"
+        'font-size:10pt;line-height:1.45;color:' + INK + ';">' +
+        "<tr><td>" + lines.join("<br />") + "</td></tr></table>"
       );
     }
 
-    function render() {
-      var html = buildSignature();
-      document.getElementById("sigPreview").innerHTML = html;
-      document.getElementById("codeOut").value = html;
-    }
+    // Linke Spalte: Person + Organisation
+    var left = [];
+    if (name) left.push('<span style="font-size:11pt;font-weight:bold;color:#222222;">' + esc(name) + "</span>");
+    if (val("roleDe")) left.push('<span style="color:' + SUB + ';">' + esc(val("roleDe")) + "</span>");
+    if (val("roleEn")) left.push('<span style="color:' + SUB + ';">' + esc(val("roleEn")) + "</span>");
+    var orgBlock = [];
+    if (val("org1")) orgBlock.push(esc(val("org1")));
+    if (val("org2")) orgBlock.push(esc(val("org2")));
+    var leftHtml = left.join("<br />");
+    if (orgBlock.length) leftHtml += (left.length ? "<br /><br />" : "") + orgBlock.join("<br />");
 
-    // Eingaben live verdrahten
-    Object.keys(els).forEach(function (k) { els[k].addEventListener("input", render); });
+    // Rechte Spalte: Adresse + Kontakt, durch roten Balken getrennt
+    var right = [];
+    if (val("street")) right.push(esc(val("street")));
+    if (val("city")) right.push(esc(val("city")));
+    if (val("country")) right.push(esc(val("country")));
+    var addrCount = right.length;
+    var contact = [];
+    if (phone) contact.push('<span style="color:' + RED + ';">T</span>&nbsp;&nbsp;' + esc(phone));
+    if (val("email"))
+      contact.push(
+        '<span style="color:' + RED + ';">E</span>&nbsp;&nbsp;' +
+        '<a href="mailto:' + esc(val("email")) + '" style="color:' + RED + ';text-decoration:none;">' +
+        esc(val("email")) + "</a>"
+      );
+    if (val("web"))
+      contact.push(
+        '<span style="color:' + RED + ';">W</span>&nbsp;&nbsp;' +
+        '<a href="' + esc(webHref(val("web"))) + '" style="color:' + RED + ';text-decoration:none;">' +
+        esc(val("web")) + "</a>"
+      );
+    var rightHtml = right.join("<br />");
+    if (contact.length) rightHtml += (addrCount ? "<br /><br />" : "") + contact.join("<br />");
 
-    // Variante umschalten
-    var variantWrap = document.getElementById("variant");
-    variantWrap.addEventListener("click", function (e) {
-      var btn = e.target.closest("button[data-variant]");
-      if (!btn) return;
-      state.variant = btn.getAttribute("data-variant");
-      Array.prototype.forEach.call(variantWrap.querySelectorAll("button"), function (b) {
-        b.classList.toggle("on", b === btn);
-      });
-      render();
+    return (
+      '<table cellpadding="0" cellspacing="0" border="0" ' +
+      'style="border-collapse:collapse;font-family:Arial,Helvetica,sans-serif;' +
+      'font-size:10pt;line-height:1.5;color:' + INK + ';">' +
+      "<tr>" +
+      '<td style="vertical-align:top;padding:0 26px 0 0;">' + leftHtml + "</td>" +
+      '<td style="vertical-align:top;border-left:2px solid ' + RED + ';padding:0 0 0 26px;">' +
+      rightHtml + "</td>" +
+      "</tr></table>"
+    );
+  }
+
+  function render() {
+    var html = buildSignature();
+    document.getElementById("sigPreview").innerHTML = html;
+    document.getElementById("codeOut").textContent = html;
+  }
+
+  // Eingaben live verdrahten
+  Object.keys(els).forEach(function (k) { els[k].addEventListener("input", render); });
+
+  // Variante umschalten
+  var variantWrap = document.getElementById("variant");
+  variantWrap.addEventListener("click", function (e) {
+    var btn = e.target.closest("button[data-variant]");
+    if (!btn) return;
+    state.variant = btn.getAttribute("data-variant");
+    Array.prototype.forEach.call(variantWrap.querySelectorAll("button"), function (b) {
+      b.classList.toggle("on", b === btn);
     });
-
-    function flash(btn, label) {
-      var old = btn.textContent;
-      btn.textContent = label;
-      btn.classList.add("ok");
-      setTimeout(function () {
-        btn.textContent = old;
-        btn.classList.remove("ok");
-      }, 1400);
-    }
-
-    // Formatiert kopieren (rich HTML) – direkt ins Mailprogramm einfuegbar
-    document.getElementById("copyRich").addEventListener("click", function () {
-      var btn = this;
-      var html = buildSignature();
-      if (navigator.clipboard && window.ClipboardItem) {
-        var item = new ClipboardItem({
-          "text/html": new Blob([html], { type: "text/html" }),
-          "text/plain": new Blob([document.getElementById("sigPreview").innerText], { type: "text/plain" })
-        });
-        navigator.clipboard.write([item]).then(
-          function () { flash(btn, "Kopiert ✓"); },
-          function () { flash(btn, "Bitte HTML-Code nutzen"); }
-        );
-      } else {
-        flash(btn, "Bitte HTML-Code nutzen");
-      }
-    });
-
-    // Rohen HTML-Code kopieren
-    document.getElementById("copyCode").addEventListener("click", function () {
-      var btn = this;
-      var ta = document.getElementById("codeOut");
-      ta.select();
-      var done = false;
-      if (navigator.clipboard) {
-        navigator.clipboard.writeText(ta.value).then(function () { flash(btn, "Kopiert ✓"); }, fallback);
-      } else {
-        fallback();
-      }
-      function fallback() {
-        try { document.execCommand("copy"); done = true; } catch (e) {}
-        flash(btn, done ? "Kopiert ✓" : "Markiert – Strg/Cmd+C");
-      }
-    });
-
-    // Als .htm herunterladen
-    document.getElementById("download").addEventListener("click", function () {
-      var doc =
-        "<!doctype html><html><head><meta charset=\"utf-8\"></head><body>" +
-        buildSignature() + "</body></html>";
-      var blob = new Blob([doc], { type: "text/html" });
-      var a = document.createElement("a");
-      a.href = URL.createObjectURL(blob);
-      var base = (val("name") || "signatur").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
-      a.download = "signatur-" + (base || "goetheanum") + ".htm";
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      setTimeout(function () { URL.revokeObjectURL(a.href); }, 2000);
-    });
-
     render();
-  </script>
+  });
+
+  function flash(btn, label) {
+    var old = btn.textContent;
+    btn.textContent = label;
+    btn.classList.add("ok");
+    setTimeout(function () {
+      btn.textContent = old;
+      btn.classList.remove("ok");
+    }, 1400);
+  }
+
+  // Formatiert kopieren (rich HTML) – direkt ins Mailprogramm einfuegbar
+  document.getElementById("copyRich").addEventListener("click", function () {
+    var btn = this;
+    var html = buildSignature();
+    if (navigator.clipboard && window.ClipboardItem) {
+      var item = new ClipboardItem({
+        "text/html": new Blob([html], { type: "text/html" }),
+        "text/plain": new Blob([document.getElementById("sigPreview").innerText], { type: "text/plain" })
+      });
+      navigator.clipboard.write([item]).then(
+        function () { flash(btn, "Kopiert ✓"); },
+        function () { flash(btn, "Bitte HTML-Code nutzen"); }
+      );
+    } else {
+      flash(btn, "Bitte HTML-Code nutzen");
+    }
+  });
+
+  // Rohen HTML-Code kopieren (beide Buttons)
+  function copyCode(btn) {
+    var text = document.getElementById("codeOut").textContent;
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(text).then(function () { flash(btn, "Kopiert ✓"); }, function () { selectFallback(btn); });
+    } else {
+      selectFallback(btn);
+    }
+  }
+  function selectFallback(btn) {
+    var r = document.createRange();
+    r.selectNodeContents(document.getElementById("codeOut"));
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(r);
+    var done = false;
+    try { done = document.execCommand("copy"); } catch (e) {}
+    flash(btn, done ? "Kopiert ✓" : "Markiert – Strg/Cmd+C");
+  }
+  document.getElementById("copyCode").addEventListener("click", function () { copyCode(this); });
+  document.getElementById("copyCode2").addEventListener("click", function () { copyCode(this); });
+
+  // Als .htm herunterladen
+  document.getElementById("download").addEventListener("click", function () {
+    var doc =
+      "<!doctype html><html><head><meta charset=\"utf-8\"></head><body>" +
+      buildSignature() + "</body></html>";
+    var blob = new Blob([doc], { type: "text/html" });
+    var a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    var base = (val("name") || "signatur").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+    a.download = "signatur-" + (base || "goetheanum") + ".htm";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(function () { URL.revokeObjectURL(a.href); }, 2000);
+  });
+
+  render();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Was sich ändert

Überarbeitung des Signatur-Generators nach erstem Sichten:

- **Helles Layout von `schriften.html`** übernommen — gleiche CSS-Werte und Komponenten
  (`--ink`/`--muted`/`--gold`/`--soft`, Schriften G-Klar/G-Laut/G-Leise, Header mit
  Logo, `.wrap`, Hero, Section, Cards). Statt des bisherigen dunklen Eigen-Themes.
- **Formularfelder gut lesbar:** ruhige Sans (Helvetica Neue/Arial), normale
  Strichstärke, 15.5px, klare Labels — statt der zu kleinen, zu fetten Titelschrift.
- **Adresse:** `CH-` aus der PLZ entfernt (jetzt „4143 Dornach"), neues Feld **Land**
  (Standard „Schweiz"), das im Adressblock der Signatur erscheint.
- Code-Ausgabe im schriften-typischen dunklen Code-Block mit Kopieren-Button.

Die erzeugte Signatur bleibt unverändert table-basiert mit Inline-CSS (kein
JavaScript, keine Web-Fonts) — nur das Tool-UI wurde umgestellt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_