### PR TITLE
Design-System: lebende Schauseite, Starter und Typo-Check als Bau-Workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,26 @@ Die v2.5-Schrift hat Funktionen erhalten, die ältere Regeln (noch) anders
 beschreiben. Solche Widersprüche **melden und vom Auftraggeber entscheiden
 lassen** — das Regelwerk **nicht** eigenmächtig umschreiben.
 
+## Bauen neuer Seiten und Werkzeuge — vom Fundament aus, nicht freihändig
+Konformität entsteht durch Konstruktion, nicht durch Nachkontrolle. Darum gilt
+für **jede** neue HTML-Seite oder jedes neue Werkzeug:
+
+1. **Vom Starter ausgehen:** `design-system/starter.html` kopieren — nicht bei
+   null beginnen. Das Schaufenster `design-system/` zeigt, was bereitsteht.
+2. **Einbinden statt kopieren:** `design-system/tokens.css` und
+   `design-system/base.css` per `<link>` einbinden. Tokens nutzen
+   (`var(--gold)`, `var(--s6)`, `var(--w-deutlich)` …), **keine** eigenen Farb-,
+   Schnitt- oder Abstandswerte erfinden. (Bestehende Apps mit kopiertem Block
+   werden schrittweise auf diese Schicht gehoben — neue Seiten starten richtig.)
+3. **Registrieren:** einen Eintrag in `tools.json` ergänzen (erscheint im Hub).
+4. **Hook aktiv halten:** `git config core.hooksPath tools/hooks` — `tools/typo-check.py`
+   prüft die geänderten HTML-Texte beim Commit und blockiert bei Schwere ‹fehler›.
+   Vor dem Commit gilt weiterhin: betroffene Regel-IDs nennen.
+
+Die eingebauten Defaults in `base.css` setzen die Hausregeln bereits um (Trennung,
+‹…› über `<q>`, tabellarische Ziffern, Betonung = Laut, Leise statt Kursive). Für
+Falsches (Unterstreichen, Versal-Hervorhebung, Sperren) gibt es **kein** Utility.
+
 ## Schnitt-System (Stand v2.5)
 - Installierbare statische Schnitte: **Leise (265) · Klar (440) · Deutlich
   (580) · Laut (680)**. Deutlich = Titel; Laut = Inline-/Office-Fettung (⌘B).

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -1,0 +1,77 @@
+# Goetheanum Design-System
+
+Das gemeinsame Fundament der Hausgrafik – Farben, Schrift, Typografie-Regeln und
+Komponenten an einem Ort, aus **einer Quelle** gerendert. Gebaut, damit beim
+Erstellen neuer Werkzeuge und Seiten **alles parat steht** und **nichts hinterher
+geprüft** werden muss.
+
+Schauseite (lebend, rendert aus den Tokens): [`index.html`](index.html).
+
+## Dateien
+
+| Datei | Rolle |
+|---|---|
+| `tokens.css` | Farben, Schnitte, Abstände, Radien und der Webfont als CSS-Custom-Properties. Quelle der Wahrheit für die Anzeige. |
+| `tokens.json` | Dieselben Werte maschinenlesbar (DTCG). Wird vom Drift-Wächter gegen `tokens.css` geprüft. |
+| `base.css` | Basis-Komponenten (Kopf, Fuss, Karten, Knöpfe, Felder) und die Typo-Regeln als Voreinstellung. Setzt `tokens.css` voraus. |
+| `index.html` | Die Schauseite – Schaufenster und Werkbank zugleich. |
+| `starter.html` | Leeres Werkzeug mit allem Verdrahteten. Startpunkt für jede neue Seite. |
+
+Verwandte Quellen ausserhalb dieses Ordners: die Typo-Regeln liegen in
+`assets/typografie/goetheanum-typo-tokens.json` (`$regeln`) und ausführbar in
+`assets/typografie/typo-regeln.yaml`. Der Check dazu ist `tools/typo-check.py`.
+
+## Bau-Workflow: ein neues Werkzeug in vier Schritten
+
+1. **Starter kopieren** – `starter.html` an den Zielort kopieren (etwa
+   `mein-werkzeug.html` oder `apps/mein-werkzeug/index.html`).
+2. **Mitte füllen** – nur die mit «DEINE MITTE» markierte Stelle setzen. Auf die
+   Tokens zugreifen (`var(--gold)`, `var(--s6)`), keine neuen Werte erfinden.
+3. **Eintragen** – eine Zeile in `tools.json` ergänzen; das Werkzeug erscheint
+   automatisch im Hub unter `start/`.
+4. **Committen** – der Typo-Hook läuft und lässt nur Konformes durch.
+
+## Warum nichts hinterher geprüft werden muss
+
+Konformität entsteht durch Konstruktion, nicht durch Kontrolle – in vier
+Stufen, von der stärksten zur letzten Absicherung:
+
+1. **Richtig durch Identität.** Eine neue Seite **bindet** `tokens.css` und
+   `base.css` **ein** statt sie zu kopieren. Farbe, Schnitt, Gewicht und Abstand
+   sind dieselbe Datei für alle – sie können gar nicht abweichen.
+2. **Richtig durch Voreinstellung.** `base.css` stellt das Korrekte bereits ein:
+   Silbentrennung und schöner Umbruch, Anführung ‹…› über `<q>` (G16),
+   tabellarische Ziffern in Tabellen (G25), Betonung mit Laut, Leise als
+   aufrechter Gegenton statt Kursive (G02/G05). Wer nichts tut, tut das Richtige.
+3. **Falsch durch Weglassen.** Für Unterstreichen, Versal-Hervorhebung oder
+   Sperren als Auszeichnung gibt es **kein** Utility (G03/G05/G23).
+4. **Den Rest fängt der Automat.** `tools/typo-check.py` führt
+   `typo-regeln.yaml` auf den geänderten Texten aus und meldet Verstösse; bei
+   Schwere ‹fehler› blockiert der Commit. Der Mensch sucht nie von Auge.
+
+## Den Typo-Hook aktivieren
+
+Einmalig je Arbeitskopie:
+
+```sh
+git config core.hooksPath tools/hooks
+```
+
+Danach prüft jeder Commit die vorgemerkten HTML-Texte (die publizierte Fläche).
+Interne Doku-Markdown bleibt aussen vor, lässt sich aber gezielt prüfen. Manuell:
+
+```sh
+tools/typo-check.py            # vorgemerkte Dateien
+tools/typo-check.py --all      # vollständiges Audit
+tools/typo-check.py datei …    # bestimmte Dateien
+```
+
+Eine einzelne Zeile lässt sich mit dem Marker `typo-ok` ausnehmen; ein ganzer
+Commit im Notfall mit `git commit --no-verify`.
+
+## Stand digital / analog
+
+Das System trägt heute den Bildschirm vollständig. Für den Druck stehen die
+Gegenstücke noch aus – CMYK- und Sonderfarben, Maße in mm, Beschnitt und
+Schnittmarken, PDF/X-Ausgabe. Diese Achse ist ein eigener nächster Schritt
+(siehe Export-Schicht im Strategieblatt, `docs/strategie.md`).

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -71,3 +71,43 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 .ds-footer .frow{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap}
 .ds-footer .frow strong{color:var(--ink);font-weight:var(--w-text)}
 .ds-footer .frow a:hover{color:var(--gold-deep)}
+
+/* =============================================================================
+   Eingebaute Typografie – Hausregeln als Voreinstellung, nicht als Nachkontrolle
+   -----------------------------------------------------------------------------
+   Wer nichts tut, tut das Richtige (Mechanismus 2). Fürs Falsche gibt es kein
+   Werkzeug (Mechanismus 3). Quelle: assets/typografie/goetheanum-typo-tokens.json.
+   ============================================================================= */
+
+/* Lesefluss: Trennung, schöner Umbruch, keine verwaisten Zeilen (G12/G24/G28).
+   Greift, weil die Seite lang="de-CH" trägt (siehe starter.html). */
+body{hyphens:auto;-webkit-hyphens:auto;text-wrap:pretty;orphans:2;widows:2}
+
+/* Betonung hat genau zwei Ämter: Laut betont, Leise ist der stille Gegenton
+   (G02/G05/S01). Keine echte Kursive – Leise steht aufrecht. Unterstreichen und
+   Versalien als Hervorhebung gibt es bewusst NICHT als Utility (G05). */
+strong,b{font-weight:var(--w-strong)}
+em,i{font-style:normal;font-weight:var(--w-leise)}
+
+/* Hausanführung: ‹…› automatisch über <q> (G16) – einfache Guillemets nach aussen. */
+q{quotes:'\2039' '\203A' '\2039' '\203A'}
+
+/* Ziffern in Tabellen: Versalziffern, dicktengleich, exakt untereinander (G25).
+   Nie mit Leerzeichen ausgerichtet – das erledigt tabular-nums. */
+table{border-collapse:collapse;font-variant-numeric:tabular-nums lining-nums}
+th,td{text-align:left;padding:var(--s2) var(--s3);border-bottom:1px solid var(--line-soft)}
+th{font-weight:var(--w-strong);color:var(--ink)}
+td.num,th.num,.num{font-variant-numeric:tabular-nums lining-nums;text-align:right;font-feature-settings:"tnum","lnum"}
+
+/* Schnitt-Utilities – die drei Stimmen der Familie, abrufbar ohne Nachdenken. */
+.leise{font-weight:var(--w-leise)}
+.klar{font-weight:var(--w-text)}
+.deutlich{font-weight:var(--w-deutlich)}
+.laut{font-weight:var(--w-strong)}
+
+/* Korrekter Kicker: getönt und leicht getrackt – aber NORMAL, nicht versal (G05). */
+.kicker{display:inline-block;color:var(--gold-deep);font-size:12.5px;letter-spacing:.04em;font-weight:var(--w-leise);margin-bottom:var(--s2)}
+
+/* Lesemass: ~66 Zeichen je Zeile für linearen Mengentext (G10). */
+.lese{max-width:min(39ch,100%)}
+.meta{color:var(--muted)}

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -1,0 +1,425 @@
+<!doctype html>
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Design-System · Goetheanum Grafik</title>
+<meta name="description" content="Das lebende Design-System der Goetheanum-Hausgrafik: Farben, Schnitte, Typografie-Regeln, Komponenten und der Bau-Workflow – aus einer Quelle gerendert." />
+<meta name="robots" content="noindex" />
+<link rel="icon" type="image/svg+xml" href="../assets/logos/goetheanum-mark-blue.svg" />
+
+<!-- Dogfooding: Diese Seite IST aus dem System gebaut. Sie bindet die echten
+     Token- und Komponenten-Dateien ein – dieselben, die jedes Werkzeug nutzt. -->
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="base.css" />
+
+<style>
+  /* Nur schauseiten-eigene Gestaltung. Werte kommen aus den Tokens. */
+  .hero{padding:clamp(44px,8vw,88px) 0 var(--s8)}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(32px,6vw,60px);line-height:1.03;letter-spacing:-.01em;max-width:16ch}
+  .hero .lede{margin-top:var(--s6);color:#565b60;font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:60ch}
+  .hero .meta{margin-top:var(--s8);display:flex;gap:var(--s2);flex-wrap:wrap}
+
+  /* Auf dieser Seite ist der Titel-Schnitt Deutlich (580), wie für Titel vorgesehen. */
+  .shead h2{font-weight:var(--w-deutlich)}
+
+  .grid{display:grid;gap:var(--s4)}
+  .cols2{grid-template-columns:1fr}
+  .cols3{grid-template-columns:1fr}
+  @media(min-width:620px){.cols2{grid-template-columns:1fr 1fr}.cols3{grid-template-columns:1fr 1fr}}
+  @media(min-width:900px){.cols3{grid-template-columns:1fr 1fr 1fr}}
+
+  /* Farb-Swatches */
+  .sw{border:1px solid var(--line);border-radius:var(--r-card);overflow:hidden;background:var(--paper);cursor:pointer;text-align:left;font:inherit}
+  .sw .chip-c{height:84px}
+  .sw .body{padding:var(--s3) var(--s4)}
+  .sw .nm{font-weight:var(--w-strong);font-size:14px}
+  .sw .hx{color:var(--muted);font-size:12.5px;font-family:var(--font-mono)}
+  .sw .ds{color:var(--muted);font-size:12.5px;margin-top:4px;line-height:1.4}
+
+  /* Schnitt-Zeile */
+  .cut{border-top:1px solid var(--line-soft);padding:var(--s4) 0;display:grid;gap:6px;grid-template-columns:1fr;align-items:baseline}
+  @media(min-width:760px){.cut{grid-template-columns:170px 1fr}}
+  .cut .nm{font-size:13px;color:var(--muted)}
+  .cut .nm b{color:var(--ink);font-weight:var(--w-strong)}
+  .cut .samp{font-size:clamp(22px,3.4vw,30px);line-height:1.1}
+  .cut .ds{grid-column:1/-1;color:var(--muted);font-size:13px;max-width:64ch}
+  .cut .grafik{color:var(--gold-deep)}
+
+  /* Regeln */
+  .rules{display:grid;gap:0}
+  .rule{display:grid;grid-template-columns:54px 1fr;gap:var(--s4);padding:var(--s3) 0;border-top:1px solid var(--line-soft)}
+  .rule .id{font-weight:var(--w-strong);color:var(--gold-deep);font-variant-numeric:tabular-nums}
+  .rule .tx{color:#3d4348;font-size:14px;line-height:1.5;max-width:72ch}
+  .rule.card-rule .id{color:var(--blue)}
+
+  /* Abstands-Balken */
+  .scale .row{display:flex;align-items:center;gap:var(--s4);padding:6px 0}
+  .scale .bar{height:16px;background:var(--gold);border-radius:4px}
+  .scale .lab{width:96px;color:var(--muted);font-size:13px;font-variant-numeric:tabular-nums}
+  .radii{display:flex;gap:var(--s4);flex-wrap:wrap}
+  .radii .r{width:120px;height:80px;background:var(--soft);border:1px solid var(--line)}
+  .radii .cap{color:var(--muted);font-size:12.5px;margin-top:6px}
+
+  /* Komponenten-Schau */
+  .demo{display:flex;gap:var(--s3);flex-wrap:wrap;align-items:center}
+  pre.code{background:#1c1f23;color:#e7e3da;border-radius:var(--r-control);padding:var(--s3) var(--s4);overflow:auto;font-family:var(--font-mono);font-size:12.5px;line-height:1.5;margin-top:var(--s3)}
+
+  /* Status digital/analog */
+  .status{display:grid;gap:8px}
+  .status li{list-style:none;display:flex;gap:10px;align-items:baseline;padding:6px 0;border-top:1px solid var(--line-soft);font-size:14px}
+  .status .mk-ok{color:#3f7d46;font-weight:var(--w-strong)}
+  .status .mk-open{color:var(--gold-deep);font-weight:var(--w-strong)}
+
+  /* Bau-Workflow */
+  .steps{counter-reset:s;display:grid;gap:var(--s3)}
+  .steps li{list-style:none;display:grid;grid-template-columns:38px 1fr;gap:var(--s4);align-items:start}
+  .steps li::before{counter-increment:s;content:counter(s);display:grid;place-items:center;width:32px;height:32px;border-radius:var(--r-pill);background:var(--gold);color:#3a2d10;font-weight:var(--w-strong)}
+  .steps b{font-weight:var(--w-strong)}
+  .steps .d{color:var(--muted);font-size:14px;line-height:1.5}
+
+  /* Drift-Wächter */
+  .guard{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s4) var(--s6);background:var(--soft)}
+  .guard .head{display:flex;align-items:center;gap:10px;font-weight:var(--w-strong)}
+  .guard .dot{width:10px;height:10px;border-radius:var(--r-pill);background:var(--muted)}
+  .guard.ok .dot{background:#3f7d46}
+  .guard.bad .dot{background:var(--bad)}
+  .guard .detail{margin-top:var(--s2);color:var(--muted);font-size:13px;line-height:1.5}
+  .guard table{margin-top:var(--s3);width:100%;font-size:13px}
+
+  .note{color:var(--muted);font-size:13px;line-height:1.5;max-width:72ch}
+  .toast{position:fixed;left:50%;bottom:24px;transform:translateX(-50%);background:var(--ink);color:#fff;padding:8px 16px;border-radius:var(--r-pill);font-size:13px;opacity:0;transition:opacity .2s;pointer-events:none;z-index:60}
+  .toast.show{opacity:1}
+</style>
+</head>
+<body>
+
+<header class="ds-header">
+  <div class="wrap bar">
+    <a class="brand" href="../" aria-label="Goetheanum Grafik – Startseite">
+      <img class="mk" src="../assets/logos/goetheanum-mark-blue.svg" alt="" />
+      <span class="wm">Goetheanum</span>
+    </a>
+    <nav class="top">
+      <a href="#farben">Farben</a>
+      <a href="#schrift">Schrift</a>
+      <a href="#regeln">Regeln</a>
+      <a href="#komponenten">Komponenten</a>
+      <a href="#bauen">Bauen</a>
+    </nav>
+  </div>
+</header>
+
+<main class="wrap">
+
+  <section class="hero">
+    <span class="kicker">Design-System</span>
+    <h1>Ein Fundament, viele Werkzeuge.</h1>
+    <p class="lede">Farben, Schnitte, Typografie-Regeln und Komponenten der Goetheanum-Hausgrafik – an einem Ort, aus einer Quelle gerendert. Was hier steht, steht beim Bauen bereits parat und muss nicht hinterher geprüft werden.</p>
+    <div class="meta" id="heroMeta"></div>
+  </section>
+
+  <!-- ================= Drift-Wächter ================= -->
+  <section id="waechter">
+    <div class="shead">
+      <h2>Eine Quelle der Wahrheit</h2>
+      <p>Selbsttest beim Laden: stimmen die CSS-Tokens (tokens.css) und die maschinenlesbaren Tokens (tokens.json) überein? Weicht etwas ab, steht es hier rot.</p>
+    </div>
+    <div class="guard" id="guard">
+      <div class="head"><span class="dot"></span><span id="guardMsg">Prüfe Tokens …</span></div>
+      <div class="detail" id="guardDetail"></div>
+    </div>
+  </section>
+
+  <!-- ================= Farben ================= -->
+  <section id="farben">
+    <div class="shead">
+      <h2>Farben</h2>
+      <p>Markenblau gliedert Zustand und Verweis, Gold ist der einzige Inhalts-Akzent – sparsam. Klick auf ein Feld kopiert den Hex-Wert.</p>
+    </div>
+    <div class="grid cols3" id="swatches"></div>
+    <p class="note" style="margin-top:var(--s4)">Kontrast-Hinweise stammen aus den Typo-Tokens (G28): tinte-leise 4.35:1 und Gold 3.94:1 tragen nur Meta, Akzent und grössere Grade – nie langen Lesetext im Kleingrad.</p>
+  </section>
+
+  <!-- ================= Schrift & Schnitte ================= -->
+  <section id="schrift">
+    <div class="shead">
+      <h2>Schrift &amp; Schnitte</h2>
+      <p>Eine Familie, drei Stimmen: Klar trägt alles, Laut betont, Leise ist der stille Gegenton. Deutlich ist der Titel-Schnitt. Flüstern und Schreien leben nur im Variable Font und sind der Grafik vorbehalten (G04).</p>
+    </div>
+    <div id="cuts"></div>
+  </section>
+
+  <!-- ================= Typo-Regeln ================= -->
+  <section id="regeln">
+    <div class="shead">
+      <h2>Typografie-Regeln</h2>
+      <p>Die Hausregeln aus den Typo-Tokens – nachschlagbar und ankerbar. Blau markiert die Kardinalregeln, die nicht verletzt werden.</p>
+    </div>
+    <div class="rules" id="rules"></div>
+    <p class="note" style="margin-top:var(--s4)">Quelle: <code>assets/typografie/goetheanum-typo-tokens.json</code> (<code>$regeln</code>). Ausführbar als Prüfung über <code>assets/typografie/typo-regeln.yaml</code>.</p>
+  </section>
+
+  <!-- ================= Maße ================= -->
+  <section id="masse">
+    <div class="shead">
+      <h2>Maße &amp; Lesemass</h2>
+      <p>Abstände in der 4er-Skala, drei Radien – und das harte Lesemass von rund 66 Zeichen je Zeile (G10).</p>
+    </div>
+    <div class="grid cols2">
+      <div class="card">
+        <div class="scale" id="scale"></div>
+      </div>
+      <div class="card">
+        <div class="radii" id="radii"></div>
+      </div>
+    </div>
+    <div class="card soft" style="margin-top:var(--s4)">
+      <p class="lese" style="line-height:1.5">Diese Spalte steht im Lesemass <code>min(39ch, 100%)</code>. Sie zeigt, wie lang eine Zeile im linearen Mengentext höchstens werden soll – rund neun Wörter, damit das Auge den Zeilenanfang sicher zurückfindet. Tabellen und Signaletik haben ihr eigenes Mass (G27).</p>
+    </div>
+  </section>
+
+  <!-- ================= Komponenten ================= -->
+  <section id="komponenten">
+    <div class="shead">
+      <h2>Komponenten</h2>
+      <p>Die Bausteine aus <code>base.css</code> – live, nicht abgebildet. Genau diese erscheinen, sobald ein Werkzeug die Datei einbindet.</p>
+    </div>
+
+    <div class="grid cols2">
+      <div class="card">
+        <span class="kicker">Knöpfe</span>
+        <div class="demo" style="margin-top:var(--s3)">
+          <button class="btn primary">Primär</button>
+          <button class="btn">Normal</button>
+          <button class="btn ghost">Leise</button>
+          <button class="btn ok">Bestätigt</button>
+        </div>
+        <pre class="code">&lt;button class="btn primary"&gt;Primär&lt;/button&gt;</pre>
+      </div>
+
+      <div class="card">
+        <span class="kicker">Chips</span>
+        <div class="demo" style="margin-top:var(--s3)">
+          <span class="chip">Sektion <b>Allgemeine Anthroposophische</b></span>
+          <span class="chip">Status <b>live</b></span>
+        </div>
+        <pre class="code">&lt;span class="chip"&gt;Status &lt;b&gt;live&lt;/b&gt;&lt;/span&gt;</pre>
+      </div>
+
+      <div class="card">
+        <span class="kicker">Formularfelder</span>
+        <div style="display:grid;gap:var(--s3);margin-top:var(--s3)">
+          <label class="field"><span class="lab">Normal</span><input placeholder="Eigene Angabe"></label>
+          <label class="field"><span class="lab">Ungültig</span><input class="invalid" value="fehlt"></label>
+        </div>
+        <pre class="code">&lt;label class="field"&gt;
+  &lt;span class="lab"&gt;Normal&lt;/span&gt;
+  &lt;input placeholder="Eigene Angabe"&gt;
+&lt;/label&gt;</pre>
+      </div>
+
+      <div class="card">
+        <span class="kicker">Auszeichnung im Fliesstext</span>
+        <p class="lese" style="margin-top:var(--s3);line-height:1.5">Hier ist etwas <strong>betont</strong> (Laut), hier ein <em>stiller Gegenton</em> (Leise). Anführung: <q>so spricht das Haus</q>. Keine Unterstreichung, keine Versalien – dafür gibt es kein Utility.</p>
+        <pre class="code">&lt;strong&gt;betont&lt;/strong&gt; · &lt;em&gt;Gegenton&lt;/em&gt; · &lt;q&gt;Zitat&lt;/q&gt;</pre>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= Digital ↔ Analog ================= -->
+  <section id="medien">
+    <div class="shead">
+      <h2>Digital &amp; analog</h2>
+      <p>Das System trägt heute den Bildschirm vollständig. Für den Druck stehen die Gegenstücke noch aus – hier ehrlich ausgewiesen, nicht stillschweigend angenommen.</p>
+    </div>
+    <div class="grid cols2">
+      <div class="card">
+        <span class="kicker">Digital – vorhanden</span>
+        <ul class="status" style="margin-top:var(--s3)">
+          <li><span class="mk-ok">✓</span> Farben als Hex, Tokens in CSS und JSON</li>
+          <li><span class="mk-ok">✓</span> Hausschrift als Webfont (Variable, wght 190–725)</li>
+          <li><span class="mk-ok">✓</span> Komponenten, Abstände, Radien</li>
+          <li><span class="mk-ok">✓</span> Typo-Regeln maschinenlesbar und prüfbar</li>
+        </ul>
+      </div>
+      <div class="card">
+        <span class="kicker">Analog / Druck – ausstehend</span>
+        <ul class="status" style="margin-top:var(--s3)">
+          <li><span class="mk-open">○</span> CMYK- und Sonderfarben-Gegenwerte zu den Hex-Farben</li>
+          <li><span class="mk-open">○</span> Maße in mm statt px für Satz und Beschnitt</li>
+          <li><span class="mk-open">○</span> Beschnitt, Schnittmarken, Sicherheitsabstand</li>
+          <li><span class="mk-open">○</span> PDF/X-Ausgabe mit eingebetteten Schriften</li>
+        </ul>
+        <p class="note" style="margin-top:var(--s3)">Eigener nächster Schritt – siehe Fahrplan im Strategieblatt (Export-Schicht).</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= Bau-Workflow ================= -->
+  <section id="bauen">
+    <div class="shead">
+      <h2>So baust du ein neues Werkzeug</h2>
+      <p>Schnell und regelkonform – weil das System eingebunden, nicht kopiert wird. Vier Schritte, und nichts muss hinterher geprüft werden.</p>
+    </div>
+    <ol class="steps">
+      <li><div><b>Starter kopieren.</b> <span class="d"><a href="starter.html">starter.html</a> ist ein leeres Werkzeug mit verdrahtetem Webfont, Tokens, Kopf, Fuss und korrektem Kicker. Du fängst nie bei null an.</span></div></li>
+      <li><div><b>Mitte füllen.</b> <span class="d">Nur den werkzeug-eigenen Teil setzen. Alles drumherum ist schon CI; greife auf die Tokens zu (<code>var(--gold)</code>, <code>var(--s6)</code>), erfinde keine neuen Werte.</span></div></li>
+      <li><div><b>Eintragen.</b> <span class="d">Eine Zeile in <code>tools.json</code> – das Werkzeug erscheint automatisch im Hub.</span></div></li>
+      <li><div><b>Committen.</b> <span class="d">Der Typo-Hook (<code>tools/typo-check.py</code>) prüft die geänderten Texte automatisch und lässt nur Konformes durch. Der Mensch prüft nie von Auge.</span></div></li>
+    </ol>
+    <div class="demo" style="margin-top:var(--s6)">
+      <a class="btn primary" href="starter.html">Starter öffnen</a>
+      <a class="btn" href="README.md">Workflow-Doku</a>
+      <a class="btn ghost" href="../tools.json">Manifest ansehen</a>
+    </div>
+  </section>
+
+</main>
+
+<footer class="ds-footer">
+  <div class="wrap frow">
+    <span><strong>Goetheanum</strong> · Design-System der Hausgrafik</span>
+    <span><a href="../start/">Interner Hub</a> · <a href="https://github.com/phtok/goeloggen/blob/main/docs/strategie.md">Strategieblatt</a></span>
+  </div>
+</footer>
+
+<div class="toast" id="toast"></div>
+
+<script>
+const $ = (s,r=document)=>r.querySelector(s);
+const el=(t,c,h)=>{const e=document.createElement(t);if(c)e.className=c;if(h!=null)e.innerHTML=h;return e;};
+const toast=(m)=>{const t=$("#toast");t.textContent=m;t.classList.add("show");setTimeout(()=>t.classList.remove("show"),1100);};
+const norm=v=>{v=(v||"").trim().toLowerCase();const m=v.match(/^#([0-9a-f]{3})$/);return m?"#"+m[1].split("").map(c=>c+c).join(""):v;};
+
+Promise.all([
+  fetch("tokens.json").then(r=>r.json()),
+  fetch("../assets/typografie/goetheanum-typo-tokens.json").then(r=>r.json())
+]).then(([tok,typo])=>{
+  buildHero(tok);
+  buildSwatches(tok,typo);
+  buildCuts(typo);
+  buildRules(typo);
+  buildScale(tok);
+  guard(tok);
+}).catch(err=>{
+  $("#guardMsg").textContent = "Tokens konnten nicht geladen werden.";
+  $("#guardDetail").textContent = String(err);
+});
+
+function buildHero(tok){
+  const cuts = 4, rules = 0;
+  $("#heroMeta").innerHTML =
+    `<span class="chip"><b>4</b> installierbare Schnitte</span>`+
+    `<span class="chip"><b>Variable</b> wght 190–725</span>`+
+    `<span class="chip">Regeln <b>eingebaut</b></span>`;
+}
+
+function buildSwatches(tok,typo){
+  const wrap=$("#swatches");
+  const order=["blue","gold","gold-deep","ink","muted","soft","paper","bad"];
+  const kontrast={ "muted":"4.35:1 – nur Meta (G28)", "gold-deep":"3.94:1 – nur Akzent (G28)", "ink":"15:1 – trägt Lesetext" };
+  order.forEach(k=>{
+    const c=tok.color[k]; if(!c) return;
+    const hex=c.$value;
+    const b=el("button","sw");
+    b.innerHTML =
+      `<div class="chip-c" style="background:${hex}; ${k==='paper'?'border-bottom:1px solid var(--line)':''}"></div>`+
+      `<div class="body"><div class="nm">${k}</div><div class="hx">${hex}</div>`+
+      `<div class="ds">${c.$description||""}${kontrast[k]?" · "+kontrast[k]:""}</div></div>`;
+    b.addEventListener("click",()=>{navigator.clipboard?.writeText(hex);toast(hex+" kopiert");});
+    wrap.appendChild(b);
+  });
+}
+
+function buildCuts(typo){
+  const wrap=$("#cuts");
+  // Installierbare Schnitte (CLAUDE.md) + variable Extreme. Werte aus Typo-Tokens,
+  // Deutlich (580) ergänzt aus design-system/tokens.css.
+  const cuts=[
+    {nm:"Leise",  w:265, role:"Legenden, Zitate, stiller Gegenton", grafik:false},
+    {nm:"Klar",   w:440, role:"Fliesstext – alles, was gelesen wird", grafik:false},
+    {nm:"Deutlich",w:580, role:"Titel-Schnitt (zwischen Klar und Laut)", grafik:false},
+    {nm:"Laut",   w:680, role:"Betonung, Signaletik, Inline-Fettung (⌘B)", grafik:false},
+    {nm:"Flüstern",w:190, role:"nur Variable Font, nur Grafik – nie Lesetext", grafik:true},
+    {nm:"Schreien",w:725, role:"nur Variable Font, nur Grafik – nie Standard-Fett", grafik:true}
+  ];
+  cuts.forEach(c=>{
+    const row=el("div","cut");
+    row.innerHTML =
+      `<div class="nm"><b>${c.nm}</b> · wght ${c.w}</div>`+
+      `<div class="samp" style="font-variation-settings:'wght' ${c.w}">Würde, Klarheit, Eigenständigkeit</div>`+
+      `<div class="ds${c.grafik?' grafik':''}">${c.role}</div>`;
+    wrap.appendChild(row);
+  });
+}
+
+function buildRules(typo){
+  const wrap=$("#rules");
+  const regeln=typo.$regeln||{};
+  const kardinal=new Set(["G01","G03","G05","G23","G25"]);
+  Object.keys(regeln).filter(k=>k.startsWith("S")||k.startsWith("G"))
+    .sort((a,b)=>a.localeCompare(b,'en',{numeric:true}))
+    .forEach(id=>{
+      const r=el("div","rule"+(kardinal.has(id)?" card-rule":""));
+      r.id="regel-"+id;
+      r.innerHTML=`<div class="id">${id}</div><div class="tx">${regeln[id]}</div>`;
+      wrap.appendChild(r);
+    });
+}
+
+function buildScale(tok){
+  const sc=$("#scale");
+  Object.entries(tok.space).filter(([k])=>k!=="$type").forEach(([k,v])=>{
+    const px=parseInt(v.$value,10);
+    const row=el("div","row");
+    row.innerHTML=`<span class="lab">--s${k} · ${v.$value}</span><span class="bar" style="width:${px*3}px"></span>`;
+    sc.appendChild(row);
+  });
+  const rd=$("#radii");
+  Object.entries(tok.radius).filter(([k])=>k!=="$type").forEach(([k,v])=>{
+    const box=el("div");
+    box.innerHTML=`<div class="r" style="border-radius:${v.$value}"></div><div class="cap">--r-${k} · ${v.$value}</div>`;
+    rd.appendChild(box);
+  });
+}
+
+function guard(tok){
+  const cs=getComputedStyle(document.documentElement);
+  const cssVar=n=>cs.getPropertyValue(n);
+  // Abbildung Token → CSS-Custom-Property
+  const map=[
+    ["color.blue","--blue"],["color.gold","--gold"],["color.gold-deep","--gold-deep"],
+    ["color.ink","--ink"],["color.muted","--muted"],["color.paper","--paper"],
+    ["color.soft","--soft"],["color.bad","--bad"],
+    ["fontWeight.leise","--w-leise"],["fontWeight.text","--w-text"],
+    ["fontWeight.deutlich","--w-deutlich"],["fontWeight.strong","--w-strong"],
+    ["space.1","--s1"],["space.2","--s2"],["space.3","--s3"],["space.4","--s4"],["space.6","--s6"],["space.8","--s8"],
+    ["radius.control","--r-control"],["radius.card","--r-card"],["radius.pill","--r-pill"],
+    ["size.header","--header-h"],["size.maxw","--maxw"]
+  ];
+  const get=(path)=>{let o=tok;for(const p of path.split("."))o=o&&o[p];return o&&o.$value;};
+  const isColor=p=>p.startsWith("color.");
+  const diffs=[];
+  map.forEach(([path,cssName])=>{
+    let want=String(get(path)??"");
+    let have=String(cssVar(cssName)??"");
+    let w=isColor(path)?norm(want):want.trim();
+    let h=isColor(path)?norm(have):have.trim();
+    if(w!==h) diffs.push({path,cssName,want:w,have:h||"(leer)"});
+  });
+  const g=$("#guard"), msg=$("#guardMsg"), det=$("#guardDetail");
+  if(diffs.length===0){
+    g.classList.add("ok");
+    msg.textContent = `Stimmig – ${map.length} Tokens geprüft, kein Drift.`;
+    det.textContent = "tokens.css und tokens.json tragen dieselben Werte. Ändert sich eine Quelle ohne die andere, schlägt diese Prüfung beim nächsten Laden aus.";
+  } else {
+    g.classList.add("bad");
+    msg.textContent = `${diffs.length} Abweichung(en) gefunden.`;
+    const rows = diffs.map(d=>`<tr><td>${d.path}</td><td class="num">${d.want}</td><td>↔</td><td>${d.cssName}</td><td class="num">${d.have}</td></tr>`).join("");
+    det.innerHTML = `<table><thead><tr><th>Token</th><th>JSON</th><th></th><th>CSS</th><th>Wert</th></tr></thead><tbody>${rows}</tbody></table>`;
+  }
+}
+</script>
+</body>
+</html>

--- a/design-system/starter.html
+++ b/design-system/starter.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<!-- =============================================================================
+     Goetheanum-Werkzeug · STARTER
+     -----------------------------------------------------------------------------
+     So baust du ein neues Werkzeug oder eine neue Seite – schnell und regelkonform:
+
+       1. Diese Datei kopieren  →  z. B.  ./mein-werkzeug.html  (oder apps/mein-werkzeug/index.html)
+       2. Nur die mit «DEINE MITTE» markierte Stelle füllen.
+       3. Einen Eintrag in  tools.json  ergänzen  →  erscheint automatisch im Hub.
+       4. Committen  →  der Typo-Hook (tools/typo-check.py) lässt nur Konformes durch.
+
+     Warum hinterher nichts geprüft werden muss:
+       · Farben/Schnitte/Abstände/Komponenten kommen aus tokens.css + base.css
+         (EINGEBUNDEN, nicht kopiert) – sie können gar nicht abweichen.
+       · base.css stellt Hausregeln als Voreinstellung ein: Trennung, ‹…› über <q>,
+         tabellarische Ziffern, Betonung = Laut, Leise statt Kursive (G02/G05/G16/G25 …).
+       · Fürs Falsche (Unterstreichen/Versal-Hervorhebung/Sperren) gibt es kein Utility.
+
+     Pfad-Hinweis: Die zwei <link> unten laden das System per absoluter URL und
+     funktionieren von JEDEM Ort. Für lokale Arbeit ohne Netz die relative Variante
+     daneben (auskommentiert) nutzen und den Pfad an die Tiefe deiner Datei anpassen.
+     ============================================================================= -->
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Neues Werkzeug · Goetheanum</title>
+<meta name="description" content="Kurzbeschreibung des Werkzeugs – ein Satz, was es tut." />
+<link rel="icon" type="image/svg+xml" href="https://phtok.github.io/goeloggen/assets/logos/goetheanum-mark-blue.svg" />
+
+<!-- Das Fundament – eine Quelle der Wahrheit. NICHT kopieren, EINBINDEN. -->
+<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/tokens.css" />
+<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/base.css" />
+<!-- Lokal/offline stattdessen (Pfadtiefe anpassen):
+<link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/base.css" /> -->
+
+<style>
+  /* NUR werkzeug-eigene Gestaltung hierher. Alles Gemeinsame steht schon in base.css.
+     Greife auf die Tokens zu (var(--gold), var(--s6) …), erfinde keine neuen Werte. */
+  .hero{padding:clamp(40px,7vw,72px) 0 var(--s8)}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);line-height:1.05;letter-spacing:-.01em;max-width:18ch}
+  .hero .lede{margin-top:var(--s6);color:#565b60;font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:58ch}
+</style>
+</head>
+<body>
+
+<!-- Kopfzeile – aus base.css (.ds-header). Wortmarke + Navigation. -->
+<header class="ds-header">
+  <div class="wrap bar">
+    <a class="brand" href="https://phtok.github.io/goeloggen/" aria-label="Goetheanum Grafik – Startseite">
+      <img class="mk" src="https://phtok.github.io/goeloggen/assets/logos/goetheanum-mark-blue.svg" alt="" />
+      <span class="wm">Goetheanum</span>
+    </a>
+    <nav class="top">
+      <a href="https://phtok.github.io/goeloggen/schriften.html">Schriften</a>
+      <a href="https://phtok.github.io/goeloggen/design-system/">System</a>
+    </nav>
+  </div>
+</header>
+
+<main class="wrap">
+
+  <section class="hero">
+    <!-- Kicker: getönt, leicht getrackt – NORMAL, nicht versal (G05). -->
+    <span class="kicker">Bereich oder Sektion</span>
+    <h1>Titel des Werkzeugs</h1>
+    <p class="lede">Ein Satz, der sagt, was die Person hier in Minuten erreicht.</p>
+  </section>
+
+  <!-- ====================== DEINE MITTE – ab hier füllen ======================= -->
+  <section>
+    <div class="shead">
+      <h2>Abschnitt</h2>
+      <p>Knappe Einleitung. Wenige Mittel, präzise gesetzt.</p>
+    </div>
+
+    <div class="card soft" style="display:grid;gap:var(--s4);max-width:520px">
+      <label class="field">
+        <span class="lab">Beispiel-Eingabe</span>
+        <input type="text" placeholder="Eigene Angabe eintragen" />
+      </label>
+      <label class="field">
+        <span class="lab">Mehrzeilig</span>
+        <textarea placeholder="Längerer Text"></textarea>
+      </label>
+      <div style="display:flex;gap:var(--s2);flex-wrap:wrap">
+        <button class="btn primary" type="button">Übernehmen</button>
+        <button class="btn" type="button">Zurücksetzen</button>
+      </div>
+    </div>
+
+    <!-- Beispiel-Fliesstext im Lesemass (G10) – zeigt die eingebauten Defaults:
+         Betonung mit <strong>Laut</strong>, Gegenton mit <em>Leise</em>, ‹Guillemets›. -->
+    <p class="lese" style="margin-top:var(--s6);line-height:1.5">
+      Dies ist <strong>betont</strong> und dies ein <em>leiser Gegenton</em>.
+      Anführung sieht so aus: <q>ein Zitat im Haus</q>. Zahlen wie 10 000 stehen
+      tabellarisch, sobald sie in einer Tabelle sitzen.
+    </p>
+  </section>
+  <!-- ====================== DEINE MITTE – bis hier ============================= -->
+
+</main>
+
+<!-- Fusszeile – aus base.css (.ds-footer). -->
+<footer class="ds-footer">
+  <div class="wrap frow">
+    <span><strong>Goetheanum</strong> · Hausgrafik</span>
+    <span><a href="https://phtok.github.io/goeloggen/design-system/">Design-System</a></span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -35,8 +35,10 @@
   --font:"Goetheanum","Helvetica Neue",Arial,sans-serif;
   --font-system:"Helvetica Neue",Arial,sans-serif;
   --font-mono:ui-monospace,Menlo,Consolas,monospace;
-  --w-text:440;          /* Fliesstext */
-  --w-strong:680;        /* Titel/Hervorhebung */
+  --w-leise:265;         /* Leise – Legenden, Zitate, stiller Gegenton (S01) */
+  --w-text:440;          /* Klar – Fliesstext, alles was gelesen wird */
+  --w-deutlich:580;      /* Deutlich – Titel-Schnitt (CLAUDE.md: Deutlich = Titel) */
+  --w-strong:680;        /* Laut – Inline-/Office-Fettung, Betonung (⌘B) */
 
   /* --- Abstands-Skala (4/8/12/16/24/32) ---------------------------------- */
   --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s6:24px; --s8:32px;

--- a/design-system/tokens.json
+++ b/design-system/tokens.json
@@ -20,8 +20,10 @@
   },
   "fontWeight": {
     "$type": "fontWeight",
-    "text":   { "$value": 440 },
-    "strong": { "$value": 680 }
+    "leise":    { "$value": 265, "$description": "Leise – Legenden, Zitate, stiller Gegenton (S01)" },
+    "text":     { "$value": 440, "$description": "Klar – Fliesstext, alles was gelesen wird" },
+    "deutlich": { "$value": 580, "$description": "Deutlich – Titel-Schnitt (CLAUDE.md: Deutlich = Titel)" },
+    "strong":   { "$value": 680, "$description": "Laut – Inline-/Office-Fettung, Betonung (⌘B)" }
   },
   "space": {
     "$type": "dimension",

--- a/tools.json
+++ b/tools.json
@@ -7,12 +7,15 @@
     "geparkt": "Konzept, später"
   },
   "categories": [
+    { "id": "system",      "title": "Design-System", "intro": "Das Fundament – Farben, Schrift, Regeln und Komponenten. Hier nachschlagen und von hier aus neue Werkzeuge bauen." },
     { "id": "generatoren", "title": "Generatoren", "intro": "Eigene Angaben eintragen, fertiges Ergebnis übernehmen. Für den täglichen Gebrauch." },
     { "id": "schrift",     "title": "Schrift & Typografie", "intro": "Die Hausschrift v2.5 und die Regeln dazu – nachschlagen, vergleichen, einbinden." },
     { "id": "werkstatt",   "title": "Werkstatt", "intro": "Werkschau und Prüfwerkzeuge rund um die Schriftentwicklung und -pflege." },
     { "id": "geparkt",     "title": "Geparkte Projekte", "intro": "Durchdachte Konzepte, die später kommen – zum schnellen Einsehen der Spezifikation." }
   ],
   "tools": [
+    { "slug": "design-system",     "cat": "system",      "status": "beta",    "tag": "Fundament",     "title": "Design-System",      "href": "design-system/",               "desc": "Farben, Schnitte, Typografie-Regeln und Komponenten – die lebende Schauseite, aus einer Quelle gerendert. Mit Starter und Bau-Workflow." },
+
     { "slug": "logo-generator",    "cat": "generatoren", "status": "live",    "tag": "Logo",          "title": "Logo-Generator",     "href": "logo-generator.html",          "desc": "Sektions- und Bereichslogos in der Hausschrift – korrekt gesetzt, als SVG zum Herunterladen." },
     { "slug": "visitenkarten",     "cat": "generatoren", "status": "live",    "tag": "Visitenkarten", "title": "Visitenkarten",      "href": "visitenkarten-generator.html", "desc": "Einheitliche Visitenkarten aus den eigenen Angaben – druckfertig, ohne Layoutprogramm." },
     { "slug": "signatur",          "cat": "generatoren", "status": "live",    "tag": "E-Mail",        "title": "Signatur",           "href": "signatur-generator.html",      "desc": "Outlook-robuste E-Mail-Signatur nach gemeinsamer Vorlage – kopieren und einsetzen." },

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Goetheanum Typo-Hook – prüft die vorgemerkten Texte vor jedem Commit.
+# Aktivieren (einmalig, je Arbeitskopie):  git config core.hooksPath tools/hooks
+# Umgehen im Notfall:                       git commit --no-verify
+set -euo pipefail
+ROOT="$(git rev-parse --show-toplevel)"
+PY="$(command -v python3 || command -v python || true)"
+if [ -z "$PY" ]; then
+  echo "Typo-Hook übersprungen: kein Python gefunden." >&2
+  exit 0
+fi
+exec "$PY" "$ROOT/tools/typo-check.py"

--- a/tools/typo-check.py
+++ b/tools/typo-check.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Goetheanum Typo-Check – führt die Hausregeln aus, statt sie hinterher zu prüfen.
+
+Quelle der Wahrheit:  assets/typografie/typo-regeln.yaml  (erkennen/korrektur/schwere).
+Geltungsbereich:      deutscher Lesetext (de-CH) auf der publizierten HTML-Fläche.
+                      Interne Doku-Markdown nur auf ausdrückliche Nennung.
+Ausgenommen:          Code, <script>/<style>/<pre>/<code>, Kommentare, URLs, E-Mails.
+
+Nutzung:
+  tools/typo-check.py                 # prüft die vorgemerkten (staged) HTML-Dateien
+  tools/typo-check.py datei …         # prüft genannte Dateien (auch .md/.txt)
+  tools/typo-check.py --all           # prüft alle versionierten .html (Audit)
+  tools/typo-check.py --fix datei …   # wendet eindeutige Korrekturen an (nur Vorschau-Hilfe)
+
+Rückgabe: 1, sobald ein Verstoss der Schwere ‹fehler› bleibt (blockiert den Commit).
+Empfehlungen werden gemeldet, blockieren aber nicht. Mit  # typo-ok  in einer Zeile
+wird diese Zeile übersprungen.
+"""
+import sys, os, re, html, subprocess
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+REGELN = os.path.join(ROOT, "assets", "typografie", "typo-regeln.yaml")
+
+# Pfade, die kein Mitarbeitenden-Lesetext sind (Werkstatt, Fremdcode, Sammlungen).
+EXCLUDE_SUBSTR = ("/archive/", "/assets/vendor/", "/collections/", "/tools/goetheanum-fontfix/")
+EXCLUDE_BASENAMES = {
+    # Werkstatt / Font-Entwicklung – kein Mitarbeiter-Lesetext.
+    "proof.html", "kerning.html", "ineinander.html", "zuordnen.html",
+    "ligvorschau.html", "werkzeug.html", "tester.html",
+    # Lehr-/Specimen-Seiten: zeigen absichtlich ‹so nicht›-Gegenbeispiele.
+    "typografie.html", "vorschau.html", "schrift-vergleich.html",
+}
+
+C = {"red":"\033[31m","yel":"\033[33m","grn":"\033[32m","dim":"\033[2m","b":"\033[1m","x":"\033[0m"}
+def col(s,c): return f"{C[c]}{s}{C['x']}" if sys.stdout.isatty() else s
+
+
+def load_rules(path):
+    """Mini-Parser für die flache Liste in typo-regeln.yaml – ohne PyYAML-Abhängigkeit.
+    Versucht zuerst PyYAML; fällt sonst auf einen gezielten Parser zurück."""
+    text = open(path, encoding="utf-8").read()
+    try:
+        import yaml  # optional
+        items = yaml.safe_load(text)
+        return [r for r in items if isinstance(r, dict)]
+    except Exception:
+        pass
+    rules, cur = [], None
+    for line in text.splitlines():
+        if re.match(r"\s*#", line) or not line.strip():
+            continue
+        m = re.match(r"-\s+(\w+):\s*(.*)$", line)
+        if m:
+            if cur: rules.append(cur)
+            cur = {}
+            key, val = m.group(1), m.group(2)
+            cur[key] = _scalar(val)
+            continue
+        m = re.match(r"\s+(\w+):\s*(.*)$", line)
+        if m and cur is not None:
+            cur[m.group(1)] = _scalar(m.group(2))
+    if cur: rules.append(cur)
+    return rules
+
+
+def _scalar(v):
+    v = v.strip()
+    if len(v) >= 2 and v[0] == v[-1] and v[0] in "'\"":
+        inner = v[1:-1]
+        return inner.replace("''", "'") if v[0] == "'" else inner
+    return v
+
+
+# --- Sichtbaren Lesetext aus HTML herauslösen ---------------------------------
+# Nicht-Lesetext: Skripte, Stile, Code-Beispiele und Kommentare. Wird entfernt,
+# Zeilenumbrüche bleiben erhalten, damit die Zeilennummern stimmen.
+STRIP_BLOCKS = re.compile(r"<(script|style|pre|code|kbd|samp)\b[^>]*>.*?</\1>", re.S | re.I)
+COMMENTS     = re.compile(r"<!--.*?-->", re.S)
+TAGS         = re.compile(r"<[^>]+>")
+URL          = re.compile(r"https?://\S+|\b[\w.+-]+@[\w-]+\.[\w.-]+\b")
+
+def _keep_lines(m):
+    return "\n" * m.group(0).count("\n")
+
+def visible_text(path, raw):
+    if path.endswith((".md", ".markdown", ".txt")):
+        # In Markdown Code-Spannen/Blöcke ausnehmen.
+        raw = re.sub(r"```.*?```", _keep_lines, raw, flags=re.S)
+        raw = re.sub(r"`[^`]*`", " ", raw)
+        out = []
+        for i, ln in enumerate(raw.splitlines()):
+            t = URL.sub(" ", ln)
+            # Leerraum kollabieren – Markdown-Tabellen, Einrückung und Listen-Marker
+            # erzeugen Mehrfach-Leerraum, der gerendert kollabiert (sonst T01 falsch).
+            t = re.sub(r"[ \t]+", " ", t)
+            out.append((i + 1, t))
+        return out
+    # HTML: Code-/Skript-Blöcke und Kommentare entfernen, dann Tags.
+    cleaned = STRIP_BLOCKS.sub(_keep_lines, raw)
+    cleaned = COMMENTS.sub(_keep_lines, cleaned)
+    out = []
+    for i, ln in enumerate(cleaned.splitlines()):
+        t = html.unescape(TAGS.sub(" ", ln))
+        t = URL.sub(" ", t)
+        # Leerraum kollabieren – der Browser tut es ebenso; verhindert Phantom-
+        # Doppelspatien aus dem Tag-Strippen (T01 bliebe sonst falsch positiv).
+        t = re.sub(r"[ \t]+", " ", t)
+        out.append((i + 1, t))
+    return out
+
+
+def to_py(repl):
+    return re.sub(r"\$(\d+)", r"\\\1", repl)
+
+
+def check_file(path, rules, fix=False):
+    rel = os.path.relpath(path, ROOT)
+    raw = open(path, encoding="utf-8").read()
+    lines = visible_text(path, raw)
+    findings = []
+    for lineno, text in lines:
+        if "typo-ok" in text:
+            continue
+        for r in rules:
+            if r.get("pruefung") == "lm" or "erkennen" not in r:
+                continue
+            try:
+                pat = re.compile(r["erkennen"])
+            except re.error:
+                continue
+            for m in pat.finditer(text):
+                snippet = m.group(0).strip()
+                if not snippet:
+                    continue
+                fixed = pat.sub(to_py(r.get("korrektur", "")), snippet) if r.get("korrektur") else ""
+                findings.append((lineno, r.get("id","?"), r.get("schwere","empfehlung"),
+                                 r.get("regel",""), snippet, fixed))
+    return rel, findings
+
+
+def excluded(path):
+    p = path.replace("\\", "/")
+    if any(s in p for s in EXCLUDE_SUBSTR):
+        return True
+    return os.path.basename(p) in EXCLUDE_BASENAMES
+
+
+def git_files(args):
+    # Auto-Modus prüft nur die publizierte Lesefläche (HTML). Interne Doku-Markdown
+    # (CLAUDE.md, README, Strategie) ist keine gesetzte Fläche und nutzt bewusst
+    # eigene Konventionen – sie wird nur auf ausdrückliche Nennung geprüft.
+    if "--all" in args:
+        out = subprocess.run(["git","-C",ROOT,"ls-files","*.html"],
+                             capture_output=True, text=True).stdout
+    else:
+        out = subprocess.run(["git","-C",ROOT,"diff","--cached","--name-only","--diff-filter=ACM"],
+                             capture_output=True, text=True).stdout
+    files = []
+    for f in out.splitlines():
+        if f.endswith(".html"):
+            files.append(os.path.join(ROOT, f))
+    return files
+
+
+def main():
+    args = sys.argv[1:]
+    fix = "--fix" in args
+    explicit = [a for a in args if not a.startswith("--")]
+    if explicit:
+        files = [os.path.abspath(f) for f in explicit]
+    else:
+        files = git_files(args)
+    files = [f for f in files if os.path.isfile(f) and not excluded(f)]
+
+    if not files:
+        print(col("Typo-Check: keine zu prüfenden Dateien.", "dim"))
+        return 0
+
+    rules = load_rules(REGELN)
+    n_fehler = n_empf = 0
+    for f in files:
+        rel, findings = check_file(f, rules, fix)
+        if not findings:
+            continue
+        print(col(f"\n{rel}", "b"))
+        for lineno, rid, schwere, regel, snip, fixed in findings:
+            is_err = (schwere == "fehler")
+            tag = col("FEHLER", "red") if is_err else col("Hinweis", "yel")
+            arrow = f"  →  {col(fixed,'grn')}" if fixed and fixed != snip else ""
+            print(f"  {tag}  Z{lineno}  {col(rid,'b')}  ‹{snip}›{arrow}")
+            print(col(f"        {regel}", "dim"))
+            if is_err: n_fehler += 1
+            else:      n_empf += 1
+
+    print()
+    if n_fehler:
+        print(col(f"✗ {n_fehler} Fehler", "red") + (f", {n_empf} Hinweise" if n_empf else "") +
+              " – Commit blockiert. Bitte beheben (oder Zeile mit  # typo-ok  ausnehmen).")
+        return 1
+    if n_empf:
+        print(col(f"✓ keine Fehler", "grn") + f", {n_empf} Hinweis(e) – Commit erlaubt.")
+        return 0
+    print(col("✓ Typografie konform.", "grn"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Worum es geht

Aus den verstreuten Design-System-Fragmenten wird ein belastbarer **Bau-Workflow**: beim Erstellen neuer Werkzeuge und Seiten stehen alle Elemente und Regeln – bis in die Typografie – bereits **parat** und müssen nicht hinterher geprüft werden.

Das Leitprinzip (steht schon im Strategieblatt: „Konformität einbacken, nicht prüfen") wird hier operativ, über vier Mechanismen von stark nach Absicherung:

1. **Richtig durch Identität** – neue Seiten *binden* `tokens.css` + `base.css` ein statt sie zu kopieren. Werte können nicht abweichen.
2. **Richtig durch Voreinstellung** – `base.css` stellt die Hausregeln schon ein (Trennung, ‹…› über `<q>`, tabellarische Ziffern, Betonung = Laut, Leise statt Kursive).
3. **Falsch durch Weglassen** – für Unterstreichen / Versal-Hervorhebung / Sperren gibt es **kein** Utility (G03/G05/G23).
4. **Den Rest fängt ein Automat** – `tools/typo-check.py` führt `typo-regeln.yaml` beim Commit aus und blockiert bei Schwere ‹fehler›.

## Der Bau-Workflow (vier Schritte)

1. `design-system/starter.html` kopieren · 2. Mitte füllen · 3. Zeile in `tools.json` · 4. committen (Hook prüft).

## Inhalt

**Neu**
- `design-system/index.html` – lebende Schauseite: rendert Farben, Schnitte, Typo-Regeln, Maße und Komponenten aus den Token-Quellen; **Drift-Wächter** vergleicht `tokens.css` gegen `tokens.json` beim Laden.
- `design-system/starter.html` – Gerüst für neue Werkzeuge, alles Markenkritische verdrahtet.
- `design-system/README.md` – Workflow und Mechanismen dokumentiert.
- `tools/typo-check.py` + `tools/hooks/pre-commit` – der Automat. Aktivieren: `git config core.hooksPath tools/hooks`.

**Fundament gehärtet**
- `base.css` – Hausregeln als Voreinstellung + Schnitt-/Lesemass-Utilities + korrekter Kicker (normal, nicht versal).
- `tokens.css` / `tokens.json` – fehlende Schnitt-Tokens ergänzt (Leise 265, Deutlich 580), in beiden Quellen gespiegelt.
- `tools.json` – neue Kategorie ‹system› mit der Schauseite (erscheint im Hub, nicht auf der minimalen Front door).
- `CLAUDE.md` – verbindlicher Bau-Workflow für neue Seiten.

## Verifiziert
- Drift-Wächter im echten Browser (Chromium): **grün, 23 Tokens, kein Drift**; 8 Farben / 6 Schnitte / 23 Regeln aus den Quellen gerendert; Titel-Schnitt computed = 580 (Deutlich).
- Typo-Check läuft beim Commit (Schritt 4 dogfood-belegt) und ist auf den neuen Dateien sauber.

## Bewusst NICHT in diesem PR (Folge-Schritte)
- CSS-aus-JSON-Build (Tokens generieren statt spiegeln).
- Die bestehenden Apps auf die geteilte Schicht heben (heute kopieren alle sechs den Block).
- Analog-/Druck-Achse der Tokens (CMYK, mm, Beschnitt, PDF/X) – auf der Schauseite als ausstehend ausgewiesen.

## Beiläufige Funde (separat zu entscheiden)
- `start/index.html` und `portal.html` nutzen `text-transform:uppercase` für Kicker/Tag/Badge → G05-Verstoß (Versalien als Auszeichnung).
- „Deutlich 580" fehlt im Schnitt-Block der Typo-Tokens, ist aber in CLAUDE.md/tokens kanonisch.
- `portal.html` schreibt „fünf Schnitte", CLAUDE.md nennt vier installierbare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_