### PR TITLE
Track 3 — mitwachsende Statistik: generischer Zähler (nav.js) + Dashboard-Abschnitt

### DIFF
--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -50,6 +50,31 @@
   // Sofort anwenden – vor dem Zeichnen, gegen Aufblitzen.
   document.documentElement.setAttribute("data-theme", getTheme());
 
+  // --- Anonyme Nutzungszählung (mitwachsend) ---------------------------------
+  // Zählt je Werkzeug (data-active) den Seitenaufruf und Download-Klicks – ohne
+  // Cookies, ohne IP/Personendaten, nur anonyme Summen über goeloggen_bump().
+  // Jedes Werkzeug mit nav.js zählt automatisch mit; neue brauchen nichts extra.
+  // Werkzeuge mit JS-Download rufen window.goeStat('download', name) selbst auf.
+  var STAT_SB = "https://dagcsnfrlbpxcmdimnrw.supabase.co";
+  var STAT_KEY = "sb_publishable_SXhY0mrhXjdTnjbJ5Uobtg_zAXW_xGY";
+  function goeStat(event, label) {
+    if (!ACTIVE || !event) return;
+    try {
+      fetch(STAT_SB + "/rest/v1/rpc/goeloggen_bump", {
+        method: "POST", keepalive: true,
+        headers: { "Content-Type": "application/json", "apikey": STAT_KEY, "Authorization": "Bearer " + STAT_KEY },
+        body: JSON.stringify({ p_tool: ACTIVE, p_event: event, p_label: (label || "").slice(0, 160) })
+      }).catch(function () {});
+    } catch (e) {}
+  }
+  window.goeStat = goeStat;
+  goeStat("view", "");
+  document.addEventListener("click", function (e) {
+    var a = e.target.closest && e.target.closest("a[download]");
+    if (!a) return;
+    goeStat("download", (a.getAttribute("download") || a.getAttribute("href") || "").split("/").pop());
+  });
+
   // Die vier meistgenutzten – nur als Desktop-Schnellzugriff in der Kopfzeile.
   var PRIMARY = [
     { label: "Logos",         slug: "logo-generator" },

--- a/statistik.html
+++ b/statistik.html
@@ -57,6 +57,12 @@
     <p class="lede">Alle Goeloggen-Anwendungen an einem Ort. Gezählt werden nur anonyme Summen – keine IP, kein Tracking, keine Drittdienste. <span id="status" class="muted">lädt …</span></p>
   </div>
 
+  <section id="sec-alle">
+    <div class="app-h"><h2>Alle Werkzeuge</h2><span class="meta" id="alleMeta"></span></div>
+    <div class="chart-t">SEITENAUFRUFE JE WERKZEUG · WÄCHST AUTOMATISCH MIT</div>
+    <div class="bars" id="alleBars"><div class="empty">lädt …</div></div>
+  </section>
+
   <section id="sec-landing">
     <div class="app-h"><h2>Landing-Page</h2><span class="meta" id="landMeta"></span></div>
     <div class="cards">
@@ -144,6 +150,34 @@
     if(fail && done===0){ st.className='err'; st.textContent='Konnte Statistik nicht laden.'; }
     else { st.className='muted'; st.textContent='Stand: ' + new Date().toLocaleString('de-CH'); }
   }
+
+  // ---- Alle Werkzeuge (generisch, mitwachsend) ----
+  Promise.all([
+    rpc('goeloggen_stats'),
+    fetch('tools.json').then(function(r){ return r.json(); }).catch(function(){ return null; })
+  ]).then(function(res){
+    var rows = res[0] || [], man = res[1], labels = {};
+    if (man && man.tools) man.tools.forEach(function(t){ labels[t.slug] = t.title; });
+    var byTool = {};
+    rows.forEach(function(r){
+      var t = byTool[r.tool] || (byTool[r.tool] = { views:0, downloads:0, last:'' });
+      if (r.event === 'view') t.views += Number(r.n);
+      else if (r.event === 'download') t.downloads += Number(r.n);
+      if (r.updated_at > t.last) t.last = r.updated_at;
+    });
+    var items = Object.keys(byTool).map(function(slug){
+      return { label: labels[slug] || slug, views: byTool[slug].views, downloads: byTool[slug].downloads };
+    }).sort(function(a,b){ return b.views - a.views; });
+    bars(document.getElementById('alleBars'), items.map(function(it){
+      return { label: it.label, value: it.views, sub: (it.downloads ? fmt(it.downloads) + ' DL' : '') };
+    }));
+    var lastA = rows.reduce(function(m,r){ return (r.updated_at > m) ? r.updated_at : m; }, '');
+    document.getElementById('alleMeta').textContent = lastA ? 'zuletzt ' + when(lastA) : 'noch keine Daten';
+    done++; finish();
+  }).catch(function(){
+    document.getElementById('alleBars').innerHTML = '<div class="err">nicht ladbar</div>';
+    fail++; finish();
+  });
 
   // ---- Landing-Page ----
   Promise.all([rpc('landing_stats'), rpc('landing_tool_stats')]).then(function(res){


### PR DESCRIPTION
Track 3: anonyme Nutzungszählung, die **automatisch mitwächst**.

## Backend (Supabase)
Die Goeloggen-Statistik liegt im Projekt **„Public Secrets App"** (`dagcsnfrlbpxcmdimnrw`) – dort, wo schon die bisherigen Per-Tool-Zähler liegen. Migration **strikt additiv und `goeloggen_`-präfixiert** (berührt keine Public-Secrets-Tabelle):
- Tabelle `goeloggen_counters(tool, event, label, n, updated_at)`, RLS an, **ohne** Direktzugriff.
- `goeloggen_bump(tool, event, label)` und `goeloggen_stats()` als `SECURITY DEFINER`, ausführbar für `anon`/`authenticated` – gleiches Sicherheitsmuster wie die bestehenden Funktionen. Smoke-getestet (Zählen, Lesen, Aufräumen).

## Frontend
- **`nav.js` zählt automatisch**: je Werkzeug (`data-active`-Slug) einen Seitenaufruf und Download-Klicks (`a[download]`) – ohne Cookies, ohne IP/Personendaten. Da jedes Werkzeug `nav.js` einbindet (und der **Starter** ebenfalls), zählt alles Bestehende **und** Künftige mit, ohne Extra-Arbeit. `window.goeStat(event, label)` für Werkzeuge mit JS-Download.
- **`statistik.html`**: neuer Abschnitt **„Alle Werkzeuge"** – Seitenaufrufe je Werkzeug (Label aus `tools.json`), wächst automatisch mit, gespeist aus `goeloggen_stats()`.

## Hinweise
- Die bisherigen Per-Tool-Abschnitte (Schriften/Signatur/GTV/Landing) bleiben unverändert daneben bestehen; der neue Abschnitt ist die mitwachsende Übersicht. Übergangsweise zählen Schriften/Signatur in beiden Systemen.
- `apps/logos/` bewusst nicht angefasst (paralleles Hinweise-Redesign); Logos zählt Aufrufe trotzdem über `nav.js`, der Engine-Download kann später per `window.goeStat` ergänzt werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_