### PR TITLE
Gesetz: kein dunkler Text auf Farbe · Auswahl als Listen · Barrierefreiheit in die Regeln

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,27 @@ Die v2.5-Schrift hat Funktionen erhalten, die ältere Regeln (noch) anders
 beschreiben. Solche Widersprüche **melden und vom Auftraggeber entscheiden
 lassen** — das Regelwerk **nicht** eigenmächtig umschreiben.
 
+### Barrierefreiheit ist verbindlich (WCAG 2.2 AA)
+Für jede Web-Oberfläche gilt, geprüft (Kontraste rechnen, nicht schätzen):
+- **B01 Kein dunkler Text auf farbigem Grund.** Auf Blau/Gold/Grün steht
+  **Weiss** (`--on-accent`). Auswahl-Pille = dunkles Gold + Weiss (≥4.5:1),
+  Aktion = volles Blau + Weiss. Nie Schwarz auf Farbe.
+- **B02 Kontrast** (WCAG 1.4.3/1.4.11): Lesetext ≥ **4.5:1**, grosse/fette
+  Schrift und UI-/Grafik-Ränder ≥ **3:1**. `--muted` nur dort, wo es das hält.
+- **B03 Mindestgrössen mobil:** Fliesstext **≥16px** (Standard 17–19), Meta
+  **≥14px**, nichts unter 13. Eingabefelder **≥16px** (sonst zoomt iOS).
+- **B04 Fingerziele ≥44px** (`--tap`); Zeilenhöhe Lesetext ≥1.5.
+- **B05 Hell/Dunkel** kommt allein aus den Tokens; Flächen tokenisieren
+  (`--paper`/`--field-bg`/`--bar-bg`), nie `#fff` hart verdrahten.
+
+### Grenzen der Hausschrift (bewusst einsetzen)
+Goetheanum ist **Display** – die Stimme. Sie hat zwei Grenzen:
+- **Textmasse:** ein paar gut gesetzte Zeilen (magisches Quadrat) sind kein
+  Problem; **echter Mengentext** läuft in **Source Sans 3** (`.prose`).
+- **Kleine UI-Schrift:** **Leise** verschwimmt klein – Minimum ist **Klar**,
+  Titel/Marken **Deutlich**. Kleine Labels nie in Leise setzen.
+Das Menü **koordiniert, es erklärt nicht**: nur Titel, kein Beiwerk-Text.
+
 ## Bauen neuer Seiten und Werkzeuge — vom Fundament aus, nicht freihändig
 Konformität entsteht durch Konstruktion, nicht durch Nachkontrolle. Darum gilt
 für **jede** neue HTML-Seite oder jedes neue Werkzeug:

--- a/apps/logos/index.html
+++ b/apps/logos/index.html
@@ -12,7 +12,7 @@
 <style>
   .hero{padding:clamp(32px,6vw,64px) 0 var(--s6)}
   .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.4vw,52px);line-height:1.04;letter-spacing:-.01em;max-width:16ch}
-  .hero .lede{margin-top:var(--s4);color:#565b60;font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:56ch}
+  .hero .lede{margin-top:var(--s4);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:56ch}
 
   /* Werkzeug – zwei Spalten, Vorschau OBEN-BÜNDIG mit der Auswahl und klebend. */
   .tool{display:grid;gap:var(--s6);grid-template-columns:1fr}
@@ -56,8 +56,8 @@
   .sheet .num{display:grid;gap:var(--s6);grid-template-columns:1fr}
   @media(min-width:720px){.sheet .num{grid-template-columns:1fr 1fr}}
   .sheet h3{display:flex;gap:8px;align-items:baseline;font-weight:var(--w-strong);font-size:15px;margin-bottom:6px}
-  .sheet h3 .n{color:var(--gold-deep);font-variant-numeric:tabular-nums}
-  .sheet p{color:#3d4348;font-size:14px;line-height:1.55;max-width:62ch}
+  .sheet h3 .n{color:var(--gold-ink);font-variant-numeric:tabular-nums}
+  .sheet p{color:var(--ink);font-size:var(--t-small);line-height:1.6;max-width:62ch}
   .vstrip{display:flex;gap:var(--s4);flex-wrap:wrap;align-items:flex-end;margin:var(--s3) 0}
   .vstrip figure{margin:0;text-align:center}
   .vstrip .box{border:1px solid var(--line);border-radius:10px;background:var(--soft);padding:14px;display:grid;place-items:center;min-height:84px}
@@ -90,22 +90,22 @@
   <section id="werkzeug">
     <div class="tool">
       <div class="controls">
-        <div class="field">
+        <label class="field">
           <span class="lab">Kategorie</span>
-          <div class="seg" id="cat"></div>
-        </div>
+          <select id="cat"></select>
+        </label>
         <label class="field" id="orgField">
           <span class="lab">Sektion / Bereich</span>
           <select id="org"></select>
         </label>
-        <div class="field">
+        <label class="field">
           <span class="lab">Layout</span>
-          <div class="seg" id="layout"></div>
-        </div>
-        <div class="field">
+          <select id="layout"></select>
+        </label>
+        <label class="field">
           <span class="lab">Farbe</span>
-          <div class="seg" id="mode"></div>
-        </div>
+          <select id="mode"></select>
+        </label>
         <label class="field">
           <span class="lab">Sprache</span>
           <select id="lang">
@@ -115,17 +115,17 @@
             <option value="es">Español</option>
           </select>
         </label>
-        <div class="field">
+        <label class="field">
           <span class="lab">Format</span>
-          <div class="seg" id="fmt"></div>
-        </div>
+          <select id="fmt"></select>
+        </label>
       </div>
 
       <div class="preview">
         <div class="stage" id="stage"><span class="meta">…</span></div>
         <div class="meta" id="dim"></div>
         <div class="download">
-          <button class="btn primary dl" id="dl" type="button">herunterladen</button>
+          <button class="btn primary" id="dl" type="button">herunterladen</button>
           <div class="dlhint" id="dlhint"></div>
         </div>
       </div>
@@ -135,7 +135,7 @@
   <!-- ===================== BEGLEITSCHREIBEN ===================== -->
   <section id="begleitschreiben">
     <div class="shead">
-      <h2>Begleitschreiben</h2>
+      <h2>Hinweise zur Anwendung</h2>
       <p>Alles auf einer Seite – wer, was, wie. (Entwurf; wird noch ausgearbeitet.)</p>
       <button class="btn pdfbtn" id="pdfSheet" type="button">Als PDF speichern</button>
     </div>
@@ -200,7 +200,7 @@
         </div>
       </div>
 
-      <p class="note"><span class="n" style="color:var(--gold-deep)">10</span> &nbsp;Holen: oben Sektion wählen und herunterladen. · Grundlage: Werkstatt-Artikel und Leitsystem-Grundsätze auf grafik.goetheanum.ch; Struktur nach gängigen Logo-Richtlinien (u. a. Smithsonian, UC Santa Barbara, Mailchimp).</p>
+      <p class="note"><span class="n" style="color:var(--gold-ink)">10</span> &nbsp;Holen: oben Sektion wählen und herunterladen. · Grundlage: Werkstatt-Artikel und Leitsystem-Grundsätze auf grafik.goetheanum.ch; Struktur nach gängigen Logo-Richtlinien (u. a. Smithsonian, UC Santa Barbara, Mailchimp).</p>
     </div>
   </section>
 
@@ -232,30 +232,23 @@
 
   var $ = function(id){ return document.getElementById(id); };
 
-  // Kategorie-Pillen: zwei Zeilen. Oben die zwei festen Allgemein-Logos
+  // Kategorie als Liste (Klappwahl): oben die zwei festen Allgemein-Logos
   // (Goetheanum, Bühne), darunter die drei wählbaren Kategorien.
-  var CAT_PILLS = [
+  var CAT_OPTS = [
     { label:"Allgemein",    cat:"allgemein",    org:"goetheanum" },
     { label:"Bühne",        cat:"allgemein",    org:"buehne" },
-    { brk:true },
     { label:"Sektionen",    cat:"sektionen" },
     { label:"Bereiche",     cat:"bereiche" },
     { label:"Teilbereiche", cat:"teilbereiche" }
   ];
-  function pillActive(p){
-    if (p.org) return sel.cat === p.cat && sel.org === p.org;   // feste Org
-    return sel.cat === p.cat && sel.cat !== "allgemein";        // wählbare Kategorie
-  }
+  function catVal(o){ return o.org ? (o.cat + ":" + o.org) : o.cat; }
   function fillCats(){
-    var box = $("cat"); box.innerHTML = "";
-    CAT_PILLS.forEach(function(p){
-      if (p.brk){ var s = document.createElement("span"); s.className = "brk"; box.appendChild(s); return; }
-      var b = document.createElement("button");
-      b.type = "button"; b.textContent = p.label;
-      b.dataset.cat = p.cat; if (p.org) b.dataset.org = p.org;
-      b.setAttribute("aria-pressed", String(pillActive(p)));
-      box.appendChild(b);
+    var s = $("cat"); s.innerHTML = "";
+    CAT_OPTS.forEach(function(o){
+      var op = document.createElement("option");
+      op.value = catVal(o); op.textContent = o.label; s.appendChild(op);
     });
+    s.value = (sel.cat === "allgemein") ? (sel.cat + ":" + sel.org) : sel.cat;
   }
   function fillOrgs(){
     var o = $("org"); o.innerHTML = "";
@@ -269,14 +262,13 @@
   }
   // Die Sektion/Bereich-Auswahl nur zeigen, wenn eine wählbare Kategorie aktiv ist.
   function syncOrgField(){ var f = $("orgField"); if (f) f.style.display = (sel.cat === "allgemein") ? "none" : ""; }
-  function fillSeg(id, pairs, current){
-    var box = $(id); box.innerHTML = "";
+  function fillSel(id, pairs, current){
+    var s = $(id); s.innerHTML = "";
     pairs.forEach(function(p){
-      var b = document.createElement("button");
-      b.type = "button"; b.textContent = p[1]; b.dataset.val = p[0];
-      b.setAttribute("aria-pressed", String(p[0] === current));
-      box.appendChild(b);
+      var op = document.createElement("option");
+      op.value = p[0]; op.textContent = p[1]; s.appendChild(op);
     });
+    s.value = current;
   }
 
   function currentSVG(){ return E.svg(sel); }
@@ -321,23 +313,22 @@
   function init(){
     if (!E || typeof ORGS === "undefined") { $("stage").innerHTML = '<span class="meta">Engine nicht geladen.</span>'; return; }
     fillCats(); fillOrgs(); syncOrgField();
-    fillSeg("layout", LAYOUT_LABELS, sel.layout);
-    fillSeg("mode", MODE_LABELS, sel.mode);
-    $("cat").addEventListener("click", function(e){
-      var b=e.target.closest("button"); if(!b)return;
-      sel.cat = b.dataset.cat;
-      if (b.dataset.org) sel.org = b.dataset.org;   // feste Org (Allgemein/Bühne)
-      fillOrgs();                                    // wählbare Kategorie: Standard-Org setzen
-      fillCats(); syncOrgField();
-      sel.org = (sel.cat === "allgemein") ? sel.org : $("org").value;
+    fillSel("layout", LAYOUT_LABELS, sel.layout);
+    fillSel("mode", MODE_LABELS, sel.mode);
+    fillSel("fmt", FMT_LABELS, sel.fmt); updateDl();
+    $("cat").addEventListener("change", function(){
+      var v = this.value, i = v.indexOf(":");
+      if (i >= 0){ sel.cat = "allgemein"; sel.org = v.slice(i + 1); }   // feste Org (Allgemein/Bühne)
+      else { sel.cat = v; }
+      fillOrgs(); syncOrgField();
+      if (sel.cat !== "allgemein") sel.org = $("org").value;
       render();
     });
     $("org").addEventListener("change", function(){ sel.org = this.value; render(); });
+    $("layout").addEventListener("change", function(){ sel.layout = this.value; render(); });
+    $("mode").addEventListener("change", function(){ sel.mode = this.value; render(); });
     $("lang").addEventListener("change", function(){ sel.lang = this.value; render(); });
-    $("layout").addEventListener("click", function(e){ var b=e.target.closest("button"); if(!b)return; sel.layout=b.dataset.val; fillSeg("layout",LAYOUT_LABELS,sel.layout); render(); });
-    $("mode").addEventListener("click", function(e){ var b=e.target.closest("button"); if(!b)return; sel.mode=b.dataset.val; fillSeg("mode",MODE_LABELS,sel.mode); render(); });
-    fillSeg("fmt", FMT_LABELS, sel.fmt); updateDl();
-    $("fmt").addEventListener("click", function(e){ var b=e.target.closest("button"); if(!b)return; sel.fmt=b.dataset.val; fillSeg("fmt",FMT_LABELS,sel.fmt); updateDl(); });
+    $("fmt").addEventListener("change", function(){ sel.fmt = this.value; updateDl(); });
     $("dl").addEventListener("click", function(){ LogoExport[sel.fmt](currentSVG(), fileBase()); });
     var pb = $("pdfSheet"); if (pb) pb.addEventListener("click", function(){ window.print(); });
     render();

--- a/assets/typografie/goetheanum-typo-tokens.json
+++ b/assets/typografie/goetheanum-typo-tokens.json
@@ -91,8 +91,8 @@
     },
     "gold-tief": {
       "$type": "color",
-      "$value": "#a07a33",
-      "$description": "Akzent auf hellem Grund. Kontrast 3.94:1 – nur für Akzent, Marken, grössere Grade; nicht für tragenden Kleingrad-Lesetext (unter WCAG AA)."
+      "$value": "#94702e",
+      "$description": "Gold dunkel – Auswahl-Fläche und Gold-Text auf hell. Weiss darauf 4.55:1 (WCAG AA). Gesetz: nie dunkle Schrift auf farbigem Grund."
     },
     "papier": {
       "$type": "color",

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -42,7 +42,7 @@ a:focus-visible,button:focus-visible,summary:focus-visible,input:focus-visible,s
 .brand .wm{font-family:var(--font-display);font-weight:var(--w-text);font-size:27px;line-height:1;color:var(--muted);letter-spacing:.005em}
 nav.top{display:flex;gap:22px}
 nav.top a{color:var(--muted);font-size:var(--t-small)}
-nav.top a:hover{color:var(--gold-deep)}
+nav.top a:hover{color:var(--gold-ink)}
 @media(max-width:720px){nav.top{display:none}}
 
 /* --- Abschnitte ------------------------------------------------------------ */
@@ -66,20 +66,18 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
   padding:10px 16px;border-radius:var(--r-control);border:1px solid var(--line);color:var(--ink);
   background:var(--field-bg);text-align:center;cursor:pointer;transition:.15s}
 .btn:hover{border-color:var(--blue)}
-.btn.primary{background:var(--blue);border-color:var(--blue);color:var(--on-accent);font-weight:var(--w-strong)}
-.btn.primary:hover{filter:brightness(.93)}
+.btn.primary{background:var(--blue-solid);border-color:var(--blue-solid);color:var(--on-accent);font-weight:var(--w-strong)}
+.btn.primary:hover{filter:brightness(1.08)}
 .btn.ghost{color:var(--muted);background:none}
-.btn.ok{background:#3f7d46;border-color:#3f7d46;color:#fff}
-/* Lade-Knopf trägt einen Pfeil – ‹Herunterladen› ist auf den ersten Blick keine Pille. */
-.btn.dl::before{content:"↓";margin-right:8px;font-weight:var(--w-strong)}
+.btn.ok{background:#3f7d46;border-color:#3f7d46;color:var(--on-accent)}
 
 /* --- Segmentierte Auswahl (Pillen) = WAHL ---------------------------------- */
 /* Anwahl = Gold/Weiss – der Hausfarbklang für Auswahl. Kapselform, kein Pfeil. */
 .seg{display:flex;flex-wrap:wrap;gap:8px}
 .seg button{font:inherit;font-size:14.5px;padding:8px 15px;border:1px solid var(--line);border-radius:var(--r-pill);
   background:var(--field-bg);color:var(--ink);cursor:pointer;transition:border-color .15s,background .15s,color .15s}
-.seg button:hover{border-color:var(--gold-deep)}
-.seg button[aria-pressed="true"]{background:var(--gold-deep);border-color:var(--gold-deep);color:var(--on-accent)}
+.seg button:hover{border-color:var(--gold-ink)}
+.seg button[aria-pressed="true"]{background:var(--gold-deep);border-color:var(--gold-ink);color:var(--on-accent);font-weight:var(--w-strong)}
 
 /* Bequeme Fingerziele auf dem Handy (Apple 44 / Material 48 / WCAG 24). */
 @media(max-width:560px){
@@ -104,7 +102,7 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 .ds-footer{border-top:1px solid var(--line);padding:var(--s8) 0 60px;color:var(--muted);font-size:var(--t-small);margin-top:var(--s8)}
 .ds-footer .frow{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap}
 .ds-footer .frow strong{color:var(--ink);font-weight:var(--w-text)}
-.ds-footer .frow a:hover{color:var(--gold-deep)}
+.ds-footer .frow a:hover{color:var(--gold-ink)}
 
 /* =============================================================================
    Eingebaute Typografie – Hausregeln als Voreinstellung, nicht als Nachkontrolle
@@ -134,7 +132,8 @@ td.num,th.num,.num{font-variant-numeric:tabular-nums lining-nums;text-align:righ
 .laut{font-weight:var(--w-strong)}
 
 /* Kicker: getönt, leicht getrackt, Display-Schrift – NORMAL, nicht versal (G05). */
-.kicker{display:inline-block;font-family:var(--font-display);color:var(--gold-deep);font-size:13px;letter-spacing:.04em;font-weight:var(--w-leise);margin-bottom:var(--s2)}
+/* Kleine UI-Schrift: nie Leise (verschwimmt klein) – mindestens Klar. */
+.kicker{display:inline-block;font-family:var(--font-display);color:var(--gold-ink);font-size:13.5px;letter-spacing:.03em;font-weight:var(--w-text);margin-bottom:var(--s2)}
 
 /* Lesemass: ~66 Zeichen je Zeile für linearen Mengentext (G10). */
 .lese{max-width:min(var(--measure),100%)}

--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -28,25 +28,25 @@ html{scrollbar-gutter:stable}
 /* „← Übersicht" – nur in der Generator-Variante sichtbar */
 .dsnav .back{display:none;align-items:center;gap:6px;color:var(--muted);font-size:13.5px;text-decoration:none}
 .dsnav.is-werkzeug .back{display:inline-flex}
-.dsnav .back:hover{color:var(--gold-deep)}
+.dsnav .back:hover{color:var(--gold-ink)}
 
 /* Primär-Welten */
 .dsnav .worlds{display:flex;gap:22px;margin-left:auto}
 .dsnav .worlds a,.dsnav .worlds button{font:inherit;font-size:13.5px;color:var(--muted);
   background:none;border:0;cursor:pointer;padding:0;text-decoration:none}
-.dsnav .worlds a:hover,.dsnav .worlds button:hover{color:var(--gold-deep)}
+.dsnav .worlds a:hover,.dsnav .worlds button:hover{color:var(--gold-ink)}
 
 /* ☾/☀ Hell-Dunkel – nur das Icon */
 .dsnav .theme{margin-left:18px;display:inline-flex;align-items:center;justify-content:center;font:inherit;
   color:var(--ink);background:none;border:0;padding:6px;cursor:pointer;line-height:1}
 .dsnav .theme .ic{font-size:18px;line-height:1}
-.dsnav .theme:hover{color:var(--gold-deep)}
+.dsnav .theme:hover{color:var(--gold-ink)}
 
 /* ☰ Burger – nur das Icon, keine Pille, kein Wort */
 .dsnav .all{margin-left:10px;display:inline-flex;align-items:center;gap:6px;font:inherit;
   color:var(--ink);background:none;border:0;padding:4px;cursor:pointer;line-height:1}
 .dsnav .all .ic{font-size:23px;line-height:1}
-.dsnav .all:hover{color:var(--gold-deep)}
+.dsnav .all:hover{color:var(--gold-ink)}
 .dsnav .all .idot{width:7px;height:7px;border-radius:var(--r-pill);background:var(--gold)}
 
 @media(max-width:720px){
@@ -84,23 +84,21 @@ html{scrollbar-gutter:stable}
 .dsnav-group>summary::-webkit-details-marker{display:none}
 .dsnav-group>summary .arr{color:var(--muted);font-weight:var(--w-text);transition:transform .15s}
 .dsnav-group[open]>summary .arr{transform:rotate(90deg)}
-.dsnav-group>summary .intro{display:block;color:var(--muted);font-weight:var(--w-text);font-size:12px;margin-top:3px;max-width:42ch}
+.dsnav-group>summary .st{margin-top:0}
 
-.dsnav-link{display:flex;align-items:baseline;gap:10px;padding:9px 22px;text-decoration:none;color:var(--ink)}
+.dsnav-link{display:flex;align-items:center;gap:10px;min-height:var(--tap);padding:6px 22px;text-decoration:none;color:var(--ink)}
 .dsnav-link:hover{background:var(--soft)}
-.dsnav-link .tt{font-size:14px}
-.dsnav-link .dd{color:var(--muted);font-size:12px;margin-top:2px;line-height:1.4}
-.dsnav-link .txt{display:flex;flex-direction:column}
+.dsnav-link .tt{font-size:15px}
 /* Aktuelle Seite im Menü hervorheben – ruhig, mit Gold-Kante. */
 .dsnav-link.is-active{background:var(--soft);box-shadow:inset 3px 0 0 var(--gold-deep)}
-.dsnav-link.is-active .tt{color:var(--gold-deep);font-weight:var(--w-strong)}
+.dsnav-link.is-active .tt{color:var(--gold-ink);font-weight:var(--w-strong)}
 
 /* Status-Punkt */
-.dsnav-link .st{width:8px;height:8px;border-radius:var(--r-pill);background:var(--muted);flex:0 0 auto;margin-top:7px}
+.dsnav-link .st{width:8px;height:8px;border-radius:var(--r-pill);background:var(--muted);flex:0 0 auto}
 .dsnav-link .st.live{background:#3f7d46}
 .dsnav-link .st.beta{background:var(--blue)}
 .dsnav-link .st.entwurf{background:var(--gold-deep)}
 .dsnav-link .st.geparkt{background:#c2c7cc}
 
 .dsnav-drawer .foot{padding:var(--s4) 22px;border-top:1px solid var(--line);color:var(--muted);font-size:12px;flex:0 0 auto}
-.dsnav-drawer .foot a{color:var(--gold-deep);text-decoration:none}
+.dsnav-drawer .foot a{color:var(--gold-ink);text-decoration:none}

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -38,7 +38,7 @@
   function updateThemeBtn() {
     if (!themeBtn) return;
     var dark = document.documentElement.getAttribute("data-theme") === "dark";
-    themeBtn.querySelector(".ic").textContent = dark ? "☀" : "☾";
+    themeBtn.querySelector(".ic").textContent = dark ? "☀" : "☾";  // ☀ U+2600 / ☾ U+263E
     themeBtn.setAttribute("aria-label", dark ? "Hell schalten" : "Dunkel schalten");
     themeBtn.setAttribute("aria-pressed", String(dark));
   }
@@ -198,9 +198,9 @@
     var g = el("details", "dsnav-group");
     g.setAttribute("data-world", w.id);
     g.open = open;
+    // Das Menü koordiniert, es erklärt nicht: nur Titel, kein Beiwerk-Text.
     g.appendChild(el("summary", null,
-      '<span><span class="ttl">' + w.label + '</span>' +
-      '<span class="intro">' + w.intro + '</span></span><span class="arr">›</span>'));
+      '<span class="ttl">' + w.label + '</span><span class="arr">›</span>'));
     tools.forEach(function (t) {
       var active = isActiveTool(t);
       var a = el("a", "dsnav-link" + (active ? " is-active" : ""));
@@ -209,8 +209,7 @@
       if (active) a.setAttribute("aria-current", "page");
       a.innerHTML =
         '<span class="st ' + (t.status || "") + '" title="' + (t.status || "") + '"></span>' +
-        '<span class="txt"><span class="tt">' + t.title + '</span>' +
-        (t.desc ? '<span class="dd">' + t.desc + '</span>' : "") + '</span>';
+        '<span class="tt">' + t.title + '</span>';
       g.appendChild(a);
     });
     return g;

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -39,9 +39,11 @@
 
 :root{
   /* --- Markenfarben ------------------------------------------------------- */
-  --blue:#0061a9;        /* Markenblau – Zustand/Verweis/Aktion */
+  --blue:#0061a9;        /* Markenblau – Zustand/Verweis/Link (hellt im Dunkel auf) */
+  --blue-solid:#0061a9;  /* Volles Blau für gefüllte Aktion-Knöpfe – immer Weiss drauf (6.4:1) */
   --gold:#d7ab68;        /* Gold – Inhalts-Akzent */
-  --gold-deep:#a07a33;   /* Gold dunkel – Auswahl/Hover auf hell */
+  --gold-deep:#94702e;   /* Gold dunkel – Auswahl-Fläche, Weiss drauf (4.55:1, WCAG AA) */
+  --gold-ink:#94702e;    /* Gold als TEXT (Kicker, Links) – hellt im Dunkel auf */
 
   /* --- Neutrale Töne ------------------------------------------------------ */
   --ink:#23272b;         /* Lesetext */
@@ -98,12 +100,15 @@
    (heller Text auf dunklem Grund „blutet"/wirkt fetter).
    ============================================================================= */
 :root[data-theme="dark"]{
-  --blue:#5aa6e0; --gold:#dfb87a; --gold-deep:#c79a4f;
+  --blue:#5aa6e0; --gold:#dfb87a;
+  /* Gesetz: NIE dunkle Schrift auf farbigem Grund. Gold-Pille bleibt dunkles Gold
+     mit weissem Text (4.55:1); Gold als TEXT hellt auf (gold-ink, 6.9:1 auf Dunkel). */
+  --gold-deep:#94702e; --gold-ink:#c79a4f;
   --ink:#e6e8ea; --muted:#9aa1a8;
   --paper:#16191c; --soft:#1e2329; --field-bg:#1e2329;
   --bar-bg:rgba(20,23,26,.85);
   --line:rgba(255,255,255,.14); --line-soft:rgba(255,255,255,.07);
-  --bad:#e0675e; --on-accent:#16191c;
+  --bad:#e0675e;        /* on-accent bleibt Weiss – kein dunkler Text auf Akzentflächen */
   --w-deutlich:540; --w-strong:620;     /* weniger Bleeding auf Dunkel */
   --shadow-card:0 10px 30px rgba(0,0,0,.45);
   color-scheme:dark;

--- a/design-system/tokens.json
+++ b/design-system/tokens.json
@@ -12,7 +12,7 @@
       "$description": "Gold – Inhalts-Akzent"
     },
     "gold-deep": {
-      "$value": "#a07a33",
+      "$value": "#94702e",
       "$description": "Gold dunkel – Hover/Links auf hell"
     },
     "ink": {


### PR DESCRIPTION
Deine Punkte als zusammenhängendes Ganzes — Zugänglichkeit + echte Bedienbarkeit.

## Gesetz B01: kein dunkler Text auf farbigem Grund
- **Aktion-Knopf:** volles Blau `#0061a9` + **weisser, zentrierter** Text, **ohne** den mickrigen Pfeil.
- **Auswahl-Pille:** dunkles Gold `#94702e` + Weiss (**4.55:1**, WCAG AA) — auch im Dunkelmodus dunkles Gold + Weiss. `--on-accent` bleibt überall Weiss.
- Gold als **Text** (Kicker/Links) ist ein eigener Token `--gold-ink`, der im Dunkel aufhellt (sonst zu wenig Kontrast).

## Auswahl als Listen
Logos-Auswahl jetzt **Klappwahl (Dropdowns)** statt Pillen — endlich kompakt. Eine blaue Aktion „als SVG herunterladen".

## ‹Hinweise zur Anwendung›
Umbenannt von „Begleitschreiben". **Kontrast behoben:** der Fliesstext war im Dunkelmodus grau auf dunkelgrau → jetzt `--ink` (hell auf dunkel). Bleibt in Goetheanum (ein paar gut gesetzte Zeilen sind kein Problem); **Source** ist für echten Mengentext reserviert (`.prose`).

## Schrift-Grenzen beachtet
Kleine UI-Schrift mind. **Klar** (Leise verschwimmt klein) — Kicker ist nicht mehr Leise. Das **Menü koordiniert statt zu erklären**: die Schublade zeigt nur noch Titel (Intros/Beschreibungen raus).

## Dark-Schalter
Exakt **☀ U+2600 / ☾ U+263E**.

## Barrierefreiheit in die Hausregeln
`CLAUDE.md`: WCAG 2.2 AA als verbindliche Regeln **B01–B05** (kein dunkler Text auf Farbe; Kontrast 4.5/3:1; Mindestgrössen; 44px-Ziele; Tokens fürs Theme) **plus die Grenzen der Hausschrift** (Textmasse → Source; kleine UI → mind. Klar). Kanon `gold-tief #94702e`. Driftwächter ✓ synchron.

## Prüfung
`typo-check` ✓ · `typo-sync` ✓. Kontraste gerechnet (nicht geschätzt). Logos hell/dunkel × Desktop/Handy gerendert: Listen-Auswahl, volle blaue Aktion ohne Pfeil, Hinweise gut lesbar im Dunkel, Schublade nur Titel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_