### PR TITLE
Track 1+3: Backstage auf 14px-Floor · --bereich = Markenblau

### DIFF
--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -68,6 +68,15 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
   Utility `.ico-invert` (Filter im Dunkelmodus) ins Fundament; auf die Schriften-
   Icons angewandt. Besser noch: Icons als Webfont/Inline-SVG mit currentColor.
 
+### Backstage/Beta auf den 14px-Floor + Org-Farbe angeglichen
+- Acht Specimen-/Backstage-Seiten (Typografie, Tester, Grotesk+, Vorschau,
+  Mischsatz, Ligaturen ×3) auf den neuen Floor gehoben: literale <14px → --t-small;
+  Reste tokenisiert (Bar-Hintergrund → --bar-bg, Gold-Tint → color-mix, Code-Chip
+  → --code-*). Alle 0 Fehler. Gesamt-Score **42 % → 72 %** (18/25 konform).
+- **Track 1**: `--bereich` von #005eb8 auf **#0061a9 = Markenblau** angeglichen
+  (so rendern es die Logo-Daten/goe-orgs.js schon). Sektionsnamen-Korrekturen aus
+  #164 (Team) übernommen; spanische Gesellschaft bleibt `prüfen`.
+
 ### Einbinden statt kopieren – eine Org-Quelle (Drift dauerhaft behoben)
 - Es gab DREI Org-Datensätze: `assets/goe-orgs.js` (36, Schaufenster), `assets/
   data/goetheanum-orgs.js` (38 inkl. it/subscriptions, live: Logos+Signatur) und

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -83,7 +83,7 @@
   --sek-srmk:#598ddc;        /* Sektion für Redende und Musizierende Künste */
   --sek-mas:#2e54a4;         /* Mathematisch-Astronomische Sektion */
   --sek-hpise:#f98a3c;       /* Sektion für Heilpädagogik und inklusive soziale Entwicklung */
-  --bereich:#005eb8;         /* Verwaltungs-/Bereichs-Standard (Empfang, Studium, Archiv …) */
+  --bereich:#0061a9;         /* Verwaltungs-/Bereichs-Standard = Markenblau (wie die Logo-Daten, goe-orgs.js) */
 
   /* --- Schrift-Familien --------------------------------------------------- */
   --font-display:"Goetheanum","Helvetica Neue",Arial,sans-serif; /* Titel, Chrome */

--- a/design-system/tokens.json
+++ b/design-system/tokens.json
@@ -63,7 +63,7 @@
       "srmk": { "$value": "#598ddc", "$description": "Sektion für Redende und Musizierende Künste" },
       "mas": { "$value": "#2e54a4", "$description": "Mathematisch-Astronomische Sektion" },
       "hpise": { "$value": "#f98a3c", "$description": "Heilpädagogik und inklusive soziale Entwicklung" },
-      "bereich": { "$value": "#005eb8", "$description": "Verwaltungs-/Bereichs-Standard" }
+      "bereich": { "$value": "#0061a9", "$description": "Verwaltungs-/Bereichs-Standard = Markenblau (wie goe-orgs.js)" }
     }
   },
   "font": {

--- a/ineinander.html
+++ b/ineinander.html
@@ -15,16 +15,16 @@ h1{margin:0 0 6px}.hint{color:var(--muted);font-size:14px;margin:6px 0 14px}
 .lig{display:inline-block;vertical-align:calc(var(--va)/1000*1em)}
 .lig svg{height:1em;fill:currentColor}
 .tools{display:flex;gap:24px;flex-wrap:wrap;margin-top:4px}
-.tool{min-width:230px}.tool label{display:flex;justify-content:space-between;font-size:13px;color:var(--muted);margin-bottom:5px}
+.tool{min-width:230px}.tool label{display:flex;justify-content:space-between;font-size:var(--t-small);color:var(--muted);margin-bottom:5px}
 .ctrls{display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:14px;margin-top:16px}
 .cell{background:var(--soft);border:1px solid var(--line);border-radius:10px;padding:12px 14px}
 .cell .ck{font-weight:600;margin-bottom:7px;font-size:15px}
-.cell label{display:flex;justify-content:space-between;font-size:13px;color:var(--muted);margin-bottom:4px}
+.cell label{display:flex;justify-content:space-between;font-size:var(--t-small);color:var(--muted);margin-bottom:4px}
 .cell b,.tool b{font-variant-numeric:tabular-nums}
 input[type=range]{width:100%}
-.readout{margin-top:16px;font-size:13px;color:var(--muted);background:var(--soft);border-radius:10px;padding:11px 13px}
+.readout{margin-top:16px;font-size:var(--t-small);color:var(--muted);background:var(--soft);border-radius:10px;padding:11px 13px}
 .code{font-family:ui-monospace,Menlo,monospace;white-space:pre-wrap}
-.btn{font:inherit;font-size:13px;border:1px solid var(--line);background:var(--soft);border-radius:8px;padding:6px 11px;cursor:pointer;margin-right:8px}
+.btn{font:inherit;font-size:var(--t-small);border:1px solid var(--line);background:var(--soft);border-radius:8px;padding:6px 11px;cursor:pointer;margin-right:8px}
 small{color:var(--muted)}
 </style></head><body>
 <script src="design-system/nav.js" data-root="./" data-section="ligaturen" data-active="ineinander"></script>

--- a/kerning.html
+++ b/kerning.html
@@ -17,12 +17,12 @@ h1{margin:0 0 6px}.hint{color:var(--muted);font-size:14px;margin:6px 0 18px}
      margin-left:calc(var(--ll)/1000*1em);margin-right:calc(var(--lr)/1000*1em)}
 .lig.L_ff{margin-left:calc(var(--ffl)/1000*1em);margin-right:calc(var(--ffr)/1000*1em)}
 .ctrls{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:18px 26px;margin-top:18px}
-.ctrl label{display:flex;justify-content:space-between;font-size:13px;color:var(--muted);margin-bottom:5px}
+.ctrl label{display:flex;justify-content:space-between;font-size:var(--t-small);color:var(--muted);margin-bottom:5px}
 .ctrl b{font-variant-numeric:tabular-nums}
 input[type=range]{width:100%}
-.readout{margin-top:18px;font-size:13px;color:var(--muted);background:var(--soft);border-radius:10px;padding:11px 13px}
+.readout{margin-top:18px;font-size:var(--t-small);color:var(--muted);background:var(--soft);border-radius:10px;padding:11px 13px}
 .code{font-family:ui-monospace,Menlo,monospace}
-.btn{font:inherit;font-size:13px;border:1px solid var(--line);background:var(--soft);border-radius:8px;padding:6px 11px;cursor:pointer;margin-right:8px}
+.btn{font:inherit;font-size:var(--t-small);border:1px solid var(--line);background:var(--soft);border-radius:8px;padding:6px 11px;cursor:pointer;margin-right:8px}
 small{color:var(--muted)}
 </style></head>
 <body>

--- a/ligvorschau.html
+++ b/ligvorschau.html
@@ -15,18 +15,18 @@ h1{margin:0 0 4px}h2{font-size:17px;margin:34px 0 12px;border-top:1px solid var(
 .card{background:var(--soft);border:1px solid var(--line);border-radius:14px;padding:20px 22px;margin:0 0 14px}
 .card svg,.lig svg{fill:var(--ink)}
 .solo{display:grid;grid-template-columns:repeat(5,1fr);gap:6px 10px;align-items:end;text-align:center}
-.solo .h{font-size:12px;color:var(--muted)}.solo .wn{font-size:12px;color:var(--muted);text-align:left;align-self:center}
+.solo .h{font-size:var(--t-small);color:var(--muted)}.solo .wn{font-size:var(--t-small);color:var(--muted);text-align:left;align-self:center}
 .solo .cell{height:110px;display:flex;align-items:flex-end;justify-content:center}
 .solo .cell svg{height:92px}
 .cmp{display:flex;gap:30px;align-items:flex-end;flex-wrap:wrap}
 .cmp .g{display:flex;flex-direction:column;align-items:center;gap:6px}
-.cmp .g svg{height:96px}.cmp .g .t{font-size:12px;color:var(--muted)}
+.cmp .g svg{height:96px}.cmp .g .t{font-size:var(--t-small);color:var(--muted)}
 .flow .sw{display:flex;gap:8px;margin:0 0 12px;flex-wrap:wrap}
 .flow .sw button{font:inherit;font-size:14px;border:1px solid var(--line);background:var(--soft);border-radius:9px;padding:7px 15px;cursor:pointer}
 .flow .sw button.on{background:var(--ink);color:var(--paper);border-color:var(--ink)}
 .sample{font-size:42px;line-height:1.6}
 .sample .lig{display:inline-block;vertical-align:-0.25em}.sample .lig svg{height:1em}
-.tool{max-width:420px;margin-top:14px}.tool label{display:flex;justify-content:space-between;font-size:13px;color:var(--muted);margin-bottom:5px}
+.tool{max-width:420px;margin-top:14px}.tool label{display:flex;justify-content:space-between;font-size:var(--t-small);color:var(--muted);margin-bottom:5px}
 input[type=range]{width:100%}
 </style></head><body>
 <script src="design-system/nav.js" data-root="./" data-section="ligaturen" data-active="ligvorschau"></script>

--- a/schrift-vergleich.html
+++ b/schrift-vergleich.html
@@ -29,13 +29,13 @@
   /* Überschriften aus dem Fundament. */
   .lede{font-size:17px;color:var(--muted);max-width:64ch;margin-top:12px}
   section{padding:30px 0;border-top:1px solid var(--line-soft)}
-  .sec{color:var(--gold-ink);font-size:13px}
+  .sec{color:var(--gold-ink);font-size:var(--t-small)}
   h2{margin:4px 0 14px}
   .ctrl{display:flex;gap:14px 22px;flex-wrap:wrap;align-items:center;background:var(--soft);border:1px solid var(--line-soft);border-radius:12px;padding:14px 18px;margin-bottom:22px;position:sticky;top:56px;z-index:20}
   .ctrl .grp{display:flex;gap:6px;flex-wrap:wrap}
-  .ctrl button{font:inherit;font-size:13px;color:var(--muted);background:var(--field-bg);border:1px solid var(--line);border-radius:20px;padding:5px 14px;cursor:pointer}
+  .ctrl button{font:inherit;font-size:var(--t-small);color:var(--muted);background:var(--field-bg);border:1px solid var(--line);border-radius:20px;padding:5px 14px;cursor:pointer}
   .ctrl button[aria-pressed=true]{color:var(--gold-ink);border-color:var(--gold);font-weight:600}
-  .ctrl label{font-size:13px;color:var(--muted);display:flex;align-items:center;gap:8px}
+  .ctrl label{font-size:var(--t-small);color:var(--muted);display:flex;align-items:center;gap:8px}
   .ctrl input[type=range]{accent-color:var(--gold-ink);width:120px}
   .ctrl b{color:var(--ink);font-variant-numeric:tabular-nums}
   .article{max-width:var(--measure);margin:0 auto}
@@ -52,10 +52,10 @@
   .card .nm{font-size:14px;color:var(--gold-ink);font-weight:600;margin-bottom:8px}
   .card .smp{font-size:17px;line-height:1.5}
   .scriptrow{display:grid;grid-template-columns:150px 1fr;gap:6px 18px;align-items:baseline;padding:10px 0;border-bottom:1px solid var(--line-soft)}
-  .scriptrow .lab{font-size:12px;color:var(--gold-ink)}
+  .scriptrow .lab{font-size:var(--t-small);color:var(--gold-ink)}
   .scriptrow .smp{font-size:26px}
   .lat{font-family:"G Klar"} .cyr{font-family:"Titillium RUS"} .grk{font-family:"Source Sans 3"} .arb{font-family:"Cairo"}
-  footer{border-top:1px solid var(--line);padding:26px 0 54px;color:var(--muted);font-size:12.5px}
+  footer{border-top:1px solid var(--line);padding:26px 0 54px;color:var(--muted);font-size:var(--t-small)}
 </style>
 </head>
 <body>
@@ -108,7 +108,7 @@
     <div class="scriptrow"><div class="lab">Kyrillisch · Titillium&nbsp;RUS</div><div class="smp cyr">Гётеанум Дорнах — Швейцария · 1913</div></div>
     <div class="scriptrow"><div class="lab">Griechisch · Source&nbsp;Sans&nbsp;3</div><div class="smp grk">Γκαίτεανουμ Ντόρναχ — Ελβετία · 1913</div></div>
     <div class="scriptrow"><div class="lab">Arabisch · Cairo</div><div class="smp arb" dir="rtl">غوتيانوم دورناخ — سويسرا · ١٩١٣</div></div>
-    <p style="font-size:13px;color:var(--muted);margin-top:14px;max-width:64ch">Wählst du <b>IBM Plex Sans</b> als Lese-Grotesk, deckt die Plex-Superfamilie zugleich Latein/Griechisch/Kyrillisch <i>und</i> Arabisch – eine Schrift für Mengentext und alle Fallbacks.</p>
+    <p style="font-size:var(--t-small);color:var(--muted);margin-top:14px;max-width:64ch">Wählst du <b>IBM Plex Sans</b> als Lese-Grotesk, deckt die Plex-Superfamilie zugleich Latein/Griechisch/Kyrillisch <i>und</i> Arabisch – eine Schrift für Mengentext und alle Fallbacks.</p>
   </section>
 </div></main>
 
@@ -142,7 +142,7 @@
     var d=document.createElement("div"); d.className="card";
     d.innerHTML='<div class="nm">'+f[0]+'</div>'+
       '<div class="smp" style="font-family:\''+f[0]+'\'">Lebendige Formen wachsen aus dem Schweigen. <em style="font-style:italic">Ein Versuch in Klarheit</em> – 1913 Plätze, 47° 32′.</div>'+
-      '<div style="font-size:11.5px;color:var(--muted);margin-top:8px">'+f[1]+'</div>';
+      '<div style="font-size:var(--t-small);color:var(--muted);margin-top:8px">'+f[1]+'</div>';
     qc.appendChild(d);
   });
 })();

--- a/tester.html
+++ b/tester.html
@@ -16,41 +16,41 @@
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:"GV","Helvetica Neue",Arial,sans-serif;font-variation-settings:"wght" 450;color:var(--ink);background:var(--paper);line-height:1.5;-webkit-font-smoothing:antialiased}
   .wrap{max-width:1000px;margin:0 auto;padding:28px 26px 80px}
-  .kick{color:var(--gold-ink);font-size:13px;letter-spacing:.02em}
+  .kick{color:var(--gold-ink);font-size:var(--t-small);letter-spacing:.02em}
   h1{margin:6px 0 4px}
   .lede{color:var(--muted);max-width:640px;margin-bottom:26px}
   .panel{border:1px solid var(--line);border-radius:16px;padding:30px;background:var(--paper)}
-  .presets{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:14px;font-size:13px;color:var(--muted)}
-  .presets button{font:inherit;font-size:12.5px;color:var(--muted);background:none;border:1px solid var(--line);border-radius:999px;padding:5px 12px;cursor:pointer}
+  .presets{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:14px;font-size:var(--t-small);color:var(--muted)}
+  .presets button{font:inherit;font-size:var(--t-small);color:var(--muted);background:none;border:1px solid var(--line);border-radius:999px;padding:5px 12px;cursor:pointer}
   .presets button:hover,.presets button.on{color:var(--gold-ink);border-color:var(--gold)}
   .compare{display:flex;gap:34px;align-items:baseline;flex-wrap:wrap;font-size:clamp(28px,5vw,46px);line-height:1.1}
-  .smallprobe{margin-top:14px;font-size:13px}
-  .smallprobe .lab{color:var(--muted);font-size:11px;margin-right:10px}
-  .smallprobe .probe{font-variation-settings:"wght" var(--w-leise,280);font-size:12.5px}
+  .smallprobe{margin-top:14px;font-size:var(--t-small)}
+  .smallprobe .lab{color:var(--muted);font-size:var(--t-small);margin-right:10px}
+  .smallprobe .probe{font-variation-settings:"wght" var(--w-leise,280);font-size:var(--t-small)}
   .sep{border:0;border-top:1px solid var(--line);margin:22px 0}
   /* live specimen */
   .title{font-variation-settings:"wght" var(--w-laut,600);font-size:40px;line-height:1.08;margin-bottom:14px}
   .body{font-variation-settings:"wght" var(--w-klar,450);font-size:18px;max-width:62ch}
   .body .em{font-variation-settings:"wght" var(--w-laut,600)}
   .caption{font-variation-settings:"wght" var(--w-leise,280);color:var(--muted);font-size:15px;margin-top:14px;max-width:62ch}
-  .small{font-size:11px}
+  .small{font-size:var(--t-small)}
   .row{display:flex;gap:18px;align-items:baseline;flex-wrap:wrap;margin-top:22px}
-  .row>.body{font-size:11px}.row>.title{font-size:11px;margin:0}
+  .row>.body{font-size:var(--t-small)}.row>.title{font-size:var(--t-small);margin:0}
   /* controls */
   .ctrls{display:grid;grid-template-columns:repeat(3,1fr);gap:22px;margin-top:30px}
   @media(max-width:760px){.ctrls{grid-template-columns:1fr}}
   .ctrl b{font-variation-settings:"wght" 600;font-weight:normal}
   .ctrl .v{float:right;color:var(--gold-ink)}
-  .ctrl .role{font-size:12px;color:var(--muted);margin-bottom:8px}
+  .ctrl .role{font-size:var(--t-small);color:var(--muted);margin-bottom:8px}
   input[type=range]{-webkit-appearance:none;appearance:none;width:100%;height:2px;background:var(--line);border-radius:2px;margin:6px 0}
   input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;width:22px;height:22px;border-radius:50%;background:var(--gold);cursor:pointer;border:3px solid var(--paper);box-shadow:0 1px 4px rgba(0,0,0,.2)}
-  .def{font-size:11px;color:var(--muted)}
+  .def{font-size:var(--t-small);color:var(--muted)}
   .metrics{margin-top:26px;border:1px solid var(--line);border-radius:14px;padding:18px 20px;background:var(--soft);font-size:14px}
   .metrics div{display:flex;justify-content:space-between;padding:4px 0}
   .metrics .lab{color:var(--muted)}
   .metrics b{font-variation-settings:"wght" 600;font-weight:normal}
-  .verdict{font-size:13px}
-  .out{margin-top:24px;font-size:13px;color:var(--muted)}
+  .verdict{font-size:var(--t-small)}
+  .out{margin-top:24px;font-size:var(--t-small);color:var(--muted)}
   .out code{background:var(--soft);border:1px solid var(--line);border-radius:6px;padding:2px 8px;color:var(--ink)}
   .q{margin-top:30px;border-top:1px solid var(--line);padding-top:18px;color:var(--muted);font-size:14px}
   .q b{font-variation-settings:"wght" 600;font-weight:normal;color:var(--ink)}

--- a/typografie.html
+++ b/typografie.html
@@ -24,18 +24,18 @@
        hyphens:auto;-webkit-hyphens:auto}
   .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
   a{color:var(--gold-ink)}
-  header{position:sticky;top:0;z-index:30;background:rgba(255,255,255,.9);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
+  header{position:sticky;top:0;z-index:30;background:var(--bar-bg);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
   .bar{display:flex;align-items:center;justify-content:space-between;height:58px}
   .brand img{height:34px;display:block}
   nav.top{display:flex;gap:22px}
-  nav.top a{color:var(--muted);text-decoration:none;font-size:13.5px}
+  nav.top a{color:var(--muted);text-decoration:none;font-size:var(--t-small)}
   nav.top a:hover{color:var(--gold-ink)}
   .hero{padding-block:58px 8px}
   .kick{color:var(--gold-ink);font-size:14px;margin-bottom:14px}
   h1{text-wrap:balance}
   .lede{font-family:"G Klar";font-size:clamp(17px,2vw,20px);color:var(--muted);max-width:48ch;margin-top:14px;text-wrap:pretty}
   section{padding:42px 0;border-top:1px solid var(--line-soft)}
-  .sec{color:var(--gold-ink);font-size:13px}
+  .sec{color:var(--gold-ink);font-size:var(--t-small)}
   /* Marginalspalte (System B): die Paragraphen-Marke wandert auf breiten Schirmen
      in eine eigene Randspalte, der Lesesatz bleibt unberührt bei seinem Mass. */
   @media(min-width:940px){
@@ -50,26 +50,26 @@
   .leise{font-family:"G Leise"}.deutlich{font-family:"G Deutlich"}.laut{font-family:"G Laut"}
   .note{display:flex;gap:10px;align-items:baseline;border-left:2px solid var(--gold);background:var(--soft);
         padding:10px 14px;border-radius:0 10px 10px 0;margin:14px 0;font-size:14px;color:var(--muted);max-width:39ch}
-  .note .rid{font-size:11px;color:var(--gold-ink);white-space:nowrap}
+  .note .rid{font-size:var(--t-small);color:var(--gold-ink);white-space:nowrap}
   .ex{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin:12px 0;max-width:640px}
   @media(max-width:560px){.ex{grid-template-columns:1fr}}
   .ex>div{border:1px solid var(--line-soft);border-radius:10px;padding:10px 14px;background:var(--soft);font-size:15px}
-  .ex .t{font-size:10.5px;letter-spacing:.02em;margin-bottom:4px}
+  .ex .t{font-size:var(--t-small);letter-spacing:.02em;margin-bottom:4px}
   .ex .no .t{color:var(--bad)} .ex .yes .t{color:var(--good)}
   code,.mono{font-family:ui-monospace,Menlo,monospace;font-size:.86em;background:var(--soft);border:1px solid var(--line-soft);border-radius:5px;padding:1px 6px}
   .files{display:grid;grid-template-columns:1fr 1fr;gap:14px;margin:18px 0;max-width:760px}
   @media(max-width:640px){.files{grid-template-columns:1fr}}
   .file{border:1px solid var(--line);border-radius:12px;padding:16px}
   .file h4{font-family:"G Laut";font-weight:400;font-size:15px;margin-bottom:4px}
-  .file p{font-size:13.5px;color:var(--muted)}
-  .file a{font-size:13px}
+  .file p{font-size:var(--t-small);color:var(--muted)}
+  .file a{font-size:var(--t-small)}
   table.spick{border-collapse:collapse;width:100%;max-width:640px;font-size:14.5px;margin-top:14px}
-  .spick th{font-family:"G Laut";font-weight:400;text-align:left;font-size:12px;color:var(--muted);padding:6px 12px;border-bottom:1px solid var(--line)}
+  .spick th{font-family:"G Laut";font-weight:400;text-align:left;font-size:var(--t-small);color:var(--muted);padding:6px 12px;border-bottom:1px solid var(--line)}
   .spick td{padding:7px 12px;border-bottom:1px solid var(--line-soft)}
   .spick td.f{color:var(--bad)} .spick td.r{color:var(--ink)}
-  .spick tr td:first-child{color:var(--muted);font-size:13px}
+  .spick tr td:first-child{color:var(--muted);font-size:var(--t-small)}
   .credo{font-family:"G Klar";font-size:clamp(19px,2.4vw,26px);line-height:1.3;color:var(--ink);max-width:none;margin-top:28px;text-wrap:balance}
-  footer{border-top:1px solid var(--line);padding:30px 0 60px;color:var(--muted);font-size:12.5px}
+  footer{border-top:1px solid var(--line);padding:30px 0 60px;color:var(--muted);font-size:var(--t-small)}
 </style>
 </head>
 <body>

--- a/vorschau.html
+++ b/vorschau.html
@@ -27,7 +27,7 @@
   h1{text-wrap:balance}
   .lede{font-size:clamp(17px,2vw,20px);color:var(--muted);max-width:48ch;margin-top:14px;text-wrap:pretty}
   section{padding:40px 0;border-top:1px solid var(--line-soft)}
-  .sec{color:var(--gold-ink);font-size:13px}
+  .sec{color:var(--gold-ink);font-size:var(--t-small)}
   h2{margin:4px 0 6px;text-wrap:balance}
   h3{font-size:16px;margin:24px 0 8px}
   p{max-width:54ch;text-wrap:pretty}
@@ -39,7 +39,7 @@
   /* Ziffern-Demo */
   .figs{display:grid;grid-template-columns:1fr;gap:10px;margin:14px 0;max-width:680px}
   .figcard{border:1px solid var(--line-soft);border-radius:12px;padding:14px 18px;background:var(--soft)}
-  .figcard .lab{font-size:11px;letter-spacing:.03em;color:var(--gold-ink);margin-bottom:6px}
+  .figcard .lab{font-size:var(--t-small);letter-spacing:.03em;color:var(--gold-ink);margin-bottom:6px}
   .figrow{font-size:30px;line-height:1.25;letter-spacing:.04em}
   .figrow small{font-size:18px;color:var(--muted);letter-spacing:0}
   .tnum{font-feature-settings:"tnum" 1,"lnum" 1}
@@ -49,37 +49,37 @@
   .vstage{border:1px solid var(--line-soft);border-radius:14px;background:var(--soft);padding:24px 22px;margin:16px 0;max-width:760px}
   .vsample{font-family:"G Variabel";font-weight:440;font-size:clamp(30px,6vw,52px);line-height:1.15;letter-spacing:.01em;
            outline:none;text-wrap:balance;font-feature-settings:normal}
-  .vsample:focus{background:rgba(215,171,104,.08);border-radius:8px}
+  .vsample:focus{background:color-mix(in srgb,var(--gold) 8%,transparent);border-radius:8px}
   .vcontrols{display:flex;align-items:center;gap:18px 22px;flex-wrap:wrap;margin-top:20px}
   .vcontrols input[type=range]{flex:1;min-width:200px;accent-color:var(--gold-ink);height:4px}
-  .vcontrols .readout{font-size:13.5px;color:var(--muted);white-space:nowrap}
+  .vcontrols .readout{font-size:var(--t-small);color:var(--muted);white-space:nowrap}
   .vcontrols .readout b{color:var(--ink);font-variant-numeric:tabular-nums}
-  .vcontrols label{font-size:13.5px;color:var(--muted);display:flex;align-items:center;gap:7px;cursor:pointer;white-space:nowrap}
+  .vcontrols label{font-size:var(--t-small);color:var(--muted);display:flex;align-items:center;gap:7px;cursor:pointer;white-space:nowrap}
   .vcontrols label input{accent-color:var(--gold-ink)}
   .vfeat{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}
-  .vfeat button{font:inherit;font-size:12.5px;color:var(--muted);background:var(--field-bg);border:1px solid var(--line);
+  .vfeat button{font:inherit;font-size:var(--t-small);color:var(--muted);background:var(--field-bg);border:1px solid var(--line);
                 border-radius:20px;padding:4px 13px;cursor:pointer}
   .vfeat button[aria-pressed=true]{color:var(--gold-ink);border-color:var(--gold);background:var(--soft)}
   /* tabular alignment demo */
   .align{display:inline-grid;gap:2px;border:1px solid var(--line-soft);border-radius:10px;padding:10px 16px;background:var(--soft);text-align:right;font-size:20px;min-width:160px}
   .twocol{display:flex;gap:18px;flex-wrap:wrap;align-items:start;margin-top:8px}
-  .twocol figcaption,.cap{font-size:12px;color:var(--muted);margin-top:6px;text-align:center}
+  .twocol figcaption,.cap{font-size:var(--t-small);color:var(--muted);margin-top:6px;text-align:center}
   /* before / after */
   .ba{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin:12px 0;max-width:640px}
   @media(max-width:560px){.ba{grid-template-columns:1fr}}
   .ba>div{border:1px solid var(--line-soft);border-radius:10px;padding:10px 14px;background:var(--soft);font-size:18px}
-  .ba .t{font-size:10.5px;letter-spacing:.02em;margin-bottom:4px}
+  .ba .t{font-size:var(--t-small);letter-spacing:.02em;margin-bottom:4px}
   .ba .no .t{color:var(--bad)} .ba .yes .t{color:var(--good)}
   /* spatien ruler */
   .ruler{display:grid;grid-template-columns:auto 1fr auto;gap:10px 16px;align-items:center;max-width:560px;margin:14px 0}
-  .ruler .nm{font-size:13px;color:var(--muted)}
-  .ruler .cp{font-family:ui-monospace,Menlo,monospace;font-size:12px;color:var(--gold-ink);text-align:right}
+  .ruler .nm{font-size:var(--t-small);color:var(--muted)}
+  .ruler .cp{font-family:ui-monospace,Menlo,monospace;font-size:var(--t-small);color:var(--gold-ink);text-align:right}
   .ruler .bar{font-size:34px;white-space:nowrap}
   .ruler .bar i{color:var(--gold);font-style:normal}
   /* draft image */
   .draft{width:100%;max-width:760px;border:1px solid var(--line);border-radius:12px;margin-top:12px;display:block}
-  .pill{display:inline-block;font-size:11px;color:var(--bad);border:1px solid var(--bad);border-radius:20px;padding:2px 10px;margin-bottom:8px}
-  footer{border-top:1px solid var(--line);padding:30px 0 60px;color:var(--muted);font-size:12.5px}
+  .pill{display:inline-block;font-size:var(--t-small);color:var(--bad);border:1px solid var(--bad);border-radius:20px;padding:2px 10px;margin-bottom:8px}
+  footer{border-top:1px solid var(--line);padding:30px 0 60px;color:var(--muted);font-size:var(--t-small)}
 </style>
 </head>
 <body>

--- a/werkzeug.html
+++ b/werkzeug.html
@@ -18,14 +18,14 @@
   .wrap{max-width:980px;margin:0 auto;padding:0 22px}
   header{border-bottom:1px solid var(--line)}
   .bar{display:flex;align-items:center;justify-content:space-between;height:56px}
-  .bar b{font-weight:400}.bar a{color:var(--muted);text-decoration:none;font-size:13.5px}
+  .bar b{font-weight:400}.bar a{color:var(--muted);text-decoration:none;font-size:var(--t-small)}
   .hero{padding-block:34px 6px}
-  .kick{color:var(--gold-ink);font-size:13.5px;margin-bottom:10px}
+  .kick{color:var(--gold-ink);font-size:var(--t-small);margin-bottom:10px}
   /* h1 aus dem Fundament */
   .lede{color:var(--muted);margin-top:10px;max-width:620px;font-size:15px}
   .panel{border:1px solid var(--line);border-radius:16px;padding:22px;margin:22px 0;background:var(--soft)}
   .panel h2{font-weight:400;font-size:20px;margin-bottom:4px}
-  .panel .hint{color:var(--muted);font-size:13px;margin-bottom:16px}
+  .panel .hint{color:var(--muted);font-size:var(--t-small);margin-bottom:16px}
   .stage{background:var(--soft);border:1px solid var(--line);border-radius:12px;padding:22px 20px;margin-bottom:18px}
   .line{font-size:clamp(26px,4.4vw,40px);line-height:1.35}
   .big{font-size:clamp(40px,9vw,84px);line-height:1.2;margin-top:6px}
@@ -33,17 +33,17 @@
   .sp{font-family:"G Var";font-variation-settings:"wght" 518}
   .ctrls{display:grid;grid-template-columns:1fr 1fr;gap:14px 26px}
   @media(max-width:640px){.ctrls{grid-template-columns:1fr}}
-  .ctrl label{display:flex;justify-content:space-between;font-size:13px;color:var(--muted);margin-bottom:6px}
+  .ctrl label{display:flex;justify-content:space-between;font-size:var(--t-small);color:var(--muted);margin-bottom:6px}
   .ctrl label b{color:var(--ink);font-weight:400;font-feature-settings:"tnum" 1}
   input[type=range]{-webkit-appearance:none;appearance:none;width:100%;height:2px;background:var(--line);border-radius:2px;margin:6px 0}
   input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;width:20px;height:20px;border-radius:50%;background:var(--gold);cursor:pointer;border:3px solid var(--paper);box-shadow:0 1px 4px rgba(0,0,0,.18)}
   input[type=range]::-moz-range-thumb{width:16px;height:16px;border-radius:50%;background:var(--gold);cursor:pointer;border:3px solid var(--paper)}
   .readout{margin-top:18px;display:flex;gap:10px;align-items:center;flex-wrap:wrap}
-  .code{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:13px;background:#1f2429;color:#e7ddc8;border-radius:9px;padding:9px 13px;letter-spacing:.02em}
-  .btn{font:inherit;font-size:13px;border:1px solid var(--line);background:var(--field-bg);color:var(--ink);border-radius:9px;padding:8px 13px;cursor:pointer}
+  .code{font-family:var(--font-mono);font-size:var(--t-small);background:var(--code-bg);color:var(--code-ink);border-radius:9px;padding:9px 13px;letter-spacing:.02em}
+  .btn{font:inherit;font-size:var(--t-small);border:1px solid var(--line);background:var(--field-bg);color:var(--ink);border-radius:9px;padding:8px 13px;cursor:pointer}
   .btn:hover{border-color:var(--gold-ink)}
-  .reset{color:var(--muted);font-size:12.5px;background:none;border:none;cursor:pointer;text-decoration:underline}
-  footer{border-top:1px solid var(--line);padding:24px 0 50px;color:var(--muted);font-size:12.5px;margin-top:10px}
+  .reset{color:var(--muted);font-size:var(--t-small);background:none;border:none;cursor:pointer;text-decoration:underline}
+  footer{border-top:1px solid var(--line);padding:24px 0 50px;color:var(--muted);font-size:var(--t-small);margin-top:10px}
 </style>
 </head>
 <body>
@@ -61,7 +61,7 @@
     <div class="stage">
       <p class="big" id="mixBig"></p>
       <p class="line" id="mixOut" style="min-height:1.4em"></p>
-      <p class="line" id="mixSmall" style="font-size:13.5px;line-height:1.75;color:var(--muted);max-width:48ch;margin-top:14px"></p>
+      <p class="line" id="mixSmall" style="font-size:var(--t-small);line-height:1.75;color:var(--muted);max-width:48ch;margin-top:14px"></p>
     </div>
     <textarea id="mixIn" rows="3" spellcheck="false" style="width:100%;font-family:inherit;font-size:15px;color:inherit;background:var(--field-bg);border:1px solid var(--line);border-radius:10px;padding:11px 13px;resize:vertical;line-height:1.5">Mitglied {BE}3477 trat 1923 bei · {AGB} §3 · {ISBN} 978-3 · das {GOETHEANUM} zählte am 24.6.1923 genau 1487 Gäste; vgl. {Bd}. II, S. 36.</textarea>
     <div class="sixgrid" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:22px;margin-top:20px">


### PR DESCRIPTION
## Track 3 — Backstage/Beta auf den neuen 14px-Floor
Acht Specimen-/Backstage-Seiten (Typografie, Tester, Grotesk+, Vorschau, Mischsatz, Ligaturen ×3): literale `<14px` → `var(--t-small)`, Reste tokenisiert (Bar-Hintergrund → `--bar-bg`, Gold-Tint → `color-mix`, Code-Chip → `--code-*`). **Alle 0 Fehler.**

**Gesamt-Score 42 % → 72 %** (18/25 Seiten konform).

## Track 1 — Org-Farbe angeglichen
`--bereich` von `#005eb8` auf **`#0061a9` = Markenblau** — so rendern es die Logo-Daten (`goe-orgs.js`) ohnehin. Die Sektionsnamen-Korrekturen aus **#164** (Team) bleiben massgeblich; ich habe sie beim Track-2-Rebase übernommen. Die spanische Gesellschaft bleibt `prüfen` (goetheanum.ch/es schwankt zwischen „General"/„mundial").

## Offen
Die **4 Generatoren** (gtv-naming, cover, briefschaften, karten) tragen grosse DS02/DS07-Zahlen — das sind **Artefakt-Farben** (Telefon-Mockup, Druck), kein Floor-Thema. Eigener Ratifizierungs-Pass mit `# ds-ok` (wie Visitenkarten/Signatur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_