### PR TITLE
Signatur-Generator: anonyme Nutzungsstatistik + Typo (lang de-CH)

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="de">
+<html lang="de-CH">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -584,7 +584,7 @@ document.getElementById("copyRich").addEventListener("click", function () {
       "text/plain": new Blob([document.getElementById("sigPreview").innerText], { type: "text/plain" })
     });
     navigator.clipboard.write([item]).then(
-      () => flash(this, "Kopiert ✓"),
+      () => { flash(this, "Kopiert ✓"); track("copy", { variant: state.variant }); },
       () => flash(this, "Bitte HTML-Code nutzen")
     );
   } else {
@@ -610,7 +610,7 @@ function selectFallback(btn) {
   try { done = document.execCommand("copy"); } catch (e) {}
   flash(btn, done ? "Kopiert ✓" : "Markiert – Strg/Cmd+C");
 }
-document.getElementById("copyCode2").addEventListener("click", function () { copyCode(this); });
+document.getElementById("copyCode2").addEventListener("click", function () { copyCode(this); track("codecopy", {}); });
 
 document.getElementById("download").addEventListener("click", function () {
   const doc = `<!doctype html><html><head><meta charset="utf-8"></head><body>${buildSignature()}</body></html>`;
@@ -624,7 +624,43 @@ document.getElementById("download").addEventListener("click", function () {
   document.body.removeChild(a);
   setTimeout(() => URL.revokeObjectURL(a.href), 2000);
   flash(this, "Geladen ✓");
+  track("download", { variant: state.variant });
 });
+
+/* ---------- Anonyme Nutzungsstatistik (Supabase, insert-only) ---------- */
+// Nur auf der Live-Site. Gezählt werden anonyme Summen – keine Eingaben des
+// Nutzers, keine IP, kein Drittdienst (eigenes Backend). Vgl. statistik.html.
+const TRACK_URL = "https://dagcsnfrlbpxcmdimnrw.supabase.co/rest/v1/signatur_events";
+const TRACK_KEY = "sb_publishable_SXhY0mrhXjdTnjbJ5Uobtg_zAXW_xGY";
+const TRACK_ON = location.hostname === "phtok.github.io";
+const SID = (() => {
+  try {
+    let s = sessionStorage.getItem("goeSigSid");
+    if (!s) { s = Math.random().toString(36).slice(2) + Date.now().toString(36); sessionStorage.setItem("goeSigSid", s); }
+    return s;
+  } catch (e) { return "x" + Date.now().toString(36); }
+})();
+function track(event, payload) {
+  if (!TRACK_ON) return;
+  try {
+    fetch(TRACK_URL, {
+      method: "POST", keepalive: true,
+      headers: { apikey: TRACK_KEY, "Content-Type": "application/json", Prefer: "return=minimal" },
+      body: JSON.stringify({ session_id: SID, event: event, payload: payload || {} })
+    }).catch(() => {});
+  } catch (e) {}
+}
+let activeSec = 0;
+if (TRACK_ON) {
+  track("visit", {
+    ref: (document.referrer || "").slice(0, 200), lang: navigator.language || "",
+    w: screen.width, h: screen.height, mob: /Mobi|Android|iPhone|iPad/.test(navigator.userAgent)
+  });
+  setInterval(() => {
+    if (document.visibilityState === "visible") { activeSec += 30; track("heartbeat", { t: activeSec }); }
+  }, 30000);
+  addEventListener("pagehide", () => track("leave", { t: activeSec }));
+}
 
 /* ---------- Start ---------- */
 const hadStored = loadStored();

--- a/statistik.html
+++ b/statistik.html
@@ -89,6 +89,17 @@
     <div class="chart-t">EREIGNISSE</div>
     <div class="bars" id="gBars"><div class="empty">lädt …</div></div>
   </section>
+
+  <section id="sec-signatur">
+    <div class="app-h"><h2>Signatur</h2><span class="meta" id="sigMeta"></span></div>
+    <div class="cards">
+      <div class="stat"><div class="num" id="sigVisits">–</div><div class="cap">Besuche</div></div>
+      <div class="stat"><div class="num" id="sigCopies">–</div><div class="cap">Signaturen kopiert</div></div>
+      <div class="stat"><div class="num" id="sigSessions">–</div><div class="cap">Besucher (Sessions)</div></div>
+    </div>
+    <div class="chart-t">EREIGNISSE</div>
+    <div class="bars" id="sigBars"><div class="empty">lädt …</div></div>
+  </section>
 </main>
 
 <footer><div class="wrap">Goeloggen · Statistik · anonyme Zählung über das eigene Supabase-Backend.</div></footer>
@@ -174,6 +185,26 @@
     done++; finish();
   }).catch(function(e){
     document.getElementById('gBars').innerHTML = '<div class="err">nicht ladbar</div>';
+    fail++; finish();
+  });
+
+  // ---- Signatur ----
+  rpc('signatur_stats').then(function(rows){
+    var by = {}; rows.forEach(function(r){ by[r.event] = r; });
+    var visit = by['visit'] || {n:0,sessions:0};
+    var copies = Number((by['copy']||{}).n||0);
+    document.getElementById('sigVisits').textContent   = fmt(visit.n);
+    document.getElementById('sigCopies').textContent   = fmt(copies);
+    document.getElementById('sigSessions').textContent = fmt(visit.sessions);
+    rows.sort(function(a,b){ return b.n - a.n; });
+    bars(document.getElementById('sigBars'), rows.map(function(r){
+      return {label:r.event, value:Number(r.n), sub:(r.sessions ? fmt(r.sessions)+' S.' : '')};
+    }));
+    var lastS = rows.reduce(function(m,r){ return (r.last>m)?r.last:m; }, '');
+    document.getElementById('sigMeta').textContent = lastS ? 'zuletzt ' + when(lastS) : '';
+    done++; finish();
+  }).catch(function(e){
+    document.getElementById('sigBars').innerHTML = '<div class="err">nicht ladbar</div>';
     fail++; finish();
   });
 </script>


### PR DESCRIPTION
Zwei Dinge: **anonyme Nutzungsstatistik ab jetzt** und die letzte **Typo-Korrektur**.

### Statistik (wie gewünscht, ab jetzt)
Konsistent zum bestehenden System (GTV-Naming), **eigenes Supabase-Backend, keine Drittdienste**:
- **Insert-only Tracking** nur auf der Live-Site (`phtok.github.io`), anonyme Session-ID, **keine Nutzereingaben** im Payload — nur Variante (lang/kurz), Referrer, Sprache, Bildschirmgrösse. Das Versprechen ‹Eingaben bleiben lokal› bleibt wahr.
- Events: `visit`, `heartbeat`, `leave`, `copy`, `download`, `codecopy`.
- **`statistik.html`:** neue Karte **‹Signatur›** (Besuche, Signaturen kopiert, Besucher/Sessions, Ereignis-Balken) über RPC `signatur_stats`.

**Backend** (separat per Supabase-Migration `signatur_events_and_stats` angelegt, daher nicht im Diff):
- Tabelle `public.signatur_events` (id, created_at, session_id, event, payload).
- RLS: anon darf **nur** insert, mit Event-Whitelist + `session_id ≤ 48` + `payload < 2 KB`.
- `signatur_stats()` (SECURITY DEFINER) für das Dashboard.
- End-to-end getestet: erlaubtes Event → 201, verbotenes → 401, RPC liest korrekt; Test-Zeilen entfernt (Start bei 0).

### Typografie (auf allen Ebenen geprüft)
- `html lang` ‹de› → **‹de-CH›** (Schweizer Konventionen).
- Der gerenderte Lesetext ist bereits regelkonform: Guillemets ‹…›, Auslassung …, Gedankenstrich – mit Spatien, „ss" statt „ß". Treffer für Uhrzeit/Einheiten/Bis-Strich lagen ausschliesslich in CSS/JS/URLs, die das Regelwerk ausnimmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_