### PR TITLE
Signatur-Generator: Layout aufgeräumt (Design-Tokens, ruhigere Rhythmik)

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -19,8 +19,12 @@
 
   :root{
     --ink:#23272b; --muted:#737a80; --line:rgba(20,24,28,.10); --line-soft:rgba(20,24,28,.055);
-    --gold:#d7ab68; --gold-deep:#a07a33; --paper:#fff; --soft:#faf8f4; --maxw:1080px;
+    --gold:#d7ab68; --gold-deep:#a07a33; --blue:#0061a9; --paper:#fff; --soft:#faf8f4; --maxw:1080px;
     --bad:#b3261e;
+    /* Abstands-Skala (4/8/12/16/24/32) */
+    --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s6:24px; --s8:32px;
+    /* Radien + Kopfhöhe */
+    --r-control:10px; --r-card:14px; --header-h:58px;
   }
   *{box-sizing:border-box;margin:0;padding:0}
   body{background:var(--paper);color:var(--ink);font-family:"Goetheanum","Helvetica Neue",Arial,sans-serif;font-weight:440;
@@ -28,114 +32,118 @@
   .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
   a{color:inherit}
   .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+  /* Zustand = Blau (Inhalts-Akzent = Gold) */
+  a:focus-visible,button:focus-visible,summary:focus-visible{outline:2px solid var(--blue);outline-offset:2px}
 
   header{position:sticky;top:0;z-index:30;background:rgba(255,255,255,.9);backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--line)}
-  .bar{display:flex;align-items:center;justify-content:space-between;height:58px}
-  .brand{display:flex;align-items:center;gap:12px;text-decoration:none}
+  .bar{display:flex;align-items:center;justify-content:space-between;height:var(--header-h)}
+  .brand{display:flex;align-items:center;gap:var(--s3);text-decoration:none}
   .brand .wm{font-family:"Goetheanum";font-weight:440;font-size:27px;line-height:1;color:#8a9097;letter-spacing:.005em}
   nav.top{display:flex;gap:22px}
   nav.top a{color:var(--muted);text-decoration:none;font-size:13.5px}
   nav.top a:hover{color:var(--gold-deep)}
   @media(max-width:720px){nav.top{display:none}}
 
-  section{padding:30px 0;border-top:1px solid var(--line-soft)}
-  main > section:first-of-type{border-top:0;padding-top:36px}
-  .shead{display:flex;align-items:baseline;justify-content:space-between;gap:30px;margin-bottom:18px;flex-wrap:wrap}
+  section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
+  main > section:first-of-type{border-top:0}
+  .shead{display:flex;align-items:baseline;justify-content:space-between;gap:var(--s8);margin-bottom:var(--s4);flex-wrap:wrap}
   .shead h2{font-family:"Goetheanum";font-weight:680;font-size:clamp(22px,3vw,30px);line-height:1.05;flex:0 0 auto}
   .shead p{color:var(--muted);font-size:14px;line-height:1.5;max-width:62ch;flex:1 1 360px}
 
-  .work{display:grid;grid-template-columns:1fr;gap:24px;align-items:start}
+  .work{display:grid;grid-template-columns:1fr;gap:var(--s6);align-items:start}
   @media(min-width:880px){.work{grid-template-columns:minmax(360px,460px) 1fr}}
   /* Vorschau bleibt beim Scrollen der Eingabemaske sichtbar */
-  @media(min-width:880px){.preview-col{position:sticky;top:74px;align-self:start}}
+  @media(min-width:880px){.preview-col{position:sticky;top:calc(var(--header-h) + var(--s4));align-self:start}}
 
-  .card{border:1px solid var(--line);border-radius:16px;padding:24px}
-  .card.soft{background:var(--soft);padding:18px 20px}
+  .card{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6)}
+  .card.soft{background:var(--soft)}
 
-  .tabs{display:inline-flex;gap:8px;margin-bottom:14px}
+  .tabs{display:inline-flex;gap:var(--s2);margin-bottom:var(--s6)}
   .tabs button{font:inherit;font-size:13.5px;color:var(--muted);background:none;border:1px solid var(--line);border-radius:999px;padding:7px 16px;cursor:pointer;transition:.15s}
   .tabs button[aria-pressed="true"]{color:var(--gold-deep);border-color:var(--gold)}
 
-  /* Einklappbare Abschnitte (Organisation, Adresse) */
-  .fold{border-top:1px solid var(--line-soft);margin-bottom:10px;padding-top:10px}
-  .fold>summary{font-family:"Goetheanum";font-weight:680;font-size:15px;color:var(--ink);cursor:pointer;list-style:none;display:flex;justify-content:space-between;align-items:center;gap:10px}
+  /* Einklappbarer Abschnitt (Standards) */
+  .fold{border-top:1px solid var(--line-soft);margin-bottom:var(--s3);padding-top:var(--s3)}
+  .fold>summary{font-family:"Goetheanum";font-weight:680;font-size:15px;color:var(--ink);cursor:pointer;list-style:none;display:flex;justify-content:space-between;align-items:center;gap:var(--s2)}
   .fold>summary::-webkit-details-marker{display:none}
   .fold>summary .sub{font-family:"Helvetica Neue",Arial,sans-serif;font-weight:400;font-size:12.5px;color:var(--muted);margin-left:auto}
   .fold>summary::after{content:"+";color:var(--muted);font-size:18px;line-height:1;width:1em;text-align:center}
   .fold[open]>summary::after{content:"–"}
-  .fold-body{display:grid;gap:10px;margin-top:10px}
+  .fold-body{display:grid;gap:var(--s3);margin-top:var(--s3)}
 
-  .code-details{margin-top:18px}
+  .code-details{margin-top:var(--s4)}
   .code-details>summary{font-size:13px;color:var(--muted);cursor:pointer;list-style:none}
   .code-details>summary::-webkit-details-marker{display:none}
   .code-details>summary::before{content:"▸ ";color:var(--gold-deep)}
   .code-details[open]>summary::before{content:"▾ "}
 
-  .fset{border:0;display:grid;gap:10px;margin-bottom:12px}
-  .fset > legend{font-family:"Goetheanum";font-weight:680;font-size:15px;color:var(--ink);margin-bottom:2px}
-  .field{display:grid;gap:4px}
-  .field > .lab{font-size:12.5px;color:var(--muted);letter-spacing:.01em}
+  .fset{border:0;display:grid;gap:var(--s3);margin-bottom:var(--s3)}
+  .field{display:grid;gap:var(--s1)}
+  .field > .lab{font-size:13px;color:var(--muted);letter-spacing:.01em}
   .field input{
     width:100%;font-family:"Helvetica Neue",Arial,sans-serif;
     font-size:14.5px;font-weight:400;line-height:1.35;color:var(--ink);
-    background:#fff;border:1px solid var(--line);border-radius:9px;
+    background:#fff;border:1px solid var(--line);border-radius:var(--r-control);
     padding:8px 11px;outline:none;transition:border-color .15s,box-shadow .15s;
   }
   .field input::placeholder{color:#aeb4b9;font-weight:400}
-  .field input:focus{border-color:var(--gold-deep);box-shadow:0 0 0 3px rgba(215,171,104,.18)}
+  .field input:focus{border-color:var(--blue);box-shadow:0 0 0 3px rgba(0,97,169,.16)}
   .field input.invalid{border-color:var(--bad);box-shadow:0 0 0 3px rgba(179,38,30,.14)}
-  .field textarea{width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:14.5px;font-weight:400;line-height:1.35;color:var(--ink);background:#fff;border:1px solid var(--line);border-radius:9px;padding:8px 11px;outline:none;resize:vertical;min-height:48px}
+  .field textarea{width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:14.5px;font-weight:400;line-height:1.35;color:var(--ink);background:#fff;border:1px solid var(--line);border-radius:var(--r-control);padding:8px 11px;outline:none;resize:vertical;min-height:48px;transition:border-color .15s,box-shadow .15s}
   .field textarea::placeholder{color:#aeb4b9;font-weight:400}
-  .field textarea:focus{border-color:var(--gold-deep);box-shadow:0 0 0 3px rgba(215,171,104,.18)}
+  .field textarea:focus{border-color:var(--blue);box-shadow:0 0 0 3px rgba(0,97,169,.16)}
   .lab .sublab{font-weight:400;font-size:11.5px;color:var(--muted);margin-left:6px}
   .field-msg{font-size:12px;color:var(--bad);min-height:0}
-  .field select{width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:14.5px;color:var(--ink);background:#fff;border:1px solid var(--line);border-radius:9px;padding:8px 11px;outline:none;cursor:pointer}
-  .field select:focus{border-color:var(--gold-deep);box-shadow:0 0 0 3px rgba(215,171,104,.18)}
+  .field select{width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:14.5px;color:var(--ink);background:#fff;border:1px solid var(--line);border-radius:var(--r-control);padding:8px 11px;outline:none;cursor:pointer;transition:border-color .15s,box-shadow .15s}
+  .field select:focus{border-color:var(--blue);box-shadow:0 0 0 3px rgba(0,97,169,.16)}
 
-  .btnrow{display:flex;gap:10px;flex-wrap:wrap;align-items:center;margin-top:4px}
-  .btn{display:inline-block;text-decoration:none;font:inherit;font-size:13.5px;padding:9px 15px;border-radius:9px;border:1px solid var(--line);color:var(--ink);background:#fff;text-align:center;cursor:pointer;transition:.15s}
+  .btnrow{display:flex;gap:var(--s3);flex-wrap:wrap;align-items:center;margin-top:var(--s6)}
+  .btn{display:inline-block;text-decoration:none;font:inherit;font-size:13.5px;padding:9px 15px;border-radius:var(--r-control);border:1px solid var(--line);color:var(--ink);background:#fff;text-align:center;cursor:pointer;transition:.15s}
   .btn:hover{border-color:var(--gold-deep)}
   .btn.primary{background:var(--gold);border-color:var(--gold);color:#3a2d10}
   .btn.primary:hover{background:#c59f56}
   .btn.ok{background:#3f7d46;border-color:#3f7d46;color:#fff}
-  .btn.ghost{font-size:12.5px;color:var(--muted);padding:7px 12px}
-  .hint{font-size:14.5px;color:#565b60;line-height:1.55;margin-top:12px}
+  .btn.ghost{color:var(--muted)}
+  .hint{font-size:14.5px;color:#565b60;line-height:1.55;margin-top:var(--s3);max-width:64ch}
+  .hint strong{color:var(--ink);font-weight:440}
+  .hint a{color:var(--gold-deep);text-decoration:none}
+  .hint ul{margin:var(--s3) 0 0;padding-left:18px;display:grid;gap:var(--s2)}
   .hint code{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:12px;background:var(--soft);border:1px solid var(--line-soft);border-radius:5px;padding:1px 5px}
 
-  .stage-lab{font-size:13px;color:var(--muted);margin-bottom:10px}
-  .mail-stage{background:#fff;border:1px solid var(--line);border-radius:14px;padding:26px 28px;box-shadow:0 10px 30px rgba(20,24,28,.06)}
+  .stage-lab{font-size:13px;color:var(--muted);margin-bottom:var(--s3)}
+  .mail-stage{background:#fff;border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);box-shadow:0 10px 30px rgba(20,24,28,.06)}
   .mail-body{font-family:Arial,Helvetica,sans-serif;font-size:10pt;color:#999;line-height:1.5}
-  .mail-greeting{margin-bottom:14px}
+  .mail-greeting{margin-bottom:var(--s4)}
   .sig-sep{color:#999;font-family:Arial,Helvetica,sans-serif;font-size:10pt;margin:6px 0 8px}
 
-  .code-wrap{position:relative;margin-top:14px}
-  pre.code{margin:0;background:#1f2428;color:#e8eef2;border-radius:14px;padding:18px;overflow:auto;
-    font:12.5px/1.55 ui-monospace,Menlo,Consolas,monospace;border:1px solid var(--line);white-space:pre-wrap;word-break:break-word;max-height:320px}
-  .copybtn{position:absolute;top:11px;right:11px;font:inherit;font-size:11.5px;border:1px solid #3a4148;background:#2b3137;color:#e8eef2;border-radius:8px;padding:5px 10px;cursor:pointer}
+  .code-wrap{position:relative;margin-top:var(--s3)}
+  pre.code{margin:0;background:#1f2428;color:#e8eef2;border-radius:var(--r-card);padding:var(--s4);overflow:auto;
+    font:12.5px/1.55 ui-monospace,Menlo,Consolas,monospace;border:1px solid #3a4148;white-space:pre-wrap;word-break:break-word;max-height:320px}
+  .copybtn{position:absolute;top:11px;right:11px;font:inherit;font-size:11.5px;border:1px solid #3a4148;background:#2b3137;color:#e8eef2;border-radius:var(--r-control);padding:5px 10px;cursor:pointer}
   .copybtn:hover{background:#343b42}
 
   /* Anleitung: Entscheidungshilfe + Schritt-für-Schritt */
-  .choose{display:grid;gap:14px;grid-template-columns:1fr;margin-bottom:24px}
+  .choose{display:grid;gap:var(--s4);grid-template-columns:1fr;margin-bottom:var(--s6)}
   @media(min-width:760px){.choose{grid-template-columns:1fr 1fr}}
-  .choose .opt{border:1px solid var(--line);border-radius:14px;padding:16px 18px;background:var(--soft)}
+  .choose .opt{border:1px solid var(--line);border-radius:var(--r-card);padding:16px 18px;background:var(--soft)}
   .choose .opt .who{color:var(--gold-deep);font-size:12px;letter-spacing:.06em;text-transform:uppercase;margin-bottom:6px}
-  .choose .opt h3{font-family:"Goetheanum";font-weight:680;font-size:17px;margin-bottom:8px}
+  .choose .opt h3{font-family:"Goetheanum";font-weight:680;font-size:15px;margin-bottom:6px}
   .choose .opt p{font-size:13.5px;color:var(--muted);line-height:1.55}
-  .guide details{border-top:1px solid var(--line-soft);padding:14px 0}
+  .guide details{border-top:1px solid var(--line-soft);padding:var(--s4) 0}
   .guide details:first-of-type{border-top:0;padding-top:0}
-  .guide summary{font-family:"Goetheanum";font-weight:680;font-size:16px;cursor:pointer;list-style:none;display:flex;align-items:center;gap:10px}
+  .guide summary{font-family:"Goetheanum";font-weight:680;font-size:15px;cursor:pointer;list-style:none;display:flex;align-items:center;gap:var(--s2)}
   .guide summary::-webkit-details-marker{display:none}
   .guide summary .tag{font-family:"Helvetica Neue",Arial,sans-serif;font-weight:400;font-size:12px;color:var(--muted);margin-left:auto}
   .guide summary::after{content:"+";color:var(--muted);font-size:18px;width:1em;text-align:center}
   .guide details[open] summary::after{content:"–"}
-  .guide ol{margin:14px 0 2px;padding-left:20px;display:grid;gap:8px}
+  .guide ol{margin:var(--s4) 0 2px;padding-left:20px;display:grid;gap:var(--s2)}
   .guide li{font-size:14px;line-height:1.5;color:var(--ink)}
   .guide code{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:12.5px;background:var(--soft);border:1px solid var(--line-soft);border-radius:5px;padding:1px 5px}
   .guide .note{font-size:13px;color:var(--muted);line-height:1.5;margin-top:6px}
   .guide a{color:var(--gold-deep);text-decoration:none}
   .guide a:hover{text-decoration:underline}
 
-  footer{border-top:1px solid var(--line);padding:34px 0 60px;color:var(--muted);font-size:12.5px}
+  footer{border-top:1px solid var(--line);padding:var(--s8) 0 60px;color:var(--muted);font-size:12.5px}
   .frow{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap}
   .frow strong{color:var(--ink);font-weight:400}
 </style>
@@ -210,7 +218,7 @@
           </div>
         </details>
 
-        <div class="btnrow" style="margin-top:4px">
+        <div class="btnrow">
           <button type="button" class="btn ghost" id="fillExample">Beispiel einfügen</button>
           <button type="button" class="btn ghost" id="clearAll">Felder leeren</button>
         </div>
@@ -228,17 +236,17 @@
             </div>
           </div>
 
-          <div class="btnrow" style="margin-top:20px">
+          <div class="btnrow">
             <button type="button" class="btn primary" id="copyRich">Signatur kopieren</button>
             <button type="button" class="btn" id="download">.htm laden</button>
           </div>
           <span class="sr-only" id="copyStatus" aria-live="polite"></span>
           <div class="hint">
-            <strong style="color:var(--ink);font-weight:400">Welcher Knopf?</strong>
+            <strong>Welcher Knopf?</strong>
             Im Normalfall ‹Signatur kopieren› und im Signatur-Editor des Mailprogramms einfügen
             (Outlook Mac, Apple Mail, Gmail, auch Outlook Windows). ‹.htm laden› nur für
             Outlook&nbsp;Windows. Schritt für Schritt:
-            <a href="#anleitung" style="color:var(--gold-deep);text-decoration:none">↓ So wird daraus eine Signatur</a>.
+            <a href="#anleitung">↓ So wird daraus eine Signatur</a>.
           </div>
 
           <details class="code-details">
@@ -257,20 +265,20 @@
             <summary>Warum kein Logo, kein Bild, keine Hausschrift?</summary>
             <div class="hint">
               Bewusst schlicht – damit die Signatur überall ankommt:
-              <ul style="margin:10px 0 0;padding-left:18px;display:grid;gap:6px">
-                <li><strong style="color:var(--ink);font-weight:400">Logos &amp; Bilder</strong> werden von
+              <ul>
+                <li><strong>Logos &amp; Bilder</strong> werden von
                   Mailprogrammen standardmässig blockiert und erscheinen dann als leerer Platzhalter; sie
                   blähen jede Nachricht auf, rutschen in den Anhang und brechen in Dark&nbsp;Mode, Antworten
                   und auf dem Handy.</li>
-                <li><strong style="color:var(--ink);font-weight:400">Die Hausschrift</strong> ist bei den
+                <li><strong>Die Hausschrift</strong> ist bei den
                   Empfängern nicht installiert und wird in E-Mails ohnehin durch eine Ersatzschrift ersetzt.
                   Eine systemsichere Schrift (Arial/Helvetica) sieht dafür überall zuverlässig gleich aus.</li>
-                <li><strong style="color:var(--ink);font-weight:400">Wiedererkennung</strong> entsteht hier
+                <li><strong>Wiedererkennung</strong> entsteht hier
                   robust über das Markenblau, klare Hierarchie und den Schriftzug ‹Goetheanum› – statt über
                   fragile Grafik.</li>
               </ul>
               Für echte Grafiken in der Hausschrift (Folien, Profile, Logos) gibt es die
-              <a href="https://grafik.goetheanum.ch" style="color:var(--gold-deep);text-decoration:none">weiteren Werkzeuge</a>.
+              <a href="https://grafik.goetheanum.ch">weiteren Werkzeuge</a>.
             </div>
           </details>
         </div>


### PR DESCRIPTION
Finaler Layout-Schliff des Signatur-Generators – ich habe einen **UI/UX-Review** machen lassen und die belastbaren Empfehlungen umgesetzt. **Struktur und Inhalt bleiben gleich**, nur das visuelle System wird konsolidiert.

**System statt Ad-hoc-Werte**
- **Abstands-Skala** als Tokens: `--s1…--s8` (4/8/12/16/24/32). Alle verstreuten 4/10/12/14/18/20/24/30/36-Werte darauf umgestellt → ruhiger vertikaler Rhythmus.
- **Radien-System:** `--r-control:10` (Inputs, Selects, Buttons, Copy) und `--r-card:14` (alle Karten, Bühne, Code-Block). Vorher u. a. 16/14/9/8 gemischt.

**Grid & Karten**
- Beide Spalten bekommen **dieselbe Karten-Anmutung**: gleiches Padding (24), Unterschied nur über **ein** Merkmal (Fläche/Farbe: Form grau, Vorschau weiss). Vorher unterschiedliche Paddings → unruhige Höhenwirkung.
- Sticky-Offset der Vorschau an die Kopfhöhe gekoppelt (`--header-h`).

**Hausregel ‹ein Merkmal› auch im UI-Chrome**
- **Zustand = Blau, Inhalts-Akzent = Gold:** Fokusringe einheitlich blau (Inputs + `:focus-visible` für Buttons/Links/Summary – vorher hatten nur Inputs einen sichtbaren Fokus). `--blue` als Token ergänzt (lebte bisher nur im JS).
- **Eine Sub-Head-Grösse (15px)** für Fold/Guide/Choose statt 15/16/17 gemischt.
- **Button-Hierarchie** geschärft: ghost nur noch über Farbe (gleiche Grösse/Padding wie sekundär) statt drei Abweichungen zugleich.

**Aufräumen**
- Button-Reihen konsistent (`margin-top:24`, Inline-Styles raus).
- Inline-Styles in Klassen überführt (`.hint strong/a/ul`).
- pre.code-Rahmen auf dunklem Grund gedämpft; Hinweis-Zeilenlänge auf 64ch begrenzt.

Signatur-Output (JS) unverändert. Keine undefinierten CSS-Variablen (20/20), JS validiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_