### PR TITLE
G25-Werkzeug: Ziffern-Sets umschalten (Web-CSS + InDesign/Office-Rezept)

### DIFF
--- a/assets/typografie/ziffern-werkzeug.md
+++ b/assets/typografie/ziffern-werkzeug.md
@@ -1,0 +1,49 @@
+# Ziffern-Sets schnell umschalten (Regel G25)
+
+Grundton der Goetheanum Schrift v2.5 ist **proportional** (ruhig im Fließtext).
+Wo Zahlen **fluchten** müssen (Tabellen, Listen, Beträge), gilt **zwingend
+tabellarisch** (`tnum`). Dieses Werkzeug macht das Umschalten schnell und – wo
+möglich – automatisch.
+
+| Einsatz | Set | OpenType |
+|---|---|---|
+| Fließtext (Standard) | proportional, Versalhöhe | `pnum` `lnum` |
+| Tabelle, Liste, Betrag | **dicktengleich** | `tnum` `lnum` |
+| Mengentext mit vielen Zahlen | Kurzziffern (x-Höhe) | `onum` |
+| Codes, Kennungen | schlummernde 0 | `zero` |
+
+## Web — automatisch
+`assets/typografie/ziffern.css` einbinden. Dann:
+- **`<table>` schaltet automatisch auf `tnum`** – kein Zutun nötig.
+- Klassen: `.tabellenziffern`, `.zahl` (rechtsbündig), `.kurzziffern`,
+  `.schlummernde-null`, `.proportional`. Komponierbar.
+
+```html
+<link rel="stylesheet" href="assets/typografie/ziffern.css">
+<td class="zahl">1 487</td>            <!-- fluchtet automatisch -->
+<span class="kurzziffern">im Jahr 1923</span>
+<span class="schlummernde-null">Kennung 0761</span>
+```
+
+## InDesign — Zeichenstile + GREP (einmal anlegen, immer schnell)
+Drei **Zeichenformate** anlegen (Fenster → Stile → Zeichenformate → OpenType):
+- **Tabellenziffern** → OpenType → Zahlenformat: *Tabellarisch, Versalziffern*
+- **Kurzziffern** → OpenType → Zahlenformat: *Proportional, Mediäval*
+- **Durchgestrichene Null** → OpenType → *Durchgestrichene Null* aktivieren
+
+**Automatisch in Tabellen:** Im Absatzformat der Tabellenzellen einen
+**GREP-Stil** ergänzen: *Zeichenformat* „Tabellenziffern" auf den Ausdruck
+`\d` anwenden → jede Ziffer in der Tabelle wird ohne Nachdenken dicktengleich.
+(Absatzformat → GREP-Stil → Neuer GREP-Stil.)
+
+Schnelltaste: den drei Zeichenformaten je einen Shortcut zuweisen
+(Zeichenformat-Optionen → Tastaturbefehl).
+
+## Office (Word/Pages, wo OpenType verfügbar)
+Über die Schrift-/Zeichendialoge die OpenType-Zahlenformate wählen
+(*Tabellarisch* für Tabellen, *Mediäval* für Kurzziffern, *Durchgestrichene
+Null*). Wo der Dialog fehlt, bleibt der proportionale Grundton.
+
+## Regelbezug
+**G25** — Grundton proportional; in Tabellen/Listen/Beträgen **zwingend** `tnum`,
+rechtsbündig, exakt untereinander, nie mit Leerzeichen ausgerichtet.

--- a/assets/typografie/ziffern.css
+++ b/assets/typografie/ziffern.css
@@ -1,0 +1,43 @@
+/* Goetheanum · Ziffern-Sets umschalten je Einsatz — Werkzeug zu Regel G25.
+ * ----------------------------------------------------------------------------
+ * Grundton der Schrift v2.5 ist PROPORTIONAL (ruhig im Fliesstext). Diese
+ * Utility schaltet pro Kontext um — Tabellen automatisch dicktengleich, dazu
+ * Klassen für Kurzziffern und die schlummernde 0. Einbinden:
+ *     <link rel="stylesheet" href="assets/typografie/ziffern.css">
+ *
+ * Steuerung über font-variant-numeric (komponierbar, modern unterstützt) mit
+ * font-feature-settings als Rückfall für ältere Engines.
+ */
+
+/* — Tabellen automatisch tabellarisch (G25: Zahlen müssen fluchten) —
+ * Greift überall, wo Zahlen untereinanderstehen, ohne dass man dran denkt. */
+table,
+.tabellenziffern {
+  font-variant-numeric: tabular-nums lining-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+}
+
+/* Zahlenzellen rechtsbündig (Beträge, Spalten) — Klasse an td/th setzen. */
+.zahl {
+  text-align: right;
+  font-variant-numeric: tabular-nums lining-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+}
+
+/* — Explizite Schalter fürs Laufende — */
+.proportional {           /* = Grundton; nur falls in tabellarischem Umfeld nötig */
+  font-variant-numeric: proportional-nums lining-nums;
+  font-feature-settings: "pnum" 1, "lnum" 1;
+}
+.kurzziffern {            /* Kurz-/Mediävalziffern auf x-Höhe, Mengentext mit vielen Zahlen */
+  font-variant-numeric: oldstyle-nums;
+  font-feature-settings: "onum" 1;
+}
+.schlummernde-null {      /* geschrägte 0 gegen 0/O-Verwechslung (Codes, Kennungen) */
+  font-variant-numeric: slashed-zero;
+  font-feature-settings: "zero" 1;
+}
+
+/* Komponierbar: tabellarische Kurzziffern, durchgestrichene 0 in Tabellen … */
+.tabellenziffern.kurzziffern { font-variant-numeric: tabular-nums oldstyle-nums; }
+.tabellenziffern.schlummernde-null { font-variant-numeric: tabular-nums lining-nums slashed-zero; }

--- a/typografie.html
+++ b/typografie.html
@@ -7,6 +7,7 @@
 <title>Goetheanum Typografie</title>
 <meta name="description" content="Goetheanum Typografie – wenige Mittel, präzise gesetzt. Hausregeln als Handbuch und maschinenlesbares System (DTCG-Tokens + prüfbare Regeln)." />
 <meta name="robots" content="noindex" />
+<link rel="stylesheet" href="assets/typografie/ziffern.css" />
 <style>
   @font-face{font-family:"G Leise";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Leise.woff2") format("woff2");font-display:swap}
   @font-face{font-family:"G Klar";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Klar.woff2") format("woff2");font-display:swap}


### PR DESCRIPTION
## G25-Werkzeug: Ziffern-Sets schnell umschalten

Antwort auf deinen Wunsch nach „Tools zum automatischen und schnellen Umschalten der Zahlensets je nach Einsatz".

- **`assets/typografie/ziffern.css`** — `<table>` schaltet **automatisch** auf `tnum` (Zahlen fluchten ohne Zutun). Dazu komponierbare Klassen `.tabellenziffern`, `.zahl` (rechtsbündig), `.kurzziffern`, `.schlummernde-null`, `.proportional` (über `font-variant-numeric`, mit `font-feature-settings`-Rückfall).
- **`assets/typografie/ziffern-werkzeug.md`** — Rezept für **Web**, **InDesign** (drei Zeichenformate + **GREP-Stil**, der Tabellenziffern automatisch dicktengleich macht, plus Shortcuts) und **Office**.
- **`typografie.html`** bindet die Utility ein — G25 lebt dort, das Tool greift jetzt live.

Regelbezug **G25**: Grundton proportional; in Tabellen/Listen/Beträgen zwingend `tnum`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aSpY9SVm7s2z5dMoG4Cy4

---
_Generated by [Claude Code](https://claude.ai/code/session_017aSpY9SVm7s2z5dMoG4Cy4)_