### PR TITLE
Logos-Feinarbeit II: eigene Klappliste (Hausschrift), Format 3+3, Sektionsfarbe, Dreizeiler

### DIFF
--- a/apps/logos/index.html
+++ b/apps/logos/index.html
@@ -24,7 +24,9 @@
   .stage{display:grid;place-items:center;min-height:300px;border:1px solid var(--line);border-radius:var(--r-card);background:#faf8f4;padding:clamp(24px,5vw,56px)}
   .stage.dark{background:#23272b}
   .stage svg{max-width:100%;height:auto;max-height:340px}
-  #dim{color:var(--muted);font-size:var(--t-small);margin-top:var(--s2)}
+  /* Format-Pillen in zwei Reihen zu drei. */
+  #fmt{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
+  #fmt button{width:100%}
   /* EINE Aktion: gross, blau (= Tun), unverwechselbar mit den Gold-Pillen (= Wahl). */
   .download{margin-top:var(--s4)}
   .download .btn{width:100%;font-size:16px;padding:14px}
@@ -123,7 +125,6 @@
 
       <div class="preview">
         <div class="stage" id="stage"><span class="meta">…</span></div>
-        <div class="meta" id="dim"></div>
         <div class="download">
           <button class="btn primary" id="dl" type="button">herunterladen</button>
         </div>
@@ -222,11 +223,13 @@
   // Default = das eigentliche Logo: blaues, einzeiliges Goetheanum-Basislogo.
   var sel = { cat:"allgemein", org:"goetheanum", layout:"desktop", mode:"original", lang:"de", fmt:"svg", scale:2.635 };
 
-  var LAYOUT_LABELS = [["desktop","Lang"],["mobile","Kurz"],["icon","Icon"],["point","Kreis"],["square","Quadrat"]];
+  var LAYOUT_LABELS = [["desktop","Lang"],["mobile","Kurz"],["triline","Dreizeiler"],["icon","Icon"],["point","Kreis"],["square","Quadrat"]];
   var LANG_LABELS   = [["de","Deutsch"],["en","English"],["fr","Français"],["es","Español"]];
   // Farbkreise – feste Farben (zeigen die echte Logo-Farbe, unabhängig vom Theme).
+  // ‹Original› zeigt die jeweilige Organisationsfarbe (ORGS[org].color).
   var MODE_SWATCH   = [["original","Original","#0061a9"],["white","Weiss","#ffffff"],["black","Schwarz","#23272b"],["gray","Grau","#9aa0a6"]];
-  var FMT_LABELS    = [["svg","SVG"],["png","PNG"],["pdf","PDF"],["webp","WebP"],["jpg","JPG"],["svg48","SVG 48"]];
+  // Reihenfolge nach Gebrauch/Gewohnheit; Pillen 3 + 3.
+  var FMT_LABELS    = [["png","PNG"],["jpg","JPG"],["pdf","PDF"],["svg","SVG"],["svg48","SVG 48"],["webp","WebP"]];
   var FMT_HINT = { svg:"Vektor – für Web und Druck", png:"Pixel mit Transparenz – fürs Office (Word, PowerPoint, Outlook)",
     pdf:"Vektor-PDF auf weissem Grund", webp:"Pixel, klein, mit Transparenz – fürs Web",
     jpg:"Pixel auf weissem Grund", svg48:"Vektor, auf 48 px Höhe normiert" };
@@ -284,8 +287,14 @@
     var o = ORGS[org] || {};
     return ["de","en","fr","es"].some(function(l){ var s=o["short_"+l], n=o["name_"+l]; return s && n && s !== n; });
   }
+  // Dreizeiler nur, wo eine Vorlage existiert (alter Generator: srmk, hpise).
+  function hasTriline(org){ return sel.cat === "sektionen" && (org === "srmk" || org === "hpise"); }
   function orgLayouts(org){
-    return LAYOUT_LABELS.filter(function(p){ return p[0] !== "mobile" || hasKurz(org); });
+    return LAYOUT_LABELS.filter(function(p){
+      if (p[0] === "mobile")  return hasKurz(org);
+      if (p[0] === "triline") return hasTriline(org);
+      return true;
+    });
   }
   function fillLayout(){
     var opts = orgLayouts(sel.org);
@@ -302,7 +311,8 @@
     var box = $("mode"); box.innerHTML = "";
     MODE_SWATCH.forEach(function(p){
       var b = document.createElement("button");
-      b.type = "button"; b.title = p[1]; b.dataset.val = p[0]; b.style.background = p[2];
+      var col = (p[0] === "original" && ORGS[sel.org] && ORGS[sel.org].color) ? ORGS[sel.org].color : p[2];
+      b.type = "button"; b.title = p[1]; b.dataset.val = p[0]; b.style.background = col;
       b.setAttribute("aria-pressed", String(p[0] === sel.mode));
       box.appendChild(b);
     });
@@ -324,11 +334,7 @@
   function render(){
     var stage = $("stage");
     stage.classList.toggle("dark", sel.mode === "white");
-    var svg = currentSVG();
-    stage.innerHTML = svg;
-    // Maße aus dem viewBox lesen
-    var m = svg.match(/viewBox="0 0 ([\d.]+) ([\d.]+)"/);
-    $("dim").textContent = m ? ("Seitenverhältnis " + (+m[1]).toFixed(0) + " × " + (+m[2]).toFixed(0)) : "";
+    stage.innerHTML = currentSVG();
   }
 
   function fileBase(){ return "goetheanum-" + sel.org + "-" + sel.layout + "-" + sel.mode; }
@@ -368,10 +374,10 @@
       else { sel.cat = v; }
       fillOrgs(); syncOrgField();
       if (sel.cat !== "allgemein") sel.org = $("org").value;
-      fillLayout(); fillLang();                 // Optionen an die neue Org anpassen
+      fillLayout(); fillLang(); fillSwatch();   // Optionen + Org-Farbe an die neue Org anpassen
       render();
     });
-    $("org").addEventListener("change", function(){ sel.org = this.value; fillLayout(); fillLang(); render(); });
+    $("org").addEventListener("change", function(){ sel.org = this.value; fillLayout(); fillLang(); fillSwatch(); render(); });
     $("layout").addEventListener("change", function(){ sel.layout = this.value; render(); });
     $("lang").addEventListener("change", function(){ sel.lang = this.value; render(); });
     $("mode").addEventListener("click", function(e){ var b=e.target.closest("button"); if(!b)return; sel.mode=b.dataset.val; fillSwatch(); render(); });
@@ -385,5 +391,6 @@
   if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init); else init();
 })();
 </script>
+<script src="../../design-system/select.js"></script>
 </body>
 </html>

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -93,8 +93,23 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
   background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);padding:11px 12px;outline:none;
   transition:border-color .15s,box-shadow .15s;
 }
-/* Aufklappliste in der Hausschrift, wo der Browser es zulässt (Firefox/Safari). */
+/* Aufklappliste in der Hausschrift, wo der Browser es zulässt (Firefox). */
 .field select option{font-family:var(--font);font-size:16px}
+
+/* Gestaltbare Klappliste (ds-select.js) – Hausschrift AUCH geöffnet (Desktop). */
+.ds-select{position:relative}
+.ds-select>select{position:absolute;width:1px;height:1px;opacity:0;pointer-events:none}  /* nativ versteckt, bleibt Quelle der Wahrheit */
+.ds-select__btn{width:100%;display:flex;align-items:center;justify-content:space-between;gap:10px;
+  font-family:var(--font);font-size:16px;font-weight:var(--w-text);line-height:1.25;color:var(--ink);text-align:left;
+  background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);padding:11px 12px;cursor:pointer;min-height:var(--tap)}
+.ds-select__btn::after{content:"";width:8px;height:8px;border-right:2px solid var(--muted);border-bottom:2px solid var(--muted);
+  transform:translateY(-2px) rotate(45deg);flex:0 0 auto}
+.ds-select__btn:hover{border-color:var(--gold-deep)}
+.ds-select__list{position:absolute;z-index:50;left:0;right:0;top:calc(100% + 4px);margin:0;padding:6px;list-style:none;
+  background:var(--paper);border:1px solid var(--line);border-radius:var(--r-control);box-shadow:var(--shadow-card);max-height:300px;overflow:auto}
+.ds-select__opt{font-family:var(--font);font-size:16px;color:var(--ink);padding:9px 11px;border-radius:8px;cursor:pointer;white-space:nowrap}
+.ds-select__opt:hover,.ds-select__opt:focus{background:var(--soft);outline:none}
+.ds-select__opt[aria-selected="true"]{color:var(--gold-ink);font-weight:var(--w-strong)}
 .field textarea{resize:vertical;min-height:48px}
 .field input::placeholder,.field textarea::placeholder{color:var(--muted);opacity:.7}
 .field input:focus,.field textarea:focus,.field select:focus{border-color:var(--blue);box-shadow:0 0 0 3px color-mix(in srgb,var(--blue) 22%,transparent)}

--- a/design-system/select.js
+++ b/design-system/select.js
@@ -1,0 +1,64 @@
+/* =============================================================================
+   Goetheanum CI – ds-select: gestaltbare Klappliste (Hausschrift auch geöffnet)
+   -----------------------------------------------------------------------------
+   Wandelt native <select> in eine gestaltete Liste, damit die GEÖFFNETE Auswahl
+   in der Hausschrift erscheint (native <option> nutzt sonst die System-Schrift,
+   v. a. in Safari/Chrome). Das native <select> bleibt Quelle der Wahrheit:
+   change-Events, Formular, Wert. Auf Touch-Geräten bleibt die native Auswahl
+   (der OS-Picker ist dort besser). Nach base.css einbinden; verbessert alle
+   .field select automatisch und re-beschriftet sich, wenn ein Werkzeug die
+   Optionen per JS ändert (MutationObserver).
+   ============================================================================= */
+(function () {
+  if (window.matchMedia && matchMedia("(pointer: coarse)").matches) return; // Touch: native
+
+  function enhance(sel) {
+    if (sel.dataset.dsSel) return; sel.dataset.dsSel = "1";
+    var wrap = document.createElement("div"); wrap.className = "ds-select";
+    sel.parentNode.insertBefore(wrap, sel); wrap.appendChild(sel);
+    var btn = document.createElement("button");
+    btn.type = "button"; btn.className = "ds-select__btn";
+    btn.setAttribute("aria-haspopup", "listbox"); btn.setAttribute("aria-expanded", "false");
+    var list = document.createElement("ul");
+    list.className = "ds-select__list"; list.setAttribute("role", "listbox"); list.hidden = true;
+    wrap.appendChild(btn); wrap.appendChild(list);
+
+    function sync() { var o = sel.options[sel.selectedIndex]; btn.textContent = o ? o.textContent : ""; }
+    function build() {
+      list.innerHTML = "";
+      [].forEach.call(sel.options, function (o, i) {
+        var li = document.createElement("li");
+        li.className = "ds-select__opt"; li.setAttribute("role", "option"); li.tabIndex = -1;
+        li.textContent = o.textContent; li.setAttribute("aria-selected", String(i === sel.selectedIndex));
+        li.addEventListener("click", function () { choose(i); });
+        list.appendChild(li);
+      });
+    }
+    function choose(i) { sel.selectedIndex = i; sync(); close(); btn.focus(); sel.dispatchEvent(new Event("change", { bubbles: true })); }
+    function open() {
+      build(); list.hidden = false; btn.setAttribute("aria-expanded", "true");
+      document.addEventListener("click", outside, true); document.addEventListener("keydown", onkey, true);
+      var cur = list.children[sel.selectedIndex] || list.children[0]; if (cur) cur.focus();
+    }
+    function close() {
+      list.hidden = true; btn.setAttribute("aria-expanded", "false");
+      document.removeEventListener("click", outside, true); document.removeEventListener("keydown", onkey, true);
+    }
+    function outside(e) { if (!wrap.contains(e.target)) close(); }
+    function onkey(e) {
+      if (list.hidden) return;
+      var opts = [].slice.call(list.children), idx = opts.indexOf(document.activeElement);
+      if (e.key === "Escape") { e.preventDefault(); close(); btn.focus(); }
+      else if (e.key === "ArrowDown") { e.preventDefault(); (opts[idx + 1] || opts[0]).focus(); }
+      else if (e.key === "ArrowUp") { e.preventDefault(); (opts[idx - 1] || opts[opts.length - 1]).focus(); }
+      else if (e.key === "Enter" || e.key === " ") { e.preventDefault(); if (idx >= 0) choose(idx); }
+    }
+    btn.addEventListener("click", function () { list.hidden ? open() : close(); });
+    btn.addEventListener("keydown", function (e) { if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") { e.preventDefault(); open(); } });
+    sel.addEventListener("change", sync);
+    new MutationObserver(sync).observe(sel, { childList: true, subtree: true, attributes: true });
+    sync();
+  }
+  function run() { [].forEach.call(document.querySelectorAll(".field select"), enhance); }
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", run); else run();
+})();


### PR DESCRIPTION
Deine fünf Punkte, alle behoben.

## Eigene Klappliste (das Safari-Problem)
`design-system/select.js` — eine gestaltbare Klappliste: die **geöffnete** Auswahl erscheint jetzt in der **Hausschrift** (native `<option>` war in Safari/Chrome System-Schrift, nicht beeinflussbar). Das native `<select>` bleibt Quelle der Wahrheit (Wert, `change`, Formular); auf **Touch** bleibt die native Auswahl (besserer OS-Picker). Tastatur (↑↓/Enter/Esc) und Klick-ausserhalb funktionieren.

## Weitere Korrekturen
- **Format nach Gebrauch:** PNG · JPG · PDF / SVG · SVG 48 · WebP — Pillen **3 + 3**.
- **‹Original›-Kreis zeigt die Organisationsfarbe** (`ORGS[org].color`), nicht mehr immer Blau; wechselt mit der Sektion.
- **‹Seitenverhältnis …›** unter der Vorschau **entfernt**.
- **Dreizeiler** wieder da, wo eine Vorlage existiert (srmk, hpise) — gemäss altem Generator (`hasTriline`).

## Prüfung
`typo-check` ✓ · `typo-sync` ✓. Verifiziert: Klapplisten-Optionen in Goetheanum, Format 3×3 in neuer Reihenfolge, Sektionsfarbe im Kreis (#a24f8a für AAS), Dreizeiler bei srmk, keine JS-Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_