### PR TITLE
Logos-Seite: Button „Herunterladen"

### DIFF
--- a/logo-generator.html
+++ b/logo-generator.html
@@ -51,7 +51,7 @@
       <h1>Das Logo des Goetheanum</h1>
       <p class="lede">Ein Zeichen, das über sich hinausweist – aus dem Bau gewonnen. Hier steht, was es bedeutet, wie es aufgebaut ist und wohin es gehört. Und du erzeugst dein Sektions- oder Bereichslogo in Minuten, korrekt gesetzt.</p>
       <div class="cta">
-        <a class="btn primary" href="apps/logo-generator/">Logo erstellen</a>
+        <a class="btn primary" href="apps/logo-generator/">Herunterladen</a>
         <a class="btn" href="#regeln">Regeln &amp; Verbote</a>
       </div>
     </div>
@@ -145,7 +145,7 @@
       <h2>Dein Logo holen</h2>
       <p>Sektion oder Bereich wählen, Layout und Farbe einstellen, als SVG herunterladen.</p>
     </div>
-    <a class="btn primary" href="apps/logo-generator/" style="font-size:15px;padding:12px 22px">Logo erstellen →</a>
+    <a class="btn primary" href="apps/logo-generator/" style="font-size:15px;padding:12px 22px">Herunterladen →</a>
   </section>
 
 </main>


### PR DESCRIPTION
Button-Beschriftung auf der Logos-Seite: **Herunterladen** statt „Logo erstellen" (Hero + unten). Es geht ums Holen eines fertigen Logos, nicht ums „Erstellen".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_