### PR TITLE
Hausschrift-Fix (relativ) + Navi/Logos-Feinschliff

### DIFF
--- a/apps/logos/index.html
+++ b/apps/logos/index.html
@@ -20,7 +20,9 @@
   .controls{display:grid;gap:var(--s4)}
   .seg{display:flex;flex-wrap:wrap;gap:6px}
   .seg button{font:inherit;font-size:13px;padding:7px 12px;border:1px solid var(--line);border-radius:var(--r-pill);background:#fff;color:var(--ink);cursor:pointer}
-  .seg button[aria-pressed="true"]{background:var(--gold);border-color:var(--gold);color:#3a2d10}
+  .seg button[aria-pressed="true"]{background:var(--ink);border-color:var(--ink);color:#fff}
+  .catbar{margin:var(--s2) 0 var(--s6)}
+  .catbar .seg{gap:8px}
   .stage{display:grid;place-items:center;min-height:280px;border:1px solid var(--line);border-radius:var(--r-card);background:var(--soft);padding:clamp(24px,5vw,56px)}
   .stage.dark{background:#23272b}
   .stage svg{max-width:100%;height:auto;max-height:340px}
@@ -66,13 +68,13 @@
 
   <!-- ===================== WERKZEUG ===================== -->
   <section id="werkzeug">
-    <div class="shead"><h2>Logo holen</h2><p>Das fertige SVG kommt aus dieser Quelle – nie nachbauen.</p></div>
+    <div class="shead"><h2>Logo holen</h2></div>
+    <div class="field catbar">
+      <span class="lab">Kategorie</span>
+      <div class="seg" id="cat"></div>
+    </div>
     <div class="tool">
       <div class="controls">
-        <div class="field">
-          <span class="lab">Kategorie</span>
-          <div class="seg" id="cat"></div>
-        </div>
         <label class="field">
           <span class="lab">Sektion / Bereich</span>
           <select id="org"></select>

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -88,7 +88,6 @@
       '<a class="brand" href="' + HOME + '" aria-label="Goetheanum Werkzeuge – zur Übersicht">' +
         '<img class="lockup" src="' + ROOT + 'assets/logos/goetheanum-werkzeuge.svg" alt="Goetheanum Werkzeuge">' +
       '</a>' +
-      '<a class="back" href="' + HOME + '">← Übersicht</a>' +
       '<nav class="worlds"></nav>' +
       '<button class="all" type="button" aria-haspopup="dialog" aria-expanded="false" aria-label="Menü">' +
         '<span class="ic">☰</span><span class="idot" hidden></span></button>' +

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -11,8 +11,8 @@
 /* Hausschrift – Variable Font, gehostet auf GitHub Pages (vgl. schriften.html#web) */
 @font-face{
   font-family:"Goetheanum";
-  src:url("https://phtok.github.io/goeloggen/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Variabel-v2.5.woff2") format("woff2"),
-      url("https://phtok.github.io/goeloggen/assets/fonts/goetheanum/Webfonts/woff/Goetheanum-Variabel-v2.5.woff") format("woff");
+  src:url("../assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Variabel-v2.5.woff2") format("woff2"),
+      url("../assets/fonts/goetheanum/Webfonts/woff/Goetheanum-Variabel-v2.5.woff") format("woff");
   font-weight:190 725; font-style:normal; font-display:swap;
 }
 


### PR DESCRIPTION
## Worum es geht

- **Hausschrift seitenweit repariert:** `tokens.css` lud die Schrift über eine absolute `phtok.github.io`-URL. Auf der eigenen Domain leitet die **301** auf `werkzeuge.goetheanum.ch` um und ist **cross-origin** → der Browser blockierte den Font, alle Seiten fielen auf Helvetica zurück. Jetzt **relativ** (same-origin) → Hausschrift lädt überall. *(Lokal verifiziert: `document.fonts.check('16px Goetheanum') === true`.)*
- **‹← Übersicht› aus dem Header entfernt** (die Wortmarke führt ohnehin zur Übersicht).
- **Logos-App:** Kategorie-Pillen auf **einer Zeile** (volle Breite); aktive Pillen von **Gold/Schwarz → Tinte/Weiss**; Untertitel ‹Das fertige SVG … nie nachbauen› entfernt.

Pillen-Aktivfarbe als Vorschlag mitgeschickt (B Tinte/Weiss angewandt; C Markenblau / D Gold-umrandet / E Sanft-gold als Alternativen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_