### PR TITLE
Track 1 — Signatur-Generator auf die Token-Schicht (Dunkelmodus, B01/B03)

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -9,6 +9,7 @@
 <link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
 <script src="../../assets/data/goetheanum-orgs.js"></script>
 <link rel="stylesheet" href="../../design-system/tokens.css" />
+<link rel="stylesheet" href="../../design-system/base.css" />
 <link rel="stylesheet" href="../../design-system/nav.css" />
 <style>
   /* Goetheanum Variable Font – gehostet von GitHub Pages (vgl. schriften.html#web) */
@@ -19,31 +20,10 @@
     font-weight:190 725; font-style:normal; font-display:swap;
   }
 
-  :root{
-    --ink:#23272b; --muted:#737a80; --line:rgba(20,24,28,.10); --line-soft:rgba(20,24,28,.055);
-    --gold:#d7ab68; --gold-deep:#a07a33; --blue:#0061a9; --paper:#fff; --soft:#faf8f4; --maxw:1080px;
-    --bad:#b3261e;
-    /* Abstands-Skala (4/8/12/16/24/32) */
-    --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s6:24px; --s8:32px;
-    /* Radien + Kopfhöhe */
-    --r-control:10px; --r-card:14px; --header-h:58px;
-  }
-  *{box-sizing:border-box;margin:0;padding:0}
-  body{background:var(--paper);color:var(--ink);font-family:"Goetheanum","Helvetica Neue",Arial,sans-serif;font-weight:440;
-       letter-spacing:normal;font-kerning:normal;text-rendering:optimizeLegibility;-webkit-font-smoothing:antialiased;line-height:1.5}
-  .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
-  a{color:inherit}
-  .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
-  /* Zustand = Blau (Inhalts-Akzent = Gold) */
-  a:focus-visible,button:focus-visible,summary:focus-visible{outline:2px solid var(--blue);outline-offset:2px}
-
-  header{position:sticky;top:0;z-index:30;background:rgba(255,255,255,.9);backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--line)}
-  .bar{display:flex;align-items:center;justify-content:space-between;height:var(--header-h)}
-  .brand{display:flex;align-items:center;gap:var(--s3);text-decoration:none}
-  .brand .wm{font-family:"Goetheanum";font-weight:440;font-size:27px;line-height:1;color:#8a9097;letter-spacing:.005em}
-  nav.top{display:flex;gap:22px}
-  nav.top a{color:var(--muted);text-decoration:none;font-size:13.5px}
-  nav.top a:hover{color:var(--gold-deep)}
+  /* Farben, Schrift, Maße, Hell-Dunkel kommen aus tokens.css/base.css.
+     Hier nur das werkzeug-eigene Layout – keine eigenen Farbwerte, kein eigenes :root.
+     Ausnahme: die Signatur-Vorschau (.mail-stage) bleibt bewusst weiss/fest, weil sie
+     eine E-Mail abbildet (die beim Empfänger immer auf Weiss steht). */
   /* Mobil: kompakter, volle Breite, kein horizontales Überlaufen */
   @media(max-width:560px){
     .wrap{padding:0 16px}
@@ -76,7 +56,7 @@
 
   .tabs{display:inline-flex;gap:var(--s2);margin-bottom:var(--s6)}
   .tabs button{font:inherit;font-size:13.5px;color:var(--muted);background:none;border:1px solid var(--line);border-radius:999px;padding:7px 16px;cursor:pointer;transition:.15s}
-  .tabs button[aria-pressed="true"]{color:var(--gold-deep);border-color:var(--gold)}
+  .tabs button[aria-pressed="true"]{color:var(--gold-ink);border-color:var(--gold)}
 
   /* Einklappbarer Abschnitt (Standards) */
   .fold{border-top:1px solid var(--line-soft);margin-bottom:var(--s3);padding-top:var(--s3)}
@@ -90,39 +70,41 @@
   .code-details{margin-top:var(--s4)}
   .code-details>summary{font-size:13px;color:var(--muted);cursor:pointer;list-style:none}
   .code-details>summary::-webkit-details-marker{display:none}
-  .code-details>summary::before{content:"▸ ";color:var(--gold-deep)}
+  .code-details>summary::before{content:"▸ ";color:var(--gold-ink)}
   .code-details[open]>summary::before{content:"▾ "}
 
   .fset{border:0;display:grid;gap:var(--s3);margin-bottom:var(--s3)}
   .field{display:grid;gap:var(--s1)}
   .field > .lab{font-size:13px;color:var(--muted);letter-spacing:.01em}
+  /* Felder: 16px (B03, kein iOS-Zoom), Fläche aus dem Token (kippt mit Hell/Dunkel). */
   .field input{
     width:100%;font-family:"Helvetica Neue",Arial,sans-serif;
-    font-size:14.5px;font-weight:400;line-height:1.35;color:var(--ink);
-    background:#fff;border:1px solid var(--line);border-radius:var(--r-control);
-    padding:8px 11px;outline:none;transition:border-color .15s,box-shadow .15s;
+    font-size:16px;font-weight:400;line-height:1.35;color:var(--ink);
+    background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);
+    padding:9px 11px;outline:none;transition:border-color .15s,box-shadow .15s;
   }
-  .field input::placeholder{color:#aeb4b9;font-weight:400}
-  .field input:focus{border-color:var(--blue);box-shadow:0 0 0 3px rgba(0,97,169,.16)}
-  .field input.invalid{border-color:var(--bad);box-shadow:0 0 0 3px rgba(179,38,30,.14)}
-  .field textarea{width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:14.5px;font-weight:400;line-height:1.35;color:var(--ink);background:#fff;border:1px solid var(--line);border-radius:var(--r-control);padding:8px 11px;outline:none;resize:vertical;min-height:48px;transition:border-color .15s,box-shadow .15s}
-  .field textarea::placeholder{color:#aeb4b9;font-weight:400}
-  .field textarea:focus{border-color:var(--blue);box-shadow:0 0 0 3px rgba(0,97,169,.16)}
+  .field input::placeholder{color:var(--muted);font-weight:400;opacity:.7}
+  .field input:focus{border-color:var(--blue);box-shadow:0 0 0 3px color-mix(in srgb,var(--blue) 22%,transparent)}
+  .field input.invalid{border-color:var(--bad);box-shadow:0 0 0 3px color-mix(in srgb,var(--bad) 20%,transparent)}
+  .field textarea{width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.35;color:var(--ink);background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);padding:9px 11px;outline:none;resize:vertical;min-height:48px;transition:border-color .15s,box-shadow .15s}
+  .field textarea::placeholder{color:var(--muted);font-weight:400;opacity:.7}
+  .field textarea:focus{border-color:var(--blue);box-shadow:0 0 0 3px color-mix(in srgb,var(--blue) 22%,transparent)}
   .lab .sublab{font-weight:400;font-size:11.5px;color:var(--muted);margin-left:6px}
   .field-msg{font-size:12px;color:var(--bad);min-height:0}
-  .field select{width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:14.5px;color:var(--ink);background:#fff;border:1px solid var(--line);border-radius:var(--r-control);padding:8px 11px;outline:none;cursor:pointer;transition:border-color .15s,box-shadow .15s}
-  .field select:focus{border-color:var(--blue);box-shadow:0 0 0 3px rgba(0,97,169,.16)}
+  .field select{width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:16px;color:var(--ink);background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);padding:9px 11px;outline:none;cursor:pointer;transition:border-color .15s,box-shadow .15s}
+  .field select:focus{border-color:var(--blue);box-shadow:0 0 0 3px color-mix(in srgb,var(--blue) 22%,transparent)}
 
   .btnrow{display:flex;gap:var(--s3);flex-wrap:wrap;align-items:center;margin-top:var(--s6)}
-  .btn{display:inline-block;text-decoration:none;font:inherit;font-size:13.5px;padding:9px 15px;border-radius:var(--r-control);border:1px solid var(--line);color:var(--ink);background:#fff;text-align:center;cursor:pointer;transition:.15s}
-  .btn:hover{border-color:var(--gold-deep)}
-  .btn.primary{background:var(--gold);border-color:var(--gold);color:#3a2d10}
-  .btn.primary:hover{background:#c59f56}
-  .btn.ok{background:#3f7d46;border-color:#3f7d46;color:#fff}
-  .btn.ghost{color:var(--muted)}
-  .hint{font-size:14.5px;color:#565b60;line-height:1.55;margin-top:var(--s3);max-width:64ch}
+  .btn{display:inline-block;text-decoration:none;font:inherit;font-size:13.5px;padding:9px 15px;border-radius:var(--r-control);border:1px solid var(--line);color:var(--ink);background:var(--field-bg);text-align:center;cursor:pointer;transition:.15s}
+  .btn:hover{border-color:var(--blue)}
+  /* Aktion = volles Blau + Weiss (B01: kein dunkler Text auf Farbe). */
+  .btn.primary{background:var(--blue-solid);border-color:var(--blue-solid);color:var(--on-accent);font-weight:var(--w-strong)}
+  .btn.primary:hover{filter:brightness(1.08)}
+  .btn.ok{background:#3f7d46;border-color:#3f7d46;color:var(--on-accent)}
+  .btn.ghost{color:var(--muted);background:none}
+  .hint{font-size:14.5px;color:var(--muted);line-height:1.55;margin-top:var(--s3);max-width:64ch}
   .hint strong{color:var(--ink);font-weight:440}
-  .hint a{color:var(--gold-deep);text-decoration:none}
+  .hint a{color:var(--gold-ink);text-decoration:none}
   .hint ul{margin:var(--s3) 0 0;padding-left:18px;display:grid;gap:var(--s2)}
   .hint code{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:12px;background:var(--soft);border:1px solid var(--line-soft);border-radius:5px;padding:1px 5px}
 
@@ -143,7 +125,7 @@
   .choose{display:grid;gap:var(--s4);grid-template-columns:1fr;margin-bottom:var(--s6)}
   @media(min-width:760px){.choose{grid-template-columns:1fr 1fr}}
   .choose .opt{border:1px solid var(--line);border-radius:var(--r-card);padding:16px 18px;background:var(--soft)}
-  .choose .opt .who{color:var(--gold-deep);font-size:12px;letter-spacing:.06em;text-transform:uppercase;margin-bottom:6px}
+  .choose .opt .who{color:var(--gold-ink);font-size:12px;letter-spacing:.06em;text-transform:uppercase;margin-bottom:6px}
   .choose .opt h3{font-family:"Goetheanum";font-weight:680;font-size:15px;margin-bottom:6px}
   .choose .opt p{font-size:13.5px;color:var(--muted);line-height:1.55}
   .guide details{border-top:1px solid var(--line-soft);padding:var(--s4) 0}
@@ -157,7 +139,7 @@
   .guide li{font-size:14px;line-height:1.5;color:var(--ink)}
   .guide code{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:12.5px;background:var(--soft);border:1px solid var(--line-soft);border-radius:5px;padding:1px 5px}
   .guide .note{font-size:13px;color:var(--muted);line-height:1.5;margin-top:6px}
-  .guide a{color:var(--gold-deep);text-decoration:none}
+  .guide a{color:var(--gold-ink);text-decoration:none}
   .guide a:hover{text-decoration:underline}
 
   footer{border-top:1px solid var(--line);padding:var(--s8) 0 60px;color:var(--muted);font-size:12.5px}


### PR DESCRIPTION
Track 1, nächster Schritt: der Signatur-Generator.

## Änderungen
- Lokales `:root` und tote Kopfzeilen-CSS (Zeit vor `nav.js`) entfernt; **`base.css` eingebunden**.
- **Felder** auf `var(--field-bg)` (kippen mit Hell/Dunkel), Platzhalter auf `--muted`, **16 px** (B03, kein iOS-Zoom-Sprung).
- **Aktion** „Signatur kopieren": Gold-Fläche + dunkler Text → **Blau + Weiss** (B01); Gold-als-Text auf `--gold-ink`.

## Bewusst unverändert
Die **Signatur-Vorschau** (`.mail-stage`) bleibt **weiss/fest** in beiden Themes – sie bildet eine E-Mail ab, die beim Empfänger immer auf Weiss steht. Nur die Werkzeug-Oberfläche reagiert auf das Theme.

## Geprüft
- Hell und Dunkel gerendert (mit Beispiel-Signatur): Chrome themt, Vorschau bleibt korrekt weiss, Aktion blau.
- pre-commit Typo-Check: konform.

## Track 1 — noch offen
Visitenkarten (3892 Z.) als letzter und grösster Batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_