### PR TITLE
Hub live (geparkte Projekte + Dokumente) + Front-door-Vorschau

### DIFF
--- a/docs/strategie.md
+++ b/docs/strategie.md
@@ -193,10 +193,36 @@ interne Grafik, externe Dienstleister).
 
 ---
 
-## 6. Offene Entscheidungen
-- **Kernziel-Priorität** bestätigen (Wildwuchs stoppen / Autonomie / Markenwirkung /
-  Wissen bündeln – im Interview als „alle wichtig" gelesen).
-- **Zugang**: offen im Web vs. sanfter Zugangsschutz (z. B. später für Schreib-/Export-Rechte).
-- **Technikstufe** der gemeinsamen Schicht (reines Vanilla vs. statisches Framework) –
-  bewusst noch vertagt; Fundament ist framework-neutral.
-- **Stichtag/Anlass** für die Öffnung (im Interview keiner genannt).
+## 6. Getroffene Entscheidungen (2. Interview)
+- **Verhältnis zur bestehenden grafik.goetheanum.ch:** *mittelfristig ablösen* – unser
+  Frontend wird das Ziel-Portal (alles an einem Ort, eine Technik, ein Hausbild).
+  Heute verlinkt das offizielle Portal bereits in unsere Tools (Logo-Download,
+  Schriften, Signatur → `phtok.github.io/goeloggen/`).
+- **Zwei Oberflächen, ein Manifest:** *Front door* (`/`, bewusst **minimal**: nur
+  Generatoren + Schriften) für Mitarbeitende; *interner Hub* (`start/`, reichhaltig:
+  alle Werkzeuge, geparkte Projekte, Konzeptdokumente) für die Pflege. Beide speisen
+  sich aus `tools.json` (Pfade root-relativ, Basis je Oberfläche aufgelöst).
+- **Nächste zu entwickelnde Funktionen:** (1) Farben & Icons (Elemente vervollständigen),
+  (2) Brief/Briefbogen, (3) Social Media & PowerPoint.
+
+### Funktions-Landkarte aus grafik.goetheanum.ch (integrieren/übernehmen/entwickeln)
+| Rubrik | Status bei uns | To-do |
+|---|---|---|
+| Logos, Schriften, Signatur | ✅ live | bereits verlinkt; Logo-Pakete aus Generator statt logopackage.app |
+| Zeichen | 🟡 in Logo-Engine | Referenzseite |
+| Icons, Farben | 🟡 Assets da | Icon-Browser + Farben-Seite **(nächste Schritte)** |
+| Social Media, PowerPoint, Wallpaper, Mailer | ❌ | Generatoren/Vorlagen mit Leitplanken |
+| Videoreihen | 🟡 Cover-Generator (Entwurf) | fertigstellen |
+| Briefpapier | 🟡 Briefschaften (Entwurf) | Brief/Briefbogen **(nächster Schritt)** |
+| Leitsystem | ❌ | Schilder-Generator |
+| Kartierung | 🅿️ geparkt | Pflichtenheft liegt vor |
+| Druckauftrag (VK/Grusskarten/Couverts/Hausdruckerei) | 🟡 VK live + Mail-Worker | Grusskarten/Couverts; Druckanfrage-Anbindung |
+| Gestaltende/Übersetzungen/Anfragen | ❌ | Info-/Intake-Seiten |
+| Werkstatt | ✅ intern | aus Frontend heraushalten |
+
+### Weiter offen
+- **Zugang**: offen im Web vs. sanfter Schutz für Schreib-/Export-Rechte (später).
+- **Technikstufe** der gemeinsamen Schicht (Vanilla vs. statisches Framework) – vertagt.
+- **Stichtag/Anlass** für die Öffnung – keiner genannt.
+- **Wurzel-Umlegung live:** Front door ersetzt erst beim Merge die bisherige
+  Weiterleitung; Deep-Links (`/logo-generator.html` etc.) bleiben unverändert.

--- a/portal.html
+++ b/portal.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Goetheanum Grafik</title>
+<meta name="description" content="Werkzeuge für die Hausgrafik des Goetheanum – Logo, Visitenkarten, Signatur und die Hausschrift." />
+<link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
+<link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/base.css" />
+<style>
+  /* Front door – bewusst minimal */
+  .hero{padding:clamp(56px,11vw,120px) 0 var(--s8)}
+  .hero .kick{color:var(--gold-deep);font-size:12.5px;letter-spacing:.08em;text-transform:uppercase;margin-bottom:var(--s4)}
+  .hero h1{font-family:var(--font);font-weight:700;font-size:clamp(38px,7vw,72px);line-height:1.0;letter-spacing:-.01em;max-width:14ch}
+  .hero .lede{margin-top:var(--s6);color:#565b60;font-size:clamp(16px,2vw,20px);line-height:1.55;max-width:52ch}
+
+  .grid{display:grid;gap:var(--s4);grid-template-columns:1fr}
+  @media(min-width:620px){.grid{grid-template-columns:1fr 1fr}}
+  @media(min-width:920px){.grid.cols3{grid-template-columns:1fr 1fr 1fr}}
+  .tile{position:relative;display:flex;flex-direction:column;border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);
+        background:var(--soft);transition:border-color .15s,box-shadow .15s,transform .15s;min-height:150px}
+  .tile:hover{border-color:var(--gold);box-shadow:var(--shadow-card);transform:translateY(-1px)}
+  .tile .tag{color:var(--gold-deep);font-size:11px;letter-spacing:.06em;text-transform:uppercase;margin-bottom:var(--s2)}
+  .tile h3{font-family:var(--font);font-weight:var(--w-strong);font-size:20px;line-height:1.15;display:flex;align-items:center;gap:8px}
+  .tile h3 .arr{color:var(--muted);font-weight:var(--w-text);transition:transform .15s,color .15s}
+  .tile:hover h3 .arr{color:var(--gold-deep);transform:translateX(3px)}
+  .tile p{margin-top:var(--s2);color:var(--muted);font-size:14px;line-height:1.5}
+  .badge{position:absolute;top:var(--s4);right:var(--s4);font-size:10.5px;letter-spacing:.04em;text-transform:uppercase;
+         color:var(--blue);border:1px solid rgba(0,97,169,.3);border-radius:var(--r-pill);padding:2px 9px}
+</style>
+</head>
+<body>
+
+<header class="ds-header"><div class="wrap bar">
+  <a class="brand" href="./" aria-label="Goetheanum Grafik – Startseite">
+    <img class="mk" src="assets/logos/goetheanum-mark-blue.svg" alt="" />
+    <span class="wm">Goetheanum</span>
+  </a>
+  <nav class="top">
+    <a href="#generatoren">Generatoren</a>
+    <a href="schriften.html">Schriften</a>
+  </nav>
+</div></header>
+
+<main>
+  <div class="wrap hero">
+    <div class="kick">Goetheanum · Hausgrafik</div>
+    <h1>Material, das stimmt.</h1>
+    <p class="lede">Logo, Visitenkarte, Signatur und die Hausschrift – in Minuten korrekt
+      erstellt, ganz im Bild des Goetheanum. Ohne Layoutprogramm, ohne Designkenntnis.</p>
+  </div>
+
+  <div class="wrap" id="sections"></div>
+</main>
+
+<footer class="ds-footer"><div class="wrap frow">
+  <span><strong>Goetheanum Grafik</strong> · Werkzeuge für die Hausgrafik</span>
+  <span><a href="start/">Alle Werkzeuge &amp; Konzepte →</a></span>
+</div></footer>
+
+<script>
+"use strict";
+
+// Front door liegt im Wurzelverzeichnis – Manifest-Pfade sind root-relativ.
+const url = h => h;
+
+function tile(t){
+  const a = document.createElement("a");
+  a.className = "tile"; a.href = url(t.href); a.dataset.slug = t.slug;
+  const badge = t.status === "beta" ? '<span class="badge">Beta</span>' : "";
+  a.innerHTML = `${badge}<span class="tag">${t.tag || ""}</span>` +
+    `<h3>${t.title} <span class="arr">→</span></h3><p>${t.desc || ""}</p>`;
+  return a;
+}
+
+function render(m){
+  const root = document.getElementById("sections");
+
+  // Generatoren – nur einsatzbereite (live/beta), bewusst schlank
+  const gens = m.tools.filter(t => t.cat === "generatoren" && (t.status === "live" || t.status === "beta"));
+  const secG = document.createElement("section"); secG.id = "generatoren";
+  secG.innerHTML = `<div class="shead"><h2>Generatoren</h2>` +
+    `<p>Eigene Angaben eintragen, fertiges Ergebnis übernehmen.</p></div>`;
+  const grid = document.createElement("div"); grid.className = "grid cols3";
+  gens.forEach(t => grid.appendChild(tile(t)));
+  secG.appendChild(grid); root.appendChild(secG);
+
+  // Schriften – ein ruhiger Verweis auf die Übersicht
+  const s = m.tools.find(t => t.slug === "schriften");
+  if(s){
+    const secS = document.createElement("section"); secS.id = "schriften";
+    secS.innerHTML = `<div class="shead"><h2>Schriften</h2>` +
+      `<p>Die Hausschrift v2.5 – fünf Schnitte, Variable Font und Icons.</p></div>`;
+    const grid2 = document.createElement("div"); grid2.className = "grid";
+    grid2.appendChild(tile(s)); secS.appendChild(grid2); root.appendChild(secS);
+  }
+}
+
+fetch("tools.json").then(r => r.json()).then(render).catch(() => {
+  document.getElementById("sections").innerHTML =
+    '<section><p style="color:var(--muted)">Werkzeuge konnten nicht geladen werden. ' +
+    '<a href="logo-generator.html">Zum Logo-Generator →</a></p></section>';
+});
+
+/* ---------- Anonyme Nutzungsstatistik (wie übrige Suite, insert-only) ---------- */
+const TRACK_URL = "https://dagcsnfrlbpxcmdimnrw.supabase.co/rest/v1/landing_events";
+const TRACK_KEY = "sb_publishable_SXhY0mrhXjdTnjbJ5Uobtg_zAXW_xGY";
+const TRACK_ON  = location.hostname === "phtok.github.io";
+const SID = (() => { try { let s = sessionStorage.getItem("goeLandingSid");
+  if(!s){ s = Math.random().toString(36).slice(2) + Date.now().toString(36); sessionStorage.setItem("goeLandingSid", s); }
+  return s; } catch(e){ return "x" + Date.now().toString(36); } })();
+function track(event, payload){ if(!TRACK_ON) return; try {
+  fetch(TRACK_URL, { method:"POST", keepalive:true,
+    headers:{ apikey:TRACK_KEY, "Content-Type":"application/json", Prefer:"return=minimal" },
+    body:JSON.stringify({ session_id:SID, event:event, payload:payload || {} }) }).catch(()=>{});
+} catch(e){} }
+document.addEventListener("click", e => {
+  const a = e.target.closest("a.tile"); if(!a) return;
+  track("open", { tool: a.dataset.slug || "?", sec: "frontdoor" });
+}, true);
+if(TRACK_ON){ track("visit", { ref:(document.referrer||"").slice(0,200), src:"frontdoor",
+  lang:navigator.language||"", w:screen.width, h:screen.height }); }
+</script>
+</body>
+</html>

--- a/start/index.html
+++ b/start/index.html
@@ -33,6 +33,7 @@
          color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:2px 9px}
   .badge.beta{color:var(--blue);border-color:rgba(0,97,169,.3)}
   .badge.entwurf{color:var(--gold-deep);border-color:rgba(160,122,51,.3)}
+  .badge.geparkt{color:var(--muted)}
 
   .list{display:grid;gap:0;grid-template-columns:1fr}
   @media(min-width:680px){.list{grid-template-columns:1fr 1fr}}
@@ -74,12 +75,17 @@
 "use strict";
 
 /* ---------- Übersicht aus dem Manifest rendern ---------- */
-const STATUS_LABEL = { beta: "Beta", entwurf: "Entwurf" };
+const STATUS_LABEL = { beta: "Beta", entwurf: "Entwurf", geparkt: "Geparkt" };
+
+// Hub liegt in /start/ – Werkzeuge eine Ebene höher. Externe Links bleiben absolut.
+const BASE = "../";
+function url(h){ return /^https?:/.test(h) ? h : BASE + h; }
+function ext(a, href){ if(/^https?:/.test(href)){ a.target = "_blank"; a.rel = "noopener"; } }
 
 function tile(t){
   const a = document.createElement("a");
   a.className = "tile" + (t.status === "live" ? " is-live" : "");
-  a.href = t.href; a.dataset.slug = t.slug; a.dataset.cat = t.cat;
+  a.href = url(t.href); a.dataset.slug = t.slug; a.dataset.cat = t.cat; ext(a, t.href);
   const badge = STATUS_LABEL[t.status]
     ? `<span class="badge ${t.status}">${STATUS_LABEL[t.status]}</span>` : "";
   a.innerHTML =
@@ -90,7 +96,7 @@ function tile(t){
 }
 function row(t){
   const a = document.createElement("a");
-  a.className = "row"; a.href = t.href; a.dataset.slug = t.slug; a.dataset.cat = t.cat;
+  a.className = "row"; a.href = url(t.href); a.dataset.slug = t.slug; a.dataset.cat = t.cat; ext(a, t.href);
   a.innerHTML = `<span class="rt">${t.title}</span><span class="rd">${t.desc || ""}</span>`;
   return a;
 }
@@ -108,8 +114,8 @@ function render(manifest){
     sec.id = cat.id;
     sec.innerHTML = `<div class="shead"><h2>${cat.title}</h2><p>${cat.intro || ""}</p></div>`;
 
-    // Werkstatt als ruhige Liste, sonst Karten-Raster
-    if(cat.id === "werkstatt"){
+    // Werkstatt & geparkte Projekte als ruhige Liste, sonst Karten-Raster
+    if(cat.id === "werkstatt" || cat.id === "geparkt"){
       const list = document.createElement("div"); list.className = "list";
       tools.forEach(t => list.appendChild(row(t)));
       sec.appendChild(list);
@@ -120,6 +126,22 @@ function render(manifest){
     }
     sections.appendChild(sec);
   });
+
+  // Konzepte & Dokumente (interner Hub – zum schnellen Einsehen)
+  if(Array.isArray(manifest.docs) && manifest.docs.length){
+    nav.insertAdjacentHTML("beforeend", `<a href="#dokumente">Dokumente</a>`);
+    const sec = document.createElement("section"); sec.id = "dokumente";
+    sec.innerHTML = `<div class="shead"><h2>Konzepte &amp; Dokumente</h2>` +
+      `<p>Strategie, Pflichtenhefte und Schrift-Dokumentation – öffnet auf GitHub.</p></div>`;
+    const list = document.createElement("div"); list.className = "list";
+    manifest.docs.forEach(d => {
+      const a = document.createElement("a"); a.className = "row"; a.href = d.href;
+      a.dataset.slug = "doc:" + (d.title || ""); a.dataset.cat = "dokumente"; ext(a, d.href);
+      a.innerHTML = `<span class="rt">${d.title}</span><span class="rd">${d.desc || ""}</span>`;
+      list.appendChild(a);
+    });
+    sec.appendChild(list); sections.appendChild(sec);
+  }
 
   // Hero-Kennzahlen aus dem Manifest
   const gen = manifest.tools.filter(t => t.cat === "generatoren").length;

--- a/tools.json
+++ b/tools.json
@@ -1,37 +1,53 @@
 {
-  "$description": "Manifest aller Goetheanum-Grafik-Werkzeuge. Einzige Quelle für die Übersicht (start/). Neues Werkzeug = ein Eintrag hier. Pfade relativ zu start/.",
+  "$description": "Manifest aller Goetheanum-Grafik-Werkzeuge. Einzige Quelle für Front door (/) und internen Hub (start/). Neues Werkzeug = ein Eintrag hier. Pfade root-relativ; jede Oberfläche löst ihre Basis selbst auf (Hub voran './../', Front door ''). Externe Links (https) bleiben unverändert.",
   "status": {
     "live":    "Im Einsatz, gepflegt",
     "beta":    "Nutzbar, in Überarbeitung",
-    "entwurf": "Grober Entwurf"
+    "entwurf": "Grober Entwurf",
+    "geparkt": "Konzept, später"
   },
   "categories": [
     { "id": "generatoren", "title": "Generatoren", "intro": "Eigene Angaben eintragen, fertiges Ergebnis übernehmen. Für den täglichen Gebrauch." },
     { "id": "schrift",     "title": "Schrift & Typografie", "intro": "Die Hausschrift v2.5 und die Regeln dazu – nachschlagen, vergleichen, einbinden." },
-    { "id": "werkstatt",   "title": "Werkstatt", "intro": "Werkschau und Prüfwerkzeuge rund um die Schriftentwicklung und -pflege." }
+    { "id": "werkstatt",   "title": "Werkstatt", "intro": "Werkschau und Prüfwerkzeuge rund um die Schriftentwicklung und -pflege." },
+    { "id": "geparkt",     "title": "Geparkte Projekte", "intro": "Durchdachte Konzepte, die später kommen – zum schnellen Einsehen der Spezifikation." }
   ],
   "tools": [
-    { "slug": "logo-generator",    "cat": "generatoren", "status": "live",    "tag": "Logo",          "title": "Logo-Generator",     "href": "../logo-generator.html",          "desc": "Sektions- und Bereichslogos in der Hausschrift – korrekt gesetzt, als SVG zum Herunterladen." },
-    { "slug": "visitenkarten",     "cat": "generatoren", "status": "live",    "tag": "Visitenkarten", "title": "Visitenkarten",      "href": "../visitenkarten-generator.html", "desc": "Einheitliche Visitenkarten aus den eigenen Angaben – druckfertig, ohne Layoutprogramm." },
-    { "slug": "signatur",          "cat": "generatoren", "status": "live",    "tag": "E-Mail",        "title": "Signatur",           "href": "../signatur-generator.html",      "desc": "Outlook-robuste E-Mail-Signatur nach gemeinsamer Vorlage – kopieren und einsetzen." },
-    { "slug": "gtv-naming",        "cat": "generatoren", "status": "beta",    "tag": "Goetheanum TV", "title": "Namens-Renderings",  "href": "../apps/gtv-naming/",             "desc": "Präsentationswerkzeug für die Umbenennung von Goetheanum TV mit umschaltbarer Wortmarke." },
-    { "slug": "karten",            "cat": "generatoren", "status": "entwurf", "tag": "Campus",        "title": "Kartentool",         "href": "../karten-generator.html",        "desc": "Lagepläne des Goetheanum-Geländes zusammenstellen und im Hausbild ausgeben." },
-    { "slug": "cover",             "cat": "generatoren", "status": "entwurf", "tag": "Goetheanum TV", "title": "Cover-Generator",    "href": "../cover-generator.html",         "desc": "Einheitliche Cover-Bilder für Goetheanum-TV-Beiträge – Titel eintragen, Bild laden." },
-    { "slug": "briefschaften",     "cat": "generatoren", "status": "entwurf", "tag": "Korrespondenz", "title": "Briefschaften",      "href": "../briefschaften.html",           "desc": "Briefbogen und Briefschaften im Hausbild – als Vorlage für die eigene Korrespondenz." },
+    { "slug": "logo-generator",    "cat": "generatoren", "status": "live",    "tag": "Logo",          "title": "Logo-Generator",     "href": "logo-generator.html",          "desc": "Sektions- und Bereichslogos in der Hausschrift – korrekt gesetzt, als SVG zum Herunterladen." },
+    { "slug": "visitenkarten",     "cat": "generatoren", "status": "live",    "tag": "Visitenkarten", "title": "Visitenkarten",      "href": "visitenkarten-generator.html", "desc": "Einheitliche Visitenkarten aus den eigenen Angaben – druckfertig, ohne Layoutprogramm." },
+    { "slug": "signatur",          "cat": "generatoren", "status": "live",    "tag": "E-Mail",        "title": "Signatur",           "href": "signatur-generator.html",      "desc": "Outlook-robuste E-Mail-Signatur nach gemeinsamer Vorlage – kopieren und einsetzen." },
+    { "slug": "gtv-naming",        "cat": "generatoren", "status": "beta",    "tag": "Goetheanum TV", "title": "Namens-Renderings",  "href": "apps/gtv-naming/",             "desc": "Präsentationswerkzeug für die Umbenennung von Goetheanum TV mit umschaltbarer Wortmarke." },
+    { "slug": "karten",            "cat": "generatoren", "status": "entwurf", "tag": "Campus",        "title": "Kartentool",         "href": "karten-generator.html",        "desc": "Lagepläne des Goetheanum-Geländes zusammenstellen und im Hausbild ausgeben." },
+    { "slug": "cover",             "cat": "generatoren", "status": "entwurf", "tag": "Goetheanum TV", "title": "Cover-Generator",    "href": "cover-generator.html",         "desc": "Einheitliche Cover-Bilder für Goetheanum-TV-Beiträge – Titel eintragen, Bild laden." },
+    { "slug": "briefschaften",     "cat": "generatoren", "status": "entwurf", "tag": "Korrespondenz", "title": "Briefschaften",      "href": "briefschaften.html",           "desc": "Briefbogen und Briefschaften im Hausbild – als Vorlage für die eigene Korrespondenz." },
 
-    { "slug": "schriften",         "cat": "schrift",     "status": "live",    "tag": "Übersicht",     "title": "Schriften",          "href": "../schriften.html",               "desc": "Fünf Schnitte von Leise bis Laut, Variable Font und Icon-Satz – mit Download." },
-    { "slug": "typografie",        "cat": "schrift",     "status": "beta",    "tag": "Hausregeln",    "title": "Typografie",         "href": "../typografie.html",              "desc": "Wenige Mittel, präzise gesetzt – als Handbuch und maschinenlesbares Token-System." },
-    { "slug": "schrift-webfont",   "cat": "schrift",     "status": "beta",    "tag": "Web",           "title": "Webfont einbinden",  "href": "../schrift-webfont.html",         "desc": "Die Goetheanum-Schrift als Webfont auf eigenen Seiten verwenden – Schritt für Schritt." },
-    { "slug": "schrift-vergleich", "cat": "schrift",     "status": "beta",    "tag": "Vergleich",     "title": "Schrift-Vergleich",  "href": "../schrift-vergleich.html",       "desc": "Begleit-Antiquas und Nicht-Latein-Fallbacks im direkten Vergleich zur Hausschrift." },
-    { "slug": "tester",            "cat": "schrift",     "status": "beta",    "tag": "Probe",         "title": "Gewichts-Tester",    "href": "../tester.html",                  "desc": "Schnittstärken der Variable Font interaktiv durchspielen und Texte ausprobieren." },
-    { "slug": "vorschau",          "cat": "schrift",     "status": "beta",    "tag": "Neu in v2.5",   "title": "Neuerungen",         "href": "../vorschau.html",                "desc": "Spatien, geschützter Bindestrich, Ziffern-Features und der Mediävalziffern-Entwurf." },
+    { "slug": "schriften",         "cat": "schrift",     "status": "live",    "tag": "Übersicht",     "title": "Schriften",          "href": "schriften.html",               "desc": "Fünf Schnitte von Leise bis Laut, Variable Font und Icon-Satz – mit Download." },
+    { "slug": "typografie",        "cat": "schrift",     "status": "beta",    "tag": "Hausregeln",    "title": "Typografie",         "href": "typografie.html",              "desc": "Wenige Mittel, präzise gesetzt – als Handbuch und maschinenlesbares Token-System." },
+    { "slug": "schrift-webfont",   "cat": "schrift",     "status": "beta",    "tag": "Web",           "title": "Webfont einbinden",  "href": "schrift-webfont.html",         "desc": "Die Goetheanum-Schrift als Webfont auf eigenen Seiten verwenden – Schritt für Schritt." },
+    { "slug": "schrift-vergleich", "cat": "schrift",     "status": "beta",    "tag": "Vergleich",     "title": "Schrift-Vergleich",  "href": "schrift-vergleich.html",       "desc": "Begleit-Antiquas und Nicht-Latein-Fallbacks im direkten Vergleich zur Hausschrift." },
+    { "slug": "tester",            "cat": "schrift",     "status": "beta",    "tag": "Probe",         "title": "Gewichts-Tester",    "href": "tester.html",                  "desc": "Schnittstärken der Variable Font interaktiv durchspielen und Texte ausprobieren." },
+    { "slug": "vorschau",          "cat": "schrift",     "status": "beta",    "tag": "Neu in v2.5",   "title": "Neuerungen",         "href": "vorschau.html",                "desc": "Spatien, geschützter Bindestrich, Ziffern-Features und der Mediävalziffern-Entwurf." },
 
-    { "slug": "proof",             "cat": "werkstatt",   "status": "entwurf", "tag": "Abnahme",       "title": "Proof",              "href": "../proof.html",                   "desc": "Schrift v2.5 systematisch abnehmen." },
-    { "slug": "ligvorschau",       "cat": "werkstatt",   "status": "entwurf", "tag": "Ligaturen",     "title": "Ligaturen – Werkschau","href": "../ligvorschau.html",           "desc": "Alle Ligaturen im Überblick." },
-    { "slug": "ineinander",        "cat": "werkstatt",   "status": "entwurf", "tag": "Ligaturen",     "title": "Ligaturen ineinander","href": "../ineinander.html",             "desc": "Überlagerung der Ligaturen prüfen." },
-    { "slug": "zuordnen",          "cat": "werkstatt",   "status": "entwurf", "tag": "Ligaturen",     "title": "Ligaturen zuordnen", "href": "../zuordnen.html",                "desc": "Zeichen den Ligaturen zuweisen." },
-    { "slug": "kerning",           "cat": "werkstatt",   "status": "entwurf", "tag": "Spacing",       "title": "Ligatur-Spacing",    "href": "../kerning.html",                 "desc": "Abstände feinjustieren." },
-    { "slug": "werkzeug",          "cat": "werkstatt",   "status": "entwurf", "tag": "Kalibrierung",  "title": "Kalibrierung",       "href": "../werkzeug.html",                "desc": "Schrift-Werkzeug zur Kalibrierung." },
-    { "slug": "statistik",         "cat": "werkstatt",   "status": "beta",    "tag": "Zahlen",        "title": "Statistik",          "href": "../statistik.html",               "desc": "Anonyme Nutzungszahlen aller Werkzeuge." }
+    { "slug": "proof",             "cat": "werkstatt",   "status": "entwurf", "tag": "Abnahme",       "title": "Proof",              "href": "proof.html",                   "desc": "Schrift v2.5 systematisch abnehmen." },
+    { "slug": "ligvorschau",       "cat": "werkstatt",   "status": "entwurf", "tag": "Ligaturen",     "title": "Ligaturen – Werkschau","href": "ligvorschau.html",           "desc": "Alle Ligaturen im Überblick." },
+    { "slug": "ineinander",        "cat": "werkstatt",   "status": "entwurf", "tag": "Ligaturen",     "title": "Ligaturen ineinander","href": "ineinander.html",             "desc": "Überlagerung der Ligaturen prüfen." },
+    { "slug": "zuordnen",          "cat": "werkstatt",   "status": "entwurf", "tag": "Ligaturen",     "title": "Ligaturen zuordnen", "href": "zuordnen.html",                "desc": "Zeichen den Ligaturen zuweisen." },
+    { "slug": "kerning",           "cat": "werkstatt",   "status": "entwurf", "tag": "Spacing",       "title": "Ligatur-Spacing",    "href": "kerning.html",                 "desc": "Abstände feinjustieren." },
+    { "slug": "werkzeug",          "cat": "werkstatt",   "status": "entwurf", "tag": "Kalibrierung",  "title": "Kalibrierung",       "href": "werkzeug.html",                "desc": "Schrift-Werkzeug zur Kalibrierung." },
+    { "slug": "statistik",         "cat": "werkstatt",   "status": "beta",    "tag": "Zahlen",        "title": "Statistik",          "href": "statistik.html",               "desc": "Anonyme Nutzungszahlen aller Werkzeuge." },
+
+    { "slug": "campus-karten",     "cat": "geparkt",     "status": "geparkt", "tag": "Kartierung",    "title": "Campus-Kartentool",  "href": "https://github.com/phtok/goeloggen/blob/main/docs/specs/campus-kartentool-pflichtenheft.md", "desc": "Veranstaltungs-/Lagekarten des Geländes, A4 druckfertig. Pflichtenheft fertig, Bau steht aus." },
+    { "slug": "brand-portrait",    "cat": "geparkt",     "status": "geparkt", "tag": "KI / Porträt",  "title": "Brand-Portrait-Generator", "href": "https://github.com/phtok/goeloggen/blob/main/reference/material/portrait_brand_generator_pflichtenheft.md", "desc": "KI-gestützte, markenkonforme Porträts. Eigener Schwerpunkt mit GPU-Infrastruktur." },
+    { "slug": "jahrgaenge",        "cat": "geparkt",     "status": "geparkt", "tag": "Sammlung",      "title": "Jahrgänge-Sammlung", "href": "https://github.com/phtok/goeloggen/blob/main/collections/jahrgaenge/README.md", "desc": "Produktionssammlung aus Jahrgängen (PDFs, Zeichnungen). Struktur vorbereitet." },
+    { "slug": "gtv-subs",          "cat": "geparkt",     "status": "geparkt", "tag": "Service",       "title": "GTV-Subs",           "href": "https://github.com/phtok/goeloggen/blob/main/services/gtv-subs/README.md", "desc": "Service-Skelett rund um Goetheanum TV. Platzhalter." }
+  ],
+  "docs": [
+    { "title": "Strategieblatt & Wesensanalyse", "tag": "Strategie",    "href": "https://github.com/phtok/goeloggen/blob/main/docs/strategie.md", "desc": "Strategieblatt nach Neumeier, Fundament, Architektur, Fahrplan." },
+    { "title": "Campus-Kartentool – Pflichtenheft", "tag": "Spec",      "href": "https://github.com/phtok/goeloggen/blob/main/docs/specs/campus-kartentool-pflichtenheft.md", "desc": "Vollständiges Pflichtenheft des Kartentools." },
+    { "title": "Brand-Portrait – Pflichtenheft", "tag": "Spec",        "href": "https://github.com/phtok/goeloggen/blob/main/reference/material/portrait_brand_generator_pflichtenheft.md", "desc": "Konzept des KI-Porträt-Generators (MVP)." },
+    { "title": "Brand-Portrait – Backlog", "tag": "Backlog",           "href": "https://github.com/phtok/goeloggen/blob/main/reference/material/portrait_brand_generator_backlog_mvp.md", "desc": "Epics, User-Stories, Sprint-Vorschlag." },
+    { "title": "Hausschrift v2.5 – Dokumentation", "tag": "Schrift",   "href": "https://github.com/phtok/goeloggen/blob/main/assets/fonts/goetheanum/README.md", "desc": "Schnitte, Variable Font, Neuerungen in v2.5." },
+    { "title": "Hausschrift – Audit", "tag": "Schrift",                "href": "https://github.com/phtok/goeloggen/blob/main/assets/fonts/goetheanum/AUDIT.md", "desc": "Reparatur- und Qualitätsaudit der Schrift." },
+    { "title": "Baustelle / Design-System", "tag": "Aufbau",          "href": "https://github.com/phtok/goeloggen/blob/main/start/README.md", "desc": "Wie das Design-System aufgebaut ist und wächst." }
   ]
 }


### PR DESCRIPTION
**Non-disruptiv** – die Wurzel `index.html` bleibt die Weiterleitung zum Logo-Generator, **keine** Font-Dateien berührt (kompatibel mit der laufenden Schrift-Arbeit auf main, inkl. ‹Deutlich› #103).

Schaltet die zwei gewünschten Dinge erreichbar:
- **Interner Hub live** (`start/`): neue Kategorie **Geparkte Projekte** + Abschnitt **Konzepte & Dokumente** → `…/goeloggen/start/`
- **Front-door-Vorschau** (`portal.html`): die minimale Startseite, ohne die Wurzel umzulegen → `…/goeloggen/portal.html`

Dazu: `tools.json` root-relativ (eine Quelle für beide Oberflächen), `docs/strategie.md` mit Entscheidungen + Funktions-Landkarte aus grafik.goetheanum.ch.

Die eigentliche Wurzel-Umlegung bleibt separat in #102 und wird weiter gehalten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018q4EPzYrZiKLAAKRuMf9UG

---
_Generated by [Claude Code](https://claude.ai/code/session_018q4EPzYrZiKLAAKRuMf9UG)_