### PR TITLE
Schrift-Vergleich: auf Begleit-Grotesken umgestellt (Atkinson, Inter, Source Sans 3, Plex)

### DIFF
--- a/schrift-vergleich.html
+++ b/schrift-vergleich.html
@@ -4,78 +4,106 @@
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Goetheanum Schriften – Begleit-Antiqua & Fallback im Vergleich</title>
-<meta name="description" content="Vergleich: OFL-Begleit-Antiquas (Source Serif 4, Newsreader, Spectral, Literata) und Nicht-Latein-Fallbacks (Titillium RUS, Cairo, Source Sans 3) zur Goetheanum-Schrift." />
+<title>Goetheanum Schriften – Begleit-Grotesk & Fallback im Vergleich</title>
+<meta name="description" content="Die Goetheanum-Display-Grotesk mit einer sehr lesbaren Text-Grotesk gemischt: Source Sans 3, IBM Plex Sans, Atkinson Hyperlegible, Inter – live im Kontext. Plus Nicht-Latein-Fallback." />
 <meta name="robots" content="noindex" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;1,8..60,400&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,600;1,6..72,400&family=Spectral:ital,wght@0,400;0,600;1,400&family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,600;1,7..72,400&family=Cairo:wght@400;700&family=Source+Sans+3:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,400;0,600;1,400&family=IBM+Plex+Sans:ital,wght@0,400;0,600;1,400&family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400&family=Inter:ital,wght@0,400;0,600;1,400&family=Cairo:wght@400;700&display=swap" rel="stylesheet">
 <style>
   @font-face{font-family:"G Klar";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Klar.woff2") format("woff2");font-display:swap}
+  @font-face{font-family:"G Deutlich";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Deutlich.woff2") format("woff2");font-display:swap}
   @font-face{font-family:"G Laut";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Laut.woff2") format("woff2");font-display:swap}
   @font-face{font-family:"Titillium RUS";src:url("assets/fonts/goetheanum/Fallback/TitilliumRUS-Regular.woff2") format("woff2");font-weight:400;font-display:swap;unicode-range:U+0400-04FF,U+0500-052F}
-  :root{--ink:#23272b;--muted:#737a80;--line:rgba(20,24,28,.10);--line-soft:rgba(20,24,28,.055);
-        --gold:#d7ab68;--gold-deep:#a07a33;--paper:#fff;--soft:#faf8f4;--maxw:980px}
+  :root{--ink:#23272b;--muted:#737a80;--line:rgba(20,24,28,.10);--line-soft:rgba(20,24,28,.06);
+        --gold:#d7ab68;--gold-deep:#a07a33;--paper:#fff;--soft:#faf8f4;--maxw:1040px;
+        --body:"Source Sans 3";--bsize:19px;--bweight:400;--measure:62ch}
   *{box-sizing:border-box;margin:0;padding:0}
   body{background:var(--paper);color:var(--ink);font-family:"G Klar","Helvetica Neue",Arial,sans-serif;line-height:1.5;font-size:16.5px;-webkit-font-smoothing:antialiased}
   .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
   a{color:var(--gold-deep)}
   header{position:sticky;top:0;z-index:30;background:rgba(255,255,255,.92);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
-  .bar{display:flex;align-items:center;justify-content:space-between;height:58px}
-  nav.top a{color:var(--muted);text-decoration:none;font-size:13.5px;margin-left:20px}
-  .hero{padding:48px 0 6px}
-  .kick{color:var(--gold-deep);font-size:14px;margin-bottom:12px}
-  h1{font-family:"G Klar";font-weight:400;font-size:clamp(30px,5vw,48px);line-height:1.1}
-  .lede{font-size:18px;color:var(--muted);max-width:60ch;margin-top:12px}
-  section{padding:34px 0;border-top:1px solid var(--line-soft)}
+  .bar{display:flex;align-items:center;justify-content:space-between;height:56px}
+  nav.top a{color:var(--muted);text-decoration:none;font-size:13.5px;margin-left:18px}
+  .hero{padding:42px 0 4px}
+  .kick{color:var(--gold-deep);font-size:14px;margin-bottom:10px}
+  h1{font-family:"G Klar";font-weight:400;font-size:clamp(28px,5vw,46px);line-height:1.1}
+  .lede{font-size:17px;color:var(--muted);max-width:64ch;margin-top:12px}
+  section{padding:30px 0;border-top:1px solid var(--line-soft)}
   .sec{color:var(--gold-deep);font-size:13px}
-  h2{font-family:"G Klar";font-weight:400;font-size:clamp(20px,3vw,28px);margin:4px 0 14px}
-  /* controls */
-  .ctrl{display:flex;gap:20px;flex-wrap:wrap;align-items:center;background:var(--soft);border:1px solid var(--line-soft);border-radius:12px;padding:14px 18px;margin-bottom:20px;position:sticky;top:58px;z-index:20}
-  .ctrl label{font-size:13px;color:var(--muted);display:flex;align-items:center;gap:10px}
-  .ctrl input[type=range]{accent-color:var(--gold-deep);width:160px}
+  h2{font-family:"G Klar";font-weight:400;font-size:clamp(20px,3vw,26px);margin:4px 0 14px}
+  .ctrl{display:flex;gap:14px 22px;flex-wrap:wrap;align-items:center;background:var(--soft);border:1px solid var(--line-soft);border-radius:12px;padding:14px 18px;margin-bottom:22px;position:sticky;top:56px;z-index:20}
+  .ctrl .grp{display:flex;gap:6px;flex-wrap:wrap}
+  .ctrl button{font:inherit;font-size:13px;color:var(--muted);background:#fff;border:1px solid var(--line);border-radius:20px;padding:5px 14px;cursor:pointer}
+  .ctrl button[aria-pressed=true]{color:var(--gold-deep);border-color:var(--gold);font-weight:600}
+  .ctrl label{font-size:13px;color:var(--muted);display:flex;align-items:center;gap:8px}
+  .ctrl input[type=range]{accent-color:var(--gold-deep);width:120px}
   .ctrl b{color:var(--ink);font-variant-numeric:tabular-nums}
-  /* serif card */
-  .card{border:1px solid var(--line-soft);border-radius:14px;padding:22px 24px;margin-bottom:18px;background:#fff}
-  .card .name{font-size:15px;color:var(--gold-deep);font-weight:600}
-  .card .desc{font-size:12.5px;color:#999;margin-bottom:14px}
-  .head{font-family:"G Klar";font-weight:400;line-height:1.1;margin-bottom:10px}
-  .body{margin-bottom:8px;text-wrap:pretty}
-  .ital{color:#555}
-  .s-sourceserif{font-family:"Source Serif 4",serif}
-  .s-newsreader{font-family:"Newsreader",serif}
-  .s-spectral{font-family:"Spectral",serif}
-  .s-literata{font-family:"Literata",serif}
-  /* script row */
-  .scriptrow{display:grid;grid-template-columns:120px 1fr;gap:8px 18px;align-items:baseline;padding:12px 0;border-bottom:1px solid var(--line-soft)}
+  .article{max-width:var(--measure);margin:0 auto}
+  .a-kick{font-family:"G Deutlich";font-size:15px;letter-spacing:.04em;color:var(--gold-deep);text-transform:uppercase;margin-bottom:10px}
+  .a-head{font-family:"G Klar";font-weight:400;font-size:calc(var(--bsize)*2.3);line-height:1.08;margin-bottom:6px;text-wrap:balance}
+  .a-sub{font-family:"G Deutlich";font-size:calc(var(--bsize)*1.15);line-height:1.25;color:#555;margin-bottom:20px}
+  .a-body{font-family:var(--body),sans-serif;font-size:var(--bsize);font-weight:var(--bweight);line-height:1.62;text-wrap:pretty}
+  .a-body p{margin-bottom:.9em}
+  .a-body em{font-style:italic}
+  .a-body .lead::first-letter{font-family:"G Klar";font-size:3.1em;line-height:.82;float:left;padding:6px 10px 0 0;color:var(--ink)}
+  .byline{font-family:var(--body),sans-serif;font-size:calc(var(--bsize)*.8);color:var(--muted);margin-top:18px;border-top:1px solid var(--line-soft);padding-top:10px}
+  .cards{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+  @media(max-width:680px){.cards{grid-template-columns:1fr}}
+  .card{border:1px solid var(--line-soft);border-radius:12px;padding:16px 18px}
+  .card .nm{font-size:14px;color:var(--gold-deep);font-weight:600;margin-bottom:8px}
+  .card .smp{font-size:17px;line-height:1.5}
+  .scriptrow{display:grid;grid-template-columns:150px 1fr;gap:6px 18px;align-items:baseline;padding:10px 0;border-bottom:1px solid var(--line-soft)}
   .scriptrow .lab{font-size:12px;color:var(--gold-deep)}
-  .scriptrow .smp{font-size:30px;line-height:1.25}
+  .scriptrow .smp{font-size:26px}
   .lat{font-family:"G Klar"} .cyr{font-family:"Titillium RUS"} .grk{font-family:"Source Sans 3"} .arb{font-family:"Cairo"}
-  footer{border-top:1px solid var(--line);padding:28px 0 56px;color:var(--muted);font-size:12.5px}
+  footer{border-top:1px solid var(--line);padding:26px 0 54px;color:var(--muted);font-size:12.5px}
 </style>
 </head>
 <body>
 <header><div class="wrap bar">
   <strong style="font-family:'G Klar';font-weight:400">Goetheanum · Schrift-Vergleich</strong>
-  <nav class="top"><a href="schriften.html">Schriften</a><a href="vorschau.html">Neu</a><a href="#antiqua">Antiqua</a><a href="#fallback">Fallback</a></nav>
+  <nav class="top"><a href="schriften.html">Schriften</a><a href="vorschau.html">Neu</a><a href="#mix">Mischung</a><a href="#cards">Kandidaten</a><a href="#fallback">Fallback</a></nav>
 </div></header>
 
 <main><div class="wrap">
   <div class="hero">
     <div class="kick">Intern · noindex</div>
-    <h1>Begleit-Antiqua &amp; Nicht-Latein-Fallback</h1>
-    <p class="lede">Die Goetheanum-Grotesk trägt Titel, Lede, Tabelle. Für lange Lesestrecken eine Antiqua mit echter Kursive – und für andere Schriftsysteme einen stimmigen Fallback. Alle Kandidaten sind <b>SIL OFL</b> (gleiche Rechtslage), nah an der Titillium-Basis.</p>
+    <h1>Display-Grotesk + Lese-Grotesk</h1>
+    <p class="lede">Keine Serife: Die Goetheanum-Grotesk trägt Titel und Auszeichnung, eine <b>sehr lesbare Text-Grotesk</b> den Mengentext. goetheanum.ch macht das längst – <b>Titillium</b> (Display) plus <b>Source Sans</b> (Text). Hier vier OFL-Kandidaten live im Kontext.</p>
   </div>
 
-  <section id="antiqua">
-    <span class="sec">Begleit-Antiqua · OFL · echte Kursive</span>
-    <h2>Vier Antiquas im Lauftext</h2>
+  <section id="mix">
+    <span class="sec">Die Mischung im Kontext · Titel = Goetheanum, Text = Grotesk</span>
+    <h2>Wähle die Lese-Grotesk</h2>
     <div class="ctrl">
-      <label>Grad <input type="range" id="sz" min="13" max="26" value="18" step="0.5"> <b id="szv">18</b> px</label>
-      <label>Gewicht <input type="range" id="wg" min="400" max="600" value="430" step="10"> <b id="wgv">430</b></label>
+      <div class="grp" id="fontpick">
+        <button data-f="Source Sans 3" aria-pressed="true">Source Sans 3</button>
+        <button data-f="IBM Plex Sans">IBM Plex Sans</button>
+        <button data-f="Atkinson Hyperlegible">Atkinson Hyperlegible</button>
+        <button data-f="Inter">Inter</button>
+      </div>
+      <label>Grad <input type="range" id="sz" min="15" max="26" value="19" step="0.5"> <b id="szv">19</b></label>
+      <label>Gewicht <input type="range" id="wg" min="400" max="600" value="400" step="10"> <b id="wgv">400</b></label>
       <label><input type="checkbox" id="dark"> dunkler Grund</label>
     </div>
-    <div id="cards"></div>
+    <article class="article">
+      <div class="a-kick">Wochenschrift · Dornach</div>
+      <div class="a-head">Die Bühne als Erkenntnisraum</div>
+      <div class="a-sub">Wie das Goetheanum seit 1913 Kunst, Forschung und Hochschule unter einem Dach verbindet – und was das für die Gegenwart bedeutet.</div>
+      <div class="a-body">
+        <p class="lead">Das Goetheanum in Dornach ist kein Museum, sondern eine Werkstatt. Wer den großen Saal betritt, steht in einem Raum, der für die Bewegung gebaut wurde – für Eurythmie, Schauspiel und die Sprache der Formen. Die <em>Wochenschrift</em> begleitet dieses Werk seit Jahrzehnten: genau, mit Haltung, ohne Behübschung.</p>
+        <p>Zahlen ordnen den Betrieb. Im Jahr 1487 fanden Plätze ihre Besucher, 23 Veranstaltungen standen allein im Oktober im Kalender, und um 11.10 Uhr öffnete sich der Vorhang. Die Tabellen der Verwaltung verlangen <em>dicktengleiche</em> Ziffern – im Fließtext dagegen laufen sie proportional und ruhig.</p>
+        <p>Anthroposophie versteht sich als Erkenntnisweg, nicht als Bekenntnis. Genau deshalb braucht ihre Schrift zweierlei: eine Stimme, die ruft – und eine, die <em>liest</em>. Die erste ist die Hausgrotesk. Die zweite suchen wir hier.</p>
+      </div>
+      <div class="byline">Redaktion · 47° 32′ nördlicher Breite · Auflage 1487</div>
+    </article>
+  </section>
+
+  <section id="cards">
+    <span class="sec">Vier Kandidaten · alle SIL OFL · echte Kursive</span>
+    <h2>Schnellvergleich</h2>
+    <div class="cards" id="quickcards"></div>
   </section>
 
   <section id="fallback">
@@ -85,7 +113,7 @@
     <div class="scriptrow"><div class="lab">Kyrillisch · Titillium&nbsp;RUS</div><div class="smp cyr">Гётеанум Дорнах — Швейцария · 1913</div></div>
     <div class="scriptrow"><div class="lab">Griechisch · Source&nbsp;Sans&nbsp;3</div><div class="smp grk">Γκαίτεανουμ Ντόρναχ — Ελβετία · 1913</div></div>
     <div class="scriptrow"><div class="lab">Arabisch · Cairo</div><div class="smp arb" dir="rtl">غوتيانوم دورناخ — سويسرا · ١٩١٣</div></div>
-    <p style="font-size:13px;color:var(--muted);margin-top:14px;max-width:62ch">Kyrillisch (Titillium&nbsp;RUS) und Arabisch (Cairo) sind direkte Titillium-Erweiterungen; Griechisch über die humanistische Source&nbsp;Sans&nbsp;3. Einbindung als CSS-Stack: <code>"Goetheanum", "Titillium RUS", "Cairo", "Source Sans 3"</code>.</p>
+    <p style="font-size:13px;color:var(--muted);margin-top:14px;max-width:64ch">Wählst du <b>IBM Plex Sans</b> als Lese-Grotesk, deckt die Plex-Superfamilie zugleich Latein/Griechisch/Kyrillisch <i>und</i> Arabisch – eine Schrift für Mengentext und alle Fallbacks.</p>
   </section>
 </div></main>
 
@@ -93,36 +121,35 @@
 
 <script>
 (function(){
-  var serifs=[
-    {cls:"s-sourceserif",name:"Source Serif 4",desc:"neutral · koheränt zur vorhandenen Source Sans · variabel"},
-    {cls:"s-newsreader",name:"Newsreader",desc:"für Wochen-/Magazinsatz gezeichnet · optische Grade · variabel"},
-    {cls:"s-spectral",name:"Spectral",desc:"ökonomisch · bildschirmtauglich (Google-Docs-Serife)"},
-    {cls:"s-literata",name:"Literata",desc:"warme Buchserife · optische Grade · variabel"}
-  ];
-  var body="Das Goetheanum in Dornach versammelt seit 1913 Bühne, Forschung und Hochschule unter einem Dach. Die Wochenschrift berichtet wöchentlich – genau, mit Haltung. Auflage 1487 · Seite 23 · 11.10 Uhr.";
-  var ital="Anthroposophie als Erkenntnisweg – ein Versuch in geprüfter Klarheit.";
-  var host=document.getElementById("cards");
-  serifs.forEach(function(s){
-    var c=document.createElement("div"); c.className="card";
-    c.innerHTML='<div class="name">'+s.name+'</div><div class="desc">'+s.desc+'</div>'+
-      '<div class="head">Wochenschrift am Goetheanum</div>'+
-      '<div class="body '+s.cls+'">'+body+'</div>'+
-      '<div class="ital '+s.cls+'" style="font-style:italic">'+ital+'</div>';
-    host.appendChild(c);
+  var pick=document.getElementById("fontpick"), root=document.documentElement;
+  pick.addEventListener("click",function(e){
+    var b=e.target.closest("button"); if(!b) return;
+    pick.querySelectorAll("button").forEach(function(x){x.setAttribute("aria-pressed","false")});
+    b.setAttribute("aria-pressed","true");
+    root.style.setProperty("--body",'"'+b.dataset.f+'"');
   });
   var sz=document.getElementById("sz"),wg=document.getElementById("wg"),
       szv=document.getElementById("szv"),wgv=document.getElementById("wgv"),dark=document.getElementById("dark");
   function upd(){
     szv.textContent=sz.value; wgv.textContent=wg.value;
-    document.querySelectorAll(".card .body,.card .ital").forEach(function(e){
-      e.style.fontSize=sz.value+"px"; e.style.fontWeight=wg.value;
-    });
-    document.querySelectorAll(".card .head").forEach(function(e){ e.style.fontSize=(sz.value*1.7)+"px"; });
+    root.style.setProperty("--bsize",sz.value+"px");
+    root.style.setProperty("--bweight",wg.value);
     document.body.style.background=dark.checked?"#23272b":"#fff";
     document.body.style.color=dark.checked?"#f3f0ea":"#23272b";
-    document.querySelectorAll(".card").forEach(function(e){ e.style.background=dark.checked?"#2c3035":"#fff"; e.style.borderColor=dark.checked?"#3a3f45":""; });
   }
   [sz,wg].forEach(function(e){e.addEventListener("input",upd)}); dark.addEventListener("change",upd); upd();
+  var fonts=[["Source Sans 3","schon euer Fallback (Griech./Kyrill.) · Kontinuität zu goetheanum.ch"],
+             ["IBM Plex Sans","deckt auch Arabisch · vereinheitlicht die Fallbacks"],
+             ["Atkinson Hyperlegible","auf maximale Lesbarkeit/Barrierefreiheit gezeichnet"],
+             ["Inter","Bildschirm-Lesegrotesk · sehr neutral"]];
+  var qc=document.getElementById("quickcards");
+  fonts.forEach(function(f){
+    var d=document.createElement("div"); d.className="card";
+    d.innerHTML='<div class="nm">'+f[0]+'</div>'+
+      '<div class="smp" style="font-family:\''+f[0]+'\'">Lebendige Formen wachsen aus dem Schweigen. <em style="font-style:italic">Ein Versuch in Klarheit</em> – 1913 Plätze, 47° 32′.</div>'+
+      '<div style="font-size:11.5px;color:#999;margin-top:8px">'+f[1]+'</div>';
+    qc.appendChild(d);
+  });
 })();
 </script>
 </body>


### PR DESCRIPTION
## Vergleichsseite auf Begleit-**Grotesken** umgestellt

Du hast recht — keine Serife. Die Seite zeigt jetzt die **Mischung im Kontext**: Goetheanum-Display-Grotesk (Titel) + sehr lesbare Text-Grotesk (Mengentext), als Artikel-Mock mit Kicker/Titel/‹Deutlich›-Subhead/Fließtext. Die Lese-Grotesk ist **live umschaltbar**: Source Sans 3, IBM Plex Sans, **Atkinson Hyperlegible**, **Inter** — plus Grad-/Gewichtsregler und dunkler Grund.

**Hintergrund:** goetheanum.ch paart bereits **Titillium** (Display) + **Source Sans Pro** (Text) — die Grotesk-Mischung ist dort gelebte Praxis (beide Font-URLs live bestätigt). Der Fallback-Block bleibt; Hinweis, dass IBM Plex zugleich alle Schriftsysteme (auch Arabisch) abdecken könnte.

Live nach Merge: **https://phtok.github.io/goeloggen/schrift-vergleich.html**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aSpY9SVm7s2z5dMoG4Cy4

---
_Generated by [Claude Code](https://claude.ai/code/session_017aSpY9SVm7s2z5dMoG4Cy4)_