### PR TITLE
Signatur-Generator: mehrzeilige Felder wachsen automatisch mit

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -573,7 +573,14 @@ function validateEmail() {
 }
 
 /* ---------- Eingaben verdrahten ---------- */
-function onInput() { render(); validateEmail(); save(); }
+// Mehrzeilige Felder (Funktion, mehrere URLs) wachsen mit dem Inhalt mit.
+function autoGrow(el) {
+  if (!el || el.tagName !== "TEXTAREA") return;
+  el.style.height = "auto";
+  el.style.height = el.scrollHeight + "px";
+}
+function growAll() { autoGrow(els.role); autoGrow(els.web); }
+function onInput() { render(); validateEmail(); growAll(); save(); }
 FIELDS.forEach(k => els[k].addEventListener("input", onInput));
 
 document.getElementById("fillExample").addEventListener("click", () => {
@@ -688,6 +695,7 @@ if (!hadStored && !hadQuery) setFields(EXAMPLE);
 setVariant(state.variant, false);
 validateEmail();
 render();
+growAll();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Für Mitarbeitende mit **mehreren URLs**: Die mehrzeiligen Felder (Website, Funktion) **wachsen jetzt automatisch mit dem Inhalt**.

- Beliebig viele URLs (je Zeile eine) bleiben **komplett sichtbar** — die Höhe passt sich an, kein manuelles Ziehen, kein interner Scrollbalken.
- Gilt für **Website** und **Funktion / Bereich / Sektion**.
- Greift beim Tippen, beim Beispiel-Einfügen, beim Leeren und beim Laden gespeicherter Daten.

Kleine, isolierte JS-Ergänzung (`autoGrow`/`growAll`); Signatur-Output unverändert. JS validiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_