### PR TITLE
Logos-Feinarbeit IV: Erklärzeile + sechs Pillen, Download bei der Auswahl, alter Generator ins Archiv, Menü/Header lesbarer

### DIFF
--- a/apps/logos/index.html
+++ b/apps/logos/index.html
@@ -20,38 +20,34 @@
   .controls{display:grid;gap:var(--s4)}
   .seg .brk{flex-basis:100%;height:0}
 
-  /* Rechte Spalte: Vorschau, darunter die Format-Wahl und die EINE Aktion –
-     die drei reisen zusammen (klebend), während links die Logo-Bestimmung scrollt. */
+  /* Rechte Spalte, von oben nach unten: Vorschau → Erklärzeile → Format → die EINE
+     Aktion. Alles reist zusammen (klebend), während links die Logo-Bestimmung scrollt. */
   .preview{position:sticky;top:calc(var(--header-h) + var(--s4))}
   .stage{display:grid;place-items:center;min-height:300px;border:1px solid var(--line);border-radius:var(--r-card);background:#faf8f4;padding:clamp(24px,5vw,56px)}
   .stage.dark{background:#23272b}
   .stage svg{max-width:100%;height:auto;max-height:340px}
-  .fmtfield{margin-top:var(--s4)}
-  /* Format-Pillen in zwei Reihen zu drei. */
-  #fmt{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
-  #fmt button{width:100%}
-  /* EINE Aktion: gross, blau (= Tun), unverwechselbar mit den Gold-Pillen (= Wahl). */
-  .download{margin-top:var(--s4)}
+  /* Erklärzeile direkt unter der Vorschau, ÜBER den Pillen (benennt das Format). */
+  .fmthint{color:var(--muted);font-size:var(--t-small);line-height:1.45;margin:var(--s3) 0 var(--s2);min-height:2.6em}
+  /* Alle sechs Formate nebeneinander – kompakt. */
+  #fmt{display:grid;grid-template-columns:repeat(6,1fr);gap:8px}
+  #fmt button{width:100%;padding:8px 4px}
+  /* EINE Aktion direkt unter der Anwahl: gross, blau (= Tun), unverwechselbar mit den Gold-Pillen. */
+  .download{margin-top:var(--s3)}
   .download .btn{width:100%;font-size:16px;padding:14px}
   /* Farbe als vier Kreise – lockert die Auswahl auf. */
   .swatches{display:flex;gap:10px;flex-wrap:wrap}
   .swatches button{width:38px;height:38px;border-radius:50%;border:1px solid var(--line);cursor:pointer;padding:0}
   .swatches button[aria-pressed="true"]{outline:2px solid var(--gold-deep);outline-offset:2px}
-  /* Format-Hinweis erscheint bei Hover/Anwahl direkt unter den Pillen. */
-  .fmthint{color:var(--muted);font-size:var(--t-small);line-height:1.45;margin-top:8px;min-height:2.7em}
 
-  /* Mobil: kompakte Mini-Vorschau klebt oben, Auswahl direkt darunter (beides
-     zugleich sichtbar); die EINE Aktion in einer festen Leiste unten. */
+  /* Mobil: zuoberst Vorschau + Format + die EINE Aktion – primär lädt das gemeinsame
+     Logo zum Download ein. Die Sonderfassungen (Auswahl) stehen darunter. Nur die
+     Mini-Vorschau klebt, damit Format und Aktion mitscrollen. */
   @media(max-width:859px){
     .tool{grid-template-columns:1fr;gap:var(--s4)}
-    main.wrap{padding-bottom:88px}
-    /* Mini-Vorschau klebt oben; nur sie, damit die Format-Wahl darunter mitscrollt
-       (sonst frisst die klebende Zone zu viel Höhe). Aktion fest unten. */
     .preview{order:-1}
     .stage{position:sticky;top:var(--header-h);z-index:10;min-height:0;padding:var(--s3);background:var(--paper);border-bottom:1px solid var(--line-soft)}
     .stage svg{max-height:150px}
-    .fmtfield{margin-top:var(--s3)}
-    .download{position:fixed;left:0;right:0;bottom:0;margin:0;z-index:30;background:var(--bar-bg);backdrop-filter:saturate(160%) blur(8px);border-top:1px solid var(--line);padding:10px 16px}
+    #fmt{grid-template-columns:repeat(3,1fr)}
   }
 
   /* Begleitschreiben als PDF drucken: nur das Blatt zeigen */
@@ -126,12 +122,9 @@
 
       <div class="preview">
         <div class="stage" id="stage"><span class="meta">…</span></div>
-        <!-- Format = letzte WAHL, direkt bei der EINEN Aktion (herunterladen). -->
-        <div class="field fmtfield">
-          <span class="lab">Format</span>
-          <div class="seg" id="fmt"></div>
-          <div class="fmthint" id="fmthint"></div>
-        </div>
+        <!-- Erklärzeile unter der Vorschau, dann die sechs Formate, dann die EINE Aktion. -->
+        <p class="fmthint" id="fmthint"></p>
+        <div class="seg" id="fmt" role="group" aria-label="Format"></div>
         <div class="download">
           <button class="btn primary" id="dl" type="button">herunterladen</button>
         </div>
@@ -345,13 +338,16 @@
     });
   }
   function fmtHint(code){ return FMT_HINT[code] || ""; }
+  // Erklärzeile benennt das Format: „PNG — Pixel mit Transparenz …".
+  function fmtName(code){ var p = FMT_LABELS.filter(function(x){return x[0]===code;})[0]; return p ? p[1] : code; }
+  function fmtLine(code){ var h = fmtHint(code); return h ? (fmtName(code) + " — " + h) : fmtName(code); }
   function fillFmt(){
     var box = $("fmt"); box.innerHTML = "";
     FMT_LABELS.forEach(function(p){
       var b = document.createElement("button");
       b.type = "button"; b.textContent = p[1]; b.dataset.val = p[0]; b.title = fmtHint(p[0]);
       b.setAttribute("aria-pressed", String(p[0] === sel.fmt));
-      b.addEventListener("mouseenter", function(){ $("fmthint").textContent = fmtHint(p[0]); });
+      b.addEventListener("mouseenter", function(){ $("fmthint").textContent = fmtLine(p[0]); });
       box.appendChild(b);
     });
   }
@@ -373,7 +369,7 @@
   function fmtLabel(){ var p = FMT_LABELS.filter(function(x){return x[0]===sel.fmt;})[0]; return p ? p[1] : "SVG"; }
   function updateDl(){
     var dl = $("dl"); if (dl) dl.textContent = "als " + fmtLabel() + " herunterladen";
-    var h = $("fmthint"); if (h) h.textContent = fmtHint(sel.fmt);
+    var h = $("fmthint"); if (h) h.textContent = fmtLine(sel.fmt);
   }
 
   // Begleitschreiben-Visuals aus der Engine
@@ -412,7 +408,7 @@
     $("lang").addEventListener("change", function(){ sel.lang = this.value; fillLayout(); render(); });
     $("mode").addEventListener("click", function(e){ var b=e.target.closest("button"); if(!b)return; sel.mode=b.dataset.val; fillSwatch(); render(); });
     $("fmt").addEventListener("click", function(e){ var b=e.target.closest("button"); if(!b)return; sel.fmt=b.dataset.val; fillFmt(); updateDl(); });
-    $("fmt").addEventListener("mouseleave", function(){ $("fmthint").textContent = fmtHint(sel.fmt); });
+    $("fmt").addEventListener("mouseleave", function(){ $("fmthint").textContent = fmtLine(sel.fmt); });
     $("dl").addEventListener("click", function(){ LogoExport[sel.fmt](currentSVG(), fileBase()); });
     var pb = $("pdfSheet"); if (pb) pb.addEventListener("click", function(){ window.print(); });
     render();

--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -21,7 +21,7 @@ html{scrollbar-gutter:stable}
 
 /* Wortmarke = das echte Goetheanum-Lockup (aus dem Logo-Generator), immer zurück zur Übersicht */
 .dsnav .brand{display:flex;align-items:center;gap:var(--s3);text-decoration:none;flex:0 0 auto}
-.dsnav .brand .lockup{height:34px;width:auto;display:block}
+.dsnav .brand .lockup{height:38px;width:auto;display:block}
 .dsnav .brand .mk{width:24px;height:24px;border-radius:6px;display:block}
 .dsnav .brand .wm{font-family:var(--font);font-weight:var(--w-text);font-size:24px;line-height:1;color:#8a9097;letter-spacing:.005em}
 
@@ -30,9 +30,10 @@ html{scrollbar-gutter:stable}
 .dsnav.is-werkzeug .back{display:inline-flex}
 .dsnav .back:hover{color:var(--gold-ink)}
 
-/* Primär-Welten */
-.dsnav .worlds{display:flex;gap:22px;margin-left:auto}
-.dsnav .worlds a,.dsnav .worlds button{font:inherit;font-size:13.5px;color:var(--muted);
+/* Primär-Welten – die vier Schnellzugriffe sollen klar lesbar sein, nicht verblassen:
+   Lese-Ink statt Grau, etwas grösser, mehr Luft. */
+.dsnav .worlds{display:flex;gap:26px;margin-left:auto}
+.dsnav .worlds a,.dsnav .worlds button{font:inherit;font-size:15px;color:var(--ink);
   background:none;border:0;cursor:pointer;padding:0;text-decoration:none}
 .dsnav .worlds a:hover,.dsnav .worlds button:hover{color:var(--gold-ink)}
 
@@ -80,14 +81,14 @@ html{scrollbar-gutter:stable}
 
 .dsnav-group{border-bottom:1px solid var(--line-soft)}
 .dsnav-group>summary{list-style:none;cursor:pointer;display:flex;align-items:center;justify-content:space-between;
-  padding:var(--s4) 22px;font-weight:var(--w-strong);font-size:14.5px}
+  padding:var(--s4) 22px;font-weight:var(--w-strong);font-size:16px}
 .dsnav-group>summary::-webkit-details-marker{display:none}
 .dsnav-group>summary .arr{color:var(--muted);font-weight:var(--w-text);transition:transform .15s}
 .dsnav-group[open]>summary .arr{transform:rotate(90deg)}
 
 .dsnav-link{display:flex;align-items:center;gap:10px;min-height:var(--tap);padding:6px 22px;text-decoration:none;color:var(--ink)}
 .dsnav-link:hover{background:var(--soft)}
-.dsnav-link .tt{font-size:15px}
+.dsnav-link .tt{font-size:17px}
 /* Aktuelle Seite im Menü hervorheben – ruhig, mit Gold-Kante. */
 .dsnav-link.is-active{background:var(--soft);box-shadow:inset 3px 0 0 var(--gold-deep)}
 .dsnav-link.is-active .tt{color:var(--gold-ink);font-weight:var(--w-strong)}

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -74,7 +74,8 @@
     { id: "schriftpflege", label: "Schriftpflege", intro: "Grotesk, Gewichte und Mischsatz prüfen.", cats: ["schriftpflege"] },
     { id: "statistik", label: "Statistik", intro: "Nutzungszahlen aller Werkzeuge.", cats: ["statistik"] },
     { id: "schau", label: "Schau & Mockups", intro: "Präsentations-Mockups und Studien.", cats: ["schau"] },
-    { id: "geparkt", label: "Geparktes", intro: "Konzepte, die später kommen.", cats: ["geparkt"] }
+    { id: "geparkt", label: "Geparktes", intro: "Konzepte, die später kommen.", cats: ["geparkt"] },
+    { id: "archiv", label: "Archiv", intro: "Frühere Stände, eingefroren.", cats: ["archiv"] }
   ];
   var PUBLIC_IDS = WORLDS.map(function (w) { return w.id; });
 

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -84,7 +84,7 @@
 
   /* --- Radien, Maße, Fingerziel ------------------------------------------ */
   --r-control:10px; --r-card:14px; --r-pill:999px;
-  --header-h:60px; --maxw:1080px; --ds-maxw:1080px;
+  --header-h:66px; --maxw:1080px; --ds-maxw:1080px;
   --tap:44px;            /* Mindest-Fingerziel (Apple 44, Material 48, WCAG 24) */
 
   /* --- Schatten ---------------------------------------------------------- */

--- a/tools.json
+++ b/tools.json
@@ -15,7 +15,8 @@
     { "id": "schriftpflege","title": "Schriftpflege", "intro": "Begleit-Grotesk, Gewichte und Mischsatz prüfen und kalibrieren." },
     { "id": "statistik",    "title": "Statistik", "intro": "Nutzungszahlen aller Werkzeuge – nur der Gebrauch legitimiert den Bau." },
     { "id": "schau",        "title": "Schau & Mockups", "intro": "Präsentations-Mockups und Studien – kein öffentliches Werkzeug." },
-    { "id": "geparkt",      "title": "Geparkte Projekte", "intro": "Durchdachte Konzepte, die später kommen – zum schnellen Einsehen der Spezifikation." }
+    { "id": "geparkt",      "title": "Geparkte Projekte", "intro": "Durchdachte Konzepte, die später kommen – zum schnellen Einsehen der Spezifikation." },
+    { "id": "archiv",       "title": "Archiv", "intro": "Frühere Stände – eingefroren zum Nachschlagen, nicht gepflegt." }
   ],
   "tools": [
     { "slug": "design-system",     "cat": "system",      "status": "beta",    "tag": "Fundament",     "title": "Design-System",      "href": "design-system/",               "desc": "Farben, Schnitte, Typografie-Regeln und Komponenten – die lebende Schauseite, aus einer Quelle gerendert. Mit Starter und Bau-Workflow." },
@@ -44,7 +45,9 @@
     { "slug": "campus-karten",     "cat": "geparkt",     "status": "geparkt", "tag": "Kartierung",    "title": "Campus-Kartentool",  "href": "https://github.com/phtok/goeloggen/blob/main/docs/specs/campus-kartentool-pflichtenheft.md", "desc": "Veranstaltungs-/Lagekarten des Geländes, A4 druckfertig. Pflichtenheft fertig, Bau steht aus." },
     { "slug": "brand-portrait",    "cat": "geparkt",     "status": "geparkt", "tag": "KI / Porträt",  "title": "Brand-Portrait-Generator", "href": "https://github.com/phtok/goeloggen/blob/main/reference/material/portrait_brand_generator_pflichtenheft.md", "desc": "KI-gestützte, markenkonforme Porträts. Eigener Schwerpunkt mit GPU-Infrastruktur." },
     { "slug": "jahrgaenge",        "cat": "geparkt",     "status": "geparkt", "tag": "Sammlung",      "title": "Jahrgänge-Sammlung", "href": "https://github.com/phtok/goeloggen/blob/main/collections/jahrgaenge/README.md", "desc": "Produktionssammlung aus Jahrgängen (PDFs, Zeichnungen). Struktur vorbereitet." },
-    { "slug": "gtv-subs",          "cat": "geparkt",     "status": "geparkt", "tag": "Service",       "title": "GTV-Subs",           "href": "https://github.com/phtok/goeloggen/blob/main/services/gtv-subs/README.md", "desc": "Service-Skelett rund um Goetheanum TV. Platzhalter." }
+    { "slug": "gtv-subs",          "cat": "geparkt",     "status": "geparkt", "tag": "Service",       "title": "GTV-Subs",           "href": "https://github.com/phtok/goeloggen/blob/main/services/gtv-subs/README.md", "desc": "Service-Skelett rund um Goetheanum TV. Platzhalter." },
+
+    { "slug": "logo-generator-alt", "cat": "archiv",     "status": "geparkt", "tag": "Archiv",        "title": "Logo-Generator (alt)", "short": "Logos alt",  "href": "archive/logo-generator-original_2026-06-27/", "desc": "Der ursprüngliche Logo-Generator, eingefroren als Referenz – dunkles UI, externe Schriften, nicht gepflegt." }
   ],
   "docs": [
     { "title": "Strategieblatt & Wesensanalyse", "tag": "Strategie",    "href": "https://github.com/phtok/goeloggen/blob/main/docs/strategie.md", "desc": "Strategieblatt nach Neumeier, Fundament, Architektur, Fahrplan." },


### PR DESCRIPTION
## Was sich ändert

**Logos – Format kompakter.** Die Erklärzeile (benennt jetzt das Format, z. B. „PNG — Pixel mit Transparenz – fürs Office") sitzt direkt unter der Vorschau, *über* den Pillen. Darunter alle **sechs Formate nebeneinander** in einer Reihe, dann der Download direkt unter der Anwahl. Reihenfolge rechts: Vorschau → Erklärzeile → Format → die EINE Aktion.

**Logos – Mobil.** Der Download ist **hochgezogen** (direkt unter Vorschau + Format); die Sonderfassungen (Kategorie, Layout, Farbe) stehen **darunter**. So lädt die Seite primär zum Herunterladen des gemeinsamen Logos ein; Sonderfassungen sind sekundär. (Auf dem Handy klebt nur die Mini-Vorschau, sechs Pillen 3+3.)

**Alter Generator ins Archiv.** Der ursprüngliche Logo-Generator ist als Welt „Archiv" im **Intern-Menü** auffindbar (`tools.json` neue Kategorie `archiv` + Eintrag, `nav.js` neue Intern-Welt). Status `geparkt` → erscheint nur intern, nicht öffentlich. Ziel: `archive/logo-generator-original_2026-06-27/`.

**Menü & Kopfzeile lesbarer.** Schublade grösser (Bereichstitel 16 px, Einträge 17 px). Kopfzeile luftiger (`--header-h` 60 → 66 px, Lockup 34 → 38 px) und die vier Schnellzugriffe in **Lese-Ink statt Grau**, etwas grösser und mit mehr Abstand – sie verstecken sich nicht mehr.

## Geprüft
- Hell/Dunkel, Desktop/Mobil gerendert.
- Intern-Menü zeigt „Archiv → Logo-Generator (alt)"; Link löst auf (200).
- Erklärzeile aktualisiert bei Hover/Anwahl; sechs Pillen passen nebeneinander.
- pre-commit Typo-Check + Typo-Sync: keine Fehler, synchron.

## Betroffene Regeln
- B03 (Mindestgrössen), B02 (Kontrast der Schnellzugriffe), G05 (Menü ohne Schmuck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_