### PR TITLE
Inkonsistenz-Aufräumen: Beta-Seiten auf die Token-Schicht (Typografie · Tester · Grotesk+)

### DIFF
--- a/schrift-vergleich.html
+++ b/schrift-vergleich.html
@@ -11,40 +11,37 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,400;0,600;1,400&family=IBM+Plex+Sans:ital,wght@0,400;0,600;1,400&family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400&family=Inter:ital,wght@0,400;0,600;1,400&family=Cairo:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/base.css" />
 <link rel="stylesheet" href="design-system/nav.css" />
 <style>
   @font-face{font-family:"G Klar";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.6-Klar.woff2") format("woff2");font-display:swap}
   @font-face{font-family:"G Deutlich";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.6-Deutlich.woff2") format("woff2");font-display:swap}
   @font-face{font-family:"G Laut";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.6-Laut.woff2") format("woff2");font-display:swap}
   @font-face{font-family:"Titillium RUS";src:url("assets/fonts/goetheanum/Fallback/TitilliumRUS-Regular.woff2") format("woff2");font-weight:400;font-display:swap;unicode-range:U+0400-04FF,U+0500-052F}
-  :root{--ink:#23272b;--muted:#737a80;--line:rgba(20,24,28,.10);--line-soft:rgba(20,24,28,.06);
-        --gold:#d7ab68;--gold-deep:#a07a33;--paper:#fff;--soft:#faf8f4;--maxw:1040px;
-        --body:"Source Sans 3";--bsize:19px;--bweight:400;--measure:62ch}
+  /* Farben/Hell-Dunkel aus tokens.css/base.css – nur seiten-eigene Werte hier. */
+  :root{--maxw:1040px;--body:"Source Sans 3";--bsize:19px;--bweight:400}
   *{box-sizing:border-box;margin:0;padding:0}
   body{background:var(--paper);color:var(--ink);font-family:"G Klar","Helvetica Neue",Arial,sans-serif;line-height:1.5;font-size:16.5px;-webkit-font-smoothing:antialiased}
   .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
-  a{color:var(--gold-deep)}
-  header{position:sticky;top:0;z-index:30;background:rgba(255,255,255,.92);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
-  .bar{display:flex;align-items:center;justify-content:space-between;height:56px}
-  nav.top a{color:var(--muted);text-decoration:none;font-size:13.5px;margin-left:18px}
+  a{color:var(--gold-ink)}
   .hero{padding:42px 0 4px}
-  .kick{color:var(--gold-deep);font-size:14px;margin-bottom:10px}
+  .kick{color:var(--gold-ink);font-size:14px;margin-bottom:10px}
   h1{font-family:"G Klar";font-weight:400;font-size:clamp(28px,5vw,46px);line-height:1.1}
   .lede{font-size:17px;color:var(--muted);max-width:64ch;margin-top:12px}
   section{padding:30px 0;border-top:1px solid var(--line-soft)}
-  .sec{color:var(--gold-deep);font-size:13px}
+  .sec{color:var(--gold-ink);font-size:13px}
   h2{font-family:"G Klar";font-weight:400;font-size:clamp(20px,3vw,26px);margin:4px 0 14px}
   .ctrl{display:flex;gap:14px 22px;flex-wrap:wrap;align-items:center;background:var(--soft);border:1px solid var(--line-soft);border-radius:12px;padding:14px 18px;margin-bottom:22px;position:sticky;top:56px;z-index:20}
   .ctrl .grp{display:flex;gap:6px;flex-wrap:wrap}
-  .ctrl button{font:inherit;font-size:13px;color:var(--muted);background:#fff;border:1px solid var(--line);border-radius:20px;padding:5px 14px;cursor:pointer}
-  .ctrl button[aria-pressed=true]{color:var(--gold-deep);border-color:var(--gold);font-weight:600}
+  .ctrl button{font:inherit;font-size:13px;color:var(--muted);background:var(--field-bg);border:1px solid var(--line);border-radius:20px;padding:5px 14px;cursor:pointer}
+  .ctrl button[aria-pressed=true]{color:var(--gold-ink);border-color:var(--gold);font-weight:600}
   .ctrl label{font-size:13px;color:var(--muted);display:flex;align-items:center;gap:8px}
-  .ctrl input[type=range]{accent-color:var(--gold-deep);width:120px}
+  .ctrl input[type=range]{accent-color:var(--gold-ink);width:120px}
   .ctrl b{color:var(--ink);font-variant-numeric:tabular-nums}
   .article{max-width:var(--measure);margin:0 auto}
-  .a-kick{font-family:"G Klar";font-size:14px;color:var(--gold-deep);margin-bottom:10px}
+  .a-kick{font-family:"G Klar";font-size:14px;color:var(--gold-ink);margin-bottom:10px}
   .a-head{font-family:"G Klar";font-weight:400;font-size:calc(var(--bsize)*2.3);line-height:1.08;margin-bottom:6px;text-wrap:balance}
-  .a-sub{font-family:"G Deutlich";font-size:calc(var(--bsize)*1.15);line-height:1.25;color:#555;margin-bottom:20px}
+  .a-sub{font-family:"G Deutlich";font-size:calc(var(--bsize)*1.15);line-height:1.25;color:var(--muted);margin-bottom:20px}
   .a-body{font-family:var(--body),sans-serif;font-size:var(--bsize);font-weight:var(--bweight);line-height:1.62;text-wrap:pretty}
   .a-body p{margin-bottom:.9em}
   .a-body em{font-style:italic}
@@ -52,10 +49,10 @@
   .cards{display:grid;grid-template-columns:1fr 1fr;gap:14px}
   @media(max-width:680px){.cards{grid-template-columns:1fr}}
   .card{border:1px solid var(--line-soft);border-radius:12px;padding:16px 18px}
-  .card .nm{font-size:14px;color:var(--gold-deep);font-weight:600;margin-bottom:8px}
+  .card .nm{font-size:14px;color:var(--gold-ink);font-weight:600;margin-bottom:8px}
   .card .smp{font-size:17px;line-height:1.5}
   .scriptrow{display:grid;grid-template-columns:150px 1fr;gap:6px 18px;align-items:baseline;padding:10px 0;border-bottom:1px solid var(--line-soft)}
-  .scriptrow .lab{font-size:12px;color:var(--gold-deep)}
+  .scriptrow .lab{font-size:12px;color:var(--gold-ink)}
   .scriptrow .smp{font-size:26px}
   .lat{font-family:"G Klar"} .cyr{font-family:"Titillium RUS"} .grk{font-family:"Source Sans 3"} .arb{font-family:"Cairo"}
   footer{border-top:1px solid var(--line);padding:26px 0 54px;color:var(--muted);font-size:12.5px}
@@ -145,7 +142,7 @@
     var d=document.createElement("div"); d.className="card";
     d.innerHTML='<div class="nm">'+f[0]+'</div>'+
       '<div class="smp" style="font-family:\''+f[0]+'\'">Lebendige Formen wachsen aus dem Schweigen. <em style="font-style:italic">Ein Versuch in Klarheit</em> – 1913 Plätze, 47° 32′.</div>'+
-      '<div style="font-size:11.5px;color:#999;margin-top:8px">'+f[1]+'</div>';
+      '<div style="font-size:11.5px;color:var(--muted);margin-top:8px">'+f[1]+'</div>';
     qc.appendChild(d);
   });
 })();

--- a/tester.html
+++ b/tester.html
@@ -7,20 +7,22 @@
 <title>Goetheanum Schriften · Gewichts-Tester</title>
 <meta name="robots" content="noindex" />
 <link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/base.css" />
 <link rel="stylesheet" href="design-system/nav.css" />
 <style>
   @font-face{font-family:"GV";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Variabel-v2.6.woff2") format("woff2");font-weight:150 725;font-display:swap}
-  :root{--ink:#23272b;--muted:#737a80;--line:rgba(20,24,28,.12);--gold:#d7ab68;--gold-deep:#a07a33;--soft:#faf8f4;--ok:#3f8f5f;--warn:#c2873a}
+  /* Farben/Hell-Dunkel aus tokens.css/base.css – nur seiten-eigene Werte hier. */
+  :root{--ok:#3f8f5f;--warn:#c2873a}
   *{box-sizing:border-box;margin:0;padding:0}
-  body{font-family:"GV","Helvetica Neue",Arial,sans-serif;font-variation-settings:"wght" 450;color:var(--ink);background:#fff;line-height:1.5;-webkit-font-smoothing:antialiased}
+  body{font-family:"GV","Helvetica Neue",Arial,sans-serif;font-variation-settings:"wght" 450;color:var(--ink);background:var(--paper);line-height:1.5;-webkit-font-smoothing:antialiased}
   .wrap{max-width:1000px;margin:0 auto;padding:28px 26px 80px}
-  .kick{color:var(--gold-deep);font-size:13px;letter-spacing:.02em}
+  .kick{color:var(--gold-ink);font-size:13px;letter-spacing:.02em}
   h1{font-variation-settings:"wght" 600;font-size:34px;line-height:1.1;margin:6px 0 4px}
   .lede{color:var(--muted);max-width:640px;margin-bottom:26px}
-  .panel{border:1px solid var(--line);border-radius:16px;padding:30px;background:#fff}
+  .panel{border:1px solid var(--line);border-radius:16px;padding:30px;background:var(--paper)}
   .presets{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:14px;font-size:13px;color:var(--muted)}
   .presets button{font:inherit;font-size:12.5px;color:var(--muted);background:none;border:1px solid var(--line);border-radius:999px;padding:5px 12px;cursor:pointer}
-  .presets button:hover,.presets button.on{color:var(--gold-deep);border-color:var(--gold)}
+  .presets button:hover,.presets button.on{color:var(--gold-ink);border-color:var(--gold)}
   .compare{display:flex;gap:34px;align-items:baseline;flex-wrap:wrap;font-size:clamp(28px,5vw,46px);line-height:1.1}
   .smallprobe{margin-top:14px;font-size:13px}
   .smallprobe .lab{color:var(--muted);font-size:11px;margin-right:10px}
@@ -38,10 +40,10 @@
   .ctrls{display:grid;grid-template-columns:repeat(3,1fr);gap:22px;margin-top:30px}
   @media(max-width:760px){.ctrls{grid-template-columns:1fr}}
   .ctrl b{font-variation-settings:"wght" 600;font-weight:normal}
-  .ctrl .v{float:right;color:var(--gold-deep)}
+  .ctrl .v{float:right;color:var(--gold-ink)}
   .ctrl .role{font-size:12px;color:var(--muted);margin-bottom:8px}
   input[type=range]{-webkit-appearance:none;appearance:none;width:100%;height:2px;background:var(--line);border-radius:2px;margin:6px 0}
-  input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;width:22px;height:22px;border-radius:50%;background:var(--gold);cursor:pointer;border:3px solid #fff;box-shadow:0 1px 4px rgba(0,0,0,.2)}
+  input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;width:22px;height:22px;border-radius:50%;background:var(--gold);cursor:pointer;border:3px solid var(--paper);box-shadow:0 1px 4px rgba(0,0,0,.2)}
   .def{font-size:11px;color:var(--muted)}
   .metrics{margin-top:26px;border:1px solid var(--line);border-radius:14px;padding:18px 20px;background:var(--soft);font-size:14px}
   .metrics div{display:flex;justify-content:space-between;padding:4px 0}
@@ -52,7 +54,7 @@
   .out code{background:var(--soft);border:1px solid var(--line);border-radius:6px;padding:2px 8px;color:var(--ink)}
   .q{margin-top:30px;border-top:1px solid var(--line);padding-top:18px;color:var(--muted);font-size:14px}
   .q b{font-variation-settings:"wght" 600;font-weight:normal;color:var(--ink)}
-  a{color:var(--gold-deep)}
+  a{color:var(--gold-ink)}
 </style>
 </head>
 <body>

--- a/typografie.html
+++ b/typografie.html
@@ -9,32 +9,33 @@
 <meta name="robots" content="noindex" />
 <link rel="stylesheet" href="assets/typografie/ziffern.css" />
 <link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/base.css" />
 <link rel="stylesheet" href="design-system/nav.css" />
 <style>
   @font-face{font-family:"G Leise";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.6-Leise.woff2") format("woff2");font-display:swap}
   @font-face{font-family:"G Klar";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.6-Klar.woff2") format("woff2");font-display:swap}
   @font-face{font-family:"G Deutlich";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.6-Deutlich.woff2") format("woff2");font-display:swap}
   @font-face{font-family:"G Laut";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.6-Laut.woff2") format("woff2");font-display:swap}
-  :root{--ink:#23272b;--muted:#737a80;--line:rgba(20,24,28,.10);--line-soft:rgba(20,24,28,.055);
-        --gold:#d7ab68;--gold-deep:#a07a33;--paper:#fff;--soft:#faf8f4;--maxw:880px;--bad:#b3433c;--good:#3f8f5f}
+  /* Farben/Schrift/Hell-Dunkel aus tokens.css/base.css – nur seiten-eigene Werte hier. */
+  :root{--maxw:880px;--good:#3f8f5f}
   *{box-sizing:border-box;margin:0;padding:0}
   body{background:var(--paper);color:var(--ink);font-family:"G Klar","Helvetica Neue",Arial,sans-serif;
        letter-spacing:normal;font-kerning:normal;-webkit-font-smoothing:antialiased;line-height:1.55;font-size:16.5px;
        hyphens:auto;-webkit-hyphens:auto}
   .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
-  a{color:var(--gold-deep)}
+  a{color:var(--gold-ink)}
   header{position:sticky;top:0;z-index:30;background:rgba(255,255,255,.9);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
   .bar{display:flex;align-items:center;justify-content:space-between;height:58px}
   .brand img{height:34px;display:block}
   nav.top{display:flex;gap:22px}
   nav.top a{color:var(--muted);text-decoration:none;font-size:13.5px}
-  nav.top a:hover{color:var(--gold-deep)}
+  nav.top a:hover{color:var(--gold-ink)}
   .hero{padding:58px 0 8px}
-  .kick{color:var(--gold-deep);font-size:14px;margin-bottom:14px}
+  .kick{color:var(--gold-ink);font-size:14px;margin-bottom:14px}
   h1{font-family:"G Klar";font-weight:400;font-size:clamp(36px,6vw,60px);line-height:1.1;text-wrap:balance}
   .lede{font-family:"G Klar";font-size:clamp(17px,2vw,20px);color:var(--muted);max-width:48ch;margin-top:14px;text-wrap:pretty}
   section{padding:42px 0;border-top:1px solid var(--line-soft)}
-  .sec{color:var(--gold-deep);font-size:13px}
+  .sec{color:var(--gold-ink);font-size:13px}
   /* Marginalspalte (System B): die Paragraphen-Marke wandert auf breiten Schirmen
      in eine eigene Randspalte, der Lesesatz bleibt unberührt bei seinem Mass. */
   @media(min-width:940px){
@@ -49,7 +50,7 @@
   .leise{font-family:"G Leise"}.deutlich{font-family:"G Deutlich"}.laut{font-family:"G Laut"}
   .note{display:flex;gap:10px;align-items:baseline;border-left:2px solid var(--gold);background:var(--soft);
         padding:10px 14px;border-radius:0 10px 10px 0;margin:14px 0;font-size:14px;color:var(--muted);max-width:39ch}
-  .note .rid{font-size:11px;color:var(--gold-deep);white-space:nowrap}
+  .note .rid{font-size:11px;color:var(--gold-ink);white-space:nowrap}
   .ex{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin:12px 0;max-width:640px}
   @media(max-width:560px){.ex{grid-template-columns:1fr}}
   .ex>div{border:1px solid var(--line-soft);border-radius:10px;padding:10px 14px;background:var(--soft);font-size:15px}


### PR DESCRIPTION
Die drei öffentlichen Beta-Seiten in die gemeinsame Welt gehoben – sie trugen eigene `:root`-Blöcke mit altem Gold (`#a07a33`) und ohne `base.css`, darum kein Dunkelmodus.

- **`base.css` eingebunden;** lokale `:root` auf seiten-eigene Werte reduziert (nur `--maxw` / `--good` / `--ok` / `--warn` / `--body` / `--bsize`), Farben/Schrift/Hell-Dunkel kommen aus den Tokens.
- **Gold als Text/Link → `--gold-ink`** (hellt im Dunkelmodus auf).
- **Harte Flächen tokenisiert:** Panel/Felder/Knöpfe auf `--paper`/`--field-bg`, Subtitel auf `--muted`; **tote Vor-`nav.js`-Kopfzeile** in Grotesk+ entfernt; Slider-Ring `--paper`.

Alle drei in Dunkel gerendert und geprüft – keine Konsolenfehler.

## Stand des Audits
Damit sind **alle öffentlichen Seiten (live + beta) in einer Welt.** Offen bleiben nur die **Entwurf-/Backstage-Seiten** (Ligaturen ×3, Mischsatz, Neuerungen) – die ziehe ich auf Wunsch in einem Rutsch nach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_