### PR TITLE
Typo-Fundament neu: Lesbarkeit mobil, robuste Maße, Dunkelmodus

### DIFF
--- a/assets/typografie/goetheanum-typo-tokens.json
+++ b/assets/typografie/goetheanum-typo-tokens.json
@@ -78,8 +78,8 @@
     },
     "tinte-leise": {
       "$type": "color",
-      "$value": "#737a80",
-      "$description": "Meta, Legenden, Nebenstimmen. Kontrast auf Papier 4.35:1 – knapp unter WCAG AA (4.5) für Fliesstext, über AA für grosse Grade. Nur für Meta und grössere Grade, nie für lange Lesetexte in Kleingrad.",
+      "$value": "#6b7177",
+      "$description": "Meta, Legenden, Nebenstimmen. Kontrast auf Papier 4.9:1 – erfüllt WCAG AA (4.5) für Fliesstext. Dennoch sparsam: für Lesetext bleibt Tinte die erste Wahl.",
       "$extensions": {
         "com.goetheanum.regel": "G28"
       }
@@ -112,8 +112,8 @@
   "mass": {
     "zeilenlaenge": {
       "$type": "dimension",
-      "$value": "39ch",
-      "$description": "Gilt der Lesetypografie (linearer Mengentext). Ziel ~66 Zeichen je Zeile / neun Wörter (45–75 zulässig). CSS min(39ch,100%). Hinweis: ch = Breite der Ziffer 0; die Goetheanum Schrift ist schmal – empirisch gezählt sind 46ch = 78 Zeichen, also 39ch ≈ 66. Konsultation (Tabellen, Verzeichnisse) und Schau (Signaletik) laufen nach eigenem Mass.",
+      "$value": "62ch",
+      "$description": "Gilt der Lesetypografie (linearer Mengentext in Source Sans 3). Ziel ~66 Zeichen je Zeile (45–75 zulässig). CSS min(62ch,100%) über --measure. Hinweis: Lesetext läuft jetzt in Source (normalbreit) statt in der schmalen Display-Grotesk; 62ch ≈ 66 Zeichen. Konsultation (Tabellen) und Schau (Signaletik) nach eigenem Mass.",
       "$extensions": {
         "com.goetheanum.regel": "G10"
       }

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -4,128 +4,136 @@
    Gemeinsame Grundlage für alle Werkzeuge: Grundlayout, Kopf-/Fusszeile,
    Abschnitte, Karten, Knöpfe, Formularfelder. Setzt design-system/tokens.css
    voraus (zuerst einbinden). Werkzeug-spezifisches gehört in die jeweilige Seite.
+
+   Schrift-Rollen (robust, mobil-first):
+   • Lesetext (Source Sans 3) trägt Fliesstext, Beschreibungen, Tabellen, Felder.
+   • Display (Goetheanum) trägt Titel, Kicker – das, was geschaut statt gelesen wird.
+   Hell/Dunkel kommt allein aus den Tokens (var(--paper)/--ink/… kippen mit dem Theme).
    ============================================================================= */
 
 *{box-sizing:border-box;margin:0;padding:0}
 
 body{
   background:var(--paper); color:var(--ink);
-  font-family:var(--font); font-weight:var(--w-text); line-height:1.5;
+  font-family:var(--font-text); font-weight:400;
+  font-size:var(--t-body); line-height:var(--lh-body);
   font-kerning:normal; text-rendering:optimizeLegibility; -webkit-font-smoothing:antialiased;
 }
 a{color:inherit;text-decoration:none}
 .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
 
+/* Display-Schrift trägt die Titel. */
+h1,h2,h3,.h-display{font-family:var(--font-display);font-weight:var(--w-deutlich);line-height:var(--lh-tight)}
+
 /* Zugänglichkeit: Zustand = Blau */
-a:focus-visible,button:focus-visible,summary:focus-visible{outline:2px solid var(--blue);outline-offset:2px;border-radius:4px}
+a:focus-visible,button:focus-visible,summary:focus-visible,input:focus-visible,select:focus-visible{outline:2px solid var(--blue);outline-offset:2px;border-radius:4px}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 
 /* --- Kopfzeile -------------------------------------------------------------- */
-.ds-header{position:sticky;top:0;z-index:30;background:rgba(255,255,255,.9);backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--line)}
+.ds-header{position:sticky;top:0;z-index:30;background:var(--bar-bg);backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--line)}
 .ds-header .bar{display:flex;align-items:center;justify-content:space-between;height:var(--header-h)}
 .brand{display:flex;align-items:center;gap:var(--s3)}
 .brand .mk{width:24px;height:24px;border-radius:6px;display:block}
-.brand .wm{font-family:var(--font);font-weight:var(--w-text);font-size:27px;line-height:1;color:#8a9097;letter-spacing:.005em}
+.brand .wm{font-family:var(--font-display);font-weight:var(--w-text);font-size:27px;line-height:1;color:var(--muted);letter-spacing:.005em}
 nav.top{display:flex;gap:22px}
-nav.top a{color:var(--muted);font-size:13.5px}
+nav.top a{color:var(--muted);font-size:var(--t-small)}
 nav.top a:hover{color:var(--gold-deep)}
 @media(max-width:720px){nav.top{display:none}}
 
 /* --- Abschnitte ------------------------------------------------------------ */
 section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 .shead{display:flex;align-items:baseline;justify-content:space-between;gap:var(--s8);margin-bottom:var(--s6);flex-wrap:wrap}
-.shead h2{font-family:var(--font);font-weight:var(--w-strong);font-size:clamp(22px,3vw,30px);line-height:1.05;flex:0 0 auto}
-.shead p{color:var(--muted);font-size:14px;line-height:1.5;max-width:54ch;flex:1 1 320px}
+.shead h2{font-size:var(--t-h2);flex:0 0 auto}
+.shead p{color:var(--muted);font-size:var(--t-small);line-height:1.5;max-width:54ch;flex:1 1 320px}
 
 /* --- Karte ----------------------------------------------------------------- */
 .card{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);background:var(--paper)}
 .card.soft{background:var(--soft)}
 
 /* --- Chips ----------------------------------------------------------------- */
-.chip{font-size:13px;color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:6px 14px}
+.chip{font-size:var(--t-small);color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:6px 14px}
 .chip b{color:var(--ink);font-weight:var(--w-strong)}
 
-/* --- Knöpfe ---------------------------------------------------------------- */
-.btn{display:inline-block;font:inherit;font-size:13.5px;padding:9px 15px;border-radius:var(--r-control);border:1px solid var(--line);color:var(--ink);background:#fff;text-align:center;cursor:pointer;transition:.15s}
-.btn:hover{border-color:var(--gold-deep)}
-.btn.primary{background:var(--gold-deep);border-color:var(--gold-deep);color:#fff}
-.btn.primary:hover{background:#8a6a2c;border-color:#8a6a2c}
-.btn.ghost{color:var(--muted)}
+/* --- Knöpfe = AKTION -------------------------------------------------------- */
+/* Aktion = Blau (Zustand/Tun); die primäre Aktion ist gefüllt. Klar getrennt von
+   der Auswahl-Pille (Gold). Mind. Fingerziel auf Touch. */
+.btn{display:inline-flex;align-items:center;justify-content:center;font:inherit;font-size:15px;line-height:1.2;
+  padding:10px 16px;border-radius:var(--r-control);border:1px solid var(--line);color:var(--ink);
+  background:var(--field-bg);text-align:center;cursor:pointer;transition:.15s}
+.btn:hover{border-color:var(--blue)}
+.btn.primary{background:var(--blue);border-color:var(--blue);color:var(--on-accent);font-weight:var(--w-strong)}
+.btn.primary:hover{filter:brightness(.93)}
+.btn.ghost{color:var(--muted);background:none}
 .btn.ok{background:#3f7d46;border-color:#3f7d46;color:#fff}
+/* Lade-Knopf trägt einen Pfeil – ‹Herunterladen› ist auf den ersten Blick keine Pille. */
+.btn.dl::before{content:"↓";margin-right:8px;font-weight:var(--w-strong)}
 
-/* --- Segmentierte Auswahl (Pillen) ----------------------------------------- */
-/* Anwahl = Gold/Weiss (--gold-deep auf Weiss) – der Hausfarbklang für Auswahl. */
+/* --- Segmentierte Auswahl (Pillen) = WAHL ---------------------------------- */
+/* Anwahl = Gold/Weiss – der Hausfarbklang für Auswahl. Kapselform, kein Pfeil. */
 .seg{display:flex;flex-wrap:wrap;gap:8px}
-.seg button{font:inherit;font-size:13px;padding:7px 14px;border:1px solid var(--line);border-radius:var(--r-pill);
-  background:#fff;color:var(--ink);cursor:pointer;transition:border-color .15s,background .15s,color .15s}
+.seg button{font:inherit;font-size:14.5px;padding:8px 15px;border:1px solid var(--line);border-radius:var(--r-pill);
+  background:var(--field-bg);color:var(--ink);cursor:pointer;transition:border-color .15s,background .15s,color .15s}
 .seg button:hover{border-color:var(--gold-deep)}
-.seg button[aria-pressed="true"]{background:var(--gold-deep);border-color:var(--gold-deep);color:#fff}
+.seg button[aria-pressed="true"]{background:var(--gold-deep);border-color:var(--gold-deep);color:var(--on-accent)}
 
-/* Auswahl vs. Aktion klar trennen: Pillen (.seg, Kapsel, gold-weiss = gewählt)
-   sind eine WAHL; Knöpfe (.btn, eckiger) sind ein TUN. Lade-Knöpfe tragen einen
-   Pfeil ↓, damit ‹Herunterladen› auf den ersten Blick keine Pille ist. */
-.btn.dl::before{content:"↓";margin-right:7px;font-weight:var(--w-strong);opacity:.9}
-
-/* Bequeme Fingerziele auf dem Handy. */
+/* Bequeme Fingerziele auf dem Handy (Apple 44 / Material 48 / WCAG 24). */
 @media(max-width:560px){
-  .seg button,.btn{min-height:42px}
+  .seg button,.btn{min-height:var(--tap)}
 }
 
 /* --- Formularfelder -------------------------------------------------------- */
+/* 16px+ verhindert das automatische Zoomen beim Fokus auf iOS. Lesetext-Schrift. */
 .field{display:grid;gap:var(--s1)}
-.field>.lab{font-size:13px;color:var(--muted);letter-spacing:.01em}
+.field>.lab{font-size:var(--t-small);color:var(--muted);letter-spacing:.01em}
 .field input,.field textarea,.field select{
-  width:100%;font-family:var(--font-system);font-size:14.5px;font-weight:400;line-height:1.35;color:var(--ink);
-  background:#fff;border:1px solid var(--line);border-radius:var(--r-control);padding:8px 11px;outline:none;
+  width:100%;font-family:var(--font-text);font-size:var(--t-body);font-weight:400;line-height:1.4;color:var(--ink);
+  background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);padding:10px 12px;outline:none;
   transition:border-color .15s,box-shadow .15s;
 }
 .field textarea{resize:vertical;min-height:48px}
-.field input::placeholder,.field textarea::placeholder{color:#aeb4b9}
-.field input:focus,.field textarea:focus,.field select:focus{border-color:var(--blue);box-shadow:0 0 0 3px rgba(0,97,169,.16)}
-.field input.invalid{border-color:var(--bad);box-shadow:0 0 0 3px rgba(179,38,30,.14)}
+.field input::placeholder,.field textarea::placeholder{color:var(--muted);opacity:.7}
+.field input:focus,.field textarea:focus,.field select:focus{border-color:var(--blue);box-shadow:0 0 0 3px color-mix(in srgb,var(--blue) 22%,transparent)}
+.field input.invalid{border-color:var(--bad);box-shadow:0 0 0 3px color-mix(in srgb,var(--bad) 20%,transparent)}
 
 /* --- Fusszeile ------------------------------------------------------------- */
-.ds-footer{border-top:1px solid var(--line);padding:var(--s8) 0 60px;color:var(--muted);font-size:12.5px;margin-top:var(--s8)}
+.ds-footer{border-top:1px solid var(--line);padding:var(--s8) 0 60px;color:var(--muted);font-size:var(--t-small);margin-top:var(--s8)}
 .ds-footer .frow{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap}
 .ds-footer .frow strong{color:var(--ink);font-weight:var(--w-text)}
 .ds-footer .frow a:hover{color:var(--gold-deep)}
 
 /* =============================================================================
    Eingebaute Typografie – Hausregeln als Voreinstellung, nicht als Nachkontrolle
-   -----------------------------------------------------------------------------
-   Wer nichts tut, tut das Richtige (Mechanismus 2). Fürs Falsche gibt es kein
-   Werkzeug (Mechanismus 3). Quelle: assets/typografie/goetheanum-typo-tokens.json.
+   Quelle: assets/typografie/goetheanum-typo-tokens.json.
    ============================================================================= */
 
-/* Lesefluss: Trennung, schöner Umbruch, keine verwaisten Zeilen (G12/G24/G28).
-   Greift, weil die Seite lang="de-CH" trägt (siehe starter.html). */
+/* Lesefluss: Trennung, schöner Umbruch, keine verwaisten Zeilen (G12/G24/G28). */
 body{hyphens:auto;-webkit-hyphens:auto;text-wrap:pretty;orphans:2;widows:2}
 
-/* Betonung hat genau zwei Ämter: Laut betont, Leise ist der stille Gegenton
-   (G02/G05/S01). Keine echte Kursive – Leise steht aufrecht. Unterstreichen und
-   Versalien als Hervorhebung gibt es bewusst NICHT als Utility (G05). */
+/* Betonung: Laut betont (Source SemiBold). Leise ist der stille Gegenton – im
+   Lesetext (Source) zurückhaltender Ton; in der Display-Schrift ein leichteres
+   Gewicht. Unterstreichen/Versalien als Hervorhebung gibt es bewusst NICHT (G05). */
 strong,b{font-weight:var(--w-strong)}
-em,i{font-style:normal;font-weight:var(--w-leise)}
+em,i{font-style:normal;font-weight:var(--w-leise);color:var(--muted)}
 
-/* Hausanführung: ‹…› automatisch über <q> (G16) – einfache Guillemets nach aussen. */
+/* Hausanführung: ‹…› automatisch über <q> (G16). */
 q{quotes:'\2039' '\203A' '\2039' '\203A'}
 
-/* Ziffern in Tabellen: Versalziffern, dicktengleich, exakt untereinander (G25).
-   Nie mit Leerzeichen ausgerichtet – das erledigt tabular-nums. */
+/* Ziffern in Tabellen: Versalziffern, dicktengleich, exakt untereinander (G25). */
 table{border-collapse:collapse;font-variant-numeric:tabular-nums lining-nums}
 th,td{text-align:left;padding:var(--s2) var(--s3);border-bottom:1px solid var(--line-soft)}
 th{font-weight:var(--w-strong);color:var(--ink)}
 td.num,th.num,.num{font-variant-numeric:tabular-nums lining-nums;text-align:right;font-feature-settings:"tnum","lnum"}
 
-/* Schnitt-Utilities – die drei Stimmen der Familie, abrufbar ohne Nachdenken. */
+/* Schnitt-Utilities. */
 .leise{font-weight:var(--w-leise)}
 .klar{font-weight:var(--w-text)}
 .deutlich{font-weight:var(--w-deutlich)}
 .laut{font-weight:var(--w-strong)}
 
-/* Korrekter Kicker: getönt und leicht getrackt – aber NORMAL, nicht versal (G05). */
-.kicker{display:inline-block;color:var(--gold-deep);font-size:12.5px;letter-spacing:.04em;font-weight:var(--w-leise);margin-bottom:var(--s2)}
+/* Kicker: getönt, leicht getrackt, Display-Schrift – NORMAL, nicht versal (G05). */
+.kicker{display:inline-block;font-family:var(--font-display);color:var(--gold-deep);font-size:13px;letter-spacing:.04em;font-weight:var(--w-leise);margin-bottom:var(--s2)}
 
 /* Lesemass: ~66 Zeichen je Zeile für linearen Mengentext (G10). */
-.lese{max-width:min(39ch,100%)}
-.meta{color:var(--muted)}
+.lese{max-width:min(var(--measure),100%)}
+.meta{color:var(--muted);font-size:var(--t-small)}
+.lede{font-size:var(--t-lede);color:var(--muted);line-height:1.45;max-width:54ch}

--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -14,7 +14,7 @@
    zwischen kurzen und langen Seiten um die Balkenbreite nach rechts. */
 html{scrollbar-gutter:stable}
 
-.dsnav{position:sticky;top:0;z-index:40;background:rgba(255,255,255,.92);
+.dsnav{position:sticky;top:0;z-index:40;background:var(--bar-bg);
   backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--line)}
 .dsnav .bar{display:flex;align-items:center;gap:var(--s4);height:var(--header-h);
   max-width:var(--ds-maxw);margin:0 auto;padding:0 26px}
@@ -36,8 +36,14 @@ html{scrollbar-gutter:stable}
   background:none;border:0;cursor:pointer;padding:0;text-decoration:none}
 .dsnav .worlds a:hover,.dsnav .worlds button:hover{color:var(--gold-deep)}
 
+/* ☾/☀ Hell-Dunkel – nur das Icon */
+.dsnav .theme{margin-left:18px;display:inline-flex;align-items:center;justify-content:center;font:inherit;
+  color:var(--ink);background:none;border:0;padding:6px;cursor:pointer;line-height:1}
+.dsnav .theme .ic{font-size:18px;line-height:1}
+.dsnav .theme:hover{color:var(--gold-deep)}
+
 /* ☰ Burger – nur das Icon, keine Pille, kein Wort */
-.dsnav .all{margin-left:22px;display:inline-flex;align-items:center;gap:6px;font:inherit;
+.dsnav .all{margin-left:10px;display:inline-flex;align-items:center;gap:6px;font:inherit;
   color:var(--ink);background:none;border:0;padding:4px;cursor:pointer;line-height:1}
 .dsnav .all .ic{font-size:23px;line-height:1}
 .dsnav .all:hover{color:var(--gold-deep)}
@@ -45,7 +51,7 @@ html{scrollbar-gutter:stable}
 
 @media(max-width:720px){
   .dsnav .worlds{display:none}
-  .dsnav .all{margin-left:auto}
+  .dsnav .theme{margin-left:auto}
 }
 
 /* --- Schublade ------------------------------------------------------------- */
@@ -67,7 +73,7 @@ html{scrollbar-gutter:stable}
 .dsnav-drawer .body{overflow:auto;padding:var(--s2) 0 var(--s8)}
 
 /* Toast für den unsichtbaren Intern-Schalter */
-.dsnav-toast{position:fixed;left:50%;bottom:24px;transform:translateX(-50%);background:var(--ink);color:#fff;
+.dsnav-toast{position:fixed;left:50%;bottom:24px;transform:translateX(-50%);background:var(--ink);color:var(--paper);
   padding:8px 16px;border-radius:var(--r-pill);font-size:13px;opacity:0;visibility:hidden;
   transition:opacity .2s,visibility .2s;z-index:60}
 .dsnav-toast.show{opacity:1;visibility:visible}

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -27,6 +27,28 @@
   var HOME  = (s && s.dataset.home)  || ROOT;
   var ACTIVE = (s && s.dataset.active) || "";   // optional: aktiver Eintrag (slug); sonst aus der URL
   var KEY = "goeNavIntern";
+  var THEME_KEY = "goeTheme";
+
+  // --- Hell/Dunkel -----------------------------------------------------------
+  function prefersDark() { return !!(window.matchMedia && matchMedia("(prefers-color-scheme: dark)").matches); }
+  function getTheme() {
+    try { var t = localStorage.getItem(THEME_KEY); if (t === "light" || t === "dark") return t; } catch (e) {}
+    return prefersDark() ? "dark" : "light";
+  }
+  function updateThemeBtn() {
+    if (!themeBtn) return;
+    var dark = document.documentElement.getAttribute("data-theme") === "dark";
+    themeBtn.querySelector(".ic").textContent = dark ? "☀" : "☾";
+    themeBtn.setAttribute("aria-label", dark ? "Hell schalten" : "Dunkel schalten");
+    themeBtn.setAttribute("aria-pressed", String(dark));
+  }
+  function setTheme(t) {
+    try { localStorage.setItem(THEME_KEY, t); } catch (e) {}
+    document.documentElement.setAttribute("data-theme", t);
+    updateThemeBtn();
+  }
+  // Sofort anwenden – vor dem Zeichnen, gegen Aufblitzen.
+  document.documentElement.setAttribute("data-theme", getTheme());
 
   // Die vier meistgenutzten – nur als Desktop-Schnellzugriff in der Kopfzeile.
   var PRIMARY = [
@@ -100,6 +122,7 @@
         '<img class="lockup" src="' + ROOT + 'assets/logos/goetheanum-werkzeuge.svg" alt="Goetheanum Werkzeuge">' +
       '</a>' +
       '<nav class="worlds"></nav>' +
+      '<button class="theme" type="button" aria-label="Dunkel schalten"><span class="ic">☾</span></button>' +
       '<button class="all" type="button" aria-haspopup="dialog" aria-expanded="false" aria-label="Menü">' +
         '<span class="ic">☰</span><span class="idot" hidden></span></button>' +
     '</div>';
@@ -121,6 +144,11 @@
   function flash(msg) { toast.textContent = msg; toast.classList.add("show"); setTimeout(function () { toast.classList.remove("show"); }, 1400); }
 
   var btnAll = header.querySelector(".all");
+  var themeBtn = header.querySelector(".theme");
+  themeBtn.addEventListener("click", function () {
+    setTheme(document.documentElement.getAttribute("data-theme") === "dark" ? "light" : "dark");
+  });
+  updateThemeBtn();
   var worldsNav = header.querySelector(".worlds");
   var drawerBody = drawer.querySelector(".body");
   var drawerTitle = drawer.querySelector(".dhead .t");

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -1,53 +1,110 @@
 /* =============================================================================
    Goetheanum CI – Design-Tokens (eine Quelle der Wahrheit)
    -----------------------------------------------------------------------------
-   Farben, Typo, Abstaende, Radien und die Hausschrift als Webfont. Jedes Tool
-   bindet diese Datei ein und ist allein durch Wiederverwendung im Hausbild.
-   Extrahiert aus dem reifsten Tool (Signatur-Generator) und vereinheitlicht.
+   Farben, Typo, Maße, Radien, beide Schriften, Hell/Dunkel. Jedes Tool bindet
+   diese Datei ein und ist allein durch Wiederverwendung im Hausbild.
 
-   Maschinenlesbare Fassung derselben Werte: design-system/tokens.json (DTCG).
+   Schrift-Grundsatz (robust, mobil-first):
+   • Goetheanum = DISPLAY: Titel, Kicker, Navigation, Knöpfe – kurze, starke Texte.
+   • Source Sans 3 = LESETEXT: Fliesstext, Beschreibungen, Tabellen, kleine Grade,
+     Formularfelder. Die Display-Grotesk wird bei kleinen/langen Texten unleserlich
+     (dünne, kontrastreiche Striche brechen weg) – darum übernimmt eine echte
+     Textschrift alles, was gelesen statt geschaut wird.
+
+   Maschinenlesbare Fassung: design-system/tokens.json (DTCG). Kanon der Typo-
+   Regeln & Farben: assets/typografie/goetheanum-typo-tokens.json (Driftwächter:
+   tools/typo-sync.py).
    ============================================================================= */
 
-/* Hausschrift – Variable Font, gehostet auf GitHub Pages (vgl. schriften.html#web) */
+/* --- Hausschrift: Goetheanum Variable (Display) ---------------------------- */
 @font-face{
   font-family:"Goetheanum";
   src:url("../assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Variabel-v2.5.woff2") format("woff2"),
       url("../assets/fonts/goetheanum/Webfonts/woff/Goetheanum-Variabel-v2.5.woff") format("woff");
   font-weight:190 725; font-style:normal; font-display:swap;
 }
+/* --- Lesetext: Source Sans 3 (selbst gehostet, OFL) ------------------------ */
+@font-face{
+  font-family:"Source Sans 3"; font-weight:400; font-style:normal; font-display:swap;
+  src:url("../assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2") format("woff2");
+}
+@font-face{
+  font-family:"Source Sans 3"; font-weight:600; font-style:normal; font-display:swap;
+  src:url("../assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2") format("woff2");
+}
+@font-face{
+  font-family:"Source Sans 3"; font-weight:400; font-style:italic; font-display:swap;
+  src:url("../assets/fonts/goetheanum/Fallback/SourceSans3-Italic.woff2") format("woff2");
+}
 
 :root{
   /* --- Markenfarben ------------------------------------------------------- */
-  --blue:#0061a9;        /* Markenblau – Zustand/Verweis (Quelle: goetheanum-orgs) */
+  --blue:#0061a9;        /* Markenblau – Zustand/Verweis/Aktion */
   --gold:#d7ab68;        /* Gold – Inhalts-Akzent */
-  --gold-deep:#a07a33;   /* Gold dunkel – Hover/Links auf hell */
+  --gold-deep:#a07a33;   /* Gold dunkel – Auswahl/Hover auf hell */
 
   /* --- Neutrale Töne ------------------------------------------------------ */
-  --ink:#23272b;         /* Text */
-  --muted:#737a80;       /* Sekundärtext */
+  --ink:#23272b;         /* Lesetext */
+  --muted:#6b7177;       /* Sekundärtext – jetzt 4.9:1 auf Papier (WCAG AA) */
   --paper:#fff;          /* Grund */
   --soft:#faf8f4;        /* gedämpfte Fläche (Karten) */
+  --field-bg:#fff;       /* Eingabefelder, Knöpfe, Pillen */
+  --bar-bg:rgba(255,255,255,.9);  /* klebende Leisten (Kopf, Schublade) */
   --line:rgba(20,24,28,.10);
   --line-soft:rgba(20,24,28,.055);
   --bad:#b3261e;         /* Fehler/Warnung */
+  --on-accent:#fff;      /* Text auf Blau/Gold-Flächen */
 
-  /* --- Typografie --------------------------------------------------------- */
-  --font:"Goetheanum","Helvetica Neue",Arial,sans-serif;
+  /* --- Schrift-Familien --------------------------------------------------- */
+  --font-display:"Goetheanum","Helvetica Neue",Arial,sans-serif; /* Titel, Chrome */
+  --font-text:"Source Sans 3","Helvetica Neue",Arial,sans-serif; /* Lesetext, klein/lang */
+  --font:var(--font-text);     /* Standard = Lesetext */
   --font-system:"Helvetica Neue",Arial,sans-serif;
   --font-mono:ui-monospace,Menlo,Consolas,monospace;
-  --w-leise:265;         /* Leise – Legenden, Zitate, stiller Gegenton (S01) */
-  --w-text:440;          /* Klar – Fliesstext, alles was gelesen wird */
-  --w-deutlich:580;      /* Deutlich – Titel-Schnitt (CLAUDE.md: Deutlich = Titel) */
-  --w-strong:680;        /* Laut – Inline-/Office-Fettung, Betonung (⌘B) */
 
-  /* --- Abstands-Skala (4/8/12/16/24/32) ---------------------------------- */
+  /* --- Schnitte (Goetheanum Variable) ------------------------------------- */
+  --w-leise:265; --w-text:440; --w-deutlich:580; --w-strong:680;
+
+  /* --- Typo-Skala (mobil-first, flüssig, nie zu klein) -------------------- */
+  /* Grund in rem → respektiert die Browser-Schriftgröße der Nutzer (Zugänglichkeit). */
+  --t-micro:0.8125rem;                                   /* 13px – nur Beiwerk (Status, Badges) */
+  --t-small:clamp(0.875rem, 0.84rem + 0.18vw, 0.9375rem);/* 14–15px – Meta, Legenden */
+  --t-body:clamp(1.0625rem, 1.01rem + 0.28vw, 1.1875rem);/* 17–19px – Fliesstext */
+  --t-lede:clamp(1.1875rem, 1.08rem + 0.5vw, 1.375rem);  /* 19–22px – Lede */
+  --t-h3:clamp(1.1875rem, 1.08rem + 0.5vw, 1.375rem);    /* 19–22px */
+  --t-h2:clamp(1.5rem, 1.18rem + 1.6vw, 1.95rem);        /* 24–31px */
+  --t-h1:clamp(2rem, 1.45rem + 2.8vw, 3rem);             /* 32–48px */
+  --lh-body:1.6; --lh-tight:1.15;
+  --measure:62ch;        /* ~66 Zeichen in Source – lineares Lesemaß (G10) */
+
+  /* --- Abstände (4/8/12/16/24/32) ---------------------------------------- */
   --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s6:24px; --s8:32px;
 
-  /* --- Radien & Maße ----------------------------------------------------- */
+  /* --- Radien, Maße, Fingerziel ------------------------------------------ */
   --r-control:10px; --r-card:14px; --r-pill:999px;
-  --header-h:58px; --maxw:1080px;
-  --ds-maxw:1080px;      /* feste Breite der globalen Navigation – von Seiten NICHT überschrieben (sonst springt die zentrierte Leiste) */
+  --header-h:60px; --maxw:1080px; --ds-maxw:1080px;
+  --tap:44px;            /* Mindest-Fingerziel (Apple 44, Material 48, WCAG 24) */
 
   /* --- Schatten ---------------------------------------------------------- */
   --shadow-card:0 10px 30px rgba(20,24,28,.06);
+
+  color-scheme:light;
+}
+
+/* =============================================================================
+   Dunkelmodus – per Schalter (data-theme) gesetzt; Voreinstellung folgt dem
+   System (nav.js setzt data-theme aus localStorage oder prefers-color-scheme).
+   Forschung: kein reines Schwarz/Weiss, Akzente entsättigen, Gewicht senken
+   (heller Text auf dunklem Grund „blutet"/wirkt fetter).
+   ============================================================================= */
+:root[data-theme="dark"]{
+  --blue:#5aa6e0; --gold:#dfb87a; --gold-deep:#c79a4f;
+  --ink:#e6e8ea; --muted:#9aa1a8;
+  --paper:#16191c; --soft:#1e2329; --field-bg:#1e2329;
+  --bar-bg:rgba(20,23,26,.85);
+  --line:rgba(255,255,255,.14); --line-soft:rgba(255,255,255,.07);
+  --bad:#e0675e; --on-accent:#16191c;
+  --w-deutlich:540; --w-strong:620;     /* weniger Bleeding auf Dunkel */
+  --shadow-card:0 10px 30px rgba(0,0,0,.45);
+  color-scheme:dark;
 }

--- a/design-system/tokens.json
+++ b/design-system/tokens.json
@@ -3,46 +3,126 @@
   "$description": "Goetheanum CI – maschinenlesbare Design-Tokens (DTCG). Spiegelt design-system/tokens.css. Quelle der Markenfarben: assets/data/goetheanum-orgs.js.",
   "color": {
     "$type": "color",
-    "blue":      { "$value": "#0061a9", "$description": "Markenblau – Zustand/Verweis" },
-    "gold":      { "$value": "#d7ab68", "$description": "Gold – Inhalts-Akzent" },
-    "gold-deep": { "$value": "#a07a33", "$description": "Gold dunkel – Hover/Links auf hell" },
-    "ink":       { "$value": "#23272b", "$description": "Text" },
-    "muted":     { "$value": "#737a80", "$description": "Sekundärtext" },
-    "paper":     { "$value": "#ffffff", "$description": "Grund" },
-    "soft":      { "$value": "#faf8f4", "$description": "gedämpfte Fläche" },
-    "bad":       { "$value": "#b3261e", "$description": "Fehler/Warnung" }
+    "blue": {
+      "$value": "#0061a9",
+      "$description": "Markenblau – Zustand/Verweis"
+    },
+    "gold": {
+      "$value": "#d7ab68",
+      "$description": "Gold – Inhalts-Akzent"
+    },
+    "gold-deep": {
+      "$value": "#a07a33",
+      "$description": "Gold dunkel – Hover/Links auf hell"
+    },
+    "ink": {
+      "$value": "#23272b",
+      "$description": "Text"
+    },
+    "muted": {
+      "$value": "#6b7177",
+      "$description": "Sekundärtext"
+    },
+    "paper": {
+      "$value": "#ffffff",
+      "$description": "Grund"
+    },
+    "soft": {
+      "$value": "#faf8f4",
+      "$description": "gedämpfte Fläche"
+    },
+    "bad": {
+      "$value": "#b3261e",
+      "$description": "Fehler/Warnung"
+    }
   },
   "font": {
     "$type": "fontFamily",
-    "house":  { "$value": ["Goetheanum", "Helvetica Neue", "Arial", "sans-serif"], "$description": "Hausschrift (Variable Font v2.5)" },
-    "system": { "$value": ["Helvetica Neue", "Arial", "sans-serif"], "$description": "Systemsicher (z. B. E-Mail)" },
-    "mono":   { "$value": ["ui-monospace", "Menlo", "Consolas", "monospace"] }
+    "house": {
+      "$value": [
+        "Goetheanum",
+        "Helvetica Neue",
+        "Arial",
+        "sans-serif"
+      ],
+      "$description": "Hausschrift (Variable Font v2.5)"
+    },
+    "system": {
+      "$value": [
+        "Helvetica Neue",
+        "Arial",
+        "sans-serif"
+      ],
+      "$description": "Systemsicher (z. B. E-Mail)"
+    },
+    "mono": {
+      "$value": [
+        "ui-monospace",
+        "Menlo",
+        "Consolas",
+        "monospace"
+      ]
+    }
   },
   "fontWeight": {
     "$type": "fontWeight",
-    "leise":    { "$value": 265, "$description": "Leise – Legenden, Zitate, stiller Gegenton (S01)" },
-    "text":     { "$value": 440, "$description": "Klar – Fliesstext, alles was gelesen wird" },
-    "deutlich": { "$value": 580, "$description": "Deutlich – Titel-Schnitt (CLAUDE.md: Deutlich = Titel)" },
-    "strong":   { "$value": 680, "$description": "Laut – Inline-/Office-Fettung, Betonung (⌘B)" }
+    "leise": {
+      "$value": 265,
+      "$description": "Leise – Legenden, Zitate, stiller Gegenton (S01)"
+    },
+    "text": {
+      "$value": 440,
+      "$description": "Klar – Fliesstext, alles was gelesen wird"
+    },
+    "deutlich": {
+      "$value": 580,
+      "$description": "Deutlich – Titel-Schnitt (CLAUDE.md: Deutlich = Titel)"
+    },
+    "strong": {
+      "$value": 680,
+      "$description": "Laut – Inline-/Office-Fettung, Betonung (⌘B)"
+    }
   },
   "space": {
     "$type": "dimension",
-    "1": { "$value": "4px" },
-    "2": { "$value": "8px" },
-    "3": { "$value": "12px" },
-    "4": { "$value": "16px" },
-    "6": { "$value": "24px" },
-    "8": { "$value": "32px" }
+    "1": {
+      "$value": "4px"
+    },
+    "2": {
+      "$value": "8px"
+    },
+    "3": {
+      "$value": "12px"
+    },
+    "4": {
+      "$value": "16px"
+    },
+    "6": {
+      "$value": "24px"
+    },
+    "8": {
+      "$value": "32px"
+    }
   },
   "radius": {
     "$type": "dimension",
-    "control": { "$value": "10px" },
-    "card":    { "$value": "14px" },
-    "pill":    { "$value": "999px" }
+    "control": {
+      "$value": "10px"
+    },
+    "card": {
+      "$value": "14px"
+    },
+    "pill": {
+      "$value": "999px"
+    }
   },
   "size": {
     "$type": "dimension",
-    "header": { "$value": "58px" },
-    "maxw":   { "$value": "1080px" }
+    "header": {
+      "$value": "58px"
+    },
+    "maxw": {
+      "$value": "1080px"
+    }
   }
 }

--- a/tools/typo-sync.py
+++ b/tools/typo-sync.py
@@ -66,7 +66,10 @@ def main():
     farbe = canon.get("farbe", {})
 
     tokens = read(TOKENS)
-    tokvars = dict(re.findall(r"(--[a-z-]+)\s*:\s*(#[0-9a-fA-F]{3,8})", tokens))
+    # Nur den hellen Basis-Block :root{…} lesen (nicht :root[data-theme="dark"]).
+    mblock = re.search(r":root\s*\{(.*?)\}", tokens, re.S)
+    base_block = mblock.group(1) if mblock else tokens
+    tokvars = dict(re.findall(r"(--[a-z-]+)\s*:\s*(#[0-9a-fA-F]{3,8})", base_block))
 
     # 1) Farben synchron
     for cname, var in COLOR_MAP.items():
@@ -91,10 +94,10 @@ def main():
     if gap:
         infos.append("Im Kanon, aber (noch) nicht im Handbuch dokumentiert: " + ", ".join(gap))
 
-    # 4) Zeilenlänge (G10) in base.css verankert
+    # 4) Zeilenlänge (G10) im Design-System verankert (Token oder .lese)
     zl = (canon.get("mass", {}).get("zeilenlaenge") or {}).get("$value")
-    if zl and zl not in read(BASE):
-        problems.append(f"Zeilenlänge {zl} (G10) nicht in base.css gefunden (.lese).")
+    if zl and zl not in (read(TOKENS) + "\n" + read(BASE)):
+        problems.append(f"Zeilenlänge {zl} (G10) nicht im Design-System gefunden (--measure / .lese).")
 
     # --- Bericht ---
     print("Goetheanum Typo-Sync — Kanon ↔ Design-System")


### PR DESCRIPTION
Das Fundament für gute Lesbarkeit auf europäischen Smartphones — und ein Dunkelmodus. Forschungsgestützt, von Grund auf.

## Schrift-Rollen (das Kern-Learning)
Die Goetheanum-Grotesk ist eine **Display**-Schrift — bei kleinen/langen Texten brechen die dünnen, kontrastreichen Striche weg. Darum:
- **Goetheanum = Display:** Titel, Kicker (das Geschaute).
- **Source Sans 3** (selbst gehostet, OFL) **= Lesetext:** Fliesstext, Beschreibungen, Tabellen, **Formularfelder**, kleine Grade (das Gelesene).

## Robuste Maße (mobil-first, in `rem`, flüssig per `clamp`)
- Fliesstext **17–19px** (nie unter 16), Meta **≥14px**, Lede 19–22px, Titel bis 48px.
- Zeilenhöhe **1.6**, Lesemass **62ch** (Source), Fingerziele **≥44px** (Apple/Material/WCAG), Felder **≥16px** (kein iOS-Zoom).
- Sekundärtext `--muted` von 4.35:1 → **4.9:1** (WCAG AA).

## Aktion vs. Auswahl per Farbe
**Aktion = Blau** (gefüllt), **Auswahl = Gold-Pille.** Die Farbe trägt die Funktion (dein „Download blau").

## Dunkelmodus
Forschung umgesetzt: kein reines Schwarz/Weiss, Akzente entsättigt, Gewichte gesenkt (heller Text „blutet" auf dunkel). Tokens kippen über `data-theme`; Schalter **☾/☀** in der Kopfzeile, Voreinstellung folgt dem System (`prefers-color-scheme`), gemerkt. Flächen in `base.css`/`nav.css` sind tokenisiert (`--paper`/`--field-bg`/`--bar-bg`).

## Kanon & Driftwächter mitgezogen
`tinte-leise #6b7177`, Zeilenmass `62ch` im Kanon aktualisiert; `typo-sync` liest nur den hellen `:root`-Block. **✓ synchron** (der Hook hat den Drift beim Bauen tatsächlich gemeldet).

## Bewusst offen (zwei Punkte zur Entscheidung)
1. **«Leise» im Lesetext:** Das Gewicht-Spiel (Leise = leichter) gibt es im statischen Source nicht — die Schrift kommt hier an ihre Grenze (wie von dir vermutet). Aktuell wird «Leise» im Lesetext getönt statt leichter. Die Haupt-Betonung «Laut» (SemiBold) trägt voll.
2. **Ältere Seiten** mit eigenem CSS (Schrift-Seiten, Generatoren) kippen erst nach der Token-Migration vollständig in Dunkel — bis dahin bleibt ihr Rumpf hell. Voll live ist der Modus auf den DS-Seiten (Logos, Design-System).

## Prüfung
`typo-sync` ✓. Lokal gerendert: Logos in Hell/Dunkel × Handy/Desktop — größere Grade, klare Auswahl/Aktion-Trennung, Dunkelmodus tragfähig, keine JS-Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_