### PR TITLE
Navigation: fokussiert, Burger, vier prominent, unsichtbarer Intern-Schalter

### DIFF
--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -28,12 +28,12 @@
   background:none;border:0;cursor:pointer;padding:0;text-decoration:none}
 .dsnav .worlds a:hover,.dsnav .worlds button:hover{color:var(--gold-deep)}
 
-/* ☰ Alles */
-.dsnav .all{margin-left:22px;display:inline-flex;align-items:center;gap:8px;font:inherit;font-size:13.5px;
-  color:var(--ink);background:none;border:1px solid var(--line);border-radius:var(--r-pill);
-  padding:6px 14px;cursor:pointer;transition:border-color .15s}
-.dsnav .all:hover{border-color:var(--gold-deep)}
-.dsnav .all .ic{font-size:15px;line-height:1}
+/* ☰ Burger – nur das Icon, keine Pille, kein Wort */
+.dsnav .all{margin-left:22px;display:inline-flex;align-items:center;gap:6px;font:inherit;
+  color:var(--ink);background:none;border:0;padding:4px;cursor:pointer;line-height:1}
+.dsnav .all .ic{font-size:23px;line-height:1}
+.dsnav .all:hover{color:var(--gold-deep)}
+.dsnav .all .idot{width:7px;height:7px;border-radius:var(--r-pill);background:var(--gold)}
 
 @media(max-width:720px){
   .dsnav .worlds{display:none}
@@ -63,6 +63,20 @@
 .dsnav-drawer .close:hover{color:var(--ink)}
 
 .dsnav-drawer .body{overflow:auto;padding:var(--s2) 0 var(--s8)}
+
+/* Die vier meistgenutzten – prominent ganz oben in der Schublade */
+.dsnav-quick{display:grid;grid-template-columns:1fr 1fr;gap:10px;padding:18px 22px var(--s2)}
+.dsnav-quick a{display:block;border:1px solid var(--line);border-radius:var(--r-card);padding:14px;
+  text-decoration:none;color:var(--ink);background:var(--soft);transition:border-color .15s,transform .15s,box-shadow .15s}
+.dsnav-quick a:hover{border-color:var(--gold);transform:translateY(-1px);box-shadow:var(--shadow-card)}
+.dsnav-quick .qt{display:block;font-weight:var(--w-strong);font-size:15px}
+.dsnav-quick .qd{display:block;color:var(--muted);font-size:12px;margin-top:3px;line-height:1.35}
+
+/* Toast für den unsichtbaren Intern-Schalter */
+.dsnav-toast{position:fixed;left:50%;bottom:24px;transform:translateX(-50%);background:var(--ink);color:#fff;
+  padding:8px 16px;border-radius:var(--r-pill);font-size:13px;opacity:0;visibility:hidden;
+  transition:opacity .2s,visibility .2s;z-index:60}
+.dsnav-toast.show{opacity:1;visibility:visible}
 
 .dsnav-group{border-bottom:1px solid var(--line-soft)}
 .dsnav-group>summary{list-style:none;cursor:pointer;display:flex;align-items:center;justify-content:space-between;

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -9,12 +9,14 @@
              data-variant="werkzeug"          (optional: zeigt „← Übersicht")
              data-path="Schrift › Tester"></script>  (optional: Kontext-Pfad)
 
-   Kopfzeile: die vier meistgenutzten Werkzeuge beim Namen, plus „Mehr".
-     Logos · Schriften · Mail-Signatur · Visitenkarte · Mehr
-   Ein Tipp auf die vier führt direkt zum Ziel. „Mehr" öffnet die Schublade
-   mit dem ganzen Sortiment, in drei nutzernahe Welten gegliedert
-   (Werkzeuge · Schrift · Elemente). Werkstatt/Geparktes sind intern und NICHT
-   im Menü (sie leben im Hub start/). Akkordeon = native <details>.
+   Kopfzeile: Lockup · Logos · Schriften · Mail-Signatur · Visitenkarte · ☰
+   Der Burger (☰) öffnet die Schublade. Ganz oben darin: die vier meistgenutzten
+   Werkzeuge als prominente Kacheln (auch auf dem Handy gut sichtbar).
+
+   FOKUS: öffentlich nur fertige Werkzeuge (Status „live") – nicht übervoll.
+   INTERN (Pflege): unsichtbarer Schalter blendet ALLES ein (alle Status +
+   Werkstatt + Geparktes). Auslöser: das Wort „intern" tippen, oder einmalig
+   ?intern an die URL. Gemerkt im localStorage; ausschalten: erneut „intern".
    ============================================================================= */
 (function () {
   var s = document.currentScript;
@@ -24,17 +26,18 @@
   var HOME  = (s && s.dataset.home)  || ROOT;
   var VARIANT = (s && s.dataset.variant) || "";
   var PATH  = (s && s.dataset.path)  || "";
+  var KEY = "goeNavIntern";
 
-  // Die vier Direkt-Sprünge der Kopfzeile (für die Breite der Mitarbeitenden).
-  // href kommt aus tools.json (per slug) – eine Quelle, keine doppelten Pfade.
+  // Die vier meistgenutzten Werkzeuge – Kopfzeile UND prominent in der Schublade.
   var PRIMARY = [
     { label: "Logos",        slug: "logo-generator" },
     { label: "Schriften",    slug: "schriften" },
     { label: "Mail-Signatur", slug: "signatur" },
     { label: "Visitenkarte", slug: "visitenkarten" }
   ];
+  var PRIMARY_SLUGS = PRIMARY.map(function (p) { return p.slug; });
 
-  // Die Schublade „Mehr" – das ganze Sortiment in drei nutzernahen Welten.
+  // Die drei öffentlichen Welten (öffentlich nur Status „live").
   var WORLDS = [
     { id: "werkzeuge", label: "Werkzeuge",
       intro: "Eintragen, fertiges Ergebnis übernehmen – für den täglichen Gebrauch.",
@@ -46,6 +49,16 @@
       intro: "Farben, Logos und das Design-System – zum Nachschlagen und Holen.",
       cats: ["system"] }
   ];
+  // Nur intern zusätzlich (Pflege).
+  var INTERN_EXTRA = [
+    { id: "werkstatt", label: "Werkstatt",
+      intro: "Werkschau und Prüfwerkzeuge der Schriftpflege – intern.", cats: ["werkstatt"] },
+    { id: "geparkt", label: "Geparktes",
+      intro: "Durchdachte Konzepte, die später kommen – intern.", cats: ["geparkt"] }
+  ];
+
+  function isIntern() { try { return localStorage.getItem(KEY) === "1"; } catch (e) { return false; } }
+  function setIntern(v) { try { localStorage.setItem(KEY, v ? "1" : "0"); } catch (e) {} }
 
   function el(tag, cls, html) {
     var e = document.createElement(tag);
@@ -60,7 +73,16 @@
   }
   function isExternal(h) { return /^https?:/i.test(h) && h.indexOf(ROOT) !== 0; }
 
-  // --- Grundgerüst (vor dem Laden des Manifests sichtbar) ---------------------
+  // ?intern in der URL auswerten (einmalig aktivieren, dann säubern)
+  (function () {
+    var m = /[?&]intern(?:=([^&]*))?/.exec(location.search);
+    if (m) {
+      setIntern(m[1] !== "0" && m[1] !== "false");
+      try { history.replaceState(null, "", location.pathname + location.hash); } catch (e) {}
+    }
+  })();
+
+  // --- Kopfzeile -------------------------------------------------------------
   var header = el("header", "dsnav" + (VARIANT === "werkzeug" ? " is-werkzeug" : "") + (PATH ? " has-path" : ""));
   header.innerHTML =
     '<div class="bar">' +
@@ -69,8 +91,8 @@
       '</a>' +
       '<a class="back" href="' + HOME + '">← Übersicht</a>' +
       '<nav class="worlds"></nav>' +
-      '<button class="all" type="button" aria-haspopup="dialog" aria-expanded="false">' +
-        '<span class="ic">☰</span> Mehr</button>' +
+      '<button class="all" type="button" aria-haspopup="dialog" aria-expanded="false" aria-label="Menü">' +
+        '<span class="ic">☰</span><span class="idot" hidden></span></button>' +
     '</div>' +
     (PATH ? '<div class="path">' + PATH.replace(/›\s*([^›]+)$/, '› <b>$1</b>') + '</div>' : "");
   document.body.insertBefore(header, document.body.firstChild);
@@ -78,18 +100,23 @@
   var backdrop = el("div", "dsnav-backdrop");
   var drawer = el("aside", "dsnav-drawer");
   drawer.setAttribute("role", "dialog");
-  drawer.setAttribute("aria-label", "Alle Werkzeuge");
+  drawer.setAttribute("aria-label", "Werkzeuge");
   drawer.innerHTML =
-    '<div class="dhead"><span class="t">Alles</span>' +
+    '<div class="dhead"><span class="t">Werkzeuge</span>' +
       '<button class="close" type="button" aria-label="Schliessen">×</button></div>' +
     '<div class="body"></div>' +
     '<div class="foot">Goetheanum Hausgrafik · <a href="' + ROOT + 'design-system/">Design-System</a></div>';
   document.body.appendChild(backdrop);
   document.body.appendChild(drawer);
 
+  var toast = el("div", "dsnav-toast"); document.body.appendChild(toast);
+  function flash(msg) { toast.textContent = msg; toast.classList.add("show"); setTimeout(function () { toast.classList.remove("show"); }, 1400); }
+
   var btnAll = header.querySelector(".all");
   var worldsNav = header.querySelector(".worlds");
   var drawerBody = drawer.querySelector(".body");
+  var drawerTitle = drawer.querySelector(".dhead .t");
+  var idot = btnAll.querySelector(".idot");
 
   function openDrawer() { backdrop.classList.add("open"); drawer.classList.add("open"); btnAll.setAttribute("aria-expanded", "true"); }
   function closeDrawer() { backdrop.classList.remove("open"); drawer.classList.remove("open"); btnAll.setAttribute("aria-expanded", "false"); }
@@ -98,42 +125,86 @@
   drawer.querySelector(".close").addEventListener("click", closeDrawer);
   document.addEventListener("keydown", function (e) { if (e.key === "Escape") closeDrawer(); });
 
-  // --- Aus dem Manifest füllen -----------------------------------------------
-  fetch(TOOLS).then(function (r) { return r.json(); }).then(function (m) {
-    var allTools = m.tools || [];
-    function bySlug(slug) { return allTools.filter(function (t) { return t.slug === slug; })[0]; }
+  // Unsichtbarer Schalter: das Wort „intern" tippen
+  var buf = "";
+  document.addEventListener("keydown", function (e) {
+    var tag = (document.activeElement && document.activeElement.tagName) || "";
+    if (tag === "INPUT" || tag === "TEXTAREA" || (e.key && e.key.length !== 1)) { return; }
+    buf = (buf + e.key.toLowerCase()).slice(-6);
+    if (buf === "intern") {
+      buf = "";
+      var now = !isIntern(); setIntern(now);
+      renderDrawer();
+      flash(now ? "Intern-Ansicht: an" : "Intern-Ansicht: aus");
+      if (now) openDrawer();
+    }
+  });
 
-    // Kopfzeile: vier Direkt-Sprünge
+  // --- Schublade rendern -----------------------------------------------------
+  var ALL = [];
+  function bySlug(slug) { return ALL.filter(function (t) { return t.slug === slug; })[0]; }
+
+  function quickBlock() {
+    var q = el("div", "dsnav-quick");
+    PRIMARY.forEach(function (p) {
+      var t = bySlug(p.slug);
+      var a = el("a", null,
+        '<span class="qt">' + p.label + '</span>' +
+        (t && t.desc ? '<span class="qd">' + t.desc + '</span>' : ""));
+      a.href = t ? resolveHref(t.href) : HOME;
+      q.appendChild(a);
+    });
+    return q;
+  }
+  function groupEl(w, tools) {
+    var g = el("details", "dsnav-group");
+    g.setAttribute("data-world", w.id);
+    g.open = true;
+    g.appendChild(el("summary", null,
+      '<span><span class="ttl">' + w.label + '</span>' +
+      '<span class="intro">' + w.intro + '</span></span><span class="arr">›</span>'));
+    tools.forEach(function (t) {
+      var a = el("a", "dsnav-link");
+      a.href = resolveHref(t.href);
+      if (isExternal(t.href)) { a.target = "_blank"; a.rel = "noopener"; }
+      a.innerHTML =
+        '<span class="st ' + (t.status || "") + '" title="' + (t.status || "") + '"></span>' +
+        '<span class="txt"><span class="tt">' + t.title + '</span>' +
+        (t.desc ? '<span class="dd">' + t.desc + '</span>' : "") + '</span>';
+      g.appendChild(a);
+    });
+    return g;
+  }
+  function renderDrawer() {
+    var intern = isIntern();
+    drawerBody.innerHTML = "";
+    drawerTitle.textContent = intern ? "Alles · intern" : "Werkzeuge";
+    idot.hidden = !intern;
+
+    // Ganz oben: die vier prominent
+    drawerBody.appendChild(quickBlock());
+
+    // Darunter der Rest (ohne die vier). Öffentlich nur „live"; intern alles + Extra.
+    var groups = intern ? WORLDS.concat(INTERN_EXTRA) : WORLDS;
+    groups.forEach(function (w) {
+      var tools = ALL.filter(function (t) {
+        return w.cats.indexOf(t.cat) !== -1 && PRIMARY_SLUGS.indexOf(t.slug) === -1;
+      });
+      if (!intern) tools = tools.filter(function (t) { return t.status === "live"; });
+      if (tools.length) drawerBody.appendChild(groupEl(w, tools));
+    });
+  }
+
+  // --- Manifest laden --------------------------------------------------------
+  fetch(TOOLS).then(function (r) { return r.json(); }).then(function (m) {
+    ALL = m.tools || [];
     PRIMARY.forEach(function (p) {
       var t = bySlug(p.slug);
       var a = el("a", null, p.label);
       a.href = t ? resolveHref(t.href) : HOME;
       worldsNav.appendChild(a);
     });
-
-    // Schublade: drei Welten mit dem ganzen Sortiment
-    WORLDS.forEach(function (w) {
-      var tools = allTools.filter(function (t) { return w.cats.indexOf(t.cat) !== -1; });
-      if (!tools.length) return;
-      var g = el("details", "dsnav-group");
-      g.setAttribute("data-world", w.id);
-      g.open = true;
-      g.appendChild(el("summary", null,
-        '<span><span class="ttl">' + w.label + '</span>' +
-        '<span class="intro">' + w.intro + '</span></span>' +
-        '<span class="arr">›</span>'));
-      tools.forEach(function (t) {
-        var a = el("a", "dsnav-link");
-        a.href = resolveHref(t.href);
-        if (isExternal(t.href)) { a.target = "_blank"; a.rel = "noopener"; }
-        a.innerHTML =
-          '<span class="st ' + (t.status || "") + '" title="' + (t.status || "") + '"></span>' +
-          '<span class="txt"><span class="tt">' + t.title + '</span>' +
-          (t.desc ? '<span class="dd">' + t.desc + '</span>' : "") + '</span>';
-        g.appendChild(a);
-      });
-      drawerBody.appendChild(g);
-    });
+    renderDrawer();
   }).catch(function () {
     drawerBody.innerHTML = '<p style="padding:22px;color:var(--muted)">Werkzeugliste konnte nicht geladen werden.</p>';
   });

--- a/design-system/navigation.html
+++ b/design-system/navigation.html
@@ -29,7 +29,7 @@
   <section class="hero">
     <span class="kicker">Prototyp</span>
     <h1>Eine Navigation für alle.</h1>
-    <p class="lede">Die Kopfzeile oben steht künftig auf jeder Seite – aus <code>tools.json</code> gespeist. Die vier meistgenutzten Werkzeuge stehen direkt beim Namen (ein Tipp = am Ziel); <strong>Mehr</strong> öffnet die Schublade mit dem ganzen Sortiment, nach Welten gegliedert.</p>
+    <p class="lede">Die Kopfzeile oben steht künftig auf jeder Seite – aus <code>tools.json</code> gespeist. Die vier meistgenutzten Werkzeuge stehen direkt beim Namen (ein Tipp = am Ziel); das <strong>☰</strong>-Menü öffnet die Schublade – ganz oben dieselben vier, prominent fürs Handy und den schnellen Griff.</p>
   </section>
 
   <section>
@@ -43,8 +43,8 @@
         <p class="lese" style="margin-top:var(--s2);line-height:1.5">Die Wortmarke <strong>Goetheanum</strong> führt von überall zurück zur Übersicht. In Generatoren steht zusätzlich ein sichtbares <q>← Übersicht</q>. Niemand bleibt stecken.</p>
       </div>
       <div class="card">
-        <span class="kicker">Vier Namen, ein Mehr</span>
-        <p class="lese" style="margin-top:var(--s2);line-height:1.5">Die Kopfzeile nennt die vier meistgenutzten Werkzeuge direkt: <strong>Logos</strong>, <strong>Schriften</strong>, <strong>Mail-Signatur</strong>, <strong>Visitenkarte</strong>. <strong>Mehr</strong> öffnet das ganze Sortiment. Interne Bereiche wie Werkstatt und Geparktes erscheinen hier nicht – sie leben im Hub, nicht vor der Breite.</p>
+        <span class="kicker">Vier, fokussiert</span>
+        <p class="lese" style="margin-top:var(--s2);line-height:1.5">Sichtbar ist nur, was gebraucht wird: <strong>Logos</strong>, <strong>Schriften</strong>, <strong>Mail-Signatur</strong>, <strong>Visitenkarte</strong> – in der Kopfzeile und prominent in der Schublade. Halbfertiges und interne Bereiche bleiben weg, nicht übervoll.</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Worum es geht

Navigation fokussiert nach dem Live-Feedback: **nicht übervoll**, und alles Übrige nur für die Pflege über einen **unsichtbaren Schalter**.

- **Burger statt Pille:** Auslöser ist nur noch das ☰-Icon – keine Pille, kein Wort „Mehr".
- **Fokus auf das Genutzte:** Öffentlich zeigt die Schublade nur fertige Werkzeuge (Status `live`). Die vier meistgenutzten – **Logos · Schriften · Mail-Signatur · Visitenkarte** – stehen prominent als Kacheln ganz oben (auch fürs Handy). Steuerhebel ist `tools.json`: was auf `live` steht, erscheint.
- **Intern (nur für die Pflege):** ein **unsichtbarer Schalter** blendet das ganze Sortiment ein (alle Status + Werkstatt + Geparktes). Auslöser: das Wort `intern` tippen oder einmalig `?intern` an die URL; gemerkt im localStorage, kein sichtbarer Knopf.

## Verifiziert (Chromium)
- Öffentlich: Schublade = nur die vier prominent, sonst nichts. Titel „Werkzeuge".
- Intern: vier oben + Werkzeuge (4) · Schrift (5) · Elemente (1) · Werkstatt (7) · Geparktes (4), Titel „Alles · intern", dezenter Punkt am Burger.
- Typo-Check sauber.

Live-Test danach: https://phtok.github.io/goeloggen/design-system/navigation.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_