### PR TITLE
Lesbarkeit/Inklusivität verankert · Icon-Darkmode · Übersetzungs-Seite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,13 @@ Für jede Web-Oberfläche gilt, geprüft (Kontraste rechnen, nicht schätzen):
   Aktion = volles Blau + Weiss. Nie Schwarz auf Farbe.
 - **B02 Kontrast** (WCAG 1.4.3/1.4.11): Lesetext ≥ **4.5:1**, grosse/fette
   Schrift und UI-/Grafik-Ränder ≥ **3:1**. `--muted` nur dort, wo es das hält.
-- **B03 Mindestgrössen mobil:** Fliesstext **≥16px** (Standard 17–19), Meta
-  **≥14px**, nichts unter 13. Eingabefelder **≥16px** (sonst zoomt iOS).
-- **B04 Fingerziele ≥44px** (`--tap`); Zeilenhöhe Lesetext ≥1.5.
+- **B03 Mindestgrössen (inklusiv, Stand 2026):** Fliesstext **≥16px**
+  (Standard **18–20**, `--t-body`), Meta/Label **≥15** (`--t-small`), nichts
+  Lesbares **unter 14** (Floor `--t-micro`). Eingabefelder **≥16px** (sonst zoomt
+  iOS). Norm: ‹bei 16 beginnen und hochskalieren› – feste px unter 14 = DS03-Fehler.
+- **B04 Fingerziele ≥44px** (`--tap`; WCAG 2.2 SC 2.5.8 fordert ≥24, wir geben 44);
+  Zeilenhöhe Lesetext **≥1.5** (`--lh-body` 1.6). Layout muss erhöhte Laufweiten
+  überstehen (WCAG 1.4.12): Container in `ch`/`%`, nicht in festen px-Höhen.
 - **B05 Hell/Dunkel** kommt allein aus den Tokens; Flächen tokenisieren
   (`--paper`/`--field-bg`/`--bar-bg`), nie `#fff` hart verdrahten.
 

--- a/apps/logos/index.html
+++ b/apps/logos/index.html
@@ -76,7 +76,7 @@
   .dl .col.ja{background:var(--soft)}
   .dl h4{display:flex;align-items:center;gap:8px;font-weight:var(--w-strong);font-size:14px;margin-bottom:var(--s2)}
   .dl .ja h4{color:var(--ok)}.dl .nein h4{color:var(--bad)}
-  .dl li{list-style:none;display:flex;gap:9px;padding:5px 0;border-top:1px solid var(--line-soft);font-size:13.5px;line-height:1.45}
+  .dl li{list-style:none;display:flex;gap:9px;padding:5px 0;border-top:1px solid var(--line-soft);font-size:var(--t-small);line-height:1.45}
   .dl .ja .mk{color:var(--ok);font-weight:var(--w-strong)}.dl .nein .mk{color:var(--bad);font-weight:var(--w-strong)}
   /* .note kommt aus base.css (kanonische Hinweis-Rolle). */
 </style>

--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -34,7 +34,7 @@
     .scroll-hint{display:block;font-size:var(--t-micro);color:var(--muted);margin-top:6px}
     .brand .wm{font-size:22px}
     nav.top{gap:14px}
-    nav.top a{font-size:13px}
+    nav.top a{font-size:var(--t-small)}
     .nav-hide-sm{display:none}
     /* iOS zoomt Felder mit Schrift < 16px beim Fokus – das verhindern */
     .field input,.field textarea,.field select{font-size:16px}
@@ -55,7 +55,7 @@
   .card.soft{background:var(--soft)}
 
   .tabs{display:inline-flex;gap:var(--s2);margin-bottom:var(--s6)}
-  .tabs button{font:inherit;font-size:13.5px;color:var(--muted);background:none;border:1px solid var(--line);border-radius:999px;padding:7px 16px;cursor:pointer;transition:.15s}
+  .tabs button{font:inherit;font-size:var(--t-small);color:var(--muted);background:none;border:1px solid var(--line);border-radius:999px;padding:7px 16px;cursor:pointer;transition:.15s}
   .tabs button[aria-pressed="true"]{color:var(--gold-ink);border-color:var(--gold)}
 
   /* Einklappbarer Abschnitt (Standards) */
@@ -68,14 +68,14 @@
   .fold-body{display:grid;gap:var(--s3);margin-top:var(--s3)}
 
   .code-details{margin-top:var(--s4)}
-  .code-details>summary{font-size:13px;color:var(--muted);cursor:pointer;list-style:none}
+  .code-details>summary{font-size:var(--t-small);color:var(--muted);cursor:pointer;list-style:none}
   .code-details>summary::-webkit-details-marker{display:none}
   .code-details>summary::before{content:"▸ ";color:var(--gold-ink)}
   .code-details[open]>summary::before{content:"▾ "}
 
   .fset{border:0;display:grid;gap:var(--s3);margin-bottom:var(--s3)}
   .field{display:grid;gap:var(--s1)}
-  .field > .lab{font-size:13px;color:var(--muted);letter-spacing:.01em}
+  .field > .lab{font-size:var(--t-small);color:var(--muted);letter-spacing:.01em}
   /* Felder: 16px (B03, kein iOS-Zoom), Fläche aus dem Token (kippt mit Hell/Dunkel). */
   .field input{
     width:100%;font-family:"Helvetica Neue",Arial,sans-serif;
@@ -102,7 +102,7 @@
   .hint ul{margin:var(--s3) 0 0;padding-left:18px;display:grid;gap:var(--s2)}
   .hint code{font-family:var(--font-mono);font-size:var(--t-micro);background:var(--soft);border:1px solid var(--line-soft);border-radius:5px;padding:1px 5px}
 
-  .stage-lab{font-size:13px;color:var(--muted);margin-bottom:var(--s3)}
+  .stage-lab{font-size:var(--t-small);color:var(--muted);margin-bottom:var(--s3)}
   .scroll-hint{display:none}
   .mail-stage{background:#fff;border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);box-shadow:0 10px 30px rgba(20,24,28,.06);overflow-x:auto}  /* # ds-ok: E-Mail-Leinwand ist immer weiss (Artefakt) */
   /* base.css setzt th,td (Padding, Rahmen) – das verfälscht die E-Mail-Tabellen der
@@ -125,7 +125,7 @@
   /* Kicker-artiges Label – normal, nicht versal (G05). */
   .choose .opt .who{color:var(--gold-ink);font-size:var(--t-micro);letter-spacing:.04em;margin-bottom:6px}
   .choose .opt h3{font-family:"Goetheanum";font-weight:680;font-size:15px;margin-bottom:6px}
-  .choose .opt p{font-size:13.5px;color:var(--muted);line-height:1.55}
+  .choose .opt p{font-size:var(--t-small);color:var(--muted);line-height:1.55}
   .guide details{border-top:1px solid var(--line-soft);padding:var(--s4) 0}
   .guide details:first-of-type{border-top:0;padding-top:0}
   .guide summary{font-family:"Goetheanum";font-weight:680;font-size:15px;cursor:pointer;list-style:none;display:flex;align-items:center;gap:var(--s2)}
@@ -136,7 +136,7 @@
   .guide ol{margin:var(--s4) 0 2px;padding-left:20px;display:grid;gap:var(--s2)}
   .guide li{font-size:14px;line-height:1.5;color:var(--ink)}
   .guide code{font-family:var(--font-mono);font-size:var(--t-micro);background:var(--soft);border:1px solid var(--line-soft);border-radius:5px;padding:1px 5px}
-  .guide .note{font-size:13px;color:var(--muted);line-height:1.5;margin-top:6px}
+  .guide .note{font-size:var(--t-small);color:var(--muted);line-height:1.5;margin-top:6px}
   .guide a{color:var(--gold-ink);text-decoration:none}
   .guide a:hover{text-decoration:underline}
 

--- a/apps/visitenkarten-generator/index.html
+++ b/apps/visitenkarten-generator/index.html
@@ -454,7 +454,7 @@
     /* Abschnittstitel = Kicker (getönt, normal – nicht versal, G05). */
     .fieldset-title {
       font-family: var(--font-display); color: var(--gold-ink);
-      font-size: 13.5px; letter-spacing: .03em; font-weight: var(--w-text); line-height: 1;
+      font-size:var(--t-small); letter-spacing: .03em; font-weight: var(--w-text); line-height: 1;
     }
 
     .row { display: grid; gap: var(--s1); }

--- a/assets/goe-terms.js
+++ b/assets/goe-terms.js
@@ -21,27 +21,28 @@ const GOE_TERMS = {
   "aag": {
     de: "Allgemeine Anthroposophische Gesellschaft",
     en: "General Anthroposophical Society",
-    fr: "Société anthroposophique universelle",
+    fr: "Société anthroposophique générale",
     es: "Sociedad Antroposófica General",
-    status: "pruefen", note: "de/en aus den Werkzeugen bestätigt; fr/es offizielle Namen – prüfen."
+    status: "pruefen",
+    note: "de/en/fr bestätigt auf goetheanum.ch. es: goetheanum.ch/es nutzt teils ‹Sociedad Antroposófica mundial› – ‹General› ist die geläufige Form; bitte ratifizieren."
   },
   "hochschule": {
     de: "Freie Hochschule für Geisteswissenschaft",
     en: "School of Spiritual Science",
-    fr: "École de science de l’esprit",
+    fr: "Université libre de science de l’esprit",
     es: "Escuela de Ciencia Espiritual",
-    status: "pruefen", note: "de/en bestätigt; fr/es prüfen."
+    status: "fest", note: "Alle vier auf goetheanum.ch bestätigt (en/fr/es-Sprachversionen)."
   },
   "geisteswissenschaft": {
     de: "Geisteswissenschaft",
     en: "Spiritual Science",
-    fr: "Science de l’esprit",
+    fr: "science de l’esprit",
     es: "Ciencia Espiritual",
-    status: "pruefen", note: "de/en bestätigt; fr/es prüfen."
+    status: "fest", note: "Auf goetheanum.ch bestätigt."
   },
   "sektion": {
     de: "Sektion", en: "Section", fr: "Section", es: "Sección",
-    status: "fest"
+    status: "fest", note: "Sektionsbezeichnung auf goetheanum.ch bestätigt."
   },
   "vorstand": {
     de: "Vorstand", en: "Executive Board", fr: "Comité directeur", es: "Junta directiva",

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -56,6 +56,25 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
   korrigierbar. Befund dabei: die Visitenkarten-App trägt eine **abgewichene
   Kopie** der Tabelle – Konsolidierung (einbinden statt kopieren) steht an.
 
+### Lesbarkeit & Inklusivität fest verankert (recherchiert, Stand 2026)
+- **Typo-Skala einen Schritt grösser**: Floor 13→**14px**, Meta/Label 14→**15–16**
+  (`--t-small`), Fliesstext 17→**18–20** (`--t-body`), Lede 19→**20–23**. Grund:
+  16px ist die Norm-Untergrenze, Best Practice ‹bei 16 beginnen, hochskalieren›
+  (WCAG resize 1.4.4; rem-basiert). Contract-Floor (DS03) 13→14 nachgezogen; die
+  literalen 13px der öffentlichen Seiten auf `--t-small` gehoben.
+- **B04**: Bezug auf WCAG 2.2 SC 2.5.8 (Ziel ≥24px, wir geben 44) und 1.4.12
+  (Layout übersteht erhöhte Laufweiten) in den Hausregeln verankert.
+- **Icons im Dunkelmodus**: schwarze Strich-Icons als `<img>` wurden verschluckt.
+  Utility `.ico-invert` (Filter im Dunkelmodus) ins Fundament; auf die Schriften-
+  Icons angewandt. Besser noch: Icons als Webfont/Inline-SVG mit currentColor.
+
+### Neue Quelle & Werkzeug
+- **`assets/goe-terms.js`** (Begriffe & Übersetzungen) – auf goetheanum.ch
+  geprüft: fr/es korrigiert (Hochschule = ‹Université libre de science de
+  l’esprit›, Gesellschaft = ‹Société anthroposophique générale›), verifizierte
+  Zeilen auf `fest`. Neue Seite **uebersetzungen.html** (durchsuchbar, klick-
+  kopierbar, für die Sekretariate) + Eintrag in `tools.json` (Startkarte).
+
 ### Behoben (Mobil & Lesbarkeit – aus echtem Geräte-Befund)
 - **Seitenrand am Handy** war weg: `.hero{padding:X 0 Y}` setzte den seitlichen
   Rand auf 0 und überschrieb `.wrap` – Text klebte am Glas. Fundament-Fix:

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -224,6 +224,11 @@ td.num,th.num,.num{font-variant-numeric:tabular-nums lining-nums;text-align:righ
    skaliert ohnehin fluid (rem-Clamps); hier nur Touch- und Layout-Garantien.
    ============================================================================= */
 img,svg,canvas,video{max-width:100%}
+/* Einfarbige (schwarze) Strich-Icons als <img> folgen dem Theme: im Dunkelmodus
+   umkehren, sonst werden sie vom dunklen Grund verschluckt. Opt-in (.ico-invert),
+   weil es nur für monochrome Marken/Piktogramme gilt – nicht für Fotos/Farblogos.
+   Besser noch: Icons als Webfont/Inline-SVG mit currentColor setzen (folgt von selbst). */
+:root[data-theme="dark"] .ico-invert{filter:invert(1) brightness(.92)}
 @media(max-width:560px){
   /* Mobil bleibt der seitliche Rand grosszügig (Luft nach aussen, Lesbarkeit) –
      nicht verkleinern. 22px Untergrenze, damit Text nie am Glas klebt. */

--- a/design-system/contract.json
+++ b/design-system/contract.json
@@ -30,12 +30,12 @@
 
   "groessen": {
     "ds_id": "DS03",
-    "regel": "Keine lesbare Schrift unter den B03-Untergrenzen. font-size in px: Fliesstext ≥16, Meta/Label ≥14, nichts Lesbares <13.",
-    "untergrenze_px": 13,
-    "warnen_unter_px": 13,
+    "regel": "Keine lesbare Schrift unter den Untergrenzen (Stand 2026, inklusiv). font-size in px: Fliesstext ≥18, Meta/Label ≥15, nichts Lesbares <14.",
+    "untergrenze_px": 14,
+    "warnen_unter_px": 14,
     "schwere": "fehler",
     "warn_schwere": "hinweis",
-    "hinweis": "B03 exakt: <13px = fehler. 13px ist erlaubt (=--t-micro). Bevorzugt die fluiden Skala-Tokens (--t-body/--t-small/--t-micro/--t-lede/--t-h*) statt fester px."
+    "hinweis": "Floor von 13 auf 14 angehoben (16px-Norm ‹bei 16 beginnen, hochskalieren›). 14px erlaubt (=--t-micro). Bevorzugt die fluiden Skala-Tokens (--t-body/--t-small/--t-micro/--t-lede/--t-h*) statt fester px."
   },
 
   "rollen": {

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -38,10 +38,10 @@
   /* Schnitt-Zeile */
   .cut{border-top:1px solid var(--line-soft);padding:var(--s4) 0;display:grid;gap:6px;grid-template-columns:1fr;align-items:baseline}
   @media(min-width:760px){.cut{grid-template-columns:170px 1fr}}
-  .cut .nm{font-size:13px;color:var(--muted)}
+  .cut .nm{font-size:var(--t-small);color:var(--muted)}
   .cut .nm b{color:var(--ink);font-weight:var(--w-strong)}
   .cut .samp{font-size:clamp(22px,3.4vw,30px);line-height:1.1}
-  .cut .ds{grid-column:1/-1;color:var(--muted);font-size:13px;max-width:64ch}
+  .cut .ds{grid-column:1/-1;color:var(--muted);font-size:var(--t-small);max-width:64ch}
   .cut .grafik{color:var(--gold-ink)}
 
   /* Regeln */
@@ -54,7 +54,7 @@
   /* Abstands-Balken */
   .scale .row{display:flex;align-items:center;gap:var(--s4);padding:6px 0}
   .scale .bar{height:16px;background:var(--gold);border-radius:4px}
-  .scale .lab{width:96px;color:var(--muted);font-size:13px;font-variant-numeric:tabular-nums}
+  .scale .lab{width:96px;color:var(--muted);font-size:var(--t-small);font-variant-numeric:tabular-nums}
   .radii{display:flex;gap:var(--s4);flex-wrap:wrap}
   .radii .r{width:120px;height:80px;background:var(--soft);border:1px solid var(--line)}
   .radii .cap{color:var(--muted);font-size:var(--t-micro);margin-top:6px}
@@ -83,11 +83,11 @@
   .guard .dot{width:10px;height:10px;border-radius:var(--r-pill);background:var(--muted)}
   .guard.ok .dot{background:var(--ok)}
   .guard.bad .dot{background:var(--bad)}
-  .guard .detail{margin-top:var(--s2);color:var(--muted);font-size:13px;line-height:1.5}
-  .guard table{margin-top:var(--s3);width:100%;font-size:13px}
+  .guard .detail{margin-top:var(--s2);color:var(--muted);font-size:var(--t-small);line-height:1.5}
+  .guard table{margin-top:var(--s3);width:100%;font-size:var(--t-small)}
 
   /* .note kommt aus base.css (kanonische Hinweis-Rolle) – hier keine Eigenfassung. */
-  .toast{position:fixed;left:50%;bottom:24px;transform:translateX(-50%);background:var(--ink);color:var(--on-accent);padding:8px 16px;border-radius:var(--r-pill);font-size:13px;opacity:0;transition:opacity .2s;pointer-events:none;z-index:60}
+  .toast{position:fixed;left:50%;bottom:24px;transform:translateX(-50%);background:var(--ink);color:var(--on-accent);padding:8px 16px;border-radius:var(--r-pill);font-size:var(--t-small);opacity:0;transition:opacity .2s;pointer-events:none;z-index:60}
   .toast.show{opacity:1}
 </style>
 </head>

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -95,15 +95,19 @@
   /* --- Schnitte (Goetheanum Variable) ------------------------------------- */
   --w-leise:265; --w-text:440; --w-deutlich:580; --w-strong:680;
 
-  /* --- Typo-Skala (mobil-first, flüssig, nie zu klein) -------------------- */
-  /* Grund in rem → respektiert die Browser-Schriftgröße der Nutzer (Zugänglichkeit). */
-  --t-micro:0.8125rem;                                   /* 13px – nur Beiwerk (Status, Badges) */
-  --t-small:clamp(0.875rem, 0.84rem + 0.18vw, 0.9375rem);/* 14–15px – Meta, Legenden */
-  --t-body:clamp(1.0625rem, 1.01rem + 0.28vw, 1.1875rem);/* 17–19px – Fliesstext */
-  --t-lede:clamp(1.1875rem, 1.08rem + 0.5vw, 1.375rem);  /* 19–22px – Lede */
-  --t-h3:clamp(1.1875rem, 1.08rem + 0.5vw, 1.375rem);    /* 19–22px */
-  --t-h2:clamp(1.375rem, 1.22rem + 0.8vw, 1.7rem);       /* 22–27px – maßvoll */
-  --t-h1:clamp(1.75rem, 1.45rem + 1.5vw, 2.4rem);        /* 28–38px – kein Plakat */
+  /* --- Typo-Skala (mobil-first, flüssig, inklusiv) ------------------------ */
+  /* Grund in rem → respektiert die Browser-Schriftgröße der Nutzer (WCAG resize,
+     1.4.4). Stand der Erkenntnis 2026: 16px ist das Minimum für Fliesstext, Norm
+     ist ‹bei 16 beginnen und hochskalieren›. Darum: Fliesstext 18–20, Lede 20–23,
+     Beiwerk nie unter 14 (Floor von 13 auf 14 angehoben). Zeilenhöhe ≥1.5 (1.4.12),
+     Klick-/Tippziele ≥24px (2.5.8; wir nutzen 44px, --tap). */
+  --t-micro:0.875rem;                                    /* 14px – Floor, nur Beiwerk (Status, Badges) */
+  --t-small:clamp(0.9375rem, 0.9rem + 0.18vw, 1rem);     /* 15–16px – Meta, Label, Hinweis */
+  --t-body:clamp(1.125rem, 1.06rem + 0.3vw, 1.25rem);    /* 18–20px – Fliesstext */
+  --t-lede:clamp(1.25rem, 1.15rem + 0.45vw, 1.45rem);    /* 20–23px – Lede */
+  --t-h3:clamp(1.25rem, 1.15rem + 0.45vw, 1.45rem);      /* 20–23px */
+  --t-h2:clamp(1.45rem, 1.28rem + 0.8vw, 1.8rem);        /* 23–29px – maßvoll */
+  --t-h1:clamp(1.85rem, 1.5rem + 1.55vw, 2.45rem);       /* 30–39px – kein Plakat */
   --lh-body:1.6; --lh-tight:1.15;
   --measure:62ch;        /* ~66 Zeichen in Source – lineares Lesemaß (G10) */
 

--- a/icons.html
+++ b/icons.html
@@ -35,7 +35,7 @@
   /* Werkzeugleiste: Gruppen-Reiter + Suche */
   .toolbar{display:flex;align-items:center;gap:14px;margin-bottom:18px;flex-wrap:wrap}
   .tabs{display:flex;gap:8px;flex-wrap:wrap}
-  .tabs button{font:inherit;font-size:13px;color:var(--muted);background:none;border:1px solid var(--line);border-radius:999px;padding:7px 14px;cursor:pointer;min-height:var(--tap)}
+  .tabs button{font:inherit;font-size:var(--t-small);color:var(--muted);background:none;border:1px solid var(--line);border-radius:999px;padding:7px 14px;cursor:pointer;min-height:var(--tap)}
   .tabs button.on{color:var(--gold-ink);border-color:var(--gold)}
   .search{flex:1;min-width:180px;display:flex;align-items:center;gap:8px;border:1px solid var(--line);border-radius:var(--r-control);padding:0 12px;background:var(--field-bg)}
   .search input{flex:1;border:0;background:none;color:var(--ink);font:inherit;font-size:16px;padding:11px 0;outline:none;min-height:var(--tap)}
@@ -59,7 +59,7 @@
   @media(min-width:820px){.use{grid-template-columns:1fr 1fr}}
   .panel{border:1px solid var(--line);border-radius:var(--r-card);padding:20px 22px;background:var(--paper)}
   .panel h3{font-weight:400;font-size:16px;margin:0 0 4px}
-  .panel p{color:var(--muted);font-size:13.5px;line-height:1.6;margin:0 0 14px;max-width:60ch}
+  .panel p{color:var(--muted);font-size:var(--t-small);line-height:1.6;margin:0 0 14px;max-width:60ch}
   /* Konsole (Fläche/Farbe/Schrift) aus base.css pre.code – hier nur Verortung. */
   pre.code{position:relative;margin:0 0 14px;border-radius:12px;padding:16px}
   .copybtn{position:absolute;top:10px;right:10px;font:inherit;font-size:var(--t-micro);border:1px solid var(--code-bg2);background:var(--code-bg2);color:var(--code-ink);border-radius:8px;padding:6px 11px;cursor:pointer;min-height:32px}
@@ -69,7 +69,7 @@
   .try .out{font-family:"G Icons";font-size:40px;line-height:1.2;color:var(--ink);min-height:52px;border:1px solid var(--line);border-radius:10px;padding:12px 14px;background:var(--soft);word-break:break-word}
   .try input{font:inherit;font-size:16px;color:var(--ink);border:1px solid var(--line);border-radius:var(--r-control);padding:11px 14px;background:var(--field-bg);min-height:var(--tap)}
   .formats{list-style:none;margin:0;padding:0}
-  .formats li{display:flex;gap:10px;align-items:baseline;padding:9px 0;border-top:1px solid var(--line-soft);font-size:13.5px;color:var(--muted);line-height:1.5}
+  .formats li{display:flex;gap:10px;align-items:baseline;padding:9px 0;border-top:1px solid var(--line-soft);font-size:var(--t-small);color:var(--muted);line-height:1.5}
   .formats li:first-child{border-top:0}
   .formats b{color:var(--ink);font-weight:400;min-width:42px;font-family:var(--font-mono);font-size:var(--t-micro)}
 
@@ -77,7 +77,7 @@
   @media(max-width:820px){.dl-cards{grid-template-columns:repeat(2,1fr)}}
   @media(max-width:480px){.dl-cards{grid-template-columns:1fr}}
   .card{border:1px solid var(--line);border-radius:14px;padding:18px;display:flex;flex-direction:column;gap:8px}
-  .card h3{font-weight:400;font-size:16px}.card p{color:var(--muted);font-size:13px;flex:1}
+  .card h3{font-weight:400;font-size:16px}.card p{color:var(--muted);font-size:var(--t-small);flex:1}
   /* .btn (inkl. .primary, Hover) kommt vollständig aus base.css. */
 
   footer{border-top:1px solid var(--line);padding:34px 0 60px;color:var(--muted);font-size:var(--t-small)}
@@ -136,7 +136,7 @@
 .icon{ font-family:"Goetheanum Icons"; }
 /* &lt;span class="icon"&gt;h&lt;/span&gt; → Bioabfall */</code></pre>
         <div class="try">
-          <label class="lab" for="tryin" style="font-size:13px;color:var(--muted)">Selbst probieren – Buchstaben tippen:</label>
+          <label class="lab" for="tryin" style="font-size:var(--t-small);color:var(--muted)">Selbst probieren – Buchstaben tippen:</label>
           <input id="tryin" type="text" value="heafu" autocomplete="off" autocapitalize="off" spellcheck="false" aria-label="Tasten eingeben" />
           <div class="out" id="tryout" aria-hidden="true">heafu</div>
         </div>
@@ -168,7 +168,7 @@
       <div class="card"><h3>Beipackzettel</h3><p>Übersicht und vollständige Tastatur-Belegung der Icons.</p>
         <a class="btn" href="assets/fonts/goetheanum/Beipackzettel-Goetheanum-Schriften.pdf" download>PDF</a></div>
     </div>
-    <p style="margin-top:18px;font-size:13px;color:var(--muted)">
+    <p style="margin-top:18px;font-size:var(--t-small);color:var(--muted)">
       <b style="color:var(--ink);font-weight:400">Teil der Hausschrift:</b> Die Icons stecken auch im Komplettpaket der
       <a style="color:var(--gold-ink)" href="schriften.html">Goetheanum Schriften</a>. Lizenz: <a style="color:var(--gold-ink)" href="assets/fonts/goetheanum/OFL.txt">SIL Open Font License 1.1</a>.
     </p>

--- a/index.html
+++ b/index.html
@@ -60,6 +60,9 @@
   .tile .sw i{width:20px;height:20px;border-radius:5px;display:block}
   /* Icons: drei Piktogramme aus dem Icon-Webfont (currentColor – folgt Hell/Dunkel) */
   .tile .icons{font-family:"G Icons";font-size:36px;line-height:1;color:var(--ink);display:flex;gap:14px}
+  /* Übersetzungen: vier Sprach-Marken */
+  .tile .tr{display:flex;gap:6px;flex-wrap:wrap;justify-content:center}
+  .tile .tr i{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:15px;font-style:normal;color:var(--ink);border:1px solid var(--line);border-radius:6px;padding:3px 9px}
 </style>
 </head>
 <body>
@@ -92,7 +95,8 @@
     "icons":           '<span class="icons" aria-hidden="true">gfx</span>',                     // drei Piktogramme (WLAN · Garderobe · Rollstuhl)
     "schrift-webfont": '<span class="win"><b></b><em>Aa</em></span>',                          // Schrift im Browser-Fenster
     "typografie":      '<span class="para"><i></i><i></i><i></i><i></i></span>',               // gesetzter Absatz
-    "design-system":   '<span class="sw"><i style="background:var(--blue)"></i><i style="background:var(--gold-deep)"></i><i style="background:var(--ink)"></i></span>' // Farbfelder
+    "design-system":   '<span class="sw"><i style="background:var(--blue)"></i><i style="background:var(--gold-deep)"></i><i style="background:var(--ink)"></i></span>', // Farbfelder
+    "uebersetzungen":  '<span class="tr"><i>DE</i><i>EN</i><i>FR</i><i>ES</i></span>' // vier Sprachen
   };
   function visual(t){
     var v = VISUAL[t.slug] || ('<span class="spec">' + (t.title || "?").slice(0, 1) + '</span>');

--- a/schriften.html
+++ b/schriften.html
@@ -55,14 +55,14 @@
   .cut .vtag{font-size:var(--t-micro);color:var(--gold-ink);border:1px solid var(--gold);border-radius:6px;padding:2px 6px}
   .office{display:flex;align-items:center;gap:14px;margin-top:24px;padding:14px 18px;border:1px solid var(--line);border-radius:12px;background:var(--soft);font-size:14px;color:var(--muted)}
   .office>span{flex:1}.office b{color:var(--ink);font-weight:400}
-  .office::before{content:"⌘B ⌘I";font-size:13px;color:var(--gold-ink);border:1px solid var(--gold);border-radius:7px;padding:4px 8px;white-space:nowrap}
+  .office::before{content:"⌘B ⌘I";font-size:var(--t-small);color:var(--gold-ink);border:1px solid var(--gold);border-radius:7px;padding:4px 8px;white-space:nowrap}
 
   .glyph{font-size:clamp(19px,2.8vw,26px);line-height:1.7;color:var(--ink)}
   .new{display:inline-flex;gap:5px;flex-wrap:wrap;margin-top:14px}
   .new span{border:1px solid var(--line);border-radius:8px;min-width:40px;height:40px;display:inline-flex;align-items:center;justify-content:center;font-size:20px}
 
   .tabs{display:flex;gap:8px;margin-bottom:18px}
-  .tabs button{font:inherit;font-size:13px;color:var(--muted);background:none;border:1px solid var(--line);border-radius:999px;padding:6px 14px;cursor:pointer}
+  .tabs button{font:inherit;font-size:var(--t-small);color:var(--muted);background:none;border:1px solid var(--line);border-radius:999px;padding:6px 14px;cursor:pointer}
   .tabs button.on{color:var(--gold-ink);border-color:var(--gold)}
   .igrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(116px,1fr));gap:10px}
   .icell{position:relative;border:1px solid var(--line-soft);border-radius:12px;padding:14px 8px 10px;background:var(--soft);text-align:center;transition:border-color .15s,background .15s}
@@ -79,7 +79,7 @@
   @media(max-width:820px){.dl-cards{grid-template-columns:repeat(2,1fr)}}
   @media(max-width:480px){.dl-cards{grid-template-columns:1fr}}
   .card{border:1px solid var(--line);border-radius:14px;padding:18px;display:flex;flex-direction:column;gap:8px}
-  .card h3{font-weight:400;font-size:16px}.card p{color:var(--muted);font-size:13px;flex:1}
+  .card h3{font-weight:400;font-size:16px}.card p{color:var(--muted);font-size:var(--t-small);flex:1}
   /* .btn (inkl. .primary, Hover) kommt vollständig aus base.css. */
 
   .webgrid{display:grid;grid-template-columns:1fr;gap:18px;align-items:start}
@@ -97,10 +97,10 @@
   .feat[open] summary::after{content:"–"}
   .feat[open] summary{border-bottom:1px solid var(--line-soft)}
   .featbody{padding:14px 18px 20px}
-  .featbody p{color:var(--muted);font-size:13.5px;max-width:62ch;margin:0 0 12px}
+  .featbody p{color:var(--muted);font-size:var(--t-small);max-width:62ch;margin:0 0 12px}
   .demo{font-size:clamp(22px,3.6vw,30px);line-height:1.5;color:var(--ink)}
   .glyphover{margin-top:22px;border:1px solid var(--line);border-radius:12px;padding:18px;background:var(--soft)}
-  .goh{font-size:13px;color:var(--muted);margin-bottom:12px}
+  .goh{font-size:var(--t-small);color:var(--muted);margin-bottom:12px}
   .gohrow{display:flex;flex-wrap:wrap;gap:8px}
   .gohrow span{min-width:52px;height:52px;border:1px solid var(--line);border-radius:9px;background:var(--paper);
     display:inline-flex;align-items:center;justify-content:center;font-size:26px}
@@ -254,7 +254,7 @@ body{ font-family:"Goetheanum", system-ui, sans-serif; }
 .frei{ font-variation-settings:"wght" 520 }  /* stufenlos */</code></pre>
       <div class="webaside">
         <p style="margin:0 0 12px">Schnitte über die Achse: <b>Flüstern 190 · Leise 265 · Klar 440 · Deutlich 580 · Laut 680 · Schreien 725</b> – dazwischen alles stufenlos.</p>
-        <p style="margin:0 0 16px;font-size:13px;color:var(--muted)">Lädt cross-origin von GitHub Pages. Für volle Kontrolle die Dateien aus dem Webfont-Ordner selbst hosten und die URLs umbiegen.</p>
+        <p style="margin:0 0 16px;font-size:var(--t-small);color:var(--muted)">Lädt cross-origin von GitHub Pages. Für volle Kontrolle die Dateien aus dem Webfont-Ordner selbst hosten und die URLs umbiegen.</p>
         <a class="btn primary" href="schrift-webfont.html">Demo &amp; Code-Schnipsel</a>
       </div>
     </div>
@@ -273,7 +273,7 @@ body{ font-family:"Goetheanum", system-ui, sans-serif; }
       <div class="card"><h3>Beipackzettel</h3><p>Übersicht, Ligaturen &amp; Sonderzeichen, Tastatur-Belegung der Icons.</p>
         <a class="btn" href="assets/fonts/goetheanum/Beipackzettel-Goetheanum-Schriften.pdf" download>PDF</a></div>
     </div>
-    <p style="margin-top:18px;font-size:13px;color:var(--muted)">
+    <p style="margin-top:18px;font-size:var(--t-small);color:var(--muted)">
       <b style="color:var(--ink);font-weight:400">Installieren (macOS):</b> ZIP entpacken → Doppelklick auf eine <code>.otf</code> → ‹Installieren›.
       Ausführliche Schritt-für-Schritt-Anleitung: <a style="color:var(--gold-ink)" href="https://support.apple.com/de-de/guide/font-book/fntbk1000/mac">Apple Schriftsammlung</a>.
       Fürs Office reichen Leise, Klar, Deutlich, Laut – ⌘B holt Laut, ⌘I holt Leise.
@@ -317,7 +317,7 @@ body{ font-family:"Goetheanum", system-ui, sans-serif; }
         var slug=it[0],label=it[1];
         var cell=document.createElement('div');cell.className='icell';
         cell.innerHTML=
-          '<img class="gl" src="'+BASE+'svg/'+slug+'.svg" alt="'+label+'" loading="lazy">'+
+          '<img class="gl ico-invert" src="'+BASE+'svg/'+slug+'.svg" alt="'+label+'" loading="lazy">'+
           '<div class="nm">'+label+'</div>'+
           '<div class="dl">'+
             '<a download href="'+BASE+'svg/'+slug+'.svg">SVG</a>'+

--- a/statistik.html
+++ b/statistik.html
@@ -25,14 +25,14 @@
   .cards{display:flex;gap:14px;flex-wrap:wrap;margin:14px 0 6px}
   .stat{flex:1;min-width:150px;border:1px solid var(--line);border-radius:14px;padding:18px 20px;background:var(--soft)}
   .stat .num{font-family:"G Laut";font-size:clamp(30px,6vw,46px);line-height:1;font-feature-settings:"tnum" 1}
-  .stat .cap{color:var(--muted);font-size:13.5px;margin-top:8px}
+  .stat .cap{color:var(--muted);font-size:var(--t-small);margin-top:8px}
   .chart-t{color:var(--muted);font-size:var(--t-micro);letter-spacing:.02em;margin:22px 0 4px}
   .bars{display:flex;flex-direction:column;gap:11px}
   .barrow{display:grid;grid-template-columns:minmax(92px,148px) 1fr auto;gap:12px;align-items:center}
-  .barrow .bl{color:var(--ink);font-size:13.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .barrow .bl{color:var(--ink);font-size:var(--t-small);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
   .bartrack{background:var(--line-soft);border-radius:7px;height:11px}
   .bartrack>span{display:block;height:11px;border-radius:7px;background:linear-gradient(90deg,var(--gold),var(--gold-ink));min-width:3px;transition:width .55s ease}
-  .barval{font-feature-settings:"tnum" 1;font-size:13px;color:var(--ink);min-width:34px;text-align:right}
+  .barval{font-feature-settings:"tnum" 1;font-size:var(--t-small);color:var(--ink);min-width:34px;text-align:right}
   .barval .sub{color:var(--muted);font-size:var(--t-micro);margin-left:5px}
   table{width:100%;border-collapse:collapse;font-size:14px;margin-top:8px}
   th,td{text-align:left;padding:10px 8px;border-bottom:1px solid var(--line-soft)}
@@ -40,8 +40,8 @@
   td.n{text-align:right;font-feature-settings:"tnum" 1;color:var(--ink)}
   td.lbl{color:var(--muted)}
   .empty{color:var(--muted);font-size:14px;padding:4px 0}
-  .muted{color:var(--muted);font-size:13px}
-  .err{color:var(--bad);font-size:13.5px}
+  .muted{color:var(--muted);font-size:var(--t-small)}
+  .err{color:var(--bad);font-size:var(--t-small)}
   footer{border-top:1px solid var(--line);padding:30px 0 56px;color:var(--muted);font-size:var(--t-small);margin-top:20px}
 </style>
 </head>

--- a/tools.json
+++ b/tools.json
@@ -1,62 +1,358 @@
 {
   "$description": "Manifest aller Goetheanum-Grafik-Werkzeuge. Einzige Quelle für Front door (/) und internen Hub (start/). Neues Werkzeug = ein Eintrag hier. Pfade root-relativ; jede Oberfläche löst ihre Basis selbst auf (Hub voran './../', Front door ''). Externe Links (https) bleiben unverändert.",
   "status": {
-    "live":    "Im Einsatz, gepflegt",
-    "beta":    "Nutzbar, in Überarbeitung",
+    "live": "Im Einsatz, gepflegt",
+    "beta": "Nutzbar, in Überarbeitung",
     "entwurf": "Grober Entwurf",
     "geparkt": "Konzept, später"
   },
   "categories": [
-    { "id": "system",       "title": "Design-System", "intro": "Das Fundament – Farben, Schrift, Regeln und Komponenten. Hier nachschlagen und von hier aus neue Werkzeuge bauen." },
-    { "id": "generatoren",  "title": "Werkzeuge", "intro": "Eigene Angaben eintragen, fertiges Ergebnis übernehmen. Für den täglichen Gebrauch." },
-    { "id": "schrift",      "title": "Schrift & Typografie", "intro": "Die Hausschrift v2.6 und die Regeln dazu – nachschlagen, vergleichen, einbinden." },
-    { "id": "vorbereitung", "title": "In Vorbereitung", "intro": "In Arbeit – noch nicht für die Breite freigegeben. Intern sichtbar." },
-    { "id": "ligaturen",    "title": "Ligaturen", "intro": "Die Kiste nur für die Ligaturen – Werkschau, Überlagerung, Abstände." },
-    { "id": "schriftpflege","title": "Schriftpflege", "intro": "Begleit-Grotesk, Gewichte und Mischsatz prüfen und kalibrieren." },
-    { "id": "statistik",    "title": "Statistik", "intro": "Nutzungszahlen aller Werkzeuge – nur der Gebrauch legitimiert den Bau." },
-    { "id": "schau",        "title": "Schau & Mockups", "intro": "Präsentations-Mockups und Studien – kein öffentliches Werkzeug." },
-    { "id": "geparkt",      "title": "Geparkte Projekte", "intro": "Durchdachte Konzepte, die später kommen – zum schnellen Einsehen der Spezifikation." },
-    { "id": "archiv",       "title": "Archiv", "intro": "Frühere Stände – eingefroren zum Nachschlagen, nicht gepflegt." }
+    {
+      "id": "system",
+      "title": "Design-System",
+      "intro": "Das Fundament – Farben, Schrift, Regeln und Komponenten. Hier nachschlagen und von hier aus neue Werkzeuge bauen."
+    },
+    {
+      "id": "generatoren",
+      "title": "Werkzeuge",
+      "intro": "Eigene Angaben eintragen, fertiges Ergebnis übernehmen. Für den täglichen Gebrauch."
+    },
+    {
+      "id": "schrift",
+      "title": "Schrift & Typografie",
+      "intro": "Die Hausschrift v2.6 und die Regeln dazu – nachschlagen, vergleichen, einbinden."
+    },
+    {
+      "id": "vorbereitung",
+      "title": "In Vorbereitung",
+      "intro": "In Arbeit – noch nicht für die Breite freigegeben. Intern sichtbar."
+    },
+    {
+      "id": "ligaturen",
+      "title": "Ligaturen",
+      "intro": "Die Kiste nur für die Ligaturen – Werkschau, Überlagerung, Abstände."
+    },
+    {
+      "id": "schriftpflege",
+      "title": "Schriftpflege",
+      "intro": "Begleit-Grotesk, Gewichte und Mischsatz prüfen und kalibrieren."
+    },
+    {
+      "id": "statistik",
+      "title": "Statistik",
+      "intro": "Nutzungszahlen aller Werkzeuge – nur der Gebrauch legitimiert den Bau."
+    },
+    {
+      "id": "schau",
+      "title": "Schau & Mockups",
+      "intro": "Präsentations-Mockups und Studien – kein öffentliches Werkzeug."
+    },
+    {
+      "id": "geparkt",
+      "title": "Geparkte Projekte",
+      "intro": "Durchdachte Konzepte, die später kommen – zum schnellen Einsehen der Spezifikation."
+    },
+    {
+      "id": "archiv",
+      "title": "Archiv",
+      "intro": "Frühere Stände – eingefroren zum Nachschlagen, nicht gepflegt."
+    }
   ],
   "tools": [
-    { "slug": "design-system",     "cat": "system",      "status": "beta",    "tag": "Fundament",     "title": "Design-System",      "href": "design-system/",               "desc": "Farben, Schnitte, Typografie-Regeln und Komponenten – die lebende Schauseite, aus einer Quelle gerendert. Mit Starter und Bau-Workflow." },
-
-    { "slug": "logo-generator",    "cat": "generatoren", "status": "live",    "tag": "Logo",          "title": "Logos",              "short": "Logos",         "href": "apps/logos/",                   "desc": "Sektions-, Bereichs- und Medienlogos in der Hausschrift – erklärt, mit Regeln, korrekt gesetzt und zum Herunterladen." },
-    { "slug": "visitenkarten",     "cat": "generatoren", "status": "live",    "tag": "Visitenkarten", "title": "Visitenkarten",      "short": "Visitenkarten", "href": "apps/visitenkarten-generator/", "desc": "Einheitliche Visitenkarten aus den eigenen Angaben – druckfertig, ohne Layoutprogramm." },
-    { "slug": "signatur",          "cat": "generatoren", "status": "live",    "tag": "E-Mail",        "title": "Signatur",           "short": "Signatur",      "href": "apps/signatur-generator/",      "desc": "Outlook-robuste E-Mail-Signatur nach gemeinsamer Vorlage – kopieren und einsetzen." },
-    { "slug": "gtv-naming",        "cat": "schau",       "status": "beta",    "tag": "Goetheanum TV", "title": "Namens-Renderings",  "short": "GTV-Namen",     "href": "apps/gtv-naming/",              "desc": "Mockup zur Vorbereitung der Goetheanum-TV-Umbenennung – kein öffentliches Werkzeug, eigene Welt." },
-    { "slug": "karten",            "cat": "vorbereitung", "status": "entwurf", "tag": "Campus",        "title": "Kartentool",         "short": "Karten",        "href": "apps/karten-generator/",        "desc": "Lagepläne des Goetheanum-Geländes zusammenstellen und im Hausbild ausgeben." },
-    { "slug": "cover",             "cat": "vorbereitung", "status": "entwurf", "tag": "Goetheanum TV", "title": "Cover-Generator",    "short": "Cover",         "href": "apps/cover-generator/",         "desc": "Einheitliche Cover-Bilder für Goetheanum-TV-Beiträge – Titel eintragen, Bild laden." },
-    { "slug": "briefschaften",     "cat": "vorbereitung", "status": "entwurf", "tag": "Korrespondenz", "title": "Briefschaften",      "short": "Briefe",        "href": "apps/briefschaften/",           "desc": "Briefbogen und Briefschaften im Hausbild – als Vorlage für die eigene Korrespondenz." },
-
-    { "slug": "schriften",         "cat": "schrift",     "status": "live",    "tag": "Übersicht",     "title": "Schriften",          "short": "Überblick",  "href": "schriften.html",               "desc": "Sechs Schnitte von Leise bis Laut, Variable Font und Icon-Satz – mit Download." },
-    { "slug": "icons",             "cat": "schrift",     "status": "live",    "tag": "Piktogramme",   "title": "Icons",              "short": "Icons",      "href": "icons.html",                   "desc": "45 benannte Piktogramme, Pfeile und Kompass – als Webfont per Taste oder einzeln als SVG, PNG und PDF." },
-    { "slug": "typografie",        "cat": "schrift",     "status": "beta",    "tag": "Hausregeln",    "title": "Typografie",         "short": "Typografie", "href": "typografie.html",              "desc": "Wenige Mittel, präzise gesetzt – als Handbuch und maschinenlesbares Token-System." },
-    { "slug": "schrift-webfont",   "cat": "schrift",     "status": "live",    "tag": "Web",           "title": "Webfont einbinden",  "short": "Webfont",    "href": "schrift-webfont.html",         "desc": "Die Goetheanum-Schrift als Webfont auf eigenen Seiten verwenden – Schritt für Schritt." },
-    { "slug": "schrift-vergleich", "cat": "schriftpflege",   "status": "beta",    "tag": "Grotesk",       "title": "Grotesk+",           "short": "Grotesk+",   "href": "schrift-vergleich.html",       "desc": "Begleit-Grotesk und Nicht-Latein-Fallbacks im direkten Vergleich zur Hausschrift." },
-    { "slug": "tester",            "cat": "schriftpflege",   "status": "beta",    "tag": "Probe",         "title": "Gewichts-Tester",    "short": "Tester",     "href": "tester.html",                  "desc": "Schnittstärken der Variable Font interaktiv durchspielen und Texte ausprobieren." },
-    { "slug": "vorschau",          "cat": "schrift",     "status": "entwurf",    "tag": "Neu in v2.6",   "title": "Neuerungen",         "short": "Neu",        "href": "vorschau.html",                "desc": "Spatien, geschützter Bindestrich, Ziffern-Features und der Mediävalziffern-Entwurf." },
-
-    { "slug": "ligvorschau",       "cat": "ligaturen",   "status": "entwurf", "tag": "Ligaturen",     "title": "Ligaturen – Werkschau","href": "ligvorschau.html",           "desc": "Alle Ligaturen im Überblick." },
-    { "slug": "ineinander",        "cat": "ligaturen",   "status": "entwurf", "tag": "Ligaturen",     "title": "Ligaturen ineinander","href": "ineinander.html",             "desc": "Überlagerung der Ligaturen prüfen." },
-    { "slug": "kerning",           "cat": "ligaturen",   "status": "entwurf", "tag": "Spacing",       "title": "Ligatur-Spacing",    "href": "kerning.html",                 "desc": "Abstände feinjustieren." },
-    { "slug": "werkzeug",          "cat": "schriftpflege",   "status": "entwurf", "tag": "Mischsatz",     "title": "Mischsatz",          "short": "Mischsatz",  "href": "werkzeug.html",                "desc": "Mischsatz aus Hausschrift und Begleit-Grotesk kalibrieren." },
-    { "slug": "statistik",         "cat": "statistik",   "status": "beta",    "tag": "Zahlen",        "title": "Statistik",          "href": "statistik.html",               "desc": "Anonyme Nutzungszahlen aller Werkzeuge." },
-
-    { "slug": "campus-karten",     "cat": "geparkt",     "status": "geparkt", "tag": "Kartierung",    "title": "Campus-Kartentool",  "href": "https://github.com/phtok/goeloggen/blob/main/docs/specs/campus-kartentool-pflichtenheft.md", "desc": "Veranstaltungs-/Lagekarten des Geländes, A4 druckfertig. Pflichtenheft fertig, Bau steht aus." },
-    { "slug": "brand-portrait",    "cat": "geparkt",     "status": "geparkt", "tag": "KI / Porträt",  "title": "Brand-Portrait-Generator", "href": "https://github.com/phtok/goeloggen/blob/main/reference/material/portrait_brand_generator_pflichtenheft.md", "desc": "KI-gestützte, markenkonforme Porträts. Eigener Schwerpunkt mit GPU-Infrastruktur." },
-    { "slug": "jahrgaenge",        "cat": "geparkt",     "status": "geparkt", "tag": "Sammlung",      "title": "Jahrgänge-Sammlung", "href": "https://github.com/phtok/goeloggen/blob/main/collections/jahrgaenge/README.md", "desc": "Produktionssammlung aus Jahrgängen (PDFs, Zeichnungen). Struktur vorbereitet." },
-    { "slug": "gtv-subs",          "cat": "geparkt",     "status": "geparkt", "tag": "Service",       "title": "GTV-Subs",           "href": "https://github.com/phtok/goeloggen/blob/main/services/gtv-subs/README.md", "desc": "Service-Skelett rund um Goetheanum TV. Platzhalter." },
-
-    { "slug": "logo-generator-alt", "cat": "archiv",     "status": "geparkt", "tag": "Archiv",        "title": "Logo-Generator (alt)", "short": "Logos alt",  "href": "archive/logo-generator-original_2026-06-27/", "desc": "Der ursprüngliche Logo-Generator, eingefroren als Referenz – dunkles UI, externe Schriften, nicht gepflegt." }
+    {
+      "slug": "design-system",
+      "cat": "system",
+      "status": "beta",
+      "tag": "Fundament",
+      "title": "Design-System",
+      "href": "design-system/",
+      "desc": "Farben, Schnitte, Typografie-Regeln und Komponenten – die lebende Schauseite, aus einer Quelle gerendert. Mit Starter und Bau-Workflow."
+    },
+    {
+      "slug": "logo-generator",
+      "cat": "generatoren",
+      "status": "live",
+      "tag": "Logo",
+      "title": "Logos",
+      "short": "Logos",
+      "href": "apps/logos/",
+      "desc": "Sektions-, Bereichs- und Medienlogos in der Hausschrift – erklärt, mit Regeln, korrekt gesetzt und zum Herunterladen."
+    },
+    {
+      "slug": "visitenkarten",
+      "cat": "generatoren",
+      "status": "live",
+      "tag": "Visitenkarten",
+      "title": "Visitenkarten",
+      "short": "Visitenkarten",
+      "href": "apps/visitenkarten-generator/",
+      "desc": "Einheitliche Visitenkarten aus den eigenen Angaben – druckfertig, ohne Layoutprogramm."
+    },
+    {
+      "slug": "signatur",
+      "cat": "generatoren",
+      "status": "live",
+      "tag": "E-Mail",
+      "title": "Signatur",
+      "short": "Signatur",
+      "href": "apps/signatur-generator/",
+      "desc": "Outlook-robuste E-Mail-Signatur nach gemeinsamer Vorlage – kopieren und einsetzen."
+    },
+    {
+      "slug": "uebersetzungen",
+      "cat": "generatoren",
+      "status": "beta",
+      "tag": "Übersetzungen",
+      "title": "Übersetzungen",
+      "short": "Übersetzungen",
+      "href": "uebersetzungen.html",
+      "desc": "Sektionen, Bereiche und institutionelle Begriffe in vier Sprachen – geprüft auf goetheanum.ch, durchsuchbar, klick-kopierbar. Für die Sekretariate."
+    },
+    {
+      "slug": "gtv-naming",
+      "cat": "schau",
+      "status": "beta",
+      "tag": "Goetheanum TV",
+      "title": "Namens-Renderings",
+      "short": "GTV-Namen",
+      "href": "apps/gtv-naming/",
+      "desc": "Mockup zur Vorbereitung der Goetheanum-TV-Umbenennung – kein öffentliches Werkzeug, eigene Welt."
+    },
+    {
+      "slug": "karten",
+      "cat": "vorbereitung",
+      "status": "entwurf",
+      "tag": "Campus",
+      "title": "Kartentool",
+      "short": "Karten",
+      "href": "apps/karten-generator/",
+      "desc": "Lagepläne des Goetheanum-Geländes zusammenstellen und im Hausbild ausgeben."
+    },
+    {
+      "slug": "cover",
+      "cat": "vorbereitung",
+      "status": "entwurf",
+      "tag": "Goetheanum TV",
+      "title": "Cover-Generator",
+      "short": "Cover",
+      "href": "apps/cover-generator/",
+      "desc": "Einheitliche Cover-Bilder für Goetheanum-TV-Beiträge – Titel eintragen, Bild laden."
+    },
+    {
+      "slug": "briefschaften",
+      "cat": "vorbereitung",
+      "status": "entwurf",
+      "tag": "Korrespondenz",
+      "title": "Briefschaften",
+      "short": "Briefe",
+      "href": "apps/briefschaften/",
+      "desc": "Briefbogen und Briefschaften im Hausbild – als Vorlage für die eigene Korrespondenz."
+    },
+    {
+      "slug": "schriften",
+      "cat": "schrift",
+      "status": "live",
+      "tag": "Übersicht",
+      "title": "Schriften",
+      "short": "Überblick",
+      "href": "schriften.html",
+      "desc": "Sechs Schnitte von Leise bis Laut, Variable Font und Icon-Satz – mit Download."
+    },
+    {
+      "slug": "icons",
+      "cat": "schrift",
+      "status": "live",
+      "tag": "Piktogramme",
+      "title": "Icons",
+      "short": "Icons",
+      "href": "icons.html",
+      "desc": "45 benannte Piktogramme, Pfeile und Kompass – als Webfont per Taste oder einzeln als SVG, PNG und PDF."
+    },
+    {
+      "slug": "typografie",
+      "cat": "schrift",
+      "status": "beta",
+      "tag": "Hausregeln",
+      "title": "Typografie",
+      "short": "Typografie",
+      "href": "typografie.html",
+      "desc": "Wenige Mittel, präzise gesetzt – als Handbuch und maschinenlesbares Token-System."
+    },
+    {
+      "slug": "schrift-webfont",
+      "cat": "schrift",
+      "status": "live",
+      "tag": "Web",
+      "title": "Webfont einbinden",
+      "short": "Webfont",
+      "href": "schrift-webfont.html",
+      "desc": "Die Goetheanum-Schrift als Webfont auf eigenen Seiten verwenden – Schritt für Schritt."
+    },
+    {
+      "slug": "schrift-vergleich",
+      "cat": "schriftpflege",
+      "status": "beta",
+      "tag": "Grotesk",
+      "title": "Grotesk+",
+      "short": "Grotesk+",
+      "href": "schrift-vergleich.html",
+      "desc": "Begleit-Grotesk und Nicht-Latein-Fallbacks im direkten Vergleich zur Hausschrift."
+    },
+    {
+      "slug": "tester",
+      "cat": "schriftpflege",
+      "status": "beta",
+      "tag": "Probe",
+      "title": "Gewichts-Tester",
+      "short": "Tester",
+      "href": "tester.html",
+      "desc": "Schnittstärken der Variable Font interaktiv durchspielen und Texte ausprobieren."
+    },
+    {
+      "slug": "vorschau",
+      "cat": "schrift",
+      "status": "entwurf",
+      "tag": "Neu in v2.6",
+      "title": "Neuerungen",
+      "short": "Neu",
+      "href": "vorschau.html",
+      "desc": "Spatien, geschützter Bindestrich, Ziffern-Features und der Mediävalziffern-Entwurf."
+    },
+    {
+      "slug": "ligvorschau",
+      "cat": "ligaturen",
+      "status": "entwurf",
+      "tag": "Ligaturen",
+      "title": "Ligaturen – Werkschau",
+      "href": "ligvorschau.html",
+      "desc": "Alle Ligaturen im Überblick."
+    },
+    {
+      "slug": "ineinander",
+      "cat": "ligaturen",
+      "status": "entwurf",
+      "tag": "Ligaturen",
+      "title": "Ligaturen ineinander",
+      "href": "ineinander.html",
+      "desc": "Überlagerung der Ligaturen prüfen."
+    },
+    {
+      "slug": "kerning",
+      "cat": "ligaturen",
+      "status": "entwurf",
+      "tag": "Spacing",
+      "title": "Ligatur-Spacing",
+      "href": "kerning.html",
+      "desc": "Abstände feinjustieren."
+    },
+    {
+      "slug": "werkzeug",
+      "cat": "schriftpflege",
+      "status": "entwurf",
+      "tag": "Mischsatz",
+      "title": "Mischsatz",
+      "short": "Mischsatz",
+      "href": "werkzeug.html",
+      "desc": "Mischsatz aus Hausschrift und Begleit-Grotesk kalibrieren."
+    },
+    {
+      "slug": "statistik",
+      "cat": "statistik",
+      "status": "beta",
+      "tag": "Zahlen",
+      "title": "Statistik",
+      "href": "statistik.html",
+      "desc": "Anonyme Nutzungszahlen aller Werkzeuge."
+    },
+    {
+      "slug": "campus-karten",
+      "cat": "geparkt",
+      "status": "geparkt",
+      "tag": "Kartierung",
+      "title": "Campus-Kartentool",
+      "href": "https://github.com/phtok/goeloggen/blob/main/docs/specs/campus-kartentool-pflichtenheft.md",
+      "desc": "Veranstaltungs-/Lagekarten des Geländes, A4 druckfertig. Pflichtenheft fertig, Bau steht aus."
+    },
+    {
+      "slug": "brand-portrait",
+      "cat": "geparkt",
+      "status": "geparkt",
+      "tag": "KI / Porträt",
+      "title": "Brand-Portrait-Generator",
+      "href": "https://github.com/phtok/goeloggen/blob/main/reference/material/portrait_brand_generator_pflichtenheft.md",
+      "desc": "KI-gestützte, markenkonforme Porträts. Eigener Schwerpunkt mit GPU-Infrastruktur."
+    },
+    {
+      "slug": "jahrgaenge",
+      "cat": "geparkt",
+      "status": "geparkt",
+      "tag": "Sammlung",
+      "title": "Jahrgänge-Sammlung",
+      "href": "https://github.com/phtok/goeloggen/blob/main/collections/jahrgaenge/README.md",
+      "desc": "Produktionssammlung aus Jahrgängen (PDFs, Zeichnungen). Struktur vorbereitet."
+    },
+    {
+      "slug": "gtv-subs",
+      "cat": "geparkt",
+      "status": "geparkt",
+      "tag": "Service",
+      "title": "GTV-Subs",
+      "href": "https://github.com/phtok/goeloggen/blob/main/services/gtv-subs/README.md",
+      "desc": "Service-Skelett rund um Goetheanum TV. Platzhalter."
+    },
+    {
+      "slug": "logo-generator-alt",
+      "cat": "archiv",
+      "status": "geparkt",
+      "tag": "Archiv",
+      "title": "Logo-Generator (alt)",
+      "short": "Logos alt",
+      "href": "archive/logo-generator-original_2026-06-27/",
+      "desc": "Der ursprüngliche Logo-Generator, eingefroren als Referenz – dunkles UI, externe Schriften, nicht gepflegt."
+    }
   ],
   "docs": [
-    { "title": "Strategieblatt & Wesensanalyse", "tag": "Strategie",    "href": "https://github.com/phtok/goeloggen/blob/main/docs/strategie.md", "desc": "Strategieblatt nach Neumeier, Fundament, Architektur, Fahrplan." },
-    { "title": "Campus-Kartentool – Pflichtenheft", "tag": "Spec",      "href": "https://github.com/phtok/goeloggen/blob/main/docs/specs/campus-kartentool-pflichtenheft.md", "desc": "Vollständiges Pflichtenheft des Kartentools." },
-    { "title": "Brand-Portrait – Pflichtenheft", "tag": "Spec",        "href": "https://github.com/phtok/goeloggen/blob/main/reference/material/portrait_brand_generator_pflichtenheft.md", "desc": "Konzept des KI-Porträt-Generators (MVP)." },
-    { "title": "Brand-Portrait – Backlog", "tag": "Backlog",           "href": "https://github.com/phtok/goeloggen/blob/main/reference/material/portrait_brand_generator_backlog_mvp.md", "desc": "Epics, User-Stories, Sprint-Vorschlag." },
-    { "title": "Hausschrift v2.6 – Dokumentation", "tag": "Schrift",   "href": "https://github.com/phtok/goeloggen/blob/main/assets/fonts/goetheanum/README.md", "desc": "Schnitte, Variable Font, Neuerungen in v2.6." },
-    { "title": "Hausschrift – Audit", "tag": "Schrift",                "href": "https://github.com/phtok/goeloggen/blob/main/assets/fonts/goetheanum/AUDIT.md", "desc": "Reparatur- und Qualitätsaudit der Schrift." },
-    { "title": "Baustelle / Design-System", "tag": "Aufbau",          "href": "https://github.com/phtok/goeloggen/blob/main/start/README.md", "desc": "Wie das Design-System aufgebaut ist und wächst." }
+    {
+      "title": "Strategieblatt & Wesensanalyse",
+      "tag": "Strategie",
+      "href": "https://github.com/phtok/goeloggen/blob/main/docs/strategie.md",
+      "desc": "Strategieblatt nach Neumeier, Fundament, Architektur, Fahrplan."
+    },
+    {
+      "title": "Campus-Kartentool – Pflichtenheft",
+      "tag": "Spec",
+      "href": "https://github.com/phtok/goeloggen/blob/main/docs/specs/campus-kartentool-pflichtenheft.md",
+      "desc": "Vollständiges Pflichtenheft des Kartentools."
+    },
+    {
+      "title": "Brand-Portrait – Pflichtenheft",
+      "tag": "Spec",
+      "href": "https://github.com/phtok/goeloggen/blob/main/reference/material/portrait_brand_generator_pflichtenheft.md",
+      "desc": "Konzept des KI-Porträt-Generators (MVP)."
+    },
+    {
+      "title": "Brand-Portrait – Backlog",
+      "tag": "Backlog",
+      "href": "https://github.com/phtok/goeloggen/blob/main/reference/material/portrait_brand_generator_backlog_mvp.md",
+      "desc": "Epics, User-Stories, Sprint-Vorschlag."
+    },
+    {
+      "title": "Hausschrift v2.6 – Dokumentation",
+      "tag": "Schrift",
+      "href": "https://github.com/phtok/goeloggen/blob/main/assets/fonts/goetheanum/README.md",
+      "desc": "Schnitte, Variable Font, Neuerungen in v2.6."
+    },
+    {
+      "title": "Hausschrift – Audit",
+      "tag": "Schrift",
+      "href": "https://github.com/phtok/goeloggen/blob/main/assets/fonts/goetheanum/AUDIT.md",
+      "desc": "Reparatur- und Qualitätsaudit der Schrift."
+    },
+    {
+      "title": "Baustelle / Design-System",
+      "tag": "Aufbau",
+      "href": "https://github.com/phtok/goeloggen/blob/main/start/README.md",
+      "desc": "Wie das Design-System aufgebaut ist und wächst."
+    }
   ]
 }

--- a/uebersetzungen.html
+++ b/uebersetzungen.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="de">
+<head>
+<link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Goetheanum – Übersetzungen</title>
+<meta name="description" content="Gängige Übersetzungen der Sektionen, Bereiche und institutionellen Begriffe (Freie Hochschule für Geisteswissenschaft, Allgemeine Anthroposophische Gesellschaft …) in Deutsch, Englisch, Französisch und Spanisch – für die Sekretariate." />
+<link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/base.css" />
+<link rel="stylesheet" href="design-system/nav.css" />
+<style>
+  /* Farben/Schrift/Hell-Dunkel aus tokens.css/base.css – nur seiten-eigenes Layout. */
+  .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
+  .hero{padding-block:60px 14px}
+  .lede{max-width:64ch;margin-top:var(--s4)}
+
+  /* Suchfeld für die Sekretariate. */
+  .find{display:flex;align-items:center;gap:10px;border:1px solid var(--line);border-radius:var(--r-control);
+    padding:0 14px;background:var(--field-bg);max-width:440px;margin:var(--s6) 0 0}
+  .find input{flex:1;border:0;background:none;color:var(--ink);font:inherit;font-size:16px;padding:12px 0;outline:none;min-height:var(--tap)}
+  .find input::placeholder{color:var(--muted)}
+
+  .tablecard{border:1px solid var(--line);border-radius:var(--r-card);background:var(--paper);overflow-x:auto;margin-top:var(--s4)}
+  table{width:100%}
+  th,td{vertical-align:top}
+  td{cursor:copy}                 /* Klick kopiert die Zelle */
+  td:hover{background:var(--soft)}
+  .sw-c{width:20px;height:20px;border-radius:5px;border:1px solid var(--line);display:inline-block}
+  caption{text-align:left;color:var(--muted);font-size:var(--t-small);padding:0 0 var(--s2)}
+  tr.hidden{display:none}
+</style>
+</head>
+<body>
+<script src="design-system/nav.js" data-root="./" data-section="generatoren" data-active="uebersetzungen"
+        data-onpage="Begriffe:#begriffe|Sektionen:#sektionen"></script>
+
+<main class="wrap">
+  <div class="hero">
+    <div class="kicker">Hausgrafik · Sprache</div>
+    <h1>Übersetzungen</h1>
+    <p class="lede">Gängige Schreibweisen und Übersetzungen der Sektionen, Bereiche und der institutionellen Begriffe – Deutsch, English, Français, Español. Für Karten, Signaturen, Briefe und die Sekretariate. Klick auf eine Zelle kopiert sie.</p>
+    <div class="find">
+      <span class="meta" aria-hidden="true">⌕</span>
+      <input id="q" type="search" placeholder="Suchen – z. B. Hochschule, Medizin, Society …" aria-label="Übersetzungen durchsuchen">
+    </div>
+  </div>
+
+  <section id="begriffe">
+    <div class="shead"><h2>Institutionelle Begriffe</h2>
+      <p>Die wiederkehrenden Namen. Quelle: <code>assets/goe-terms.js</code>. Auf <a href="https://goetheanum.ch">goetheanum.ch</a> geprüft; <span class="badge">prüfen</span> = noch zu ratifizieren.</p></div>
+    <div class="tablecard">
+      <table>
+        <thead><tr><th>Deutsch</th><th>English</th><th>Français</th><th>Español</th><th>Status</th></tr></thead>
+        <tbody id="terms-body"></tbody>
+      </table>
+    </div>
+  </section>
+
+  <section id="sektionen">
+    <div class="shead"><h2>Sektionen &amp; Bereiche</h2>
+      <p>Volle Namen in vier Sprachen. Quelle: <code>assets/goe-orgs.js</code> (speist Logos und Formulare).</p></div>
+    <div class="tablecard">
+      <table>
+        <thead><tr><th>Farbe</th><th>Deutsch</th><th>English</th><th>Français</th><th>Español</th><th>Gruppe</th></tr></thead>
+        <tbody id="orgs-body"></tbody>
+      </table>
+    </div>
+    <p class="note" style="margin-top:var(--s4)">Korrigieren = die Quelle bearbeiten (<a href="https://github.com/phtok/goeloggen/blob/main/assets/goe-orgs.js">goe-orgs.js</a> · <a href="https://github.com/phtok/goeloggen/blob/main/assets/goe-terms.js">goe-terms.js</a>). Einzelne französische/spanische Sektions-Kurznamen weichen noch leicht von goetheanum.ch ab (z. B. ‹Mathématiques et astronomie›) – Abgleich offen.</p>
+  </section>
+</main>
+
+<footer class="ds-footer">
+  <div class="wrap frow">
+    <span><strong>Goetheanum</strong> · Übersetzungen für die Hausgrafik</span>
+    <span>Quelle <a href="https://goetheanum.ch">goetheanum.ch</a> · <a href="./">alle Werkzeuge</a></span>
+  </div>
+</footer>
+
+<div class="toast" id="toast" style="position:fixed;left:50%;bottom:24px;transform:translateX(-50%);background:var(--ink);color:var(--on-accent);padding:8px 16px;border-radius:var(--r-pill);font-size:var(--t-small);opacity:0;transition:opacity .2s;pointer-events:none;z-index:60"></div>
+
+<script src="assets/goe-orgs.js"></script>
+<script src="assets/goe-terms.js"></script>
+<script>
+"use strict";
+var $=function(s){return document.querySelector(s);};
+function toast(m){var t=$("#toast");t.textContent=m;t.style.opacity="1";setTimeout(function(){t.style.opacity="0";},1100);}
+function cell(text){var td=document.createElement("td");td.textContent=text||"–";return td;}
+
+// Institutionelle Begriffe
+(function(){
+  var T=window.GOE_TERMS, body=$("#terms-body"); if(!T||!body) return;
+  Object.keys(T).forEach(function(k){
+    var t=T[k], pruefen=t.status!=="fest";
+    var tr=document.createElement("tr");
+    var de=cell(t.de); de.innerHTML="<b>"+(t.de||"")+"</b>";
+    tr.appendChild(de); tr.appendChild(cell(t.en));
+    var fr=cell(t.fr), es=cell(t.es);
+    if(pruefen){fr.className="meta";es.className="meta";}
+    tr.appendChild(fr); tr.appendChild(es);
+    var st=document.createElement("td"); st.style.cursor="default";
+    st.innerHTML=pruefen?'<span class="badge">prüfen</span>':'<span class="meta">fest</span>';
+    if(t.note) st.title=t.note;
+    tr.appendChild(st);
+    body.appendChild(tr);
+  });
+})();
+
+// Sektionen & Bereiche
+(function(){
+  var O=window.GOE_GCI_ORGS, C=window.GOE_GCI_CATS, body=$("#orgs-body"); if(!O||!body) return;
+  var grp={}; if(C) Object.keys(C).forEach(function(g){(C[g].items||[]).forEach(function(k){grp[k]=C[g].label_de||g;});});
+  Object.keys(O).forEach(function(k){
+    var o=O[k]||{};
+    var tr=document.createElement("tr");
+    var c=document.createElement("td"); c.style.cursor="default";
+    c.innerHTML='<span class="sw-c" style="background:'+(o.color||"transparent")+'"></span>';
+    tr.appendChild(c);
+    var de=document.createElement("td"); de.innerHTML="<b>"+(o.name_de||"")+"</b>"; tr.appendChild(de);
+    tr.appendChild(cell(o.name_en)); tr.appendChild(cell(o.name_fr)); tr.appendChild(cell(o.name_es));
+    var g=document.createElement("td"); g.className="meta"; g.style.cursor="default"; g.textContent=grp[k]||"–";
+    tr.appendChild(g);
+    body.appendChild(tr);
+  });
+})();
+
+// Klick kopiert die Zelle
+document.addEventListener("click",function(e){
+  var td=e.target.closest("td"); if(!td||td.style.cursor==="default") return;
+  var txt=td.textContent.trim(); if(!txt||txt==="–") return;
+  if(navigator.clipboard) navigator.clipboard.writeText(txt);
+  toast(txt.length>40?"kopiert":"„"+txt+"“ kopiert");
+});
+
+// Suche filtert beide Tabellen zeilenweise
+$("#q").addEventListener("input",function(){
+  var q=this.value.trim().toLowerCase();
+  document.querySelectorAll("tbody tr").forEach(function(tr){
+    tr.classList.toggle("hidden", q && tr.textContent.toLowerCase().indexOf(q)<0);
+  });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Zwei Befunde behoben + eine neue Quelle

### Lesbarkeit/Inklusivität fest verankert (recherchiert, Stand 2026)
Die Typo-Skala einen gemessenen Schritt grösser — die kleinen Stufen waren zu klein:
- **Floor 13→14px**, Meta/Label 14→**15–16** (`--t-small`), Fliesstext 17→**18–20** (`--t-body`), Lede 19→**20–23**.
- Grundlage: 16px ist die Norm-Untergrenze für Fliesstext, Best Practice ist *„bei 16 beginnen und hochskalieren"* (WCAG 1.4.4 resize, rem-basiert). DS03-Floor 13→14 nachgezogen; die literalen 13px der öffentlichen Seiten auf `--t-small` gehoben.
- Hausregeln B03/B04 auf **WCAG 2.2** bezogen: SC 2.5.8 Target Size (≥24px; wir geben 44), SC 1.4.12 Text Spacing (Layout übersteht erhöhte Laufweiten), Zeilenhöhe ≥1.5.

### Icons im Dunkelmodus „verschluckt"
Schwarze Strich-Icons als `<img>`-SVG verschwanden auf Dunkel. Utility **`.ico-invert`** ins Fundament (Filter im Dunkelmodus), auf die Schriften-Icons angewandt. (Besser noch: Webfont/Inline-SVG mit `currentColor` — wie die dedizierte Icons-Seite.)

### Neue Quelle & Werkzeug: Übersetzungen
- **`assets/goe-terms.js`** auf **goetheanum.ch geprüft** — die Recherche korrigierte zwei meiner Vorschläge: Hochschule FR = *„Université libre de science de l'esprit"*, Gesellschaft FR = *„Société anthroposophique générale"*. Verifizierte Zeilen → `fest`.
- **`uebersetzungen.html`** — durchsuchbare, klick-kopierbare Tabelle (Sektionen/Bereiche + institutionelle Begriffe, 4 Sprachen) für die **Sekretariate**; als Startkarte in `tools.json` registriert.

Alle öffentlichen Seiten bleiben **100 %** konform.

> Hinweis: Backstage-/Beta-Seiten zeigen durch den 13→14-Floor neue DS03-Hinweise — das ist der nächste Sweep, nicht Teil dieses PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_