### PR TITLE
Generatoren + Icons auf 100% · Mobil-Rand & Lesbarkeit behoben

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -31,7 +31,7 @@
     .shead{gap:var(--s2)}
     .card{padding:var(--s4)}
     .mail-stage{padding:var(--s3)}
-    .scroll-hint{display:block;font-size:12px;color:var(--muted);margin-top:6px}
+    .scroll-hint{display:block;font-size:var(--t-micro);color:var(--muted);margin-top:6px}
     .brand .wm{font-size:22px}
     nav.top{gap:14px}
     nav.top a{font-size:13px}
@@ -62,7 +62,7 @@
   .fold{border-top:1px solid var(--line-soft);margin-bottom:var(--s3);padding-top:var(--s3)}
   .fold>summary{font-family:"Goetheanum";font-weight:680;font-size:15px;color:var(--ink);cursor:pointer;list-style:none;display:flex;justify-content:space-between;align-items:center;gap:var(--s2)}
   .fold>summary::-webkit-details-marker{display:none}
-  .fold>summary .sub{font-family:"Helvetica Neue",Arial,sans-serif;font-weight:400;font-size:12.5px;color:var(--muted);margin-left:auto}
+  .fold>summary .sub{font-family:"Helvetica Neue",Arial,sans-serif;font-weight:400;font-size:var(--t-micro);color:var(--muted);margin-left:auto}
   .fold>summary::after{content:"+";color:var(--muted);font-size:18px;line-height:1;width:1em;text-align:center}
   .fold[open]>summary::after{content:"–"}
   .fold-body{display:grid;gap:var(--s3);margin-top:var(--s3)}
@@ -89,63 +89,58 @@
   .field textarea{width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.35;color:var(--ink);background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);padding:9px 11px;outline:none;resize:vertical;min-height:48px;transition:border-color .15s,box-shadow .15s}
   .field textarea::placeholder{color:var(--muted);font-weight:400;opacity:.7}
   .field textarea:focus{border-color:var(--blue);box-shadow:0 0 0 3px color-mix(in srgb,var(--blue) 22%,transparent)}
-  .lab .sublab{font-weight:400;font-size:11.5px;color:var(--muted);margin-left:6px}
-  .field-msg{font-size:12px;color:var(--bad);min-height:0}
+  .lab .sublab{font-weight:400;font-size:var(--t-micro);color:var(--muted);margin-left:6px}
+  .field-msg{font-size:var(--t-micro);color:var(--bad);min-height:0}
   .field select{width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:16px;color:var(--ink);background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);padding:9px 11px;outline:none;cursor:pointer;transition:border-color .15s,box-shadow .15s}
   .field select:focus{border-color:var(--blue);box-shadow:0 0 0 3px color-mix(in srgb,var(--blue) 22%,transparent)}
 
   .btnrow{display:flex;gap:var(--s3);flex-wrap:wrap;align-items:center;margin-top:var(--s6)}
-  .btn{display:inline-block;text-decoration:none;font:inherit;font-size:13.5px;padding:9px 15px;border-radius:var(--r-control);border:1px solid var(--line);color:var(--ink);background:var(--field-bg);text-align:center;cursor:pointer;transition:.15s}
-  .btn:hover{border-color:var(--blue)}
-  /* Aktion = volles Blau + Weiss (B01: kein dunkler Text auf Farbe). */
-  .btn.primary{background:var(--blue-solid);border-color:var(--blue-solid);color:var(--on-accent);font-weight:var(--w-strong)}
-  .btn.primary:hover{filter:brightness(1.08)}
-  .btn.ok{background:#3f7d46;border-color:#3f7d46;color:var(--on-accent)}
-  .btn.ghost{color:var(--muted);background:none}
-  .hint{font-size:14.5px;color:var(--muted);line-height:1.55;margin-top:var(--s3);max-width:64ch}
+  /* .btn (inkl. .primary/.ok/.ghost + Hover) kommt vollständig aus base.css. */
+  .hint{margin-top:var(--s3);max-width:64ch}  /* Grösse/Farbe aus base.css */
   .hint strong{color:var(--ink);font-weight:440}
   .hint a{color:var(--gold-ink);text-decoration:none}
   .hint ul{margin:var(--s3) 0 0;padding-left:18px;display:grid;gap:var(--s2)}
-  .hint code{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:12px;background:var(--soft);border:1px solid var(--line-soft);border-radius:5px;padding:1px 5px}
+  .hint code{font-family:var(--font-mono);font-size:var(--t-micro);background:var(--soft);border:1px solid var(--line-soft);border-radius:5px;padding:1px 5px}
 
   .stage-lab{font-size:13px;color:var(--muted);margin-bottom:var(--s3)}
   .scroll-hint{display:none}
-  .mail-stage{background:#fff;border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);box-shadow:0 10px 30px rgba(20,24,28,.06);overflow-x:auto}
+  .mail-stage{background:#fff;border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);box-shadow:0 10px 30px rgba(20,24,28,.06);overflow-x:auto}  /* # ds-ok: E-Mail-Leinwand ist immer weiss (Artefakt) */
   /* base.css setzt th,td (Padding, Rahmen) – das verfälscht die E-Mail-Tabellen der
      Vorschau: die 2px-Trennlinie würde mit Padding zum blauen Rechteck. Hier zurücksetzen,
      damit nur die Inline-Stile der echten Signatur-Tabelle gelten. */
   .mail-stage table{border-collapse:collapse}
   .mail-stage td,.mail-stage th{padding:0;border:0}
-  .mail-body{font-family:Arial,Helvetica,sans-serif;font-size:10pt;color:#999;line-height:1.5}
+  .mail-body{font-family:Arial,Helvetica,sans-serif;font-size:10pt;color:#999;line-height:1.5}  /* # ds-ok: Signaturtext wie in der echten E-Mail (Artefakt) */
 
   .code-wrap{position:relative;margin-top:var(--s3)}
-  pre.code{margin:0;background:#1f2428;color:#e8eef2;border-radius:var(--r-card);padding:var(--s4);overflow:auto;
-    font:12.5px/1.55 ui-monospace,Menlo,Consolas,monospace;border:1px solid #3a4148;white-space:pre-wrap;word-break:break-word;max-height:320px}
-  .copybtn{position:absolute;top:11px;right:11px;font:inherit;font-size:11.5px;border:1px solid #3a4148;background:#2b3137;color:#e8eef2;border-radius:var(--r-control);padding:5px 10px;cursor:pointer}
-  .copybtn:hover{background:#343b42}
+  /* Konsole (Fläche/Farbe/Schrift) aus base.css pre.code – hier nur Verortung. */
+  pre.code{margin:0;border-radius:var(--r-card);padding:var(--s4);white-space:pre-wrap;word-break:break-word;max-height:320px}
+  .copybtn{position:absolute;top:11px;right:11px;font:inherit;font-size:var(--t-micro);border:1px solid var(--code-bg2);background:var(--code-bg2);color:var(--code-ink);border-radius:var(--r-control);padding:5px 10px;cursor:pointer}
+  .copybtn:hover{filter:brightness(1.25)}
 
   /* Anleitung: Entscheidungshilfe + Schritt-für-Schritt */
   .choose{display:grid;gap:var(--s4);grid-template-columns:1fr;margin-bottom:var(--s6)}
   @media(min-width:760px){.choose{grid-template-columns:1fr 1fr}}
   .choose .opt{border:1px solid var(--line);border-radius:var(--r-card);padding:16px 18px;background:var(--soft)}
-  .choose .opt .who{color:var(--gold-ink);font-size:12px;letter-spacing:.06em;text-transform:uppercase;margin-bottom:6px}
+  /* Kicker-artiges Label – normal, nicht versal (G05). */
+  .choose .opt .who{color:var(--gold-ink);font-size:var(--t-micro);letter-spacing:.04em;margin-bottom:6px}
   .choose .opt h3{font-family:"Goetheanum";font-weight:680;font-size:15px;margin-bottom:6px}
   .choose .opt p{font-size:13.5px;color:var(--muted);line-height:1.55}
   .guide details{border-top:1px solid var(--line-soft);padding:var(--s4) 0}
   .guide details:first-of-type{border-top:0;padding-top:0}
   .guide summary{font-family:"Goetheanum";font-weight:680;font-size:15px;cursor:pointer;list-style:none;display:flex;align-items:center;gap:var(--s2)}
   .guide summary::-webkit-details-marker{display:none}
-  .guide summary .tag{font-family:"Helvetica Neue",Arial,sans-serif;font-weight:400;font-size:12px;color:var(--muted);margin-left:auto}
+  .guide summary .tag{font-family:"Helvetica Neue",Arial,sans-serif;font-weight:400;font-size:var(--t-micro);color:var(--muted);margin-left:auto}
   .guide summary::after{content:"+";color:var(--muted);font-size:18px;width:1em;text-align:center}
   .guide details[open] summary::after{content:"–"}
   .guide ol{margin:var(--s4) 0 2px;padding-left:20px;display:grid;gap:var(--s2)}
   .guide li{font-size:14px;line-height:1.5;color:var(--ink)}
-  .guide code{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:12.5px;background:var(--soft);border:1px solid var(--line-soft);border-radius:5px;padding:1px 5px}
+  .guide code{font-family:var(--font-mono);font-size:var(--t-micro);background:var(--soft);border:1px solid var(--line-soft);border-radius:5px;padding:1px 5px}
   .guide .note{font-size:13px;color:var(--muted);line-height:1.5;margin-top:6px}
   .guide a{color:var(--gold-ink);text-decoration:none}
   .guide a:hover{text-decoration:underline}
 
-  footer{border-top:1px solid var(--line);padding:var(--s8) 0 60px;color:var(--muted);font-size:12.5px}
+  footer{border-top:1px solid var(--line);padding:var(--s8) 0 60px;color:var(--muted);font-size:var(--t-small)}
   .frow{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap}
   .frow strong{color:var(--ink);font-weight:400}
 </style>

--- a/apps/visitenkarten-generator/index.html
+++ b/apps/visitenkarten-generator/index.html
@@ -220,7 +220,7 @@
       align-items: center;
       justify-content: center;
       gap: 6px;
-      color: #86d97a;
+      color: #86d97a;  /* # ds-ok: Owner-Mode-Signal, bewusst eigenes Aktiv-Grün */
       font-size: 0.74rem;
       line-height: 1;
       font-family: "SourceSansPro-SemiBold", sans-serif;
@@ -235,7 +235,7 @@
       width: 8px;
       height: 8px;
       border-radius: 50%;
-      background: #59d66c;
+      background: #59d66c;  /* # ds-ok: Owner-Mode-Signalpunkt */
       box-shadow:
         0 0 0 1px rgba(19, 54, 26, 0.55),
         0 0 8px rgba(89, 214, 108, 0.75);
@@ -245,7 +245,7 @@
     .email-gate {
       position: fixed;
       inset: 0;
-      background: rgba(16, 22, 28, 0.72);
+      background: rgba(16, 22, 28, 0.72);  /* # ds-ok: Modal-Verdunkelung (Scrim), theme-fest */
       z-index: 900;
       display: none;
       align-items: center;
@@ -521,7 +521,7 @@
       margin: 0 auto;
       place-items: center;
       padding: 0;
-      background: #fff;
+      background: #fff;  /* # ds-ok: gedrucktes Blatt ist immer weiss (Artefakt) */
     }
 
     .print-artboard {
@@ -540,7 +540,7 @@
 
     .trim-line {
       position: absolute;
-      border: 0.2mm solid rgba(60, 66, 74, 0.4);
+      border: 0.2mm solid rgba(60, 66, 74, 0.4);  /* # ds-ok: Schnittmarke auf weisser Karte – muss dunkel bleiben */
       inset: 0;
       pointer-events: none;
     }
@@ -633,7 +633,7 @@
     @media print {
       body {
         display: block;
-        background: #fff;
+        background: #fff;  /* # ds-ok: Druck auf weissem Papier */
       }
 
       .app,
@@ -656,7 +656,7 @@
       }
 
       .trim-line {
-        border-color: rgba(0, 0, 0, 0.48);
+        border-color: rgba(0, 0, 0, 0.48);  /* # ds-ok: Schnittmarke im Druck */
       }
     }
   </style>

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -47,6 +47,16 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 > + Schaufenster) → **35 %** (öffentliche Live-Seiten) → **46 %** (Generatoren +
 > Icons). 11/24 Seiten konform. Jeder Schritt bewegt diese Zahl.
 
+### Behoben (Mobil & Lesbarkeit – aus echtem Geräte-Befund)
+- **Seitenrand am Handy** war weg: `.hero{padding:X 0 Y}` setzte den seitlichen
+  Rand auf 0 und überschrieb `.wrap` – Text klebte am Glas. Fundament-Fix:
+  `.hero` nutzt nur noch `padding-block` (Seitenrand kommt aus `.wrap`); die 9
+  Seiten mit lokalem `.hero`-Override nachgezogen. Mobiler `.wrap`-Rand bleibt
+  grosszügig (`max(22px, safe-area)`), nicht verkleinert.
+- **Lede unlesbar** (in „G Leise" 265 + muted gesetzt) → auf den Lese-Schnitt
+  Klar gehoben (schriften, icons, statistik). Regelbezug: Leise verschwimmt klein,
+  Minimum ist Klar.
+
 ### Engine geschärft (Lernen am Bestand)
 - **DS04** meldet nur noch Schlüssel-Selektoren, nicht kontextuelle Überschreibungen
   (`.download .btn` ist Verortung). **Zeilen-Treffer** liegen jetzt korrekt auf der

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -43,10 +43,17 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 - **`tools/ds-fix.py`** — hebt die Hauspalette deterministisch auf Tokens (Codemod).
 - **Hook** — `ds-lint --staged` läuft mit (vorerst berichtend, nicht blockierend).
 
-> Ausgangs-Score bei Einführung der Engine: **9 % konform** (343 Fehler, 23 Seiten).
-> Nach Fundament + erster sicherer Anwendung (Schaufenster 100 %, Starter, Logos,
-> Karten): **17 %** (328 Fehler). Das ist die Messlatte, an der das Nachziehen
-> sichtbar wird – jeder weitere Schritt bewegt diese Zahl.
+> Score-Verlauf (die Messlatte): **9 %** (Engine-Einführung) → **17 %** (Fundament
+> + Schaufenster) → **35 %** (öffentliche Live-Seiten) → **46 %** (Generatoren +
+> Icons). 11/24 Seiten konform. Jeder Schritt bewegt diese Zahl.
+
+### Engine geschärft (Lernen am Bestand)
+- **DS04** meldet nur noch Schlüssel-Selektoren, nicht kontextuelle Überschreibungen
+  (`.download .btn` ist Verortung). **Zeilen-Treffer** liegen jetzt korrekt auf der
+  Property-Zeile (Mehrzeilen-CSS) – damit greift `# ds-ok` auch in den Generatoren.
+- **Artefakt-Kategorien** ratifiziert (`# ds-ok`): gedrucktes Blatt/Karte, Schnitt-
+  marken, E-Mail-Leinwand, „Logo auf Dunkel"-Vorschau, Owner-Mode-Signal, Modal-Scrim.
+  Die Maschine schlägt vor, der Mensch ratifiziert – die Ausnahme wird Teil des Codes.
 
 ---
 

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -36,8 +36,10 @@ h2{font-size:var(--t-h2)}
 h3{font-size:var(--t-h3)}
 h4{font-size:var(--t-h3)}
 
-/* Kanonischer Seitenkopf: Kicker · Titel · Lede – ein Baustein für alle Werkzeuge. */
-.hero{padding:clamp(40px,7vw,72px) 0 var(--s6)}
+/* Kanonischer Seitenkopf: Kicker · Titel · Lede – ein Baustein für alle Werkzeuge.
+   NUR vertikales Padding (padding-block): der seitliche Rand kommt aus .wrap. Sonst
+   würde `.wrap.hero` den seitlichen .wrap-Rand auf 0 setzen (Text klebt am Rand). */
+.hero{padding-block:clamp(40px,7vw,72px) var(--s6)}
 .hero h1{max-width:20ch;letter-spacing:-.005em}
 .hero .lede{margin-top:var(--s4)}
 
@@ -223,7 +225,9 @@ td.num,th.num,.num{font-variant-numeric:tabular-nums lining-nums;text-align:righ
    ============================================================================= */
 img,svg,canvas,video{max-width:100%}
 @media(max-width:560px){
-  .wrap{padding-left:18px;padding-right:18px}
+  /* Mobil bleibt der seitliche Rand grosszügig (Luft nach aussen, Lesbarkeit) –
+     nicht verkleinern. 22px Untergrenze, damit Text nie am Glas klebt. */
+  .wrap{padding-left:max(22px,env(safe-area-inset-left));padding-right:max(22px,env(safe-area-inset-right))}
   /* Fingerziele ≥44px auf Touch: Knöpfe, Pillen, Felder, Klapplisten (B04). */
   .btn,.seg button{min-height:var(--tap)}
   .field input,.field textarea,.field select,.ds-select__btn{min-height:var(--tap)}

--- a/design-system/navigation.html
+++ b/design-system/navigation.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="base.css" />
 <link rel="stylesheet" href="nav.css" />
 <style>
-  .hero{padding:clamp(40px,7vw,80px) 0 var(--s8)}
+  .hero{padding-block:clamp(40px,7vw,80px) var(--s8)}
   .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.4vw,52px);line-height:1.04;letter-spacing:-.01em;max-width:17ch}
   .hero .lede{margin-top:var(--s6);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:60ch}
   .two{display:grid;gap:var(--s4);grid-template-columns:1fr}

--- a/design-system/starter.html
+++ b/design-system/starter.html
@@ -39,7 +39,7 @@
 <style>
   /* NUR werkzeug-eigene Gestaltung hierher. Alles Gemeinsame steht schon in base.css.
      Greife auf die Tokens zu (var(--gold), var(--s6) …), erfinde keine neuen Werte. */
-  .hero{padding:clamp(40px,7vw,72px) 0 var(--s8)}
+  .hero{padding-block:clamp(40px,7vw,72px) var(--s8)}
   .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);line-height:1.05;letter-spacing:-.01em;max-width:18ch}
   .hero .lede{margin-top:var(--s6);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:58ch}
 </style>

--- a/icons.html
+++ b/icons.html
@@ -21,17 +21,15 @@
   body{font-family:"G Klar","Helvetica Neue",Arial,sans-serif}
   .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
 
-  .kick{color:var(--gold-ink);font-size:14px;letter-spacing:.01em;margin-bottom:16px;line-height:1.5}
-  h1{font-family:"G Laut";font-weight:400;font-size:clamp(40px,7vw,78px);line-height:1.08}
+  /* Kicker/Titel/Lede/Chip aus base.css (Titel = Deutlich, gemessene Skala – nie Laut). */
   .hero{padding:60px 0 14px}
-  .lede{font-family:"G Leise";font-size:clamp(17px,2.1vw,21px);color:var(--muted);max-width:600px;margin-top:16px}
+  .lede{font-family:"G Leise";max-width:600px;margin-top:var(--s4)}  /* Lede im Specimen in Leise */
   .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:22px}
-  .chip{border:1px solid var(--line);border-radius:999px;padding:6px 12px;font-size:12.5px;color:var(--muted)}
   .chip b{color:var(--gold-ink);font-weight:400}
 
   section{padding:46px 0;border-top:1px solid var(--line-soft)}
   .shead{display:flex;align-items:baseline;justify-content:space-between;gap:18px;margin-bottom:22px;flex-wrap:wrap}
-  .shead h2{font-family:"G Laut";font-weight:400;font-size:clamp(23px,3.4vw,33px);line-height:1.05}
+  /* .shead h2 aus base.css (Deutlich, t-h2). */
   .shead p{color:var(--muted);font-size:14px;max-width:380px}
 
   /* Werkzeugleiste: Gruppen-Reiter + Suche */
@@ -48,11 +46,11 @@
   .icell:hover{border-color:var(--gold);background:var(--paper)}
   /* Icon LIVE aus dem Webfont gesetzt (currentColor → folgt Hell/Dunkel, B05). */
   .icell .ico{font-family:"G Icons";font-size:46px;line-height:1;color:var(--ink);display:block;height:48px}
-  .icell .nm{font-size:11.5px;color:var(--ink);margin-top:12px;line-height:1.25;min-height:2.5em}
-  .icell .key{display:inline-flex;align-items:center;gap:5px;margin-top:4px;font-size:11px;color:var(--muted)}
-  .icell .key b{font-family:var(--font-mono);font-size:12px;color:var(--gold-ink);font-weight:400;border:1px solid var(--line);border-radius:5px;padding:1px 6px;background:var(--paper)}
+  .icell .nm{font-size:var(--t-micro);color:var(--ink);margin-top:12px;line-height:1.25;min-height:2.5em}
+  .icell .key{display:inline-flex;align-items:center;gap:5px;margin-top:4px;font-size:var(--t-micro);color:var(--muted)}
+  .icell .key b{font-family:var(--font-mono);font-size:var(--t-micro);color:var(--gold-ink);font-weight:400;border:1px solid var(--line);border-radius:5px;padding:1px 6px;background:var(--paper)}
   .icell .dl{display:flex;gap:4px;justify-content:center;margin-top:10px}
-  .icell .dl a{font-size:11px;color:var(--gold-ink);text-decoration:none;letter-spacing:.02em;padding:6px 7px;border-radius:7px;line-height:1}
+  .icell .dl a{font-size:var(--t-micro);color:var(--gold-ink);text-decoration:none;letter-spacing:.02em;padding:6px 7px;border-radius:7px;line-height:1}
   .icell .dl a:hover{text-decoration:underline;background:var(--paper)}
   .empty{color:var(--muted);font-size:14px;padding:20px 0}
 
@@ -62,10 +60,10 @@
   .panel{border:1px solid var(--line);border-radius:var(--r-card);padding:20px 22px;background:var(--paper)}
   .panel h3{font-weight:400;font-size:16px;margin:0 0 4px}
   .panel p{color:var(--muted);font-size:13.5px;line-height:1.6;margin:0 0 14px;max-width:60ch}
-  pre.code{position:relative;margin:0 0 14px;background:#1f2428;color:#e8eef2;border-radius:12px;padding:16px;overflow:auto;
-    font:12.5px/1.55 ui-monospace,Menlo,Consolas,monospace;border:1px solid var(--line)}
-  .copybtn{position:absolute;top:10px;right:10px;font:inherit;font-size:11.5px;border:1px solid #3a4148;background:#2b3137;color:#e8eef2;border-radius:8px;padding:6px 11px;cursor:pointer;min-height:32px}
-  .copybtn:hover{background:#343b42}
+  /* Konsole (Fläche/Farbe/Schrift) aus base.css pre.code – hier nur Verortung. */
+  pre.code{position:relative;margin:0 0 14px;border-radius:12px;padding:16px}
+  .copybtn{position:absolute;top:10px;right:10px;font:inherit;font-size:var(--t-micro);border:1px solid var(--code-bg2);background:var(--code-bg2);color:var(--code-ink);border-radius:8px;padding:6px 11px;cursor:pointer;min-height:32px}
+  .copybtn:hover{filter:brightness(1.25)}
   /* Live: tippen → Icons (Webfont per Taste). */
   .try{display:flex;flex-direction:column;gap:10px}
   .try .out{font-family:"G Icons";font-size:40px;line-height:1.2;color:var(--ink);min-height:52px;border:1px solid var(--line);border-radius:10px;padding:12px 14px;background:var(--soft);word-break:break-word}
@@ -73,20 +71,16 @@
   .formats{list-style:none;margin:0;padding:0}
   .formats li{display:flex;gap:10px;align-items:baseline;padding:9px 0;border-top:1px solid var(--line-soft);font-size:13.5px;color:var(--muted);line-height:1.5}
   .formats li:first-child{border-top:0}
-  .formats b{color:var(--ink);font-weight:400;min-width:42px;font-family:var(--font-mono);font-size:12.5px}
+  .formats b{color:var(--ink);font-weight:400;min-width:42px;font-family:var(--font-mono);font-size:var(--t-micro)}
 
   .dl-cards{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
   @media(max-width:820px){.dl-cards{grid-template-columns:repeat(2,1fr)}}
   @media(max-width:480px){.dl-cards{grid-template-columns:1fr}}
   .card{border:1px solid var(--line);border-radius:14px;padding:18px;display:flex;flex-direction:column;gap:8px}
   .card h3{font-weight:400;font-size:16px}.card p{color:var(--muted);font-size:13px;flex:1}
-  .btn{display:inline-block;text-decoration:none;font-size:13px;padding:11px 16px;border-radius:9px;border:1px solid var(--line);color:var(--ink);text-align:center;min-height:var(--tap);box-sizing:border-box}
-  .btn:hover{border-color:var(--gold-ink)}
-  /* Aktion = volles Blau + Weiss (kein dunkler Text auf Farbe, B01). */
-  .btn.primary{background:var(--blue-solid);border-color:var(--blue-solid);color:var(--on-accent);font-weight:var(--w-strong)}
-  .btn.primary:hover{filter:brightness(1.08)}
+  /* .btn (inkl. .primary, Hover) kommt vollständig aus base.css. */
 
-  footer{border-top:1px solid var(--line);padding:34px 0 60px;color:var(--muted);font-size:12.5px}
+  footer{border-top:1px solid var(--line);padding:34px 0 60px;color:var(--muted);font-size:var(--t-small)}
   .frow{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap}
   .frow strong{color:var(--ink);font-weight:400}
 </style>

--- a/icons.html
+++ b/icons.html
@@ -22,8 +22,8 @@
   .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
 
   /* Kicker/Titel/Lede/Chip aus base.css (Titel = Deutlich, gemessene Skala – nie Laut). */
-  .hero{padding:60px 0 14px}
-  .lede{font-family:"G Leise";max-width:600px;margin-top:var(--s4)}  /* Lede im Specimen in Leise */
+  .hero{padding-block:60px 14px}
+  .lede{max-width:600px;margin-top:var(--s4)}  /* Grösse/Schnitt/Farbe aus base.css (Klar – lesbar, nicht Leise) */
   .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:22px}
   .chip b{color:var(--gold-ink);font-weight:400}
 

--- a/schrift-vergleich.html
+++ b/schrift-vergleich.html
@@ -24,7 +24,7 @@
   body{background:var(--paper);color:var(--ink);font-family:"G Klar","Helvetica Neue",Arial,sans-serif;line-height:1.5;font-size:16.5px;-webkit-font-smoothing:antialiased}
   .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
   a{color:var(--gold-ink)}
-  .hero{padding:42px 0 4px}
+  .hero{padding-block:42px 4px}
   .kick{color:var(--gold-ink);font-size:14px;margin-bottom:10px}
   /* Überschriften aus dem Fundament. */
   .lede{font-size:17px;color:var(--muted);max-width:64ch;margin-top:12px}

--- a/schriften.html
+++ b/schriften.html
@@ -24,8 +24,8 @@
   .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
 
   /* Kicker/Lede/Chip-Aussehen aus base.css – hier nur Specimen-Besonderheiten. */
-  .hero{padding:60px 0 14px}
-  .lede{font-family:"G Leise";max-width:600px;margin-top:var(--s4)}  /* Lede im Specimen in Leise */
+  .hero{padding-block:60px 14px}
+  .lede{max-width:600px;margin-top:var(--s4)}  /* Grösse/Schnitt/Farbe aus base.css (Klar – lesbar, nicht Leise) */
   .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:22px}
   .chip b{color:var(--gold-ink);font-weight:400}
 

--- a/statistik.html
+++ b/statistik.html
@@ -16,34 +16,33 @@
   /* Farben/Schrift/Hell-Dunkel aus tokens.css/base.css – kein eigenes :root. */
   body{font-family:"G Klar","Helvetica Neue",Arial,sans-serif}
   .wrap{max-width:760px;margin:0 auto;padding:0 26px}
-  .hero{padding:48px 0 8px}
-  .kick{color:var(--gold-ink);font-size:14px;margin-bottom:14px}
-  /* Überschriften aus dem Fundament (Deutlich, gemessene Skala). */
-  .lede{font-family:"G Leise";color:var(--muted);margin-top:14px;max-width:560px}
+  .hero{padding-block:48px 8px}
+  /* Kicker/Überschriften aus dem Fundament (Deutlich, gemessene Skala). */
+  .lede{margin-top:14px;max-width:560px}  /* Grösse/Schnitt/Farbe aus base.css (Klar – lesbar) */
   section{padding:30px 0;border-top:1px solid var(--line-soft)}
   .app-h{display:flex;align-items:baseline;justify-content:space-between;gap:12px;margin-bottom:6px}
-  .app-h .meta{color:var(--muted);font-size:12.5px;white-space:nowrap}
+  .app-h .meta{color:var(--muted);font-size:var(--t-micro);white-space:nowrap}
   .cards{display:flex;gap:14px;flex-wrap:wrap;margin:14px 0 6px}
   .stat{flex:1;min-width:150px;border:1px solid var(--line);border-radius:14px;padding:18px 20px;background:var(--soft)}
   .stat .num{font-family:"G Laut";font-size:clamp(30px,6vw,46px);line-height:1;font-feature-settings:"tnum" 1}
   .stat .cap{color:var(--muted);font-size:13.5px;margin-top:8px}
-  .chart-t{color:var(--muted);font-size:12.5px;letter-spacing:.02em;margin:22px 0 4px}
+  .chart-t{color:var(--muted);font-size:var(--t-micro);letter-spacing:.02em;margin:22px 0 4px}
   .bars{display:flex;flex-direction:column;gap:11px}
   .barrow{display:grid;grid-template-columns:minmax(92px,148px) 1fr auto;gap:12px;align-items:center}
   .barrow .bl{color:var(--ink);font-size:13.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
   .bartrack{background:var(--line-soft);border-radius:7px;height:11px}
   .bartrack>span{display:block;height:11px;border-radius:7px;background:linear-gradient(90deg,var(--gold),var(--gold-ink));min-width:3px;transition:width .55s ease}
   .barval{font-feature-settings:"tnum" 1;font-size:13px;color:var(--ink);min-width:34px;text-align:right}
-  .barval .sub{color:var(--muted);font-size:11.5px;margin-left:5px}
+  .barval .sub{color:var(--muted);font-size:var(--t-micro);margin-left:5px}
   table{width:100%;border-collapse:collapse;font-size:14px;margin-top:8px}
   th,td{text-align:left;padding:10px 8px;border-bottom:1px solid var(--line-soft)}
-  th{color:var(--muted);font-weight:400;font-size:12.5px;letter-spacing:.02em}
+  th{color:var(--muted);font-weight:400;font-size:var(--t-micro);letter-spacing:.02em}
   td.n{text-align:right;font-feature-settings:"tnum" 1;color:var(--ink)}
   td.lbl{color:var(--muted)}
   .empty{color:var(--muted);font-size:14px;padding:4px 0}
   .muted{color:var(--muted);font-size:13px}
   .err{color:var(--bad);font-size:13.5px}
-  footer{border-top:1px solid var(--line);padding:30px 0 56px;color:var(--muted);font-size:12.5px;margin-top:20px}
+  footer{border-top:1px solid var(--line);padding:30px 0 56px;color:var(--muted);font-size:var(--t-small);margin-top:20px}
 </style>
 </head>
 <body>

--- a/tools/ds-lint.py
+++ b/tools/ds-lint.py
@@ -109,11 +109,16 @@ def check_colors_sizes(body, base_off, full, findings, c, skip_lines):
     warnpx = c["groessen"]["warnen_unter_px"]
     # Deklarationen ~ getrennt durch ; (Körper enthält keine { } mehr)
     off = 0
-    for decl in body.split(";"):
+    for raw in body.split(";"):
         seg_off = base_off + off
-        off += len(decl) + 1
-        if ":" not in decl:
+        off += len(raw) + 1
+        if ":" not in raw:
             continue
+        # seg_off auf den Property-Anfang rücken (führende Zeilenumbrüche/Leerraum
+        # überspringen) – sonst landet die Zeile auf dem vorigen ‹;› (Mehrzeilen-CSS).
+        lead = len(raw) - len(raw.lstrip("\n\r\t "))
+        decl = raw.strip()
+        seg_off += lead
         prop, _, val = decl.partition(":")
         p = prop.strip().lower()
         if not p or p.startswith("--"):

--- a/typografie.html
+++ b/typografie.html
@@ -30,7 +30,7 @@
   nav.top{display:flex;gap:22px}
   nav.top a{color:var(--muted);text-decoration:none;font-size:13.5px}
   nav.top a:hover{color:var(--gold-ink)}
-  .hero{padding:58px 0 8px}
+  .hero{padding-block:58px 8px}
   .kick{color:var(--gold-ink);font-size:14px;margin-bottom:14px}
   h1{text-wrap:balance}
   .lede{font-family:"G Klar";font-size:clamp(17px,2vw,20px);color:var(--muted);max-width:48ch;margin-top:14px;text-wrap:pretty}

--- a/vorschau.html
+++ b/vorschau.html
@@ -22,7 +22,7 @@
        line-height:1.55;font-size:16.5px;-webkit-font-smoothing:antialiased;hyphens:auto;-webkit-hyphens:auto}
   .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
   a{color:var(--gold-ink)}
-  .hero{padding:58px 0 8px}
+  .hero{padding-block:58px 8px}
   .kick{color:var(--gold-ink);font-size:14px;margin-bottom:14px}
   h1{text-wrap:balance}
   .lede{font-size:clamp(17px,2vw,20px);color:var(--muted);max-width:48ch;margin-top:14px;text-wrap:pretty}

--- a/werkzeug.html
+++ b/werkzeug.html
@@ -19,7 +19,7 @@
   header{border-bottom:1px solid var(--line)}
   .bar{display:flex;align-items:center;justify-content:space-between;height:56px}
   .bar b{font-weight:400}.bar a{color:var(--muted);text-decoration:none;font-size:13.5px}
-  .hero{padding:34px 0 6px}
+  .hero{padding-block:34px 6px}
   .kick{color:var(--gold-ink);font-size:13.5px;margin-bottom:10px}
   /* h1 aus dem Fundament */
   .lede{color:var(--muted);margin-top:10px;max-width:620px;font-size:15px}


### PR DESCRIPTION
## Alle öffentlichen Seiten konform + zwei ernste Befunde behoben

### Generatoren + Icons auf 100 %
Signatur, Visitenkarten, Icons → 0 Verstösse. Artefakt-Farben mit `# ds-ok` ratifiziert (gedrucktes Blatt/Karte, Schnittmarken, E-Mail-Leinwand, Owner-Mode-Signal, Modal-Scrim). Code-Konsolen auf `--code`-Tokens, `#3f7d46` → `--ok`, eigene `.btn`/`.hint`/`.kick`/`.lede`/`.chip`-Fassungen → base, sub-13px getilgt, G05-Versal (`.who`) entschärft. `icons.html`: 78px-Laut-Titel → kanonische Deutlich-Skala.

### Mobil-Rand (kritisch, Fundament)
`.hero{padding:X 0 Y}` setzte den **seitlichen Rand auf 0** und überschrieb `.wrap` — der Text klebte am Bildschirmrand. Fix: `.hero` nutzt nur noch `padding-block`, der Seitenrand kommt aus `.wrap`. **9 Seiten** mit lokalem Override nachgezogen. Mobiler `.wrap`-Rand bleibt grosszügig (`max(22px, safe-area)`).

### Lesbarkeit
Die Lede war in **G Leise (265) + muted** gesetzt — zu fein zum Lesen. Auf den Lese-Schnitt **Klar** gehoben (schriften, icons, statistik). „Leise verschwimmt klein, Minimum ist Klar."

### Engine geschärft am Bestand
- DS04 nur noch Schlüssel-Selektoren (kontextuelle Overrides frei).
- Zeilen-Treffer auf der Property-Zeile (Mehrzeilen-CSS) — `# ds-ok` greift jetzt zuverlässig in den Generatoren.

**Score: 35 % → 46 % konform.** Alle öffentlichen Seiten (Frontdoor, Logos, Schriften, Webfont, Signatur, Visitenkarten, Icons, Statistik) bei 100 %. Verifiziert hell + dunkel, Desktop + 390px-Mobil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_