### PR TITLE
Eigene Domain: werkzeuge.goetheanum.ch (CNAME + Deploy)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -51,6 +51,10 @@ jobs:
           # Manifest der Werkzeuge (treibt die Uebersicht).
           if [ -f tools.json ]; then cp tools.json _site/tools.json; fi
 
+          # Eigene Domain: GitHub Pages liest die CNAME aus dem Artefakt. Ohne
+          # diese Zeile ginge die Domain-Anbindung beim naechsten Deploy verloren.
+          if [ -f CNAME ]; then cp CNAME _site/CNAME; fi
+
           # Sprechende Abschnitts-Pfade (saubere URLs -> Weiterleitung auf die
           # Zielseite). Zentral gepflegt in sektionen.json.
           if [ -f sektionen.json ]; then python3 tools/build_sections.py _site; fi

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+werkzeuge.goetheanum.ch


### PR DESCRIPTION
## Worum es geht

`werkzeuge.goetheanum.ch` zeigt per DNS bereits auf `phtok.github.io`, aber GitHub Pages führte die Domain noch nicht → 404 „There isn't a GitHub Pages site here" und kein Zertifikat.

- **`CNAME`** (neu): macht `werkzeuge.goetheanum.ch` zur kanonischen Domain der Pages-Seite.
- **`deploy-pages.yml`**: kopiert die `CNAME` bei jedem Build ins `_site` – sonst ginge die Anbindung beim nächsten Deploy verloren.

Nach dem Merge stellt GitHub das HTTPS-Zertifikat aus (ein paar Minuten), dann antwortet die Domain.

Hinweis: `tools.goetheanum.ch` zeigt ebenfalls auf die Pages, ist aber nicht die kanonische Domain – es würde weiter 404 zeigen, bis es per DNS auf `werkzeuge.goetheanum.ch` umgeleitet oder entfernt wird (Sache der URL-Verwaltung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_