### PR TITLE
Sprechende Pfade live (/logo) + Versalien auf der Front door entfernt (G05)

### DIFF
--- a/briefe/index.html
+++ b/briefe/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Weiterleitung … briefe</title>
+  <link rel="canonical" href="../briefschaften.html" />
+  <meta http-equiv="refresh" content="0; url=../briefschaften.html" />
+  <script>location.replace("../briefschaften.html" + location.search + location.hash)</script>
+  <style>
+    body { margin:0; min-height:100vh; display:grid; place-items:center;
+      background:#36424f; color:#dbe0e4;
+      font:400 16px/1.4 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    a { color:#ebb565; }
+  </style>
+</head>
+<body>
+  <p>Weiter zu briefe … <a href="../briefschaften.html">hier klicken</a>.</p>
+</body>
+</html>

--- a/cover/index.html
+++ b/cover/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Weiterleitung … cover</title>
+  <link rel="canonical" href="../cover-generator.html" />
+  <meta http-equiv="refresh" content="0; url=../cover-generator.html" />
+  <script>location.replace("../cover-generator.html" + location.search + location.hash)</script>
+  <style>
+    body { margin:0; min-height:100vh; display:grid; place-items:center;
+      background:#36424f; color:#dbe0e4;
+      font:400 16px/1.4 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    a { color:#ebb565; }
+  </style>
+</head>
+<body>
+  <p>Weiter zu cover … <a href="../cover-generator.html">hier klicken</a>.</p>
+</body>
+</html>

--- a/hub/index.html
+++ b/hub/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Weiterleitung … hub</title>
+  <link rel="canonical" href="../start/" />
+  <meta http-equiv="refresh" content="0; url=../start/" />
+  <script>location.replace("../start/" + location.search + location.hash)</script>
+  <style>
+    body { margin:0; min-height:100vh; display:grid; place-items:center;
+      background:#36424f; color:#dbe0e4;
+      font:400 16px/1.4 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    a { color:#ebb565; }
+  </style>
+</head>
+<body>
+  <p>Weiter zu hub … <a href="../start/">hier klicken</a>.</p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <style>
   /* Front door – bewusst minimal */
   .hero{padding:clamp(56px,11vw,120px) 0 var(--s8)}
-  .hero .kick{color:var(--gold-deep);font-size:12.5px;letter-spacing:.08em;text-transform:uppercase;margin-bottom:var(--s4)}
+  .hero .kick{color:var(--gold-deep);font-size:13px;letter-spacing:.02em;margin-bottom:var(--s4)}
   .hero h1{font-family:var(--font);font-weight:700;font-size:clamp(38px,7vw,72px);line-height:1.0;letter-spacing:-.01em;max-width:14ch}
   .hero .lede{margin-top:var(--s6);color:#565b60;font-size:clamp(16px,2vw,20px);line-height:1.55;max-width:52ch}
 
@@ -21,13 +21,13 @@
   .tile{position:relative;display:flex;flex-direction:column;border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);
         background:var(--soft);transition:border-color .15s,box-shadow .15s,transform .15s;min-height:150px}
   .tile:hover{border-color:var(--gold);box-shadow:var(--shadow-card);transform:translateY(-1px)}
-  .tile .tag{color:var(--gold-deep);font-size:11px;letter-spacing:.06em;text-transform:uppercase;margin-bottom:var(--s2)}
+  .tile .tag{color:var(--gold-deep);font-size:12px;letter-spacing:.02em;margin-bottom:var(--s2)}
   .tile h3{font-family:var(--font);font-weight:var(--w-strong);font-size:20px;line-height:1.15;display:flex;align-items:center;gap:8px}
   .tile h3 .arr{color:var(--muted);font-weight:var(--w-text);transition:transform .15s,color .15s}
   .tile:hover h3 .arr{color:var(--gold-deep);transform:translateX(3px)}
   .tile p{margin-top:var(--s2);color:var(--muted);font-size:14px;line-height:1.5}
-  .badge{position:absolute;top:var(--s4);right:var(--s4);font-size:10.5px;letter-spacing:.04em;text-transform:uppercase;
-         color:var(--blue);border:1px solid rgba(0,97,169,.3);border-radius:var(--r-pill);padding:2px 9px}
+  .badge{position:absolute;top:var(--s4);right:var(--s4);font-size:11px;letter-spacing:.01em;
+         color:var(--blue);border:1px solid rgba(0,97,169,.3);border-radius:var(--r-pill);padding:2px 10px}
 </style>
 </head>
 <body>

--- a/karten/index.html
+++ b/karten/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Weiterleitung … karten</title>
+  <link rel="canonical" href="../karten-generator.html" />
+  <meta http-equiv="refresh" content="0; url=../karten-generator.html" />
+  <script>location.replace("../karten-generator.html" + location.search + location.hash)</script>
+  <style>
+    body { margin:0; min-height:100vh; display:grid; place-items:center;
+      background:#36424f; color:#dbe0e4;
+      font:400 16px/1.4 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    a { color:#ebb565; }
+  </style>
+</head>
+<body>
+  <p>Weiter zu karten … <a href="../karten-generator.html">hier klicken</a>.</p>
+</body>
+</html>

--- a/logo/index.html
+++ b/logo/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Weiterleitung … logo</title>
+  <link rel="canonical" href="../logo-generator.html" />
+  <meta http-equiv="refresh" content="0; url=../logo-generator.html" />
+  <script>location.replace("../logo-generator.html" + location.search + location.hash)</script>
+  <style>
+    body { margin:0; min-height:100vh; display:grid; place-items:center;
+      background:#36424f; color:#dbe0e4;
+      font:400 16px/1.4 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    a { color:#ebb565; }
+  </style>
+</head>
+<body>
+  <p>Weiter zu logo … <a href="../logo-generator.html">hier klicken</a>.</p>
+</body>
+</html>

--- a/schriften/index.html
+++ b/schriften/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Weiterleitung … schriften</title>
+  <link rel="canonical" href="../schriften.html" />
+  <meta http-equiv="refresh" content="0; url=../schriften.html" />
+  <script>location.replace("../schriften.html" + location.search + location.hash)</script>
+  <style>
+    body { margin:0; min-height:100vh; display:grid; place-items:center;
+      background:#36424f; color:#dbe0e4;
+      font:400 16px/1.4 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    a { color:#ebb565; }
+  </style>
+</head>
+<body>
+  <p>Weiter zu schriften … <a href="../schriften.html">hier klicken</a>.</p>
+</body>
+</html>

--- a/signatur/index.html
+++ b/signatur/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Weiterleitung … signatur</title>
+  <link rel="canonical" href="../signatur-generator.html" />
+  <meta http-equiv="refresh" content="0; url=../signatur-generator.html" />
+  <script>location.replace("../signatur-generator.html" + location.search + location.hash)</script>
+  <style>
+    body { margin:0; min-height:100vh; display:grid; place-items:center;
+      background:#36424f; color:#dbe0e4;
+      font:400 16px/1.4 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    a { color:#ebb565; }
+  </style>
+</head>
+<body>
+  <p>Weiter zu signatur … <a href="../signatur-generator.html">hier klicken</a>.</p>
+</body>
+</html>

--- a/statistik/index.html
+++ b/statistik/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Weiterleitung … statistik</title>
+  <link rel="canonical" href="../statistik.html" />
+  <meta http-equiv="refresh" content="0; url=../statistik.html" />
+  <script>location.replace("../statistik.html" + location.search + location.hash)</script>
+  <style>
+    body { margin:0; min-height:100vh; display:grid; place-items:center;
+      background:#36424f; color:#dbe0e4;
+      font:400 16px/1.4 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    a { color:#ebb565; }
+  </style>
+</head>
+<body>
+  <p>Weiter zu statistik … <a href="../statistik.html">hier klicken</a>.</p>
+</body>
+</html>

--- a/typografie/index.html
+++ b/typografie/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Weiterleitung … typografie</title>
+  <link rel="canonical" href="../typografie.html" />
+  <meta http-equiv="refresh" content="0; url=../typografie.html" />
+  <script>location.replace("../typografie.html" + location.search + location.hash)</script>
+  <style>
+    body { margin:0; min-height:100vh; display:grid; place-items:center;
+      background:#36424f; color:#dbe0e4;
+      font:400 16px/1.4 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    a { color:#ebb565; }
+  </style>
+</head>
+<body>
+  <p>Weiter zu typografie … <a href="../typografie.html">hier klicken</a>.</p>
+</body>
+</html>

--- a/visitenkarten/index.html
+++ b/visitenkarten/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Weiterleitung … visitenkarten</title>
+  <link rel="canonical" href="../visitenkarten-generator.html" />
+  <meta http-equiv="refresh" content="0; url=../visitenkarten-generator.html" />
+  <script>location.replace("../visitenkarten-generator.html" + location.search + location.hash)</script>
+  <style>
+    body { margin:0; min-height:100vh; display:grid; place-items:center;
+      background:#36424f; color:#dbe0e4;
+      font:400 16px/1.4 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    a { color:#ebb565; }
+  </style>
+</head>
+<body>
+  <p>Weiter zu visitenkarten … <a href="../visitenkarten-generator.html">hier klicken</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Worum es geht

- **`/logo` (und alle sprechenden Pfade) gehen jetzt.** Ursache des 404: GitHub Pages liefert den **Repo-Branch** aus, nicht das kuratierte `_site`-Artefakt des Deploy-Workflows (Beleg: `/README.md`, `/tools/…`, `/docs/…` sind live abrufbar, obwohl der Workflow sie ausschließt). Die von `build_sections` nur ins `_site` erzeugten Weiterleitungs-Stubs fehlten daher live. **Sofort-Fix:** die Stubs aus `sektionen.json` in den Repo-Stand schreiben → `/logo`, `/schriften`, `/signatur`, `/hub` usw. funktionieren.
- **Versalien auf der Front door entfernt (G05).** Kicker, Tags und Badge stehen jetzt in normaler Schreibweise statt VERSAL – die Kardinalregel, die wir selbst aufgestellt haben.

## Grundsätzliche Empfehlung (separat zu entscheiden)
Die saubere Lösung des 404-Themas ist, die **Pages-Quelle auf „GitHub Actions" umzustellen** (Settings → Pages → Build and deployment → Source). Dann greift der kuratierte Workflow wirklich: sprechende Pfade kommen aus `build_sections` (die committeten Stubs werden überflüssig), und interne Ordner (`docs/`, `tools/`, `reference/`, `services/`) sind nicht mehr öffentlich. Heute ist faktisch das **ganze Repo** öffentlich abrufbar.

## Verifiziert
- `/logo/` lokal 200; Front-door-Kicker `text-transform:none` (Normalschrift); Tags normal.
- Typo-Check sauber (inkl. Stubs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_