### PR TITLE
Signatur-Generator: dezente Erklärung „Warum kein Logo, kein Bild, keine Hausschrift?"

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -274,6 +274,27 @@
               den HTML-Quelltext braucht. Für die meisten reicht ‹Signatur kopieren›.
             </div>
           </details>
+
+          <details class="code-details">
+            <summary>Warum kein Logo, kein Bild, keine Hausschrift?</summary>
+            <div class="hint">
+              Bewusst schlicht – damit die Signatur überall ankommt:
+              <ul style="margin:10px 0 0;padding-left:18px;display:grid;gap:6px">
+                <li><strong style="color:var(--ink);font-weight:400">Logos &amp; Bilder</strong> werden von
+                  Mailprogrammen standardmässig blockiert und erscheinen dann als leerer Platzhalter; sie
+                  blähen jede Nachricht auf, rutschen in den Anhang und brechen in Dark&nbsp;Mode, Antworten
+                  und auf dem Handy.</li>
+                <li><strong style="color:var(--ink);font-weight:400">Die Hausschrift</strong> ist bei den
+                  Empfängern nicht installiert und wird in E-Mails ohnehin durch eine Ersatzschrift ersetzt.
+                  Eine systemsichere Schrift (Arial/Helvetica) sieht dafür überall zuverlässig gleich aus.</li>
+                <li><strong style="color:var(--ink);font-weight:400">Wiedererkennung</strong> entsteht hier
+                  robust über das Markenblau, klare Hierarchie und den Schriftzug «Goetheanum» – statt über
+                  fragile Grafik.</li>
+              </ul>
+              Für echte Grafiken in der Hausschrift (Folien, Profile, Logos) gibt es die
+              <a href="https://grafik.goetheanum.ch" style="color:var(--gold-deep);text-decoration:none">weiteren Werkzeuge</a>.
+            </div>
+          </details>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Beantwortet die naheliegende Frage „wo ist das Logo / die Hausschrift?" – **elegant statt aufdringlich**.

**Ansatz:** kein Banner, keine Dauer-Warnung (das würde dem bewusst schlichten Eindruck widersprechen). Stattdessen eine **zusammenklappbare Notiz im selben `<details>`-Stil**, den die Seite schon nutzt, **direkt bei der Vorschau** und **eingeklappt by default**. Wer sich wundert, findet die Begründung mit einem Klick genau dort, wo die Frage entsteht.

**Inhalt (knapp):**
- **Logos & Bilder** werden von Mailprogrammen blockiert (leerer Platzhalter), blähen Mails auf, rutschen in den Anhang, brechen in Dark Mode / Antworten / mobil.
- **Hausschrift** ist bei Empfängern nicht installiert und wird in E-Mails ohnehin ersetzt → systemsichere Schrift sieht überall gleich aus.
- **Wiedererkennung** entsteht robust über Markenblau, Hierarchie und den Schriftzug «Goetheanum».
- Verweis auf **grafik.goetheanum.ch** für echte Grafiken in der Hausschrift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_