### PR TITLE
Sprechende Abschnitts-Pfade (saubere URLs unter einer Domain)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -51,6 +51,10 @@ jobs:
           # Manifest der Werkzeuge (treibt die Uebersicht).
           if [ -f tools.json ]; then cp tools.json _site/tools.json; fi
 
+          # Sprechende Abschnitts-Pfade (saubere URLs -> Weiterleitung auf die
+          # Zielseite). Zentral gepflegt in sektionen.json.
+          if [ -f sektionen.json ]; then python3 tools/build_sections.py _site; fi
+
           touch _site/.nojekyll
 
       - name: Setup Pages

--- a/sektionen.json
+++ b/sektionen.json
@@ -1,0 +1,13 @@
+{
+  "$beschreibung": "Sprechende Abschnitts-Pfade (saubere URLs). Schlüssel = Pfad unter der Wurzel (z. B. /schriften/), Wert = Zielseite. Der Deploy erzeugt daraus je eine Weiterleitung (tools/build_sections.py). Neue Sektion: hier eine Zeile ergänzen.",
+  "schriften": "schriften.html",
+  "typografie": "typografie.html",
+  "logo": "logo-generator.html",
+  "signatur": "signatur-generator.html",
+  "visitenkarten": "visitenkarten-generator.html",
+  "karten": "karten-generator.html",
+  "cover": "cover-generator.html",
+  "briefe": "briefschaften.html",
+  "statistik": "statistik.html",
+  "hub": "start/"
+}

--- a/tools/build_sections.py
+++ b/tools/build_sections.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Erzeugt sprechende Abschnitts-Pfade als Weiterleitungs-Stubs.
+
+Liest sektionen.json { "<sauberer-pfad>": "<zielseite>" } und schreibt je
+<out>/<sauberer-pfad>/index.html, das RELATIV auf ../<zielseite> weiterleitet –
+so funktioniert dieselbe Datei unter / (Custom-Domain) wie unter /goeloggen/
+(github.io). Schlüssel mit $ (Kommentare) werden übersprungen.
+
+Aufruf:  python3 tools/build_sections.py [ZIELORDNER]   (Default: _site)
+"""
+import json, os, sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+OUT = sys.argv[1] if len(sys.argv) > 1 else os.path.join(ROOT, "_site")
+MAP = json.load(open(os.path.join(ROOT, "sektionen.json"), encoding="utf-8"))
+
+TEMPLATE = """<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Weiterleitung … {label}</title>
+  <link rel="canonical" href="../{target}" />
+  <meta http-equiv="refresh" content="0; url=../{target}" />
+  <script>location.replace("../{target}" + location.search + location.hash)</script>
+  <style>
+    body {{ margin:0; min-height:100vh; display:grid; place-items:center;
+      background:#36424f; color:#dbe0e4;
+      font:400 16px/1.4 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }}
+    a {{ color:#ebb565; }}
+  </style>
+</head>
+<body>
+  <p>Weiter zu {label} … <a href="../{target}">hier klicken</a>.</p>
+</body>
+</html>
+"""
+
+def main():
+    n = 0
+    for clean, target in MAP.items():
+        if clean.startswith("$"):
+            continue
+        d = os.path.join(OUT, clean)
+        os.makedirs(d, exist_ok=True)
+        label = clean.replace("-", " ")
+        with open(os.path.join(d, "index.html"), "w", encoding="utf-8") as f:
+            f.write(TEMPLATE.format(label=label, target=target))
+        n += 1
+    print(f"build_sections: {n} Abschnitts-Pfade nach {OUT} geschrieben.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Variante **B** (eine Subdomain, Bereiche als Pfade): sprechende, teilbare URLs, die relativ auf die jeweilige Zielseite leiten — funktioniert unter `/goeloggen/` **und** später unter der Custom-Domain.

| Pfad | → Ziel |
|---|---|
| `/schriften/` `/typografie/` | Schrift-Seiten |
| `/logo/` `/signatur/` `/visitenkarten/` `/karten/` `/cover/` `/briefe/` | Generatoren |
| `/statistik/` | Statistik |
| `/hub/` | interner Hub (`start/`) |

- **`sektionen.json`** — zentrale, editierbare Zuordnung *sauberer Pfad → Zielseite*. Neue Sektion = eine Zeile.
- **`tools/build_sections.py`** — erzeugt je Pfad einen Weiterleitungs-Stub.
- **`deploy-pages.yml`** — generiert die Pfade beim Deploy.

**Additiv & non-disruptiv:** keine bestehende Seite, kein Root, keine Font-Datei berührt. Lokal voll durchgebaut, alle Ziele lösen auf. Das Domain-Scharfschalten (CNAME, #106) bleibt separat und wartet auf DNS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018q4EPzYrZiKLAAKRuMf9UG

---
_Generated by [Claude Code](https://claude.ai/code/session_018q4EPzYrZiKLAAKRuMf9UG)_