### PR TITLE
Schrift-Seiten: einheitliche ds-nav mit zweistufigem Menü (Phase 1)

### DIFF
--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -6,6 +6,10 @@
    Akkordeon = native <details>/<summary> (klappbar, zugänglich, ohne Skript).
    ============================================================================= */
 
+/* Die globale Navigation trägt immer die Hausschrift – unabhängig von der
+   Body-Schrift der Gastseite (sonst erbt sie z. B. Helvetica). */
+.dsnav,.dsnav-sub,.dsnav-drawer{font-family:var(--font)}
+
 .dsnav{position:sticky;top:0;z-index:40;background:rgba(255,255,255,.92);
   backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--line)}
 .dsnav .bar{display:flex;align-items:center;gap:var(--s4);height:var(--header-h);

--- a/schrift-vergleich.html
+++ b/schrift-vergleich.html
@@ -10,6 +10,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,400;0,600;1,400&family=IBM+Plex+Sans:ital,wght@0,400;0,600;1,400&family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400&family=Inter:ital,wght@0,400;0,600;1,400&family=Cairo:wght@400;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/nav.css" />
 <style>
   @font-face{font-family:"G Klar";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Klar.woff2") format("woff2");font-display:swap}
   @font-face{font-family:"G Deutlich";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Deutlich.woff2") format("woff2");font-display:swap}
@@ -60,10 +62,7 @@
 </style>
 </head>
 <body>
-<header><div class="wrap bar">
-  <strong style="font-family:'G Klar';font-weight:400">Goetheanum · Schrift-Vergleich</strong>
-  <nav class="top"><a href="schriften.html">Schriften</a><a href="vorschau.html">Neu</a><a href="#mix">Mischung</a><a href="#cards">Kandidaten</a><a href="#fallback">Fallback</a></nav>
-</div></header>
+<script src="design-system/nav.js" data-root="./" data-section="schrift" data-active="schrift-vergleich"></script>
 
 <main><div class="wrap">
   <div class="hero">

--- a/schrift-webfont.html
+++ b/schrift-webfont.html
@@ -3,6 +3,8 @@
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" /><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Goetheanum Schrift — als Webfont einbinden</title>
+<link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/nav.css" />
 <style>
 /* === Goetheanum Variable Font einbinden === */
 @font-face{
@@ -38,7 +40,9 @@ pre .k{color:#9ecbff}pre .s{color:#c3e88d}pre .c{color:#7f868d}
 .swatch{display:flex;flex-direction:column;gap:4px}
 .swatch .s{font-family:"Goetheanum";font-size:34px}
 </style></head>
-<body><div class="wrap">
+<body>
+<script src="design-system/nav.js" data-root="./" data-section="schrift" data-active="schrift-webfont"></script>
+<div class="wrap">
 
 <h1 class="goe" style="font-weight:600">Goetheanum Schrift — als Webfont</h1>
 <p class="lead">Fertige Einbindung mit <code>@font-face</code>. Diese Seite lädt die Schrift selbst über die unten gezeigten Zeilen — was du siehst, ist die echte Webfont.</p>

--- a/schriften.html
+++ b/schriften.html
@@ -7,6 +7,8 @@
 <title>Goetheanum Schriften</title>
 <meta name="description" content="Goetheanum Schriften 2.5 – Leise, Klar, Deutlich, Laut, Variabel und Icons. Repariert, vervollständigt und optimiert." />
 <meta name="robots" content="noindex" />
+<link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/nav.css" />
 <style>
   @font-face{font-family:"G Leise";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Leise.woff2") format("woff2");font-weight:400;font-display:swap}
   @font-face{font-family:"G Klar";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Klar.woff2") format("woff2");font-weight:400;font-display:swap}
@@ -131,15 +133,7 @@
 </head>
 <body>
 
-<header><div class="wrap bar">
-  <a class="brand" href="https://grafik.goetheanum.ch" aria-label="Zur Grafikseite – grafik.goetheanum.ch">
-    <img src="assets/logos/am-goetheanum-dark.svg" alt="Am Goetheanum" />
-  </a>
-  <nav class="top">
-    <a href="#variabel">Variabel</a><a href="#schnitte">Schnitte</a>
-    <a href="#features">Features</a><a href="#icons">Icons</a><a href="#web">Im&nbsp;Web</a><a href="typografie.html">Typografie</a><a href="vorschau.html">Neu</a><a href="#download">Download</a>
-  </nav>
-</div></header>
+<script src="design-system/nav.js" data-root="./" data-section="schrift" data-active="schriften"></script>
 
 <main>
   <div class="wrap hero">
@@ -300,7 +294,7 @@ body{ font-family:"Goetheanum", system-ui, sans-serif; }
         <a class="btn" href="assets/fonts/goetheanum/Beipackzettel-Goetheanum-Schriften.pdf" download>PDF</a></div>
     </div>
     <p style="margin-top:18px;font-size:13px;color:var(--muted)">
-      <b style="color:var(--ink);font-weight:400">Installieren (macOS):</b> ZIP entpacken → Doppelklick auf eine <code>.otf</code> → „Installieren". 
+      <b style="color:var(--ink);font-weight:400">Installieren (macOS):</b> ZIP entpacken → Doppelklick auf eine <code>.otf</code> → ‹Installieren›.
       Ausführliche Schritt-für-Schritt-Anleitung: <a style="color:var(--gold-deep)" href="https://support.apple.com/de-de/guide/font-book/fntbk1000/mac">Apple Schriftsammlung</a>.
       Fürs Office reichen Leise, Klar, Deutlich, Laut – ⌘B holt Laut, ⌘I holt Leise.
     </p>

--- a/tester.html
+++ b/tester.html
@@ -6,6 +6,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Goetheanum Schriften · Gewichts-Tester</title>
 <meta name="robots" content="noindex" />
+<link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/nav.css" />
 <style>
   @font-face{font-family:"GV";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Variabel-v2.5.woff2") format("woff2");font-weight:150 725;font-display:swap}
   :root{--ink:#23272b;--muted:#737a80;--line:rgba(20,24,28,.12);--gold:#d7ab68;--gold-deep:#a07a33;--soft:#faf8f4;--ok:#3f8f5f;--warn:#c2873a}
@@ -54,6 +56,7 @@
 </style>
 </head>
 <body>
+<script src="design-system/nav.js" data-root="./" data-section="schrift" data-active="tester"></script>
 <div class="wrap">
   <div class="kick">Goetheanum Schriften · Werkzeug</div>
   <h1>Gewichts-Tester</h1>

--- a/typografie.html
+++ b/typografie.html
@@ -8,6 +8,8 @@
 <meta name="description" content="Goetheanum Typografie – wenige Mittel, präzise gesetzt. Hausregeln als Handbuch und maschinenlesbares System (DTCG-Tokens + prüfbare Regeln)." />
 <meta name="robots" content="noindex" />
 <link rel="stylesheet" href="assets/typografie/ziffern.css" />
+<link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/nav.css" />
 <style>
   @font-face{font-family:"G Leise";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Leise.woff2") format("woff2");font-display:swap}
   @font-face{font-family:"G Klar";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Klar.woff2") format("woff2");font-display:swap}
@@ -70,10 +72,7 @@
 </style>
 </head>
 <body>
-<header><div class="wrap bar">
-  <a class="brand" href="https://grafik.goetheanum.ch" aria-label="Zur Grafikseite"><img src="assets/logos/am-goetheanum-dark.svg" alt="Am Goetheanum"></a>
-  <nav class="top"><a href="schriften.html">Schriften</a><a href="#mikro">Mikrotypografie</a><a href="#spickzettel">Spickzettel</a><a href="vorschau.html">Neu</a></nav>
-</div></header>
+<script src="design-system/nav.js" data-root="./" data-section="schrift" data-active="typografie"></script>
 
 <main><div class="wrap">
   <div class="hero">

--- a/vorschau.html
+++ b/vorschau.html
@@ -7,6 +7,8 @@
 <title>Goetheanum Schriften – Neuerungen v2.5</title>
 <meta name="description" content="Vorschau aller Neuerungen der Goetheanum Schriften v2.5: typografische Spatien, geschützter Bindestrich, Ziffern-Features (pnum/onum/tnum) und der Mediävalziffern-Entwurf." />
 <meta name="robots" content="noindex" />
+<link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/nav.css" />
 <style>
   @font-face{font-family:"G Leise";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Leise.woff2") format("woff2");font-display:swap}
   @font-face{font-family:"G Klar";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.5-Klar.woff2") format("woff2");font-display:swap}
@@ -86,10 +88,7 @@
 </style>
 </head>
 <body>
-<header><div class="wrap bar">
-  <a class="brand" href="https://grafik.goetheanum.ch" aria-label="Zur Grafikseite"><img src="assets/logos/am-goetheanum-dark.svg" alt="Am Goetheanum"></a>
-  <nav class="top"><a href="schriften.html">Schriften</a><a href="typografie.html">Typografie</a><a href="#variabel">Variabel</a><a href="#ziffern">Ziffern</a><a href="#spatien">Spatien</a><a href="#handbuch">Handbuch</a></nav>
-</div></header>
+<script src="design-system/nav.js" data-root="./" data-section="schrift" data-active="vorschau"></script>
 
 <main><div class="wrap">
   <div class="hero">


### PR DESCRIPTION
## Was

Rollout der zweistufigen Navigation auf **alle sechs Schrift-Seiten** – Beginn der Phase-1-Vereinheitlichung (eigene Kopfzeilen → globale `ds-nav`).

| Seite | aktiv |
|---|---|
| schriften.html | Überblick |
| typografie.html | Typografie |
| schrift-webfont.html | Webfont |
| schrift-vergleich.html | Vergleich |
| tester.html | Tester |
| vorschau.html | Neu |

Jede Seite bindet `tokens.css` + `nav.css` ein (vor dem Seiten-`<style>`, damit die lokale Gestaltung unverändert bleibt) und aktiviert die Welt-Unterleiste mit `data-section="schrift"`. Die je eigene Kopfzeile entfällt.

- **nav.css:** die globale Navigation trägt nun immer die Hausschrift, unabhängig von der Body-Schrift der Gastseite (sonst erbte sie auf Webfont/Tester z. B. Helvetica).
- **schriften.html:** macOS-Knopf ‹Installieren› in Hausanführung gesetzt (G16).

## Bewusst noch nicht
Das **Body-Layout** der Seiten bleibt vorerst wie gehabt – nur die Kopf-Navigation ist vereinheitlicht. Der vollständige Reskin auf das Design-System ist Phase 2. Die seiteninterne Sprungnavigation (#variabel, #mikro …) entfällt mit den alten Kopfzeilen (war in der gewählten Variante 1 nicht vorgesehen).

## Regeln
Aktiv-Markierung als Farbe + feiner Gold-Strich (kein Versal/Unterstreichen, G05). G16-Anführung korrigiert.

## Prüfung
`tools/typo-check.py` ✓ keine Fehler. Alle sechs Seiten lokal gerendert (Desktop): Kopfzeile + Unterleiste, korrekter aktiver Eintrag, keine CSS-Kollision, Body unverändert; Navigation durchgängig in der Hausschrift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_