### PR TITLE
Navigation: Breadcrumb raus, versteckter Tipp-Schalter (handy-tauglich)

### DIFF
--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -40,12 +40,6 @@
   .dsnav .all{margin-left:auto}
 }
 
-/* Kontext-Pfad (in welcher Welt bin ich) */
-.dsnav .path{max-width:var(--maxw);margin:0 auto;padding:6px 26px;font-size:12px;color:var(--muted);
-  border-top:1px solid var(--line-soft);display:none}
-.dsnav.has-path .path{display:block}
-.dsnav .path b{color:var(--ink);font-weight:var(--w-text)}
-
 /* --- Schublade ------------------------------------------------------------- */
 .dsnav-backdrop{position:fixed;inset:0;background:rgba(20,24,28,.32);opacity:0;visibility:hidden;
   transition:opacity .18s,visibility .18s;z-index:45}

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -25,7 +25,6 @@
   var TOOLS = (s && s.dataset.tools) || ROOT + "tools.json";
   var HOME  = (s && s.dataset.home)  || ROOT;
   var VARIANT = (s && s.dataset.variant) || "";
-  var PATH  = (s && s.dataset.path)  || "";
   var KEY = "goeNavIntern";
 
   // Die vier meistgenutzten Werkzeuge – Kopfzeile UND prominent in der Schublade.
@@ -83,7 +82,7 @@
   })();
 
   // --- Kopfzeile -------------------------------------------------------------
-  var header = el("header", "dsnav" + (VARIANT === "werkzeug" ? " is-werkzeug" : "") + (PATH ? " has-path" : ""));
+  var header = el("header", "dsnav" + (VARIANT === "werkzeug" ? " is-werkzeug" : ""));
   header.innerHTML =
     '<div class="bar">' +
       '<a class="brand" href="' + HOME + '" aria-label="Goetheanum Werkzeuge – zur Übersicht">' +
@@ -93,8 +92,7 @@
       '<nav class="worlds"></nav>' +
       '<button class="all" type="button" aria-haspopup="dialog" aria-expanded="false" aria-label="Menü">' +
         '<span class="ic">☰</span><span class="idot" hidden></span></button>' +
-    '</div>' +
-    (PATH ? '<div class="path">' + PATH.replace(/›\s*([^›]+)$/, '› <b>$1</b>') + '</div>' : "");
+    '</div>';
   document.body.insertBefore(header, document.body.firstChild);
 
   var backdrop = el("div", "dsnav-backdrop");
@@ -125,19 +123,33 @@
   drawer.querySelector(".close").addEventListener("click", closeDrawer);
   document.addEventListener("keydown", function (e) { if (e.key === "Escape") closeDrawer(); });
 
-  // Unsichtbarer Schalter: das Wort „intern" tippen
+  // Unsichtbarer Schalter (zwei Wege, gleicher Effekt)
+  function toggleIntern() {
+    var now = !isIntern(); setIntern(now);
+    renderDrawer();
+    flash(now ? "Intern-Ansicht: an" : "Intern-Ansicht: aus");
+    if (now) openDrawer();
+  }
+
+  // (1) Desktop: das Wort „intern" tippen
   var buf = "";
   document.addEventListener("keydown", function (e) {
     var tag = (document.activeElement && document.activeElement.tagName) || "";
     if (tag === "INPUT" || tag === "TEXTAREA" || (e.key && e.key.length !== 1)) { return; }
     buf = (buf + e.key.toLowerCase()).slice(-6);
-    if (buf === "intern") {
-      buf = "";
-      var now = !isIntern(); setIntern(now);
-      renderDrawer();
-      flash(now ? "Intern-Ansicht: an" : "Intern-Ansicht: aus");
-      if (now) openDrawer();
-    }
+    if (buf === "intern") { buf = ""; toggleIntern(); }
+  });
+
+  // (2) Handy & Desktop: drei schnelle Tipps in die leere Mitte der Kopfzeile
+  // (alles, was kein Link/Knopf ist – also der Bereich zwischen Lockup und Navi).
+  var bar = header.querySelector(".bar");
+  var taps = [];
+  bar.addEventListener("click", function (e) {
+    if (e.target.closest("a,button")) return;        // echte Bedienelemente nicht zählen
+    var now = e.timeStamp;
+    taps.push(now);
+    taps = taps.filter(function (t) { return now - t < 800; });
+    if (taps.length >= 3) { taps = []; toggleIntern(); }
   });
 
   // --- Schublade rendern -----------------------------------------------------

--- a/design-system/navigation.html
+++ b/design-system/navigation.html
@@ -22,7 +22,7 @@
 <body>
 
 <!-- Globale Navigation: erzeugt Kopfzeile + Schublade aus tools.json -->
-<script src="nav.js" data-root="../" data-path="Elemente › Navigation"></script>
+<script src="nav.js" data-root="../"></script>
 
 <main class="wrap">
 


### PR DESCRIPTION
## Worum es geht

Zwei Korrekturen am Live-Prototyp:

- **Breadcrumb entfernt:** Die Kontext-Pfad-Zeile unter der Kopfzeile (z. B. „Elemente › Navigation") ist raus – sie hat den Header gestört.
- **Versteckter Schalter handy-tauglich:** Auf dem Telefon gibt es keine Tastatur, „intern" tippen ging dort nicht. Neu: **drei schnelle Tipps in die leere Mitte der Kopfzeile** (zwischen Lockup und Navi) schalten die Intern-Ansicht an/aus – funktioniert auf Handy (Tippen) und Desktop (Klick). Das Wort `intern` tippen bleibt zusätzlich; `?intern` an die URL auch.

## Verifiziert (Chromium)
- Kein Breadcrumb mehr im Header.
- Drei Tipps in die Header-Mitte → Intern-Ansicht an (Flag gesetzt, Schublade auf, voller Satz, Punkt am Burger). Keine JS-Fehler.
- Typo-Check sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_