### PR TITLE
Signatur-Generator: neues Layout (zwei Blöcke, eine Grösse, nur Farbe)

### DIFF
--- a/apps/signatur-generator/TESTING.md
+++ b/apps/signatur-generator/TESTING.md
@@ -28,14 +28,18 @@ genannten Clients öffnen. Vorschau im Generator ≠ Realität im Client.
 
 ## Prüfpunkte (das sind die bekannten Outlook-Bruchstellen)
 
+- [ ] **Layout**: Person links (Name → Funktion → Kontakt), Organisation rechts
+      (Goetheanum → Gesellschaft → Adresse), dazwischen der blaue Trennbalken.
 - [ ] **Blauer Trennbalken** ist sichtbar, durchgehend, 2px, klappt nicht weg
       (Spacer-Zelle, nicht `border`).
-- [ ] **Abstände** zwischen Person/Organisation bzw. Adresse/Kontakt stimmen
+- [ ] **Abstände** (Funktion → Kontakt) stimmen
       (Spacer-Zeilen, nicht `<br><br>` — Word staucht/dehnt sonst).
 - [ ] **Spaltenbreiten** stabil, kein Umbruch/Verrutschen, keine ungewollte
       Volldehnung über die Mailbreite.
-- [ ] **Schrift** = Arial 10pt, **kein** Goetheanum-Webfont im Output.
-- [ ] **Farben**: Name dunkel, Funktion grau, Kontakt-Links Goetheanum-Blau.
+- [ ] **Eine Grösse**: Arial 10.5pt durchgängig, **kein** Fett, **kein**
+      Goetheanum-Webfont im Output.
+- [ ] **Farben** (einziges Auszeichnungsmittel): Name dunkel, Funktion/Adresse grau,
+      Kontakt-Links **und** Organisations-Hauptzeile (Goetheanum) im Goetheanum-Blau.
 - [ ] **Links** funktionieren: `mailto:`, Website, `tel:` (auf Mobile).
 - [ ] **Lang- und Kurz-Variante** je einzeln prüfen.
 - [ ] **Dark Mode** des Clients: Signatur bleibt lesbar (Apple Mail/iOS invertieren gern).
@@ -44,7 +48,7 @@ genannten Clients öffnen. Vorschau im Generator ≠ Realität im Client.
 ## Funktion / Rollout
 
 - [ ] `localStorage`: Eingaben überstehen ein Reload.
-- [ ] Query-Prefill: `?name=Test&roleDe=Probe` füllt die Felder.
+- [ ] Query-Prefill: `?name=Test&role=Probe` füllt die Felder.
 - [ ] ‹Beispiel einfügen› / ‹Felder leeren› funktionieren.
 - [ ] E-Mail-Validierung markiert offensichtlich falsche Adressen.
 

--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -208,11 +208,11 @@
         <details class="fold">
           <summary>Organisation <span class="sub">meist unverändert</span></summary>
           <div class="fold-body">
-            <label class="field"><span class="lab">Zeile 1</span>
-              <input type="text" id="org1" placeholder="Allgemeine Anthroposophische Gesellschaft" />
+            <label class="field"><span class="lab">Hauptzeile <span class="sublab">erscheint blau</span></span>
+              <input type="text" id="org1" placeholder="Goetheanum" />
             </label>
-            <label class="field"><span class="lab">Zeile 2</span>
-              <input type="text" id="org2" placeholder="Goetheanum" />
+            <label class="field"><span class="lab">Unterzeile</span>
+              <input type="text" id="org2" placeholder="Allgemeine Anthroposophische Gesellschaft" />
             </label>
           </div>
         </details>
@@ -288,7 +288,7 @@
                   Empfängern nicht installiert und wird in E-Mails ohnehin durch eine Ersatzschrift ersetzt.
                   Eine systemsichere Schrift (Arial/Helvetica) sieht dafür überall zuverlässig gleich aus.</li>
                 <li><strong style="color:var(--ink);font-weight:400">Wiedererkennung</strong> entsteht hier
-                  robust über das Markenblau, klare Hierarchie und den Schriftzug «Goetheanum» – statt über
+                  robust über das Markenblau, klare Hierarchie und den Schriftzug ‹Goetheanum› – statt über
                   fragile Grafik.</li>
               </ul>
               Für echte Grafiken in der Hausschrift (Folien, Profile, Logos) gibt es die
@@ -412,17 +412,18 @@
 /* ---------- Konstanten ---------- */
 // Markenblau: einzige Quelle ist das Org-/Logo-System (goetheanum-orgs.js).
 const BRAND_BLUE = (window.ORGS && ORGS.goetheanum && ORGS.goetheanum.color) || "#0061a9";
-// Neutrale Graustufen für den (Arial-)Signatur-Output – an einer Stelle gepflegt.
-const SIG = { name: "#1a1a1a", text: "#333333", sub: "#777777" };
+// Farbsystem des Signatur-Outputs (Arial). Hausregel: eine Auszeichnung – nur Farbe,
+// eine Schriftgrösse. Köpfe farbig (Name dunkel, Goetheanum/Verweise blau), Rest ruhig grau.
+const SIG = { name: "#1a1a1a", sub: "#767676" };
 
 const FIELDS = ["name","role","org1","org2","street","city","country","phone","email","web"];
-const STORE_KEY = "goe-signatur-v1";
+const STORE_KEY = "goe-signatur-v2";
 
 const EXAMPLE = {
   name: "Edith Maryon",
   role: "Sektion für Bildende Künste\nVisual Art Section",
-  org1: "Allgemeine Anthroposophische Gesellschaft",
-  org2: "Goetheanum",
+  org1: "Goetheanum",
+  org2: "Allgemeine Anthroposophische Gesellschaft",
   street: "Rüttiweg 45",
   city: "4143 Dornach",
   country: "Schweiz",
@@ -450,57 +451,56 @@ const isEmail = e => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e);
 const FONT = "Arial,Helvetica,sans-serif";
 
 // Baut eine Spalte als verschachtelte Tabelle. items: {html} oder {gap:px}.
+// Eine Grösse für alles (10.5pt); Grundton grau, Köpfe/Verweise setzen ihre Farbe per span.
 function colTable(items) {
   const rows = items.map(it =>
     it.gap != null
       ? `<tr><td height="${it.gap}" style="height:${it.gap}px;font-size:0;line-height:0;mso-line-height-rule:exactly;">&nbsp;</td></tr>`
-      : `<tr><td style="font-family:${FONT};font-size:10pt;line-height:1.45;color:${SIG.text};">${it.html}</td></tr>`
+      : `<tr><td style="font-family:${FONT};font-size:10.5pt;line-height:1.5;color:${SIG.sub};">${it.html}</td></tr>`
   ).join("");
   return `<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;">${rows}</table>`;
 }
 
 function phoneCell() {
-  return `<a href="${telHref(val("phone"))}" style="color:${SIG.text};text-decoration:none;">${esc(val("phone"))}</a>`;
+  return `<a href="${telHref(val("phone"))}" style="color:${BRAND_BLUE};text-decoration:none;">${esc(val("phone"))}</a>`;
 }
 
 function buildSignature() {
   const name = val("name"), phone = val("phone");
 
+  // Kurz (Antwort): Name + Telefon. Eine Grösse, Farbe als einziges Merkmal.
   if (state.variant === "short") {
     const items = [];
-    if (name) items.push({ html: `<span style="font-size:10pt;font-weight:bold;color:${SIG.name};">${esc(name)}</span>` });
+    if (name) items.push({ html: `<span style="color:${SIG.name};">${esc(name)}</span>` });
     if (phone) items.push({ html: phoneCell() });
     return colTable(items.length ? items : [{ html: "&nbsp;" }]);
   }
 
-  // Linke Spalte: Person + Organisation
+  // Linke Spalte: Person – Name (dunkel), Funktion (grau), Kontakt (blaue Verweise).
   const L = [];
-  if (name) L.push({ html: `<span style="font-size:11pt;font-weight:bold;color:${SIG.name};">${esc(name)}</span>` });
+  if (name) L.push({ html: `<span style="color:${SIG.name};">${esc(name)}</span>` });
   val("role").split(/\r?\n/).map(s => s.trim()).filter(Boolean).forEach(line => {
-    L.push({ html: `<span style="color:${SIG.sub};">${esc(line)}</span>` });
+    L.push({ html: esc(line) });
   });
-  if (val("org1") || val("org2")) {
-    L.push({ gap: 12 });
-    if (val("org1")) L.push({ html: esc(val("org1")) });
-    if (val("org2")) L.push({ html: esc(val("org2")) });
-  }
-
-  // Rechte Spalte: Adresse + Kontakt
-  const R = [];
-  if (val("street")) R.push({ html: esc(val("street")) });
-  if (val("city")) R.push({ html: esc(val("city")) });
-  if (val("country")) R.push({ html: esc(val("country")) });
-  const hasAddr = R.length > 0;
   const contact = [];
   if (phone) contact.push({ html: phoneCell() });
   if (val("email")) contact.push({ html: `<a href="mailto:${esc(val("email"))}" style="color:${BRAND_BLUE};text-decoration:none;">${esc(val("email"))}</a>` });
   if (val("web")) contact.push({ html: `<a href="${esc(webHref(val("web")))}" style="color:${BRAND_BLUE};text-decoration:none;">${esc(val("web"))}</a>` });
   if (contact.length) {
-    if (hasAddr) R.push({ gap: 12 });
-    contact.forEach(c => R.push(c));
+    if (L.length) L.push({ gap: 10 });
+    contact.forEach(c => L.push(c));
   }
 
-  const LW = 300, RW = 250, PAD = 26;
+  // Rechte Spalte: Organisation – Hauptzeile (blau) + Unterzeile/Adresse (grau).
+  const R = [];
+  if (val("org1")) R.push({ html: `<span style="color:${BRAND_BLUE};">${esc(val("org1"))}</span>` });
+  if (val("org2")) R.push({ html: esc(val("org2")) });
+  [val("street"), val("city"), val("country")].forEach(t => { if (t) R.push({ html: esc(t) }); });
+
+  // Ohne Organisations-/Adressdaten: einspaltig, ohne Trennlinie.
+  if (!R.length) return colTable(L.length ? L : [{ html: "&nbsp;" }]);
+
+  const LW = 250, RW = 240, PAD = 24;
   const total = LW + RW + PAD * 2 + 2;
   return (
     `<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="${total}" ` +


### PR DESCRIPTION
Pflegt den gewählten **Entwurf 2** in den Generator ein und folgt dabei der Hausregel **G01 ‹eine Abweichung, ein Merkmal›**.

**Neues Signatur-Layout**
- **Zwei gleichwertige Blöcke nebeneinander**, getrennt durch den blauen Balken:
  - **Person** links: Name (dunkel) → Funktion (grau) → Kontakt (blaue Verweise)
  - **Organisation** rechts: ‹Goetheanum› als **blaue Hauptzeile** → Gesellschaft/Adresse (grau)
- **Eine Schriftgrösse** (Arial 10.5 pt), **kein Fett** mehr – Unterscheidung **allein über Farbe**.
- Fällt ohne Organisations-/Adressdaten elegant auf **eine Spalte ohne Trennlinie** zurück.

**Formular**
- Org-Felder neu geordnet: **Hauptzeile (blau) = Goetheanum**, Unterzeile = Gesellschaft. Platzhalter/Beispiel angepasst, `STORE_KEY → v2` (alte, anders gemeinte Org-Daten würden sonst falsch eingefärbt).

**Typografie** (Hausregeln beachtet)
- Schriftzug **‹Goetheanum›** statt `«Goetheanum»` (einfache Guillemets nach aussen). Seite auf weitere Verstösse geprüft – sonst sauber.

**Doku**
- `TESTING.md` aktualisiert: Layout, eine Grösse, Farben, `?role=`-Query.

> Hinweis: E-Mail-HTML rendert je Client anders – vor breitem Rollout bitte real in Outlook (Win/Mac), Apple Mail und Gmail gegenprüfen (siehe TESTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_