### PR TITLE
Signatur-Generator: Funktionsfeld als Zweizeiler, Layout (Vorschau sichtbar), Beispiel vorbelegt, Nav verschlankt, „T" weg

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -38,18 +38,20 @@
   nav.top a:hover{color:var(--gold-deep)}
   @media(max-width:720px){nav.top{display:none}}
 
-  .kick{color:var(--gold-deep);font-size:14px;letter-spacing:.01em;margin-bottom:16px;line-height:1.5}
-  h1{font-family:"Goetheanum";font-weight:680;font-size:clamp(40px,7vw,78px);line-height:1.08}
-  .hero{padding:60px 0 14px}
-  .lede{font-family:"Goetheanum";font-weight:265;font-size:clamp(17px,2.1vw,21px);color:var(--muted);max-width:620px;margin-top:16px}
+  .kick{color:var(--gold-deep);font-size:13px;letter-spacing:.01em;margin-bottom:8px;line-height:1.4}
+  h1{font-family:"Goetheanum";font-weight:680;font-size:clamp(30px,4.2vw,50px);line-height:1.04}
+  .hero{padding:28px 0 6px}
+  .lede{font-family:"Goetheanum";font-weight:265;font-size:clamp(15px,1.8vw,18px);color:var(--muted);max-width:600px;margin-top:10px}
 
-  section{padding:46px 0;border-top:1px solid var(--line-soft)}
-  .shead{display:flex;align-items:baseline;justify-content:space-between;gap:18px;margin-bottom:22px;flex-wrap:wrap}
-  .shead h2{font-family:"Goetheanum";font-weight:680;font-size:clamp(23px,3.4vw,33px);line-height:1.05}
+  section{padding:30px 0;border-top:1px solid var(--line-soft)}
+  .shead{display:flex;align-items:baseline;justify-content:space-between;gap:18px;margin-bottom:18px;flex-wrap:wrap}
+  .shead h2{font-family:"Goetheanum";font-weight:680;font-size:clamp(22px,3vw,30px);line-height:1.05}
   .shead p{color:var(--muted);font-size:14px;max-width:380px}
 
-  .work{display:grid;grid-template-columns:1fr;gap:22px;align-items:start}
-  @media(min-width:880px){.work{grid-template-columns:minmax(320px,420px) 1fr}}
+  .work{display:grid;grid-template-columns:1fr;gap:24px;align-items:start}
+  @media(min-width:880px){.work{grid-template-columns:minmax(360px,460px) 1fr}}
+  /* Vorschau bleibt beim Scrollen der Eingabemaske sichtbar */
+  @media(min-width:880px){.preview-col{position:sticky;top:74px;align-self:start}}
 
   .card{border:1px solid var(--line);border-radius:16px;padding:24px}
   .card.soft{background:var(--soft)}
@@ -86,6 +88,10 @@
   .field input::placeholder{color:#aeb4b9;font-weight:400}
   .field input:focus{border-color:var(--gold-deep);box-shadow:0 0 0 3px rgba(215,171,104,.18)}
   .field input.invalid{border-color:var(--bad);box-shadow:0 0 0 3px rgba(179,38,30,.14)}
+  .field textarea{width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:15.5px;font-weight:400;line-height:1.4;color:var(--ink);background:#fff;border:1px solid var(--line);border-radius:10px;padding:11px 13px;outline:none;resize:vertical;min-height:62px}
+  .field textarea::placeholder{color:#aeb4b9;font-weight:400}
+  .field textarea:focus{border-color:var(--gold-deep);box-shadow:0 0 0 3px rgba(215,171,104,.18)}
+  .lab .sublab{font-weight:400;font-size:11.5px;color:var(--muted);margin-left:6px}
   .field-msg{font-size:12px;color:var(--bad);min-height:0}
   .field select{width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:15px;color:var(--ink);background:#fff;border:1px solid var(--line);border-radius:10px;padding:10px 12px;outline:none;cursor:pointer}
   .field select:focus{border-color:var(--gold-deep);box-shadow:0 0 0 3px rgba(215,171,104,.18)}
@@ -146,9 +152,7 @@
   </a>
   <nav class="top">
     <a href="#anleitung">Anleitung</a>
-    <a href="../../schriften.html">Schriften</a>
-    <a href="../../typografie.html">Typografie</a>
-    <a href="https://grafik.goetheanum.ch/signatur">Signatur-Leitfaden</a>
+    <a href="https://grafik.goetheanum.ch">Weitere Werkzeuge</a>
   </nav>
 </div></header>
 
@@ -182,11 +186,8 @@
           <label class="field"><span class="lab">Name</span>
             <input type="text" id="name" placeholder="Edith Maryon" autocomplete="name" />
           </label>
-          <label class="field"><span class="lab">Funktion (Deutsch)</span>
-            <input type="text" id="roleDe" placeholder="Sektion für Bildende Künste" />
-          </label>
-          <label class="field"><span class="lab">Funktion (English, optional)</span>
-            <input type="text" id="roleEn" placeholder="Visual Art Section" />
+          <label class="field"><span class="lab">Funktion / Bereich / Sektion <span class="sublab">zweizeilig möglich</span></span>
+            <textarea id="role" rows="2" placeholder="Sektion für Bildende Künste&#10;Visual Art Section"></textarea>
           </label>
         </fieldset>
 
@@ -238,7 +239,7 @@
       </div>
 
       <!-- Vorschau + Ausgabe -->
-      <div>
+      <div class="preview-col">
         <div class="card">
           <div class="stage-lab">Vorschau</div>
           <div class="mail-stage">
@@ -393,13 +394,12 @@ const BRAND_BLUE = (window.ORGS && ORGS.goetheanum && ORGS.goetheanum.color) || 
 // Neutrale Graustufen für den (Arial-)Signatur-Output – an einer Stelle gepflegt.
 const SIG = { name: "#1a1a1a", text: "#333333", sub: "#777777" };
 
-const FIELDS = ["name","roleDe","roleEn","org1","org2","street","city","country","phone","email","web"];
+const FIELDS = ["name","role","org1","org2","street","city","country","phone","email","web"];
 const STORE_KEY = "goe-signatur-v1";
 
 const EXAMPLE = {
   name: "Edith Maryon",
-  roleDe: "Sektion für Bildende Künste",
-  roleEn: "Visual Art Section",
+  role: "Sektion für Bildende Künste\nVisual Art Section",
   org1: "Allgemeine Anthroposophische Gesellschaft",
   org2: "Goetheanum",
   street: "Rüttiweg 45",
@@ -439,8 +439,7 @@ function colTable(items) {
 }
 
 function phoneCell() {
-  return `<span style="color:${BRAND_BLUE};">T</span>&nbsp;&nbsp;` +
-    `<a href="${telHref(val("phone"))}" style="color:${SIG.text};text-decoration:none;">${esc(val("phone"))}</a>`;
+  return `<a href="${telHref(val("phone"))}" style="color:${SIG.text};text-decoration:none;">${esc(val("phone"))}</a>`;
 }
 
 function buildSignature() {
@@ -456,8 +455,9 @@ function buildSignature() {
   // Linke Spalte: Person + Organisation
   const L = [];
   if (name) L.push({ html: `<span style="font-size:11pt;font-weight:bold;color:${SIG.name};">${esc(name)}</span>` });
-  if (val("roleDe")) L.push({ html: `<span style="color:${SIG.sub};">${esc(val("roleDe"))}</span>` });
-  if (val("roleEn")) L.push({ html: `<span style="color:${SIG.sub};">${esc(val("roleEn"))}</span>` });
+  val("role").split(/\r?\n/).map(s => s.trim()).filter(Boolean).forEach(line => {
+    L.push({ html: `<span style="color:${SIG.sub};">${esc(line)}</span>` });
+  });
   if (val("org1") || val("org2")) {
     L.push({ gap: 12 });
     if (val("org1")) L.push({ html: esc(val("org1")) });
@@ -509,15 +509,18 @@ function save() {
 function loadStored() {
   try {
     const data = JSON.parse(localStorage.getItem(STORE_KEY) || "null");
-    if (!data) return;
+    if (!data) return false;
     FIELDS.forEach(k => { if (typeof data[k] === "string") els[k].value = data[k]; });
     if (data.variant) setVariant(data.variant, false);
-  } catch (e) {}
+    return true;
+  } catch (e) { return false; }
 }
 function applyQuery() {
   const q = new URLSearchParams(location.search);
-  FIELDS.forEach(k => { if (q.has(k)) els[k].value = q.get(k); });
-  if (q.has("variant")) setVariant(q.get("variant") === "short" ? "short" : "long", false);
+  let any = false;
+  FIELDS.forEach(k => { if (q.has(k)) { els[k].value = q.get(k); any = true; } });
+  if (q.has("variant")) { setVariant(q.get("variant") === "short" ? "short" : "long", false); any = true; }
+  return any;
 }
 function setFields(obj) { FIELDS.forEach(k => { els[k].value = obj[k] || ""; }); }
 
@@ -617,8 +620,10 @@ document.getElementById("download").addEventListener("click", function () {
 });
 
 /* ---------- Start ---------- */
-loadStored();
-applyQuery();
+const hadStored = loadStored();
+const hadQuery = applyQuery();
+// Beim ersten Öffnen das Beispiel einfügen (frei änderbar); gespeicherte Daten haben Vorrang.
+if (!hadStored && !hadQuery) setFields(EXAMPLE);
 setVariant(state.variant, false);
 validateEmail();
 render();


### PR DESCRIPTION
Mehrere UX-Wünsche in einem PR.

- **Funktionsfeld zusammengefasst:** statt „Funktion (Deutsch)" + „Funktion (English, optional)" jetzt **ein zweizeiliges Feld** mit Titel **„Funktion / Bereich / Sektion"**. Jede Zeile wird zu einer Signaturzeile (1 oder 2 Zeilen möglich).
- **Layout – Eingabe und Vorschau gleichzeitig sichtbar:** kompakterer Seitenkopf (kleinere Headline, weniger Abstand), **erste Spalte breiter** (360–460px), und die **Vorschau-Spalte bleibt beim Scrollen sichtbar** (sticky). So muss man zum Abgleich nicht mehr scrollen.
- **Beispiel beim Öffnen vorbelegt:** Edith Maryon ist beim ersten Aufruf eingefügt und **frei änderbar**. Gespeicherte Eingaben (localStorage) und Rollout-Links (`?name=…`) haben Vorrang.
- **„T" vor der Telefonnummer entfernt.**
- **Header verschlankt:** Schriften/Typografie/Signatur-Leitfaden entfernt (gehören nicht hierher bzw. werden durch den Generator ersetzt); stattdessen ein Link **„Weitere Werkzeuge" → grafik.goetheanum.ch**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_