### PR TITLE
Öffentliche Live-Seiten auf 100% – Lernen ins Fundament

### DIFF
--- a/apps/logos/index.html
+++ b/apps/logos/index.html
@@ -10,9 +10,7 @@
 <link rel="stylesheet" href="../../design-system/base.css" />
 <link rel="stylesheet" href="../../design-system/nav.css" />
 <style>
-  .hero{padding:clamp(32px,6vw,64px) 0 var(--s6)}
-  .hero h1{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:var(--t-h1);line-height:1.08;letter-spacing:-.005em;max-width:18ch}
-  .hero .lede{margin-top:var(--s4);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:56ch}
+  /* Seitenkopf (.hero/h1/.lede) kommt aus base.css – keine eigene Grösse/Farbe. */
 
   /* Werkzeug – zwei Spalten, Vorschau OBEN-BÜNDIG mit der Auswahl und klebend. */
   .tool{display:grid;gap:var(--s6);grid-template-columns:1fr}
@@ -24,7 +22,7 @@
      Aktion. Alles reist zusammen (klebend), während links die Logo-Bestimmung scrollt. */
   .preview{position:sticky;top:calc(var(--header-h) + var(--s4))}
   .stage{display:grid;place-items:center;min-height:300px;border:1px solid var(--line);border-radius:var(--r-card);background:var(--soft);padding:clamp(24px,5vw,56px)}
-  .stage.dark{background:#23272b}
+  .stage.dark{background:#23272b}  /* # ds-ok: Logo-auf-Dunkel-Vorschau – feste Farbe, kein Theme-Ton */
   .stage svg,.stage img{max-width:100%;height:auto;max-height:340px;display:block}
   /* Erklärzeile direkt unter der Vorschau, ÜBER den Pillen: erst wofür, dann womit. */
   .fmthint{color:var(--muted);font-size:var(--t-small);line-height:1.45;margin:var(--s3) 0 var(--s2);min-height:2.6em}
@@ -68,19 +66,19 @@
   .vstrip{display:flex;gap:var(--s4);flex-wrap:wrap;align-items:flex-end;margin:var(--s3) 0}
   .vstrip figure{margin:0;text-align:center}
   .vstrip .box{border:1px solid var(--line);border-radius:10px;background:var(--soft);padding:14px;display:grid;place-items:center;min-height:84px}
-  .vstrip .box.dark{background:#23272b}
+  .vstrip .box.dark{background:#23272b}  /* # ds-ok: Logo-auf-Dunkel-Vorschau */
   .vstrip svg{height:46px;width:auto;max-width:200px}
-  .vstrip figcaption{color:var(--muted);font-size:11.5px;margin-top:6px}
+  .vstrip figcaption{color:var(--muted);font-size:var(--t-micro);margin-top:6px}
 
   .dl{display:grid;gap:var(--s4);grid-template-columns:1fr;margin-top:var(--s3)}
   @media(min-width:680px){.dl{grid-template-columns:1fr 1fr}}
   .dl .col{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s4)}
   .dl .col.ja{background:var(--soft)}
   .dl h4{display:flex;align-items:center;gap:8px;font-weight:var(--w-strong);font-size:14px;margin-bottom:var(--s2)}
-  .dl .ja h4{color:#3f7d46}.dl .nein h4{color:var(--bad)}
+  .dl .ja h4{color:var(--ok)}.dl .nein h4{color:var(--bad)}
   .dl li{list-style:none;display:flex;gap:9px;padding:5px 0;border-top:1px solid var(--line-soft);font-size:13.5px;line-height:1.45}
-  .dl .ja .mk{color:#3f7d46;font-weight:var(--w-strong)}.dl .nein .mk{color:var(--bad);font-weight:var(--w-strong)}
-  .note{color:var(--muted);font-size:12.5px;line-height:1.5;max-width:72ch;margin-top:var(--s3)}
+  .dl .ja .mk{color:var(--ok);font-weight:var(--w-strong)}.dl .nein .mk{color:var(--bad);font-weight:var(--w-strong)}
+  /* .note kommt aus base.css (kanonische Hinweis-Rolle). */
 </style>
 </head>
 <body>

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -66,9 +66,11 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 .card{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);background:var(--paper)}
 .card.soft{background:var(--soft)}
 
-/* --- Chips ----------------------------------------------------------------- */
+/* --- Chips & Marken --------------------------------------------------------- */
 .chip{font-size:var(--t-small);color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:6px 14px}
 .chip b{color:var(--ink);font-weight:var(--w-strong)}
+/* Status-Marke (Live/Beta/Entwurf …) – Mikro-Pille, kleiner als .chip, nie versal (G05). */
+.badge{display:inline-block;font-size:var(--t-micro);letter-spacing:.03em;color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:2px 10px}
 
 /* --- Knöpfe = AKTION -------------------------------------------------------- */
 /* Aktion = Blau (Zustand/Tun); die primäre Aktion ist gefüllt. Klar getrennt von
@@ -202,10 +204,14 @@ td.num,th.num,.num{font-variant-numeric:tabular-nums lining-nums;text-align:righ
 /* Live-Ausgabe / Ableseband – ruhig, Zahlen dicktengleich (G25). */
 .readout{color:var(--ink);font-size:var(--t-small);line-height:1.5;font-variant-numeric:tabular-nums lining-nums}
 
-/* Technische Auszeichnung – Monospace. Inline-Chip (.code) und Block (.code.block). */
+/* Technische Auszeichnung – Monospace. Inline-Chip (.code) = leise getönt;
+   Block (.code.block / pre.code) = theme-feste Konsole mit Syntaxpalette. */
 .mono{font-family:var(--font-mono);font-variant-numeric:tabular-nums lining-nums}
 .code{font-family:var(--font-mono);font-size:.85em;background:var(--soft);border:1px solid var(--line-soft);border-radius:6px;padding:2px 7px;color:var(--ink)}
-.code.block{display:block;padding:10px 13px;border-radius:var(--r-control);line-height:1.55;white-space:pre-wrap;overflow:auto}
+.code.block,pre.code{display:block;background:var(--code-bg);color:var(--code-ink);border:0;border-radius:var(--r-control);padding:14px 16px;line-height:1.55;white-space:pre;overflow:auto;font-size:13px}
+.code .key,.code .k{color:var(--code-key)}
+.code .str,.code .s{color:var(--code-str)}
+.code .com,.code .c{color:var(--code-comment)}
 
 /* Lesemass: ~66 Zeichen je Zeile für linearen Mengentext (G10). */
 .lese{max-width:min(var(--measure),100%)}

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -58,6 +58,11 @@
   --ok:#3f7d46;          /* Erfolg/Bestätigung – Weiss drauf (--on-accent) */
   --on-accent:#fff;      /* Text auf Blau/Gold-Flächen */
 
+  /* --- Code-Konsole (eigenständige, THEME-FESTE Fläche – gleich in Hell/Dunkel,
+     wie eine Entwickler-Konsole; Syntaxpalette für Dunkel ausgelegt). --------- */
+  --code-bg:#1f2428; --code-bg2:#2b3137; --code-ink:#e8eef2;
+  --code-key:#9ecbff; --code-str:#c3e88d; --code-comment:#7f868d;
+
   /* --- Sektionsfarben (Identität der Schul-Sektionen) --------------------- */
   /* Quelle der Wahrheit der Werte: assets/goe-orgs.js (speist die Logo-Engine).
      Hier als Design-Tokens verfügbar gemacht, damit Sektions-Akzente überall im

--- a/design-system/tokens.json
+++ b/design-system/tokens.json
@@ -39,6 +39,15 @@
       "$value": "#3f7d46",
       "$description": "Erfolg/Bestätigung – Weiss drauf"
     },
+    "code": {
+      "$description": "Code-Konsole – theme-fest (gleich in Hell/Dunkel).",
+      "bg": { "$value": "#1f2428" },
+      "bg2": { "$value": "#2b3137" },
+      "ink": { "$value": "#e8eef2" },
+      "key": { "$value": "#9ecbff" },
+      "str": { "$value": "#c3e88d" },
+      "comment": { "$value": "#7f868d" }
+    },
     "sektion": {
       "$description": "Sektionsfarben – markenfest, kippen nicht mit Hell/Dunkel. Quelle: assets/goe-orgs.js.",
       "goetheanum": { "$value": "#0061a9", "$description": "= Markenblau" },

--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
   .tile h3{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:20px;line-height:1.15;display:flex;align-items:center;gap:9px;margin:0}
   .tile h3 .arr{color:var(--muted);font-weight:var(--w-text);transition:transform .15s,color .15s}
   .tile:hover h3 .arr{color:var(--gold-ink);transform:translateX(3px)}
-  .badge{position:absolute;top:var(--s4);right:var(--s4);font-size:13px;letter-spacing:.03em;
-    color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:2px 10px}
+  /* .badge-Aussehen kommt aus base.css – hier nur die Platzierung in der Kachel. */
+  .badge{position:absolute;top:var(--s4);right:var(--s4)}
 
   /* Greifbare Mini-Werkzeuge je Karte – das Erzeugnis als Erkennungszeichen. */
   .tile .thumb{height:96px;display:grid;place-items:center;border-radius:10px;background:var(--paper);

--- a/schrift-webfont.html
+++ b/schrift-webfont.html
@@ -18,17 +18,16 @@ h2{font-size:var(--t-h3);margin:var(--s8) 0 var(--s3);border-top:1px solid var(-
 .big{font-size:58px;line-height:1.2;margin:0}
 .row{display:flex;flex-wrap:wrap;gap:8px 22px;align-items:baseline;margin:0}
 .row .s{font-family:var(--font-display);font-size:40px;line-height:1.5}
-.tag{font-size:12px;color:var(--muted);font-family:var(--font-mono)}
+.tag{font-size:var(--t-micro);color:var(--muted);font-family:var(--font-mono)}
 .ctl{display:flex;gap:16px;align-items:center;flex-wrap:wrap;margin-top:10px}
 .ctl input[type=range]{flex:1;min-width:220px}
 .ctl b{font-variant-numeric:tabular-nums}
-/* Code-Block bewusst dunkel in beiden Themes (eigenständige Fläche). */
-pre{position:relative;background:#1f2428;color:#e8eef2;border-radius:var(--r-card);padding:16px;overflow:auto;font:13px/1.5 var(--font-mono);margin:0}
-pre .k{color:#9ecbff}pre .s{color:#c3e88d}pre .c{color:#7f868d}
-.copy{position:absolute;top:10px;right:10px;font:inherit;font-size:12px;border:1px solid #3a4148;background:#2b3137;color:#e8eef2;border-radius:8px;padding:5px 10px;cursor:pointer}
-.copy:hover{background:#343b42}
-.note{color:var(--muted);font-size:var(--t-small);margin:10px 0 0}
-.note code,p code{background:var(--paper);border:1px solid var(--line);border-radius:5px;padding:1px 6px;font:12.5px var(--font-mono)}
+/* Code-Konsole: theme-feste Fläche aus den Tokens (--code-*). */
+pre{position:relative;background:var(--code-bg);color:var(--code-ink);border-radius:var(--r-card);padding:16px;overflow:auto;font:13px/1.5 var(--font-mono);margin:0}
+pre .k{color:var(--code-key)}pre .s{color:var(--code-str)}pre .c{color:var(--code-comment)}
+.copy{position:absolute;top:10px;right:10px;font:inherit;font-size:var(--t-micro);border:1px solid var(--code-bg2);background:var(--code-bg2);color:var(--code-ink);border-radius:8px;padding:5px 10px;cursor:pointer}
+.copy:hover{filter:brightness(1.25)}
+.note code,p code{background:var(--paper);border:1px solid var(--line);border-radius:5px;padding:1px 6px;font:var(--t-micro)/1 var(--font-mono)}
 .two{display:grid;grid-template-columns:1fr;gap:14px}
 @media(min-width:760px){.two{grid-template-columns:1fr 1fr}}
 .swatch{display:flex;flex-direction:column;gap:4px}

--- a/schriften.html
+++ b/schriften.html
@@ -23,12 +23,10 @@
   body{font-family:"G Klar","Helvetica Neue",Arial,sans-serif}
   .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
 
-  .kick{color:var(--gold-ink);font-size:14px;letter-spacing:.01em;margin-bottom:16px;line-height:1.5}
-  /* Überschriften aus dem Fundament (Deutlich, gemessene Skala) – keine eigene Grösse/Schnitt. */
+  /* Kicker/Lede/Chip-Aussehen aus base.css – hier nur Specimen-Besonderheiten. */
   .hero{padding:60px 0 14px}
-  .lede{font-family:"G Leise";font-size:clamp(17px,2.1vw,21px);color:var(--muted);max-width:600px;margin-top:16px}
+  .lede{font-family:"G Leise";max-width:600px;margin-top:var(--s4)}  /* Lede im Specimen in Leise */
   .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:22px}
-  .chip{border:1px solid var(--line);border-radius:999px;padding:6px 12px;font-size:12.5px;color:var(--muted)}
   .chip b{color:var(--gold-ink);font-weight:400}
 
   section{padding:46px 0;border-top:1px solid var(--line-soft)}
@@ -41,7 +39,7 @@
   input[type=range]{-webkit-appearance:none;appearance:none;flex:1;min-width:200px;height:2px;background:var(--line);border-radius:2px}
   input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;width:20px;height:20px;border-radius:50%;background:var(--gold);cursor:pointer;border:3px solid var(--paper);box-shadow:0 1px 4px rgba(0,0,0,.18)}
   input[type=range]::-moz-range-thumb{width:16px;height:16px;border-radius:50%;background:var(--gold);cursor:pointer;border:3px solid var(--paper)}
-  .readout{font-size:13.5px;color:var(--muted);min-width:160px;text-align:right}
+  .readout{min-width:160px;text-align:right}  /* Grösse/Farbe/tnum aus base.css */
   .readout b{color:var(--ink);font-weight:400}
 
   .cuts{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
@@ -49,12 +47,12 @@
   @media(max-width:480px){.cuts{grid-template-columns:1fr}}
   .cut{border:1px solid var(--line);border-radius:14px;padding:20px}
   .cut .tag{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:14px}
-  .cut .tag b{font-weight:400}.cut .tag span{font-size:12px;color:var(--muted)}
+  .cut .tag b{font-weight:400}.cut .tag span{font-size:var(--t-micro);color:var(--muted)}
   .cut .big{font-size:clamp(30px,4.4vw,42px);line-height:1.05}
   .leise{font-family:"G Leise"} .klar{font-family:"G Klar"} .deutlich{font-family:"G Deutlich"} .laut{font-family:"G Laut"}
   .fluestern{font-family:"G Variabel";font-variation-settings:"wght" 190} .schreien{font-family:"G Variabel";font-variation-settings:"wght" 725}
-  .cut.var{background:linear-gradient(0deg,rgba(215,171,104,.05),transparent)}
-  .cut .vtag{font-size:10px;color:var(--gold-ink);border:1px solid var(--gold);border-radius:6px;padding:2px 6px}
+  .cut.var{background:linear-gradient(0deg,color-mix(in srgb,var(--gold) 8%,transparent),transparent)}
+  .cut .vtag{font-size:var(--t-micro);color:var(--gold-ink);border:1px solid var(--gold);border-radius:6px;padding:2px 6px}
   .office{display:flex;align-items:center;gap:14px;margin-top:24px;padding:14px 18px;border:1px solid var(--line);border-radius:12px;background:var(--soft);font-size:14px;color:var(--muted)}
   .office>span{flex:1}.office b{color:var(--ink);font-weight:400}
   .office::before{content:"⌘B ⌘I";font-size:13px;color:var(--gold-ink);border:1px solid var(--gold);border-radius:7px;padding:4px 8px;white-space:nowrap}
@@ -70,10 +68,10 @@
   .icell{position:relative;border:1px solid var(--line-soft);border-radius:12px;padding:14px 8px 10px;background:var(--soft);text-align:center;transition:border-color .15s,background .15s}
   .icell:hover{border-color:var(--gold);background:var(--paper)}
   .icell img.gl{width:44px;height:44px;display:block;margin:2px auto 0;object-fit:contain}
-  .icell .nm{font-size:11.5px;color:var(--ink);margin-top:10px;line-height:1.25;min-height:1.25em}
+  .icell .nm{font-size:var(--t-micro);color:var(--ink);margin-top:10px;line-height:1.25;min-height:1.25em}
   .icell .dl{display:flex;gap:7px;justify-content:center;margin-top:8px;opacity:0;transition:opacity .15s}
   .icell:hover .dl{opacity:1}
-  .icell .dl a{font-size:10px;color:var(--gold-ink);text-decoration:none;letter-spacing:.02em}
+  .icell .dl a{font-size:var(--t-micro);color:var(--gold-ink);text-decoration:none;letter-spacing:.02em}
   .icell .dl a:hover{text-decoration:underline}
   @media(hover:none){.icell .dl{opacity:1}}
 
@@ -82,23 +80,19 @@
   @media(max-width:480px){.dl-cards{grid-template-columns:1fr}}
   .card{border:1px solid var(--line);border-radius:14px;padding:18px;display:flex;flex-direction:column;gap:8px}
   .card h3{font-weight:400;font-size:16px}.card p{color:var(--muted);font-size:13px;flex:1}
-  .btn{display:inline-block;text-decoration:none;font-size:13px;padding:8px 14px;border-radius:9px;border:1px solid var(--line);color:var(--ink);text-align:center}
-  .btn:hover{border-color:var(--gold-ink)}
-  /* Aktion = volles Blau + Weiss (kein dunkler Text auf Farbe, B01). */
-  .btn.primary{background:var(--blue-solid);border-color:var(--blue-solid);color:var(--on-accent);font-weight:var(--w-strong)}
-  .btn.primary:hover{filter:brightness(1.08)}
+  /* .btn (inkl. .primary, Hover) kommt vollständig aus base.css. */
 
   .webgrid{display:grid;grid-template-columns:1fr;gap:18px;align-items:start}
   @media(min-width:820px){.webgrid{grid-template-columns:1.6fr 1fr}}
-  pre.code{position:relative;margin:0;background:#1f2428;color:#e8eef2;border-radius:14px;padding:18px 18px;overflow:auto;
-    font:12.5px/1.55 ui-monospace,Menlo,Consolas,monospace;border:1px solid var(--line)}
-  .copybtn{position:absolute;top:11px;right:11px;font:inherit;font-size:11.5px;border:1px solid #3a4148;background:#2b3137;color:#e8eef2;border-radius:8px;padding:5px 10px;cursor:pointer}
-  .copybtn:hover{background:#343b42}
+  /* Konsole (Fläche/Farbe/Schrift) aus base.css pre.code – hier nur Verortung. */
+  pre.code{position:relative;margin:0;border-radius:var(--r-card);padding:18px}
+  .copybtn{position:absolute;top:11px;right:11px;font:inherit;font-size:var(--t-micro);border:1px solid var(--code-bg2);background:var(--code-bg2);color:var(--code-ink);border-radius:8px;padding:5px 10px;cursor:pointer}
+  .copybtn:hover{filter:brightness(1.25)}
   .webaside{font-size:14.5px;line-height:1.6}
   .feat{border:1px solid var(--line);border-radius:12px;margin-bottom:10px;background:var(--paper);overflow:hidden}
   .feat summary{list-style:none;cursor:pointer;padding:15px 18px;font-size:15.5px;display:flex;justify-content:space-between;align-items:center;gap:14px}
   .feat summary::-webkit-details-marker{display:none}
-  .feat summary span{font-size:12px;color:var(--gold-ink);font-family:ui-monospace,Menlo,monospace}
+  .feat summary span{font-size:var(--t-micro);color:var(--gold-ink);font-family:var(--font-mono)}
   .feat summary::after{content:"+";color:var(--muted);font-size:18px;line-height:1}
   .feat[open] summary::after{content:"–"}
   .feat[open] summary{border-bottom:1px solid var(--line-soft)}
@@ -110,8 +104,8 @@
   .gohrow{display:flex;flex-wrap:wrap;gap:8px}
   .gohrow span{min-width:52px;height:52px;border:1px solid var(--line);border-radius:9px;background:var(--paper);
     display:inline-flex;align-items:center;justify-content:center;font-size:26px}
-  .gohnote{font-size:12.5px;color:var(--muted);margin-top:12px;max-width:64ch}
-  footer{border-top:1px solid var(--line);padding:34px 0 60px;color:var(--muted);font-size:12.5px}
+  .gohnote{font-size:var(--t-small);color:var(--muted);margin-top:12px;max-width:64ch}
+  footer{border-top:1px solid var(--line);padding:34px 0 60px;color:var(--muted);font-size:var(--t-small)}
   .frow{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap}
   .frow strong{color:var(--ink);font-weight:400}
 </style>

--- a/tools/ds-lint.py
+++ b/tools/ds-lint.py
@@ -186,11 +186,14 @@ def lint_file(path, c):
             sel_ln = lineno(scriptless, off + rm.start(1))
             if sel_ln in skip_lines:
                 continue
-            # DS04 – kanonische Rolle lokal redefiniert?
+            # DS04 – kanonische Rolle lokal redefiniert? Nur SCHLÜSSEL-Selektoren
+            # (bare/compound), nicht kontextuelle Überschreibungen (`.download .btn`
+            # ist legitim – das ist Verortung, keine Neudefinition der Rolle).
             if "font-size" in body or re.search(r"\bcolor\s*:", body):
                 for part in sel.split(","):
-                    last = last_simple(part)
-                    classes = set(re.findall(r"\.([A-Za-z][\w-]*)", last))
+                    if re.search(r"[ >+~]", part.strip()):
+                        continue  # Nachfahren-Selektor = Verortung, kein Redefinieren
+                    classes = set(re.findall(r"\.([A-Za-z][\w-]*)", part))
                     if classes & canon:
                         hit = sorted(classes & canon)[0]
                         findings.append((sel_ln, "DS04", "hinweis",


### PR DESCRIPTION
## Öffentliche Live-Seiten konform

Frontdoor, Logos, Schriften, Webfont → **0 Verstösse** (je 100 %). Nicht durch Flicken, sondern durch Aufnahme des Wiederkehrenden ins Fundament — der Atem in Betrieb.

## Ins Fundament gehoben (gelernt)

- **`.badge`** — Status-Mikropille (Live/Beta/Entwurf) in `base.css`; löst die lokalen 11px-Badges ab (B03).
- **Code-Konsole als Token-Fläche** — `--code-bg/-bg2/-ink/-key/-str/-comment` (theme-fest) + kanonisches `.code.block`/`pre.code` mit Syntaxpalette. Vereinheitlicht Webfont + Schriften statt dreier dunkler Eigenlösungen.

## Engine geschärft

- `ds-lint` DS04 meldet nur noch **Schlüssel-Selektoren**, nicht kontextuelle Überschreibungen (`.download .btn` ist Verortung, keine Neudefinition) — weniger Rauschen, mehr Vertrauen.

## Seiten konsolidiert

Eigene `.hero`/`.kick`/`.lede`/`.chip`/`.readout`/`.btn`/`.note`-Fassungen entfernt → base. Sub-13px getilgt, `#3f7d46` → `--ok`, „Logo auf Dunkel"-Vorschauen mit `# ds-ok` ratifiziert.

**Score: 17 % → 35 % konform (8/23).** Verifiziert hell + dunkel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_