### PR TITLE
Track 2 — neue Startseite mit visuellen Karten (Erklär-Ebene)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,112 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Goetheanum-Logo</title>
-<meta http-equiv="refresh" content="0; url=./apps/logos/" />
-<link rel="canonical" href="./apps/logos/" />
-<script>location.replace("./apps/logos/" + location.search + location.hash);</script>
-<style>body{margin:0;min-height:100vh;display:grid;place-items:center;font:400 16px/1.4 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#565b60}a{color:#a07a33}</style>
+<title>Goetheanum Werkzeuge – Hausgrafik</title>
+<meta name="description" content="Werkzeuge für die Hausgrafik des Goetheanum: Logos, Schriften, E-Mail-Signatur, Visitenkarten und das Design-System – schlank, im Browser, einheitlich im Bild." />
+<link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
+<link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/base.css" />
+<link rel="stylesheet" href="design-system/nav.css" />
+<style>
+  /* Startseite: die Erklär-Ebene, die das Menü bewusst weglässt. */
+  .hero{padding:clamp(44px,8vw,92px) 0 var(--s8)}
+  .hero .kicker{margin-bottom:var(--s4)}
+  .hero h1{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:var(--t-h1);line-height:1.04;letter-spacing:-.01em;max-width:18ch}
+  .hero .lede{margin-top:var(--s6);max-width:60ch}
+  .hero .meta{margin-top:var(--s6);display:flex;gap:var(--s2);flex-wrap:wrap}
+
+  section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
+  section:first-of-type{border-top:0}
+
+  .grid{display:grid;gap:var(--s4);grid-template-columns:1fr}
+  @media(min-width:620px){.grid{grid-template-columns:1fr 1fr}}
+  @media(min-width:960px){.grid.cols3{grid-template-columns:1fr 1fr 1fr}}
+
+  /* Karte = Werkzeug, mit Erklärung. Live ruht auf weicher Fläche, Gold-Kante bei Hover. */
+  .tile{position:relative;display:flex;flex-direction:column;gap:var(--s2);border:1px solid var(--line);
+    border-radius:var(--r-card);padding:var(--s6);background:var(--paper);text-decoration:none;color:var(--ink);
+    min-height:150px;transition:border-color .15s,box-shadow .15s,transform .15s}
+  .tile.is-live{background:var(--soft)}
+  .tile:hover{border-color:var(--gold-ink);box-shadow:var(--shadow-card);transform:translateY(-1px)}
+  .tile .tag{font-family:var(--font-display);color:var(--gold-ink);font-size:12.5px;letter-spacing:.03em}
+  .tile h3{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:20px;line-height:1.15;display:flex;align-items:center;gap:9px}
+  .tile h3 .arr{color:var(--muted);font-weight:var(--w-text);transition:transform .15s,color .15s}
+  .tile:hover h3 .arr{color:var(--gold-ink);transform:translateX(3px)}
+  .tile p{color:var(--muted);font-size:14.5px;line-height:1.55}
+  .badge{position:absolute;top:var(--s4);right:var(--s4);font-size:11px;letter-spacing:.03em;
+    color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:2px 10px}
+</style>
 </head>
 <body>
-<p>Weiter zu den Logos – <a href="./apps/logos/">hier entlang</a>.</p>
+
+<script src="design-system/nav.js" data-root="./" data-active="start"></script>
+
+<main class="wrap">
+  <section class="hero">
+    <div class="kicker">Goetheanum · Hausgrafik</div>
+    <h1>Werkzeuge für ein einheitliches Bild.</h1>
+    <p class="lede prose">Logo, Visitenkarte, E-Mail-Signatur, die Hausschrift mit ihren Regeln – und das Design-System dahinter. Schlank, im Browser, ohne Login: jeder pflegt seine eigenen Angaben, das Bild bleibt einheitlich.</p>
+    <div class="meta" id="heroMeta"></div>
+  </section>
+
+  <div id="sections"></div>
+</main>
+
+<footer class="ds-footer">
+  <div class="wrap frow">
+    <span><strong>Goetheanum</strong> · Werkzeuge für die Hausgrafik</span>
+    <span>Allgemeine Anthroposophische Gesellschaft · <a href="https://www.goetheanum.org">goetheanum.org</a></span>
+  </div>
+</footer>
+
+<script>
+"use strict";
+(function(){
+  // Öffentliche Welten = die Erklär-Ebene der Startseite (Menü-Welten, aber mit Text).
+  var WORLDS = [
+    { id:"werkzeuge", title:"Werkzeuge", intro:"Eigene Angaben eintragen, fertiges Ergebnis übernehmen – für den täglichen Gebrauch.", cats:["generatoren"] },
+    { id:"schrift",   title:"Schrift & Typografie", intro:"Die Hausschrift v2.5 und ihre Regeln – ansehen, herunterladen, einbinden.", cats:["schrift"] },
+    { id:"elemente",  title:"Fundament", intro:"Farben, Schnitte und Komponenten – das Design-System, aus dem alles gebaut ist.", cats:["system"] }
+  ];
+  var STATUS_LABEL = { beta:"in Überarbeitung" };
+
+  function isExt(h){ return /^https?:/.test(h); }
+  function tile(t){
+    var a = document.createElement("a");
+    a.className = "tile" + (t.status === "live" ? " is-live" : "");
+    a.href = t.href;
+    if (isExt(t.href)) { a.target = "_blank"; a.rel = "noopener"; }
+    var badge = STATUS_LABEL[t.status] ? '<span class="badge">' + STATUS_LABEL[t.status] + '</span>' : "";
+    a.innerHTML = badge +
+      '<span class="tag">' + (t.tag || "") + '</span>' +
+      '<h3>' + t.title + ' <span class="arr">›</span></h3>' +
+      '<p>' + (t.desc || "") + '</p>';
+    return a;
+  }
+  function render(man){
+    var host = document.getElementById("sections");
+    WORLDS.forEach(function(w){
+      var tools = (man.tools || []).filter(function(t){
+        return w.cats.indexOf(t.cat) !== -1 && (t.status === "live" || t.status === "beta");
+      });
+      if (!tools.length) return;
+      tools.sort(function(a,b){ return (a.status === "live" ? 0 : 1) - (b.status === "live" ? 0 : 1); });
+      var sec = document.createElement("section");
+      sec.innerHTML = '<div class="shead"><h2>' + w.title + '</h2><p>' + w.intro + '</p></div>';
+      var grid = document.createElement("div"); grid.className = "grid cols3";
+      tools.forEach(function(t){ grid.appendChild(tile(t)); });
+      sec.appendChild(grid); host.appendChild(sec);
+    });
+    var gen = (man.tools || []).filter(function(t){ return t.cat === "generatoren" && (t.status === "live" || t.status === "beta"); }).length;
+    document.getElementById("heroMeta").innerHTML =
+      '<span class="chip"><b>' + gen + '</b> Werkzeuge</span>' +
+      '<span class="chip"><b>Variable</b> Hausschrift</span>' +
+      '<span class="chip">Typografie als <b>System</b></span>';
+  }
+  fetch("tools.json").then(function(r){ return r.json(); }).then(render).catch(function(){
+    document.getElementById("sections").innerHTML = '<section><p class="meta">Werkzeugliste konnte nicht geladen werden.</p></section>';
+  });
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
Track 2: die Wurzel `/` war bisher nur eine **Weiterleitung auf die Logos**. Jetzt eine echte **Startseite** – die Erklär-Ebene, die das Menü bewusst weglässt.

- **Im Design-System gebaut** (`tokens.css`/`base.css`/`nav.js`): globale Kopfzeile, Hell/Dunkel, und sie **zählt automatisch mit** (über `nav.js`, `data-active="start"`).
- **Hero + Karten-Raster je öffentlicher Welt** – Werkzeuge · Schrift & Typografie · Fundament – gerendert aus `tools.json` (live + beta). Jede Karte trägt **die Erklärung** (Tag, Titel, Beschreibung), die im Menü fehlt: *„Das Menü koordiniert, es erklärt nicht."*
- Live-Werkzeuge ruhen auf weicher Fläche, Gold-Kante bei Hover; Beta trägt ein ruhiges „in Überarbeitung".
- Der interne Hub `/start/` bleibt unverändert daneben bestehen.

## Geprüft
- Hell **und** Dunkel gerendert (Hero, drei Welten, Karten, Footer) – sauber, tokenkonform.
- Keine echten Konsolenfehler (nur die erwartete Supabase-Offline-Meldung in der Sandbox).

Erste Fassung zum Draufschauen – Feinschliff (z. B. echte Mini-Visuals je Karte) gern als nächster Schritt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_