### PR TITLE
Konformitäts-Engine: das Design-System prüft, korrigiert und atmet selbst

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,9 +66,10 @@ für **jede** neue HTML-Seite oder jedes neue Werkzeug:
    Schnitt- oder Abstandswerte erfinden. (Bestehende Apps mit kopiertem Block
    werden schrittweise auf diese Schicht gehoben — neue Seiten starten richtig.)
 3. **Registrieren:** einen Eintrag in `tools.json` ergänzen (erscheint im Hub).
-4. **Hook aktiv halten:** `git config core.hooksPath tools/hooks` — `tools/typo-check.py`
-   prüft die geänderten HTML-Texte beim Commit und blockiert bei Schwere ‹fehler›.
-   Vor dem Commit gilt weiterhin: betroffene Regel-IDs nennen.
+4. **Hook aktiv halten:** `git config core.hooksPath tools/hooks` — beim Commit
+   laufen `tools/typo-check.py` (Sprache, blockiert bei ‹fehler›) **und**
+   `tools/ds-lint.py --staged` (Gestalt, vorerst berichtend). Vor dem Commit gilt
+   weiterhin: betroffene Regel-IDs nennen — sprachlich (G/B) wie strukturell (DS).
 
 Die eingebauten Defaults in `base.css` setzen die Hausregeln bereits um (Trennung,
 ‹…› über `<q>`, tabellarische Ziffern, Betonung = Laut, Leise statt Kursive). Für
@@ -79,6 +80,33 @@ Was an **einer** Seite am Design verbessert wird (z. B. die Gold/Weiss-Anwahl de
 Buttons und Pillen), gehört **sofort in `tokens.css`/`base.css`** und von dort in
 alle Werkzeuge — nicht lokal in einer Seite belassen. Eine Verbesserung am Rand
 ist erst fertig, wenn sie im Design-System steht und überall gilt.
+
+## Konformitäts-Engine — das System prüft, korrigiert, atmet selbst
+Konformität wird **konstruiert und durch eine Maschine erzwungen**, nicht von Hand
+nachkontrolliert. Symmetrisch zur sprachlichen Schleife (`typo-check`/`typo-sync`)
+gibt es die **Gestalt-Schleife**:
+
+- **Vertrag:** `design-system/contract.json` (Regeln DS01–DS07: Pflicht-Includes,
+  nur Token-Farben, Grössen-Untergrenze B03, kanonische Rollen, verbotene Muster).
+- **Prüfen:** `tools/ds-lint.py` — `ds-lint.py` (Audit + **Score**),
+  `--staged` (Hook), `--score`. Meldet Verstösse nach Regel-ID + `Datei:Zeile`.
+- **Korrigieren:** `tools/ds-fix.py` — hebt die Hauspalette **property-bewusst**
+  auf Tokens (weisse Schrift → `--on-accent`, weisse Fläche → `--paper`).
+  Vorschau ohne, schreiben mit `--apply`. Idempotent.
+
+**Artefakt-Farben schützen:** physische Farben (gedruckte Karte ist immer weiss,
+ein Telefon-Mockup zeigt die echte App) sind **keine** Theme-Flächen. Solche
+Literale mit `# ds-ok` in der Zeile markieren — Checker und Codemod lassen sie
+dann in Ruhe. Die Maschine *schlägt vor*, der Mensch *ratifiziert* die echte
+Ausnahme; diese Ratifizierung wird Teil des Codes.
+
+### Der Atem (Aufnahme-Schleife)
+Neue Lösung auf einer Seite → `ds-lint` erkennt die Abweichung (DS04) → **aufnehmen**
+(in `tokens.css`/`base.css` + ggf. `contract.json`, Eintrag in
+`design-system/CHANGELOG.md`, `version` erhöhen) **oder auflösen** (`ds-fix`).
+Aufgenommenes gilt ab dann überall. Der **Beschluss-Ledger**
+(`design-system/CHANGELOG.md`) ist das Gedächtnis; der Score (`ds-lint --score`)
+macht „wie weit weg" zu einer Zahl statt eines Gefühls.
 
 ## Schnitt-System (Stand v2.6)
 - Installierbare statische Schnitte: **Leise (265) · Klar (440) · Deutlich

--- a/apps/karten-generator/index.html
+++ b/apps/karten-generator/index.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Goetheanum Kartentool</title>
   <link rel="stylesheet" href="../../design-system/tokens.css" />
+<link rel="stylesheet" href="../../design-system/base.css" />
   <link rel="stylesheet" href="../../design-system/nav.css" />
   <style>
     @font-face {
@@ -212,7 +213,7 @@
 
     button.on {
       background: var(--venue);
-      color: #fff;
+      color: var(--on-accent);
     }
 
     .hint {

--- a/apps/logos/index.html
+++ b/apps/logos/index.html
@@ -23,7 +23,7 @@
   /* Rechte Spalte, von oben nach unten: Vorschau → Erklärzeile → Format → die EINE
      Aktion. Alles reist zusammen (klebend), während links die Logo-Bestimmung scrollt. */
   .preview{position:sticky;top:calc(var(--header-h) + var(--s4))}
-  .stage{display:grid;place-items:center;min-height:300px;border:1px solid var(--line);border-radius:var(--r-card);background:#faf8f4;padding:clamp(24px,5vw,56px)}
+  .stage{display:grid;place-items:center;min-height:300px;border:1px solid var(--line);border-radius:var(--r-card);background:var(--soft);padding:clamp(24px,5vw,56px)}
   .stage.dark{background:#23272b}
   .stage svg,.stage img{max-width:100%;height:auto;max-height:340px;display:block}
   /* Erklärzeile direkt unter der Vorschau, ÜBER den Pillen: erst wofür, dann womit. */
@@ -52,7 +52,7 @@
   /* Begleitschreiben als PDF drucken: nur das Blatt zeigen */
   @media print{
     .dsnav,.dsnav-drawer,.dsnav-backdrop,.dsnav-toast,.hero,#werkzeug,.ds-footer,.pdfbtn{display:none !important}
-    body{background:#fff}
+    body{background:var(--paper)}
     main.wrap{max-width:none;padding:0}
     #begleitschreiben .shead{display:block}
     .sheet{border:none;padding:0;margin-top:0}

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Design-System — Beschluss-Ledger (das Gedächtnis)
+
+Hier atmet das System: jede Verbesserung, die aus einer Seite ins **Fundament**
+aufgenommen wird, steht hier mit Datum, Grund und Wirkung. Der Ledger ist die
+Erinnerung des Systems an sein eigenes Wachstum — und die Quelle der
+Versionsnummer (`design-system/contract.json` → `version`, SemVer).
+
+**Der Atem (Aufnahme-Schleife).** Eine neue Lösung taucht auf einer Seite auf →
+`tools/ds-lint.py` erkennt die Abweichung (DS04) → Entscheid: **aufnehmen**
+(in `tokens.css`/`base.css` + `contract.json`, Eintrag hier) oder **auflösen**
+(`tools/ds-fix.py` hebt sie auf die Token-Schicht zurück). Aufgenommenes gilt ab
+dann überall und wird vom Checker erwartet. So wird aus einer Rand-Verbesserung
+Fundament — nie lokal belassen.
+
+Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
+
+---
+
+## [Unveröffentlicht]
+
+### Aufgenommen
+- **Textrollen als gemessene Grundlage** (`base.css`) — Kicker · Lede · Hinweis
+  (`.note`/`.hint`/`.help`/`.desc`) · Meta (`.cap`/`.caption`/`.legend`/`.byline`) ·
+  Label (`.lab`/`.role`) · Wert (`.readout`) · Code (`.code`/`.mono`).
+  *Warum:* jede Seite erfand eigene Grade (11–15px) und Farben für denselben
+  Zweck — uneinheitlich und teils unter der Leseschwelle. *Wirkung:* eine Quelle,
+  B03-sicher, löst die Eigenlösungen ab (DS04).
+- **Mobil-Baseline** (`base.css`) — Fingerziele ≥44px, Felder ≥16px, kein
+  Überlauf, umbrechende Köpfe. *Wirkung:* B03/B04 als Konstruktion, nicht als
+  Nachkontrolle.
+- **Sektionsfarben als Tokens** (`tokens.css`/`tokens.json`) — `--sek-*` aus
+  `assets/goe-orgs.js`. *Warum:* die Sektions-Identitätsfarben lebten nur in der
+  Logo-Engine. *Wirkung:* überall gleich benannt, markenfest (kippen nicht mit
+  Hell/Dunkel).
+- **`--ok` (Erfolgsgrün)** (`tokens.css`/`tokens.json`). *Warum:* die Engine fand
+  das Grün `#3f7d46` hartverdrahtet in `base.css .btn.ok` und im Schaufenster –
+  ein fehlendes Token. *Wirkung:* erste echte Atem-Aufnahme: aus einer entdeckten
+  Abweichung wurde Fundament; `.btn.ok` und die Status-Punkte ziehen jetzt `--ok`.
+
+### Engine (neu)
+- **`design-system/contract.json`** — maschinenlesbarer Struktur-Vertrag (DS01–DS07).
+- **`tools/ds-lint.py`** — prüft Gestalt-Konformität, meldet je Regel + Score.
+- **`tools/ds-fix.py`** — hebt die Hauspalette deterministisch auf Tokens (Codemod).
+- **Hook** — `ds-lint --staged` läuft mit (vorerst berichtend, nicht blockierend).
+
+> Ausgangs-Score bei Einführung der Engine: **9 % konform** (343 Fehler, 23 Seiten).
+> Nach Fundament + erster sicherer Anwendung (Schaufenster 100 %, Starter, Logos,
+> Karten): **17 %** (328 Fehler). Das ist die Messlatte, an der das Nachziehen
+> sichtbar wird – jeder weitere Schritt bewegt diese Zahl.
+
+---
+
+## Wie eine Verbesserung aufgenommen wird (Kurz-Rezept)
+1. Lösung an *einer* Seite bewährt? `ds-lint` zeigt sie als DS04-Abweichung.
+2. In `tokens.css`/`base.css` heben (Token oder Rolle/Komponente). Bei neuer
+   Pflicht: `contract.json` ergänzen (Regel/Klasse) **und** `version` erhöhen.
+3. Eintrag hier (was · warum · Wirkung).
+4. `ds-fix` über die Seiten laufen lassen, `ds-lint --score` prüfen, shippen.

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -80,7 +80,7 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 .btn.primary{background:var(--blue-solid);border-color:var(--blue-solid);color:var(--on-accent);font-weight:var(--w-strong)}
 .btn.primary:hover{filter:brightness(1.08)}
 .btn.ghost{color:var(--muted);background:none}
-.btn.ok{background:#3f7d46;border-color:#3f7d46;color:var(--on-accent)}
+.btn.ok{background:var(--ok);border-color:var(--ok);color:var(--on-accent)}
 
 /* --- Segmentierte Auswahl (Pillen) = WAHL ---------------------------------- */
 /* Anwahl = Gold/Weiss – der Hausfarbklang für Auswahl. Kapselform, kein Pfeil. */
@@ -159,11 +159,69 @@ td.num,th.num,.num{font-variant-numeric:tabular-nums lining-nums;text-align:righ
 .deutlich{font-weight:var(--w-deutlich)}
 .laut{font-weight:var(--w-strong)}
 
-/* Kicker: getönt, leicht getrackt, Display-Schrift – NORMAL, nicht versal (G05). */
-/* Kleine UI-Schrift: nie Leise (verschwimmt klein) – mindestens Klar. */
-.kicker,.kick{display:inline-block;font-family:var(--font-display);color:var(--gold-ink);font-size:13.5px;letter-spacing:.03em;font-weight:var(--w-text);margin-bottom:var(--s2)}
+/* =============================================================================
+   Textrollen – gemessene Grundlage für ALLE Texte (eine Quelle der Wahrheit)
+   -----------------------------------------------------------------------------
+   Jede Seite verwendet diese Rollen statt eigener Grade/Farben/Schnitte. Keine
+   Seite setzt mehr font-size/color für Standardtext selbst – so kann keine aus-
+   scheren (Konformität durch Konstruktion). Mobil-sicher: Mengentext 17–19,
+   Meta/Label/Hinweis 14–15, nichts Lesbares unter 13 (B03). Farbe nur aus den
+   Tokens; Betonung nur über Gewicht (Laut), nie Versal/Sperren/Unterstrich (G05).
+
+     Rolle     Klasse(n)              Wofür                       Grad · Ton
+     ─────────────────────────────────────────────────────────────────────────
+     Kicker    .kicker .kick          Überzeile, getönt, normal   13.5 · Gold·Display
+     Titel     h1–h4 .h-display       geschaute Hierarchie        Skala · ink·Deutlich
+     Lede      .lede                  Anriss unter dem Titel      19–22 · muted
+     Fliess    <body> · .prose        Lese-/Mengentext            17–19 · ink
+     Hinweis   .note .hint .help …    erklärender Beisatz         14–15 · muted
+     Meta      .meta .cap .legend …   Legende, Datum, Byline      14–15 · muted
+     Label     .lab .role             Bedienelement-/Wert-Schild  14–15 · muted, getrackt
+     Wert      .readout               Live-Ausgabe/Ableseband     14–15 · ink, tnum
+     Code      .code .mono            technische Auszeichnung     mono · soft
+   ============================================================================= */
+
+/* Kicker: getönt, leicht getrackt, Display – NORMAL, nicht versal (G05).
+   Kleine UI-Schrift: nie Leise (verschwimmt klein) – mindestens Klar. */
+.kicker,.kick{display:inline-block;font-family:var(--font-display);color:var(--gold-ink);font-size:13.5px;letter-spacing:.03em;font-weight:var(--w-text);line-height:1.3;margin-bottom:var(--s2)}
+
+/* Anriss unter dem Titel. */
+.lede{font-size:var(--t-lede);color:var(--muted);line-height:1.45;max-width:54ch}
+
+/* Erklärender Beisatz (Hilfetext, Untertitel eines Abschnitts oder einer Karte).
+   Ein Grad, eine Farbe – egal auf welcher Seite. Löst hint/sub/desc/help ab. */
+.note,.hint,.help,.desc,.subhead{color:var(--muted);font-size:var(--t-small);line-height:1.5;max-width:60ch}
+
+/* Legende, Bildunterschrift, Datum, Byline – das knappe Beiwerk. */
+.meta,.cap,.caption,.legend,.byline{color:var(--muted);font-size:var(--t-small);line-height:1.45}
+
+/* Aufschrift eines Bedienelements oder Werts – getrackt, nie versal (G05). */
+.lab,.role{color:var(--muted);font-size:var(--t-small);letter-spacing:.01em;line-height:1.35}
+.lab b,.lab strong,.role b,.role strong{color:var(--ink);font-weight:var(--w-strong)}
+
+/* Live-Ausgabe / Ableseband – ruhig, Zahlen dicktengleich (G25). */
+.readout{color:var(--ink);font-size:var(--t-small);line-height:1.5;font-variant-numeric:tabular-nums lining-nums}
+
+/* Technische Auszeichnung – Monospace. Inline-Chip (.code) und Block (.code.block). */
+.mono{font-family:var(--font-mono);font-variant-numeric:tabular-nums lining-nums}
+.code{font-family:var(--font-mono);font-size:.85em;background:var(--soft);border:1px solid var(--line-soft);border-radius:6px;padding:2px 7px;color:var(--ink)}
+.code.block{display:block;padding:10px 13px;border-radius:var(--r-control);line-height:1.55;white-space:pre-wrap;overflow:auto}
 
 /* Lesemass: ~66 Zeichen je Zeile für linearen Mengentext (G10). */
 .lese{max-width:min(var(--measure),100%)}
-.meta{color:var(--muted);font-size:var(--t-small)}
-.lede{font-size:var(--t-lede);color:var(--muted);line-height:1.45;max-width:54ch}
+
+/* =============================================================================
+   Mobil-Baseline – ein Satz Leitplanken, damit JEDE Seite auf dem Handy trägt
+   (B03 Mindestgrössen, B04 Fingerziele, kein horizontaler Überlauf). Die Typo
+   skaliert ohnehin fluid (rem-Clamps); hier nur Touch- und Layout-Garantien.
+   ============================================================================= */
+img,svg,canvas,video{max-width:100%}
+@media(max-width:560px){
+  .wrap{padding-left:18px;padding-right:18px}
+  /* Fingerziele ≥44px auf Touch: Knöpfe, Pillen, Felder, Klapplisten (B04). */
+  .btn,.seg button{min-height:var(--tap)}
+  .field input,.field textarea,.field select,.ds-select__btn{min-height:var(--tap)}
+  /* Köpfe brechen um statt zu quetschen. */
+  .shead{gap:var(--s3)}
+  .ds-footer .frow{gap:var(--s3)}
+}

--- a/design-system/contract.json
+++ b/design-system/contract.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://goetheanum/design-system/contract.schema.json",
+  "version": "1.0.0",
+  "titel": "Goetheanum Design-System – Struktur-Vertrag",
+  "zweck": "Maschinenlesbare Grundlage der GESTALT-Konformität (symmetrisch zum sprachlichen Kanon in assets/typografie/). ds-lint.py prüft jede Seite hiergegen, ds-fix.py korrigiert deterministisch, das Schaufenster bildet es ab. Eine Quelle der Wahrheit für Struktur; Werte/Farben/Schnitte bleiben in tokens.css/tokens.json.",
+
+  "geltungsbereich": {
+    "prüfe": "versionierte *.html mit einem <body> (publizierte Werkzeug- und Schau-Seiten)",
+    "ausgenommen_substr": ["/assets/", "/tools/goetheanum-fontfix/", "archive/", "vendor/"],
+    "ausgenommen_dateien": ["design-system/navigation.html"],
+    "weiterleitungs_stubs": "Root-Stubs ohne eigenes <style>/<link> (reine Redirects) werden übersprungen."
+  },
+
+  "includes": {
+    "pflicht": ["design-system/tokens.css", "design-system/base.css"],
+    "hinweis": "Reihenfolge: tokens.css VOR base.css. nav.css zusätzlich für Seiten mit globaler Kopfzeile.",
+    "ds_id": "DS01",
+    "schwere": "fehler"
+  },
+
+  "farben": {
+    "ds_id": "DS02",
+    "regel": "Farbwerte nur über Tokens (var(--…)). Hartverdrahtete Hex-/rgb()-Farben in color/background/border-color/fill/stroke sind verboten – ausser in Custom-Property-DEFINITIONEN (--x:…), @font-face und url().",
+    "schwere": "fehler",
+    "erlaubte_property_präfixe": ["--"],
+    "ignorierte_properties": ["box-shadow", "-webkit-box-shadow", "filter", "background-image", "text-shadow"],
+    "hinweis": "box-shadow/Filter dürfen rgba() für Schatten nutzen. Seiten-eigene Tokens (--good:#…) sind die seltene Ausnahme, kein Normalfall."
+  },
+
+  "groessen": {
+    "ds_id": "DS03",
+    "regel": "Keine lesbare Schrift unter den B03-Untergrenzen. font-size in px: Fliesstext ≥16, Meta/Label ≥14, nichts Lesbares <13.",
+    "untergrenze_px": 13,
+    "warnen_unter_px": 13,
+    "schwere": "fehler",
+    "warn_schwere": "hinweis",
+    "hinweis": "B03 exakt: <13px = fehler. 13px ist erlaubt (=--t-micro). Bevorzugt die fluiden Skala-Tokens (--t-body/--t-small/--t-micro/--t-lede/--t-h*) statt fester px."
+  },
+
+  "rollen": {
+    "ds_id": "DS04",
+    "regel": "Kanonische Textrollen (base.css) NICHT seiten-lokal mit eigener font-size/color redefinieren. Klasse verwenden, nicht neu erfinden.",
+    "schwere": "hinweis",
+    "kanonische_klassen": ["kicker", "kick", "lede", "note", "hint", "help", "desc", "subhead", "meta", "cap", "caption", "legend", "byline", "lab", "role", "readout", "mono", "code", "lese", "prose", "chip", "btn", "seg", "field", "shead", "hero", "card"],
+    "hinweis": "Treffer = Seite definiert .note/.hint/.lede/… selbst. ds-fix kann die lokale Regel entfernen, sobald base.css die Rolle trägt."
+  },
+
+  "hervorhebung": {
+    "ds_id": "DS05",
+    "regel": "Betonung nur über Gewicht/Laut. Verboten als Hervorhebung: Unterstreichen (text-decoration:underline auf em/strong/Fliesstext), Versalien (text-transform:uppercase auf Kicker/Titel/Betonung), Sperren über Leertasten.",
+    "schwere": "hinweis",
+    "verbotene_muster": ["text-decoration:underline", "text-transform:uppercase"],
+    "bezug": ["G05", "G23"],
+    "hinweis": "Links dürfen unterstrichen sein; Treffer auf Betonungs-Selektoren (strong/b/em/.kicker/h1..h4) sind der Verstoss."
+  },
+
+  "kopfzeile": {
+    "ds_id": "DS06",
+    "regel": "Keine eigene Kopfzeile/Fake-Logo. Die globale Leiste kommt aus nav.js (design-system/nav.js). Seiten setzen keine eigene sticky .ds-header / kein eigenes Marken-Logo im Kopf.",
+    "schwere": "hinweis",
+    "verdächtige_muster": ["class=\"ds-header\"", "class=\"page-head", "<header"],
+    "hinweis": "Treffer prüfen: nutzt die Seite nav.js? Eigener <header> mit Logo = Verstoss (siehe design-system/index.html, behoben in #161)."
+  },
+
+  "theme": {
+    "ds_id": "DS07",
+    "regel": "Flächen tokenisiert, damit Hell/Dunkel allein aus den Tokens kippt. Kein hartes #fff/#000/white/black als Flächen- oder Textfarbe.",
+    "schwere": "fehler",
+    "verbotene_literale": ["#fff", "#ffffff", "#000", "#000000", "white", "black"],
+    "hinweis": "Teilmenge von DS02, separat gemeldet, weil es der häufigste Dunkelmodus-Bruch ist (--paper/--ink/--soft/--field-bg statt #fff)."
+  },
+
+  "score": {
+    "definition": "konforme Seiten / geprüfte Seiten. Konform = kein Verstoss der Schwere ‹fehler›.",
+    "ziel": 1.0
+  }
+}

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -32,8 +32,8 @@
   .sw .chip-c{height:84px}
   .sw .body{padding:var(--s3) var(--s4)}
   .sw .nm{font-weight:var(--w-strong);font-size:14px}
-  .sw .hx{color:var(--muted);font-size:12.5px;font-family:var(--font-mono)}
-  .sw .ds{color:var(--muted);font-size:12.5px;margin-top:4px;line-height:1.4}
+  .sw .hx{color:var(--muted);font-size:var(--t-micro);font-family:var(--font-mono)}
+  .sw .ds{color:var(--muted);font-size:var(--t-micro);margin-top:4px;line-height:1.4}
 
   /* Schnitt-Zeile */
   .cut{border-top:1px solid var(--line-soft);padding:var(--s4) 0;display:grid;gap:6px;grid-template-columns:1fr;align-items:baseline}
@@ -48,7 +48,7 @@
   .rules{display:grid;gap:0}
   .rule{display:grid;grid-template-columns:54px 1fr;gap:var(--s4);padding:var(--s3) 0;border-top:1px solid var(--line-soft)}
   .rule .id{font-weight:var(--w-strong);color:var(--gold-ink);font-variant-numeric:tabular-nums}
-  .rule .tx{color:#3d4348;font-size:14px;line-height:1.5;max-width:72ch}
+  .rule .tx{color:var(--ink);font-size:14px;line-height:1.5;max-width:72ch}
   .rule.card-rule .id{color:var(--blue)}
 
   /* Abstands-Balken */
@@ -57,16 +57,16 @@
   .scale .lab{width:96px;color:var(--muted);font-size:13px;font-variant-numeric:tabular-nums}
   .radii{display:flex;gap:var(--s4);flex-wrap:wrap}
   .radii .r{width:120px;height:80px;background:var(--soft);border:1px solid var(--line)}
-  .radii .cap{color:var(--muted);font-size:12.5px;margin-top:6px}
+  .radii .cap{color:var(--muted);font-size:var(--t-micro);margin-top:6px}
 
   /* Komponenten-Schau */
   .demo{display:flex;gap:var(--s3);flex-wrap:wrap;align-items:center}
-  pre.code{background:#1c1f23;color:#e7e3da;border-radius:var(--r-control);padding:var(--s3) var(--s4);overflow:auto;font-family:var(--font-mono);font-size:12.5px;line-height:1.5;margin-top:var(--s3)}
+  pre.code{background:var(--soft);color:var(--ink);border:1px solid var(--line-soft);border-radius:var(--r-control);padding:var(--s3) var(--s4);overflow:auto;font-family:var(--font-mono);font-size:var(--t-micro);line-height:1.55;margin-top:var(--s3)}
 
   /* Status digital/analog */
   .status{display:grid;gap:8px}
   .status li{list-style:none;display:flex;gap:10px;align-items:baseline;padding:6px 0;border-top:1px solid var(--line-soft);font-size:14px}
-  .status .mk-ok{color:#3f7d46;font-weight:var(--w-strong)}
+  .status .mk-ok{color:var(--ok);font-weight:var(--w-strong)}
   .status .mk-open{color:var(--gold-ink);font-weight:var(--w-strong)}
 
   /* Bau-Workflow */
@@ -80,13 +80,13 @@
   .guard{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s4) var(--s6);background:var(--soft)}
   .guard .head{display:flex;align-items:center;gap:10px;font-weight:var(--w-strong)}
   .guard .dot{width:10px;height:10px;border-radius:var(--r-pill);background:var(--muted)}
-  .guard.ok .dot{background:#3f7d46}
+  .guard.ok .dot{background:var(--ok)}
   .guard.bad .dot{background:var(--bad)}
   .guard .detail{margin-top:var(--s2);color:var(--muted);font-size:13px;line-height:1.5}
   .guard table{margin-top:var(--s3);width:100%;font-size:13px}
 
-  .note{color:var(--muted);font-size:13px;line-height:1.5;max-width:72ch}
-  .toast{position:fixed;left:50%;bottom:24px;transform:translateX(-50%);background:var(--ink);color:#fff;padding:8px 16px;border-radius:var(--r-pill);font-size:13px;opacity:0;transition:opacity .2s;pointer-events:none;z-index:60}
+  /* .note kommt aus base.css (kanonische Hinweis-Rolle) – hier keine Eigenfassung. */
+  .toast{position:fixed;left:50%;bottom:24px;transform:translateX(-50%);background:var(--ink);color:var(--on-accent);padding:8px 16px;border-radius:var(--r-pill);font-size:13px;opacity:0;transition:opacity .2s;pointer-events:none;z-index:60}
   .toast.show{opacity:1}
 </style>
 </head>
@@ -370,13 +370,18 @@ function buildScale(tok){
 }
 
 function guard(tok){
-  const cs=getComputedStyle(document.documentElement);
+  // tokens.json spiegelt die HELLE Quelle (:root). Darum gegen Hell prüfen –
+  // sonst meldet der Dunkelmodus seine bewussten Überschreibungen als Drift.
+  const root=document.documentElement;
+  const prevTheme=root.getAttribute("data-theme");
+  root.setAttribute("data-theme","light");
+  const cs=getComputedStyle(root);
   const cssVar=n=>cs.getPropertyValue(n);
   // Abbildung Token → CSS-Custom-Property
   const map=[
     ["color.blue","--blue"],["color.gold","--gold"],["color.gold-deep","--gold-deep"],
     ["color.ink","--ink"],["color.muted","--muted"],["color.paper","--paper"],
-    ["color.soft","--soft"],["color.bad","--bad"],
+    ["color.soft","--soft"],["color.bad","--bad"],["color.ok","--ok"],
     ["fontWeight.leise","--w-leise"],["fontWeight.text","--w-text"],
     ["fontWeight.deutlich","--w-deutlich"],["fontWeight.strong","--w-strong"],
     ["space.1","--s1"],["space.2","--s2"],["space.3","--s3"],["space.4","--s4"],["space.6","--s6"],["space.8","--s8"],
@@ -393,6 +398,8 @@ function guard(tok){
     let h=isColor(path)?norm(have):have.trim();
     if(w!==h) diffs.push({path,cssName,want:w,have:h||"(leer)"});
   });
+  // Theme zurücksetzen (synchron – kein sichtbares Flackern).
+  if(prevTheme) root.setAttribute("data-theme",prevTheme); else root.removeAttribute("data-theme");
   const g=$("#guard"), msg=$("#guardMsg"), det=$("#guardDetail");
   if(diffs.length===0){
     g.classList.add("ok");

--- a/design-system/navigation.html
+++ b/design-system/navigation.html
@@ -13,7 +13,7 @@
 <style>
   .hero{padding:clamp(40px,7vw,80px) 0 var(--s8)}
   .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.4vw,52px);line-height:1.04;letter-spacing:-.01em;max-width:17ch}
-  .hero .lede{margin-top:var(--s6);color:#565b60;font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:60ch}
+  .hero .lede{margin-top:var(--s6);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:60ch}
   .two{display:grid;gap:var(--s4);grid-template-columns:1fr}
   @media(min-width:760px){.two{grid-template-columns:1fr 1fr}}
   .tall{min-height:60vh}

--- a/design-system/starter.html
+++ b/design-system/starter.html
@@ -41,7 +41,7 @@
      Greife auf die Tokens zu (var(--gold), var(--s6) …), erfinde keine neuen Werte. */
   .hero{padding:clamp(40px,7vw,72px) 0 var(--s8)}
   .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);line-height:1.05;letter-spacing:-.01em;max-width:18ch}
-  .hero .lede{margin-top:var(--s6);color:#565b60;font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:58ch}
+  .hero .lede{margin-top:var(--s6);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:58ch}
 </style>
 </head>
 <body>

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -55,7 +55,30 @@
   --line:rgba(20,24,28,.10);
   --line-soft:rgba(20,24,28,.055);
   --bad:#b3261e;         /* Fehler/Warnung */
+  --ok:#3f7d46;          /* Erfolg/Bestätigung – Weiss drauf (--on-accent) */
   --on-accent:#fff;      /* Text auf Blau/Gold-Flächen */
+
+  /* --- Sektionsfarben (Identität der Schul-Sektionen) --------------------- */
+  /* Quelle der Wahrheit der Werte: assets/goe-orgs.js (speist die Logo-Engine).
+     Hier als Design-Tokens verfügbar gemacht, damit Sektions-Akzente überall im
+     System gleich heissen. MARKENFEST: kippen NICHT mit Hell/Dunkel – eine
+     Sektionsfarbe ist Identität, kein Flächenton. Als Fläche gilt B01: Text
+     darauf ist Weiss (--on-accent) NUR wo der Kontrast ≥4.5:1 (sonst dunkler
+     Ton der Sektion als Linie/Akzent, nicht als Textgrund). */
+  --sek-goetheanum:#0061a9;  /* = Markenblau */
+  --sek-aas:#a24f8a;         /* Allgemeine Anthroposophische Sektion */
+  --sek-ps:#3b4881;          /* Pädagogische Sektion */
+  --sek-ms:#5f5599;          /* Medizinische Sektion */
+  --sek-nws:#1e7b6e;         /* Naturwissenschaftliche Sektion */
+  --sek-lws:#63b145;         /* Sektion für Landwirtschaft */
+  --sek-sbk:#d072a0;         /* Sektion für Bildende Künste */
+  --sek-ssw:#5168c0;         /* Sektion für Schöne Wissenschaften */
+  --sek-szw:#df4164;         /* Sektion für Sozialwissenschaft */
+  --sek-js:#ff675d;          /* Jugendsektion */
+  --sek-srmk:#598ddc;        /* Sektion für Redende und Musizierende Künste */
+  --sek-mas:#2e54a4;         /* Mathematisch-Astronomische Sektion */
+  --sek-hpise:#f98a3c;       /* Sektion für Heilpädagogik und inklusive soziale Entwicklung */
+  --bereich:#005eb8;         /* Verwaltungs-/Bereichs-Standard (Empfang, Studium, Archiv …) */
 
   /* --- Schrift-Familien --------------------------------------------------- */
   --font-display:"Goetheanum","Helvetica Neue",Arial,sans-serif; /* Titel, Chrome */
@@ -108,7 +131,7 @@
   --paper:#16191c; --soft:#1e2329; --field-bg:#1e2329;
   --bar-bg:rgba(20,23,26,.85);
   --line:rgba(255,255,255,.14); --line-soft:rgba(255,255,255,.07);
-  --bad:#e0675e;        /* on-accent bleibt Weiss – kein dunkler Text auf Akzentflächen */
+  --bad:#e0675e; --ok:#5aa367;   /* on-accent bleibt Weiss – kein dunkler Text auf Akzentflächen */
   --w-deutlich:540; --w-strong:620;     /* weniger Bleeding auf Dunkel */
   --shadow-card:0 10px 30px rgba(0,0,0,.45);
   color-scheme:dark;

--- a/design-system/tokens.json
+++ b/design-system/tokens.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://design-tokens.github.io/community-group/format/",
-  "$description": "Goetheanum CI – maschinenlesbare Design-Tokens (DTCG). Spiegelt design-system/tokens.css. Quelle der Markenfarben: assets/data/goetheanum-orgs.js.",
+  "$description": "Goetheanum CI – maschinenlesbare Design-Tokens (DTCG). Spiegelt design-system/tokens.css. Quelle der Sektionsfarben: assets/goe-orgs.js (speist die Logo-Engine).",
   "color": {
     "$type": "color",
     "blue": {
@@ -34,6 +34,27 @@
     "bad": {
       "$value": "#b3261e",
       "$description": "Fehler/Warnung"
+    },
+    "ok": {
+      "$value": "#3f7d46",
+      "$description": "Erfolg/Bestätigung – Weiss drauf"
+    },
+    "sektion": {
+      "$description": "Sektionsfarben – markenfest, kippen nicht mit Hell/Dunkel. Quelle: assets/goe-orgs.js.",
+      "goetheanum": { "$value": "#0061a9", "$description": "= Markenblau" },
+      "aas": { "$value": "#a24f8a", "$description": "Allgemeine Anthroposophische Sektion" },
+      "ps": { "$value": "#3b4881", "$description": "Pädagogische Sektion" },
+      "ms": { "$value": "#5f5599", "$description": "Medizinische Sektion" },
+      "nws": { "$value": "#1e7b6e", "$description": "Naturwissenschaftliche Sektion" },
+      "lws": { "$value": "#63b145", "$description": "Sektion für Landwirtschaft" },
+      "sbk": { "$value": "#d072a0", "$description": "Sektion für Bildende Künste" },
+      "ssw": { "$value": "#5168c0", "$description": "Sektion für Schöne Wissenschaften" },
+      "szw": { "$value": "#df4164", "$description": "Sektion für Sozialwissenschaft" },
+      "js": { "$value": "#ff675d", "$description": "Jugendsektion" },
+      "srmk": { "$value": "#598ddc", "$description": "Sektion für Redende und Musizierende Künste" },
+      "mas": { "$value": "#2e54a4", "$description": "Mathematisch-Astronomische Sektion" },
+      "hpise": { "$value": "#f98a3c", "$description": "Heilpädagogik und inklusive soziale Entwicklung" },
+      "bereich": { "$value": "#005eb8", "$description": "Verwaltungs-/Bereichs-Standard" }
     }
   },
   "font": {
@@ -119,7 +140,7 @@
   "size": {
     "$type": "dimension",
     "header": {
-      "$value": "58px"
+      "$value": "74px"
     },
     "maxw": {
       "$value": "1080px"

--- a/tools/ds-fix.py
+++ b/tools/ds-fix.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Goetheanum DS-Fix – wendet die EINDEUTIGEN Struktur-Korrekturen an (Codemod).
+
+Selbstkorrektur-Hälfte der Engine: was tools/ds-lint.py meldet, hebt dieses
+Werkzeug deterministisch auf die Token-Schicht. Idempotent (var(--…) bleibt
+unangetastet). Es löst NUR die Hauspalette auf – property-bewusst (weisse
+SCHRIFT → --on-accent, weisse FLÄCHE → --paper). Unbekannte Einzelfarben und
+physische Artefakt-Farben (gedruckte Karte ist immer weiss) bleiben stehen;
+letztere mit  # ds-ok  in der Zeile schützen.
+
+Quelle der Wahrheit:  design-system/tokens.css  (die Tokens, auf die abgebildet wird).
+
+Nutzung:
+  tools/ds-fix.py datei …            # Vorschau (dry-run, ändert nichts)
+  tools/ds-fix.py --apply datei …    # schreibt die Änderungen
+  tools/ds-fix.py --apply --all      # über alle versionierten Seiten
+  tools/ds-fix.py --include datei …  # fügt fehlende Pflicht-Includes ein
+
+NICHT automatisiert (zu kontext-/layoutgebunden – bewusst Handarbeit, ds-lint
+zeigt die Stellen): Schriftgrößen <13px, Entfernen lokaler Rollen-Definitionen.
+"""
+import sys, os, re, subprocess
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+C = {"red": "\033[31m", "grn": "\033[32m", "dim": "\033[2m", "b": "\033[1m", "x": "\033[0m"}
+def col(s, c): return f"{C[c]}{s}{C['x']}" if sys.stdout.isatty() else s
+
+# --- Hauspalette: (Property-Gruppe) Literal → Token ---------------------------
+TEXT = {
+    "#fff": "var(--on-accent)", "#ffffff": "var(--on-accent)", "white": "var(--on-accent)",
+    "#23272b": "var(--ink)", "#1f2329": "var(--ink)", "#181c20": "var(--ink)", "#23262a": "var(--ink)",
+    "#737a80": "var(--muted)", "#6b7177": "var(--muted)", "#5d5d5d": "var(--muted)",
+    "#565b60": "var(--muted)", "#3a3f44": "var(--muted)", "#9aa0a6": "var(--muted)",
+    "#9aa1a8": "var(--muted)", "#7a8086": "var(--muted)",
+    "#94702e": "var(--gold-ink)", "#a07a33": "var(--gold-ink)",
+    "#d7ab68": "var(--gold)", "#0061a9": "var(--blue)",
+    "#3f7d46": "var(--ok)", "#b3261e": "var(--bad)", "#b3433c": "var(--bad)",
+}
+BG = {
+    "#fff": "var(--paper)", "#ffffff": "var(--paper)", "white": "var(--paper)",
+    "#faf8f4": "var(--soft)", "#f3efe7": "var(--soft)", "#f7f5f0": "var(--soft)", "#f6f3ee": "var(--soft)",
+    "#0061a9": "var(--blue-solid)", "#94702e": "var(--gold-deep)", "#3f7d46": "var(--ok)",
+}
+PAINT = {
+    "#fff": "var(--on-accent)", "#ffffff": "var(--on-accent)",
+    "#23272b": "var(--ink)", "#1f2329": "var(--ink)",
+    "#94702e": "var(--gold-ink)", "#d7ab68": "var(--gold)",
+}
+# Sektionsfarben sind Identität: dasselbe Token, egal ob Schrift/Fläche/Rand.
+SEK = {
+    "#a24f8a": "var(--sek-aas)", "#3b4881": "var(--sek-ps)", "#5f5599": "var(--sek-ms)",
+    "#1e7b6e": "var(--sek-nws)", "#63b145": "var(--sek-lws)", "#d072a0": "var(--sek-sbk)",
+    "#5168c0": "var(--sek-ssw)", "#df4164": "var(--sek-szw)", "#ff675d": "var(--sek-js)",
+    "#598ddc": "var(--sek-srmk)", "#2e54a4": "var(--sek-mas)", "#f98a3c": "var(--sek-hpise)",
+    "#005eb8": "var(--bereich)",
+}
+ALLPROPS = ["color", "background", "background-color", "fill", "stroke",
+            "border", "border-color", "border-top", "border-bottom", "outline-color"]
+GROUPS = [
+    (["color"], TEXT),
+    (["background", "background-color"], BG),
+    (["fill", "stroke"], PAINT),
+    (ALLPROPS, SEK),
+]
+BORDER_PROPS = ["border", "border-color", "border-top", "border-right", "border-bottom",
+                "border-left", "border-top-color", "border-bottom-color", "outline", "outline-color"]
+
+RE_RGBA_LINE = re.compile(r"rgba\(\s*20\s*,\s*24\s*,\s*28\s*,\s*([0-9.]+)\s*\)")
+
+
+def prop_pat(prop, literal):
+    # property-verankert: nicht Teil eines --custom-props / background-color usw.
+    return re.compile(r"(?<![-\w])(" + re.escape(prop) + r")(?![-\w])(\s*:\s*[^;{}]*?)" +
+                      re.escape(literal) + r"\b", re.I)
+
+
+def fix_line(line):
+    """Eine CSS-Zeile property-bewusst auf Tokens heben. Gibt (neu, n_änderungen)."""
+    n = 0
+    for props, mp in GROUPS:
+        for prop in props:
+            for lit, tok in mp.items():
+                pat = prop_pat(prop, lit)
+                def repl(m, tok=tok):
+                    return m.group(1) + m.group(2) + tok
+                line, k = pat.subn(repl, line)
+                n += k
+    # rgba(20,24,28,a) NUR in Rand-/Outline-Properties → --line / --line-soft
+    for prop in BORDER_PROPS:
+        pat = re.compile(r"(?<![-\w])(" + re.escape(prop) + r")(?![-\w])(\s*:\s*[^;{}]*?)" +
+                         r"rgba\(\s*20\s*,\s*24\s*,\s*28\s*,\s*([0-9.]+)\s*\)", re.I)
+        def repl(m):
+            a = float(m.group(3))
+            return m.group(1) + m.group(2) + ("var(--line-soft)" if a <= 0.07 else "var(--line)")
+        line, k = pat.subn(repl, line)
+        n += k
+    return line, n
+
+
+def ensure_includes(text):
+    """Fehlende Pflicht-Includes (tokens.css, base.css) vor nav.css/erstes <script> setzen."""
+    changed = 0
+    needs = []
+    for css in ["tokens.css", "base.css"]:
+        if not re.search(r'href\s*=\s*["\'][^"\']*' + re.escape(css), text):
+            needs.append(css)
+    if not needs:
+        return text, 0
+    # Pfadpräfix aus vorhandenem tokens/base/nav-Link ableiten, sonst design-system/.
+    m = re.search(r'href\s*=\s*["\']([^"\']*?)(?:tokens|base|nav)\.css', text)
+    prefix = m.group(1) if m else "design-system/"
+    links = "".join(f'<link rel="stylesheet" href="{prefix}{c}" />\n' for c in needs)
+    # vor nav.css einsetzen, sonst vor </head>.
+    mnav = re.search(r'[ \t]*<link[^>]*nav\.css[^>]*>\n?', text)
+    if mnav:
+        text = text[:mnav.start()] + links + text[mnav.start():]
+    else:
+        text = re.sub(r"</head>", links + "</head>", text, count=1)
+    return text, len(needs)
+
+
+def process(path, apply, do_includes):
+    full = open(os.path.join(ROOT, path), encoding="utf-8").read()
+    out, in_script, total = [], False, 0
+    for line in full.splitlines(keepends=True):
+        low = line.lower()
+        if "<script" in low:
+            in_script = True
+        if in_script:
+            out.append(line)
+            if "</script>" in low:
+                in_script = False
+            continue
+        if "# ds-ok" in line or "url(" in low and "color" not in low:
+            out.append(line); continue
+        new, n = fix_line(line)
+        total += n
+        out.append(new)
+    text = "".join(out)
+    inc = 0
+    if do_includes:
+        text, inc = ensure_includes(text)
+    if apply and (total or inc):
+        open(os.path.join(ROOT, path), "w", encoding="utf-8").write(text)
+    return total, inc, text, full
+
+
+def tracked_html():
+    out = subprocess.check_output(["git", "ls-files", "*.html"], cwd=ROOT, text=True)
+    # Gleicher Geltungsbereich wie der Vertrag: Archiv/Referenz/Fremdcode in Ruhe lassen.
+    skip = ("/assets/", "archive/", "reference/", "vendor/", "/tools/goetheanum-fontfix/")
+    return [l for l in out.splitlines() if l.strip() and not any(s in l for s in skip)]
+
+
+def main():
+    args = sys.argv[1:]
+    apply = "--apply" in args
+    do_includes = "--include" in args or "--apply" in args
+    if "--all" in args:
+        files = tracked_html()
+    else:
+        files = [a for a in args if not a.startswith("--")]
+    if not files:
+        print("ds-fix: Dateien nennen oder --all. (Vorschau ohne --apply)")
+        return 0
+    grand = 0
+    for path in sorted(set(files)):
+        fp = os.path.join(ROOT, path)
+        if not os.path.exists(fp):
+            continue
+        n, inc, newtext, old = process(path, apply, do_includes)
+        if n or inc:
+            grand += n + inc
+            tag = col("geschrieben", "grn") if apply else col("Vorschau", "dim")
+            print(f"{col(path,'b')}: {n} Farb-Swaps" + (f", {inc} Include(s)" if inc else "") + f"  [{tag}]")
+            if not apply:
+                # knappe Vorschau der geänderten Zeilen
+                for o, nw in zip(old.splitlines(), newtext.splitlines()):
+                    if o != nw:
+                        print(col("   - " + o.strip()[:90], "dim"))
+                        print(col("   + " + nw.strip()[:90], "grn"))
+    print(col(f"\n∑ {grand} Korrekturen " + ("angewendet." if apply else "(Vorschau – mit --apply schreiben)."), "b"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ds-lint.py
+++ b/tools/ds-lint.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Goetheanum DS-Lint – prüft die GESTALT-Konformität jeder Seite gegen den Vertrag.
+
+Symmetrisch zu tools/typo-check.py (Sprache): dieses Werkzeug erzwingt die
+Struktur des Design-Systems, statt sie hinterher von Hand nachzukontrollieren.
+
+Quelle der Wahrheit:  design-system/contract.json  (Regeln DS01–DS07).
+Geltungsbereich:      versionierte *.html mit <body> (Werkzeug-/Schau-Seiten).
+                      Reine Weiterleitungs-Stubs (meta refresh) werden übersprungen.
+Geprüft wird nur CSS: <style>-Blöcke und style="…"-Attribute; <script> bleibt aussen
+                      vor. Inline-SVG-Attribute (fill="…") sind Inhalt, kein Stil.
+
+Nutzung:
+  tools/ds-lint.py                 # Audit über ALLE Seiten + Score
+  tools/ds-lint.py datei …         # nur genannte Seiten
+  tools/ds-lint.py --staged        # nur vorgemerkte (staged) HTML (für den Hook)
+  tools/ds-lint.py --score         # nur die Score-Zeile
+
+Rückgabe: 1, sobald ein Verstoss der Schwere ‹fehler› bleibt (gate-fähig).
+Hinweise (‹hinweis›) melden, blockieren aber nicht.  # ds-ok  überspringt eine Zeile.
+"""
+import sys, os, re, json, subprocess
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CONTRACT = os.path.join(ROOT, "design-system", "contract.json")
+
+C = {"red": "\033[31m", "yel": "\033[33m", "grn": "\033[32m",
+     "dim": "\033[2m", "b": "\033[1m", "x": "\033[0m"}
+def col(s, c): return f"{C[c]}{s}{C['x']}" if sys.stdout.isatty() else s
+
+SEV_COL = {"fehler": "red", "hinweis": "yel"}
+
+
+def load_contract():
+    with open(CONTRACT, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def tracked_html():
+    try:
+        out = subprocess.check_output(["git", "ls-files", "*.html"], cwd=ROOT, text=True)
+    except Exception:
+        out = ""
+    return [l for l in out.splitlines() if l.strip()]
+
+
+def staged_html():
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"], cwd=ROOT, text=True)
+    except Exception:
+        out = ""
+    return [l for l in out.splitlines() if l.endswith(".html")]
+
+
+def excluded(path, c):
+    g = c["geltungsbereich"]
+    if any(s in path for s in g["ausgenommen_substr"]):
+        return True
+    if path in g["ausgenommen_dateien"]:
+        return True
+    return False
+
+
+def is_stub(text):
+    """Reine Weiterleitung oder kein eigener Körper → nicht prüfen."""
+    if "<body" not in text.lower():
+        return True
+    if re.search(r'http-equiv\s*=\s*["\']?refresh', text, re.I):
+        return True
+    return False
+
+
+def lineno(text, pos):
+    return text.count("\n", 0, pos) + 1
+
+
+# --- CSS-Kontexte aus der Datei lösen -----------------------------------------
+RE_STYLE = re.compile(r"<style\b[^>]*>(.*?)</style>", re.S | re.I)
+RE_SCRIPT = re.compile(r"<script\b[^>]*>.*?</script>", re.S | re.I)
+RE_INLINE = re.compile(r'style\s*=\s*"([^"]*)"', re.I)
+RE_ATRULE = re.compile(r"@(?:media|supports|keyframes)[^{]*\{", re.I)
+RE_RULE = re.compile(r"([^{}]+)\{([^{}]*)\}", re.S)
+
+HEXLIT = re.compile(r"#[0-9a-fA-F]{3,8}\b")
+RGBLIT = re.compile(r"\brgba?\s*\(", re.I)
+NAMED = re.compile(r"\b(white|black)\b", re.I)
+FSPX = re.compile(r"font-size\s*:\s*([0-9.]+)px", re.I)
+
+
+def css_blocks(text):
+    """Liste (inhalt, abs_offset) aller <style>-Blöcke."""
+    return [(m.group(1), m.start(1)) for m in RE_STYLE.finditer(text)]
+
+
+def last_simple(selpart):
+    """Letztes einfaches Selektor-Glied (für DS04-Schlüsselklasse)."""
+    tok = selpart.strip().split()[-1] if selpart.strip().split() else ""
+    return tok.split(":")[0]  # Pseudoklassen weg
+
+
+def check_colors_sizes(body, base_off, full, findings, c, skip_lines):
+    """DS02/DS03/DS07 auf einem Deklarations-Körper (Regel oder inline)."""
+    ign = set(c["farben"]["ignorierte_properties"])
+    forb = {l.lower() for l in c["theme"]["verbotene_literale"]}
+    floor = c["groessen"]["untergrenze_px"]
+    warnpx = c["groessen"]["warnen_unter_px"]
+    # Deklarationen ~ getrennt durch ; (Körper enthält keine { } mehr)
+    off = 0
+    for decl in body.split(";"):
+        seg_off = base_off + off
+        off += len(decl) + 1
+        if ":" not in decl:
+            continue
+        prop, _, val = decl.partition(":")
+        p = prop.strip().lower()
+        if not p or p.startswith("--"):
+            continue
+        ln = lineno(full, seg_off)
+        if ln in skip_lines:
+            continue
+        # --- Größen (DS03) ---
+        m = FSPX.search(decl)
+        if m:
+            px = float(m.group(1))
+            if px < floor:
+                findings.append((ln, "DS03", "fehler",
+                                 f"font-size:{m.group(1)}px unter {floor}px (B03)"))
+            elif px < warnpx:
+                findings.append((ln, "DS03", "hinweis",
+                                 f"font-size:{m.group(1)}px < {warnpx}px – besser Skala-Token (--t-small)"))
+        # --- Farben (DS02/DS07): nur farbtragende Properties ---
+        if p in ign or "url(" in val.lower():
+            continue
+        vlow = val.lower()
+        hexes = HEXLIT.findall(val)
+        named = NAMED.findall(val)
+        has_rgb = bool(RGBLIT.search(val))
+        if not (hexes or named or has_rgb):
+            continue
+        forb_hit = [h for h in hexes if h.lower() in forb] + \
+                   [n for n in named if n.lower() in forb]
+        if forb_hit:
+            findings.append((ln, "DS07", "fehler",
+                             f"{prop.strip()}: hartes {forb_hit[0]} statt Token (--paper/--ink/--soft)"))
+        # übrige Hex/rgb-Farbwerte → DS02 (Schatten etc. sind oben ausgenommen)
+        other = [h for h in hexes if h.lower() not in forb]
+        if other or has_rgb:
+            lit = other[0] if other else "rgb()"
+            findings.append((ln, "DS02", "fehler",
+                             f"{prop.strip()}: hartverdrahtete Farbe {lit} – var(--…) nutzen"))
+
+
+def lint_file(path, c):
+    full = open(os.path.join(ROOT, path), encoding="utf-8").read()
+    if is_stub(full):
+        return None  # übersprungen
+    findings = []
+    skip_lines = {lineno(full, m.start()) for m in re.finditer(r"#\s*ds-ok", full)}
+
+    # DS01 – Pflicht-Includes
+    for inc in c["includes"]["pflicht"]:
+        base = os.path.basename(inc)
+        if not re.search(r'href\s*=\s*["\'][^"\']*' + re.escape(base), full):
+            findings.append((1, "DS01", "fehler", f"Pflicht-Include fehlt: {inc}"))
+
+    # DS06 – eigene Kopfzeile / Fake-Logo (nur wenn nav.js NICHT eingebunden)
+    has_nav = bool(re.search(r'nav\.js', full))
+    if not has_nav and re.search(r"<header\b", full, re.I):
+        findings.append((lineno(full, re.search(r"<header\b", full, re.I).start()),
+                         "DS06", "hinweis", "eigene <header>-Kopfzeile ohne nav.js – Fundament-Leiste nutzen"))
+
+    # CSS-Kontexte (Blöcke + inline) – ohne <script>
+    scriptless = RE_SCRIPT.sub(lambda m: "\n" * m.group(0).count("\n"), full)
+    canon = set(c["rollen"]["kanonische_klassen"])
+    emph_sel = re.compile(r"\b(strong|b|i|em|h[1-4]|body)\b|\.(kicker|kick|lede|note|hint)")
+
+    for content, off in css_blocks(scriptless):
+        cleaned = RE_ATRULE.sub(lambda m: " " * len(m.group(0)), content)
+        for rm in RE_RULE.finditer(cleaned):
+            sel, body = rm.group(1), rm.group(2)
+            body_off = off + rm.start(2)
+            check_colors_sizes(body, body_off, scriptless, findings, c, skip_lines)
+            sel_ln = lineno(scriptless, off + rm.start(1))
+            if sel_ln in skip_lines:
+                continue
+            # DS04 – kanonische Rolle lokal redefiniert?
+            if "font-size" in body or re.search(r"\bcolor\s*:", body):
+                for part in sel.split(","):
+                    last = last_simple(part)
+                    classes = set(re.findall(r"\.([A-Za-z][\w-]*)", last))
+                    if classes & canon:
+                        hit = sorted(classes & canon)[0]
+                        findings.append((sel_ln, "DS04", "hinweis",
+                                         f".{hit} lokal redefiniert – kanonische Rolle aus base.css nutzen"))
+                        break
+            # DS05 – verbotene Hervorhebung
+            if "text-transform" in body and "uppercase" in body:
+                findings.append((sel_ln, "DS05", "hinweis",
+                                 f"text-transform:uppercase ({sel.strip()[:32]}) – Versal nicht als Hervorhebung (G05)"))
+            if "underline" in body and emph_sel.search(sel):
+                findings.append((sel_ln, "DS05", "hinweis",
+                                 f"underline auf Betonung ({sel.strip()[:32]}) – Laut statt Unterstrich (G05)"))
+
+    # Inline-styles im Markup
+    for m in RE_INLINE.finditer(scriptless):
+        check_colors_sizes(m.group(1), m.start(1), scriptless, findings, c, skip_lines)
+
+    findings.sort(key=lambda f: (f[0], f[1]))
+    return findings
+
+
+def main():
+    args = [a for a in sys.argv[1:]]
+    c = load_contract()
+    only_score = "--score" in args
+    args = [a for a in args if a != "--score"]
+
+    if "--staged" in args:
+        files = staged_html()
+    elif args:
+        files = args
+    else:
+        files = tracked_html()
+    files = [f for f in files if not excluded(f, c)]
+
+    checked = 0
+    conformant = 0
+    total_err = 0
+    total_warn = 0
+    by_rule = {}
+    report = []
+
+    for path in sorted(set(files)):
+        fp = os.path.join(ROOT, path)
+        if not os.path.exists(fp):
+            continue
+        res = lint_file(path, c)
+        if res is None:
+            continue  # Stub
+        checked += 1
+        errs = [f for f in res if f[2] == "fehler"]
+        warns = [f for f in res if f[2] == "hinweis"]
+        total_err += len(errs)
+        total_warn += len(warns)
+        for ln, rid, sev, msg in res:
+            by_rule[rid] = by_rule.get(rid, 0) + 1
+        if not errs:
+            conformant += 1
+        if res:
+            report.append((path, res))
+
+    if not only_score:
+        for path, res in report:
+            print(col(path, "b"))
+            for ln, rid, sev, msg in res:
+                tag = col(f"{rid} {sev}", SEV_COL.get(sev, "dim"))
+                print(f"  {col(str(ln).rjust(4),'dim')}  {tag}  {msg}")
+            print()
+
+    score = (conformant / checked) if checked else 1.0
+    bar = "█" * round(score * 24) + "·" * (24 - round(score * 24))
+    print(col("── Konformität ─────────────────────────────────────────", "dim"))
+    print(f"  Seiten geprüft:   {checked}")
+    print(f"  konform (0 Fehler): {conformant}")
+    print(f"  Verstöße:         {col(str(total_err),'red')} Fehler · {col(str(total_warn),'yel')} Hinweise")
+    if by_rule:
+        order = sorted(by_rule.items(), key=lambda kv: kv[0])
+        print("  je Regel:         " + " · ".join(f"{k} {v}" for k, v in order))
+    pct = f"{score*100:.0f}%"
+    print(f"  Score:            {col(bar,'grn' if score==1 else 'yel')} {col(pct,'b')}")
+    print(col("────────────────────────────────────────────────────────", "dim"))
+
+    return 1 if total_err else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -10,8 +10,13 @@ if [ -z "$PY" ]; then
   exit 0
 fi
 
-# 1) Hausregeln auf den vorgemerkten HTML-Texten ausführen.
+# 1) Hausregeln auf den vorgemerkten HTML-Texten ausführen (Sprache).
 "$PY" "$ROOT/tools/typo-check.py"
+
+# 1b) Struktur-Konformität der vorgemerkten Seiten (Gestalt) – DS-Lint.
+#     Vorläufig BERICHTEND (blockiert nicht), solange der Backlog abgebaut wird.
+#     Sobald der Score 100% erreicht, das `|| true` entfernen → dann gate-fähig.
+"$PY" "$ROOT/tools/ds-lint.py" --staged || true
 
 # 2) Driftwächter Kanon ↔ Design-System – nur wenn eine der beteiligten
 #    Schichten betroffen ist (Tokens, Kanon, Regel-YAML, Handbuch).


### PR DESCRIPTION
## Die grosse Klammer

Bisher wurde **Sprache** konstruktiv erzwungen (`typo-check`/`typo-sync`), **Gestalt** aber von Hand nachkontrolliert — Seite für Seite, Nadel im Heuhaufen. Diese Asymmetrie war die fehlende Strategie. Hier kommt die symmetrische **Gestalt-Schleife** dazu: das System prüft, korrigiert und atmet selbst.

## Fundament (eine Quelle)

- **`base.css` — Textrollen:** vollständige, gemessene Grundlage für *alle* Texte (Kicker · Lede · Hinweis · Meta · Label · Wert · Code). Löst die Eigenlösungen ab — jede Seite erfand denselben Zweck in 11–15px und eigenen Farben, teils unter der Leseschwelle. Jetzt B03-sicher, aus einer Quelle.
- **`base.css` — Mobil-Baseline:** Fingerziele ≥44px, Felder ≥16px, kein horizontaler Überlauf, umbrechende Köpfe.
- **`tokens.css`/`tokens.json` — Sektionsfarben** (`--sek-*`, Quelle `assets/goe-orgs.js`, markenfest: kippen nicht mit Hell/Dunkel) und **`--ok`** (Erfolgsgrün).

## Engine (neu)

| Schleife | Datei | Wirkung |
|---|---|---|
| Vertrag | `design-system/contract.json` | DS01–DS07 maschinenlesbar |
| Prüfen | `tools/ds-lint.py` | Verstösse je Regel + `Datei:Zeile` + **Score** |
| Korrigieren | `tools/ds-fix.py` | hebt Hauspalette property-bewusst auf Tokens (idempotent) |
| Hook | `tools/hooks/pre-commit` | `ds-lint --staged` läuft mit (vorerst berichtend) |

**Artefakt-Grenze:** physische Farben (gedruckte Karte, Telefon-Mockup) sind keine Theme-Flächen — mit `# ds-ok` markiert, lassen Checker und Codemod sie in Ruhe. Die Maschine schlägt vor, der Mensch ratifiziert die echte Ausnahme.

## Atem (Gedächtnis)

- **`design-system/CHANGELOG.md`** — Beschluss-Ledger: jede Aufnahme ins Fundament mit Grund und Wirkung.
- **`CLAUDE.md`** — die Aufnahme-Schleife als Doktrin (erkennen → aufnehmen *oder* auflösen → propagieren).
- Erste echte Atem-Aufnahme: die Engine fand `#3f7d46` hartverdrahtet in `base.css .btn.ok` → als `--ok` ins Fundament gehoben.

## Erste sichere Anwendung (verifiziert Hell + Dunkel)

- Schaufenster auf **100 % konform**; Starter, Logos, Karten auf Tokens gehoben.
- Schaufenster-Selbsttest gegen die helle Quelle geprüft — fand dabei echten Drift (`tokens.json` header 58→74px) und wurde nachgezogen.

**Score: 9 % → 17 % konform.** Ab jetzt ist „wie weit weg" eine Zahl statt eines Gefühls.

## Offen (jetzt sicher & messbar)

Generatoren (Visitenkarten/Signatur/GTV-Mockup): Artefakt-Farben mit `# ds-ok` ratifizieren, übrige Hauspalette per `ds-fix`. Dann die DS03-Untergrößen und lokalen Rollen-Definitionen je Seite auflösen — Schritt für Schritt, jeder Schritt bewegt den Score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_