### PR TITLE
Mehr Luft im und unter dem Header

### DIFF
--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -84,7 +84,7 @@
 
   /* --- Radien, Maße, Fingerziel ------------------------------------------ */
   --r-control:10px; --r-card:14px; --r-pill:999px;
-  --header-h:66px; --maxw:1080px; --ds-maxw:1080px;
+  --header-h:74px; --maxw:1080px; --ds-maxw:1080px;
   --tap:44px;            /* Mindest-Fingerziel (Apple 44, Material 48, WCAG 24) */
 
   /* --- Schatten ---------------------------------------------------------- */

--- a/index.html
+++ b/index.html
@@ -10,8 +10,9 @@
 <link rel="stylesheet" href="design-system/base.css" />
 <link rel="stylesheet" href="design-system/nav.css" />
 <style>
-  /* Startseite: nur die Karten – kein Hero, keine Überschriften, keine Erklärungen. */
-  main{padding:clamp(28px,5vw,48px) 0}
+  /* Startseite: nur die Karten – kein Hero, keine Überschriften, keine Erklärungen.
+     Etwas Luft unter dem Header, bevor das Raster beginnt. */
+  main{padding:clamp(40px,6vw,72px) 0 clamp(32px,5vw,56px)}
   .grid{display:grid;gap:var(--s4);grid-template-columns:repeat(auto-fill,minmax(230px,1fr))}
 
   .tile{position:relative;display:flex;flex-direction:column;gap:var(--s3);border:1px solid var(--line);


### PR DESCRIPTION
- **Im Header:** Kopfzeile etwas höher (`--header-h` 66 → 74 px) – mehr Ruhe um die Wortmarke. Global über alle Werkzeuge; die Sticky-Offsets (Logos-Vorschau u. a.) folgen dem Token automatisch.
- **Unter dem Header:** auf der Startseite beginnt das Karten-Raster mit mehr Abstand.

Start und ein Werkzeug (Logos) gerendert – Header sitzt ruhiger, Inhalt fliesst korrekt darunter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_