### PR TITLE
Custom-Domain werkzeuge.goetheanum.ch vorbereiten (erst nach DNS mergen)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -51,6 +51,10 @@ jobs:
           # Manifest der Werkzeuge (treibt die Uebersicht).
           if [ -f tools.json ]; then cp tools.json _site/tools.json; fi
 
+          # Custom-Domain (werkzeuge.goetheanum.ch). Muss im veroeffentlichten
+          # Bundle-Root liegen, sonst verwirft Pages die Domain bei jedem Deploy.
+          if [ -f CNAME ]; then cp CNAME _site/CNAME; fi
+
           touch _site/.nojekyll
 
       - name: Setup Pages

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+werkzeuge.goetheanum.ch


### PR DESCRIPTION
**Bewusst als Draft / NICHT mergen, bevor die DNS-Einträge stehen.** Sobald `CNAME` auf `main` liegt, schaltet GitHub Pages auf die Custom-Domain um — ohne DNS wäre die Seite kurz nicht erreichbar.

Inhalt:
- `CNAME` = `werkzeuge.goetheanum.ch` (Primäradresse)
- Deploy-Workflow kopiert `CNAME` ins veröffentlichte Bundle (sonst verwirft Pages die Domain bei jedem Deploy)

**Reihenfolge der Inbetriebnahme:**
1. Verwalter setzt die DNS-Einträge (siehe Chat-Übergabeblatt): `werkzeuge` **und** `tools` je als CNAME → `phtok.github.io.`
2. DNS-Propagation abwarten (`dig werkzeuge.goetheanum.ch +short` zeigt `phtok.github.io`).
3. Dieses PR mergen → Pages übernimmt die Domain.
4. In Repo-Settings → Pages „Enforce HTTPS" aktivieren, sobald das Zertifikat ausgestellt ist.

`tools.goetheanum.ch` zeigt ebenfalls auf `phtok.github.io`; da im `CNAME` `werkzeuge` steht, leitet GitHub `tools.` automatisch per 301 dorthin um.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018q4EPzYrZiKLAAKRuMf9UG

---
_Generated by [Claude Code](https://claude.ai/code/session_018q4EPzYrZiKLAAKRuMf9UG)_