### PR TITLE
Startseite: Atem über den Karten (main.wrap statt main)

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,9 @@
 <link rel="stylesheet" href="design-system/nav.css" />
 <style>
   /* Startseite: nur die Karten – kein Hero, keine Überschriften, keine Erklärungen.
-     Etwas Luft unter dem Header, bevor das Raster beginnt. */
-  main{padding:clamp(40px,6vw,72px) 0 clamp(32px,5vw,56px)}
+     Spürbar Atem unter dem Header. main.wrap, sonst gewinnt .wrap (0 26px) und der
+     Abstand oben bliebe wirkungslos – nur top/bottom setzen, 26px seitlich bleiben. */
+  main.wrap{padding-top:clamp(64px,9vw,120px);padding-bottom:clamp(40px,6vw,64px)}
   .grid{display:grid;gap:var(--s4);grid-template-columns:repeat(auto-fill,minmax(230px,1fr))}
 
   .tile{position:relative;display:flex;flex-direction:column;gap:var(--s3);border:1px solid var(--line);


### PR DESCRIPTION
Die Karten klebten an der oberen Linie. Ursache: `main` trägt auch die Klasse `.wrap`, und `base.css .wrap{padding:0 26px}` überstimmt per Spezifität das `main{padding}` – der obere Abstand blieb wirkungslos.

Fix: den Abstand auf `main.wrap` setzen und nur `padding-top`/`padding-bottom` (die seitlichen 26 px von `.wrap` bleiben). Die Karten beginnen jetzt spürbar unter der Linie (~108 px statt klebend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_