### PR TITLE
Schrift-Grenze: Source Sans 3 für Funktion/Daten · Hausschrift-Faktoren

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,11 +51,21 @@ Für jede Web-Oberfläche gilt, geprüft (Kontraste rechnen, nicht schätzen):
   (`--paper`/`--field-bg`/`--bar-bg`), nie `#fff` hart verdrahten.
 
 ### Grenzen der Hausschrift (bewusst einsetzen)
-Goetheanum ist **Display** – die Stimme. Sie hat zwei Grenzen:
-- **Textmasse:** ein paar gut gesetzte Zeilen (magisches Quadrat) sind kein
-  Problem; **echter Mengentext** läuft in **Source Sans 3** (`.prose`).
-- **Kleine UI-Schrift:** **Leise** verschwimmt klein – Minimum ist **Klar**,
-  Titel/Marken **Deutlich**. Kleine Labels nie in Leise setzen.
+Goetheanum ist **Display** – die **Stimme**. Sie trägt alles, was als **Sprache**
+gelesen wird: Titel, Kicker, Lede, **Fliesstext** und erklärende Hinweise. Die
+Lesbarkeit bei normalem Grad kommt aus den **Faktoren**, nicht aus einem
+Schriftwechsel: Zeilenhöhe **≥1.6** (`--lh-body` 1.66), Lesemass **~62ch**
+(`--measure`), Schnitt **Klar**, Betonung **Laut** (nie Leise im Lesetext).
+
+**Die Schrift-Grenze – wo Lesbarkeit über Identität geht:** wo Text zu **Funktion
+und Daten** wird und klein/konventionell gelesen wird, trägt die Lese-Grotesk
+**Source Sans 3** (`--font-text`): **Label, Wert/Readout, Meta/Legende,
+Badge/Chip, Formularfelder, Tabellen**. Das ist im Fundament (`base.css`) so
+verdrahtet – nicht je Seite entscheiden.
+- **Textmasse:** ein paar gut gesetzte Zeilen sind in der Hausschrift kein
+  Problem; **echter Mengentext** (lange Artikel) darf in `.prose` (Source) laufen.
+- **Kleine UI-Schrift:** **Leise** verschwimmt klein – Minimum **Klar**,
+  Titel/Marken **Deutlich**. Kleine Labels nie in Leise.
 Das Menü **koordiniert, es erklärt nicht**: nur Titel, kein Beiwerk-Text.
 
 ## Bauen neuer Seiten und Werkzeuge — vom Fundament aus, nicht freihändig

--- a/apps/logos/index.html
+++ b/apps/logos/index.html
@@ -37,7 +37,7 @@
   .swatches button{width:38px;height:38px;border-radius:50%;border:1px solid var(--line);cursor:pointer;padding:0}
   .swatches button[aria-pressed="true"]{outline:2px solid var(--gold-deep);outline-offset:2px}
   /* Ausnahme-Kreis (frei umfärben) – Regenbogen zeigt: keine feste Hausfarbe. */
-  .swatches button.free{background:conic-gradient(#df4164,#f98a3c,#63b145,#2e54a4,#a24f8a,#df4164)}
+  .swatches button.free{background:conic-gradient(var(--sek-szw),var(--sek-hpise),var(--sek-lws),var(--sek-mas),var(--sek-aas),var(--sek-szw))}
 
   /* Versteckte Profi-Optionen (Backstage): erscheinen NUR mit der Intern-Ansicht
      (nav.js, „intern" tippen) – gleiches Schloss wie die Backstage-Welten. Bewusst
@@ -50,7 +50,7 @@
   .advinput{font:inherit;font-size:16px;padding:10px 12px;min-height:var(--tap);border:1px solid var(--line);border-radius:var(--r-control);background:var(--field-bg);color:var(--ink)}
   .advcolors{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
   .advcolors input[type=color]{width:var(--tap);height:var(--tap);padding:0;border:1px solid var(--line);border-radius:var(--r-control);background:none;cursor:pointer}
-  .advnote{font-size:12.5px;line-height:1.5;color:var(--muted);margin:0}
+  .advnote{font-size:var(--t-small);line-height:1.5;color:var(--muted);margin:0}
 
   /* Mobil: zuoberst Vorschau + Format + die EINE Aktion – primär lädt das gemeinsame
      Logo zum Download ein. Die Sonderfassungen (Auswahl) stehen darunter. Nur die

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -68,6 +68,15 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
   Utility `.ico-invert` (Filter im Dunkelmodus) ins Fundament; auf die Schriften-
   Icons angewandt. Besser noch: Icons als Webfont/Inline-SVG mit currentColor.
 
+### Die Schrift-Grenze gezogen – Source Sans 3 endlich im Einsatz
+- Die zweite Groteske (Source Sans 3) war geladen, aber ungenutzt. Jetzt verdrahtet:
+  **Funktion & Daten** tragen sie (Label, Wert/Readout, Meta/Legende, Badge/Chip,
+  Formularfelder, Tabellen) – klein & konventionell deutlich lesbarer.
+- **Identität bleibt Hausschrift**: Titel, Kicker, Lede, **Fliesstext und erklärende
+  Hinweise** (Sprache). Lesbarkeit dort aus den **Faktoren**: --lh-body 1.6 → **1.66**,
+  Mass ~62ch, Schnitt Klar, Betonung Laut. Die Grenze ‹wo Lesbarkeit über Identität
+  geht› in CLAUDE.md verankert.
+
 ### Backstage/Beta auf den 14px-Floor + Org-Farbe angeglichen
 - Acht Specimen-/Backstage-Seiten (Typografie, Tester, Grotesk+, Vorschau,
   Mischsatz, Ligaturen ×3) auf den neuen Floor gehoben: literale <14px → --t-small;

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -62,17 +62,17 @@ nav.top a:hover{color:var(--gold-ink)}
 section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 .shead{display:flex;align-items:baseline;justify-content:space-between;gap:var(--s8);margin-bottom:var(--s6);flex-wrap:wrap}
 .shead h2{font-size:var(--t-h2);flex:0 0 auto}
-.shead p{color:var(--muted);font-size:var(--t-small);line-height:1.5;max-width:54ch;flex:1 1 320px}
+.shead p{color:var(--muted);font-size:var(--t-small);line-height:1.6;max-width:58ch;flex:1 1 320px}
 
 /* --- Karte ----------------------------------------------------------------- */
 .card{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);background:var(--paper)}
 .card.soft{background:var(--soft)}
 
-/* --- Chips & Marken --------------------------------------------------------- */
-.chip{font-size:var(--t-small);color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:6px 14px}
-.chip b{color:var(--ink);font-weight:var(--w-strong)}
+/* --- Chips & Marken (Lese-Grotesk, kleine Grade) --------------------------- */
+.chip{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:6px 14px}
+.chip b{color:var(--ink);font-weight:600}
 /* Status-Marke (Live/Beta/Entwurf …) – Mikro-Pille, kleiner als .chip, nie versal (G05). */
-.badge{display:inline-block;font-size:var(--t-micro);letter-spacing:.03em;color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:2px 10px}
+.badge{display:inline-block;font-family:var(--font-text);font-size:var(--t-micro);letter-spacing:.03em;color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:2px 10px}
 
 /* --- Knöpfe = AKTION -------------------------------------------------------- */
 /* Aktion = Blau (Zustand/Tun); die primäre Aktion ist gefüllt. Klar getrennt von
@@ -104,25 +104,25 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 .field{display:grid;gap:var(--s1)}
 .field>.lab{font-size:var(--t-small);color:var(--muted);letter-spacing:.01em}
 .field input,.field textarea,.field select{
-  width:100%;font-family:var(--font);font-size:16px;font-weight:var(--w-text);line-height:1.25;color:var(--ink);
+  width:100%;font-family:var(--font-text);font-size:16px;font-weight:400;line-height:1.3;color:var(--ink);
   background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);padding:11px 12px;outline:none;
   transition:border-color .15s,box-shadow .15s;
 }
-/* Aufklappliste in der Hausschrift, wo der Browser es zulässt (Firefox). */
-.field select option{font-family:var(--font);font-size:16px}
+/* Eingaben in der Lese-Grotesk (Source Sans 3): lesbarer als die Display-Schrift. */
+.field select option{font-family:var(--font-text);font-size:16px}
 
-/* Gestaltbare Klappliste (ds-select.js) – Hausschrift AUCH geöffnet (Desktop). */
+/* Gestaltbare Klappliste (ds-select.js) – Lese-Grotesk, offen wie geschlossen. */
 .ds-select{position:relative}
 .ds-select>select{position:absolute;width:1px;height:1px;opacity:0;pointer-events:none}  /* nativ versteckt, bleibt Quelle der Wahrheit */
 .ds-select__btn{width:100%;display:flex;align-items:center;justify-content:space-between;gap:10px;
-  font-family:var(--font);font-size:16px;font-weight:var(--w-text);line-height:1.25;color:var(--ink);text-align:left;
+  font-family:var(--font-text);font-size:16px;font-weight:400;line-height:1.3;color:var(--ink);text-align:left;
   background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);padding:11px 12px;cursor:pointer;min-height:var(--tap)}
 .ds-select__btn::after{content:"";width:8px;height:8px;border-right:2px solid var(--muted);border-bottom:2px solid var(--muted);
   transform:translateY(-2px) rotate(45deg);flex:0 0 auto}
 .ds-select__btn:hover{border-color:var(--gold-deep)}
 .ds-select__list{position:absolute;z-index:50;left:0;right:0;top:calc(100% + 4px);margin:0;padding:6px;list-style:none;
   background:var(--paper);border:1px solid var(--line);border-radius:var(--r-control);box-shadow:var(--shadow-card);max-height:300px;overflow:auto}
-.ds-select__opt{font-family:var(--font);font-size:16px;color:var(--ink);padding:9px 11px;border-radius:8px;cursor:pointer;white-space:nowrap}
+.ds-select__opt{font-family:var(--font-text);font-size:16px;color:var(--ink);padding:9px 11px;border-radius:8px;cursor:pointer;white-space:nowrap}
 .ds-select__opt:hover,.ds-select__opt:focus{background:var(--soft);outline:none}
 .ds-select__opt[aria-selected="true"]{color:var(--gold-ink);font-weight:var(--w-strong)}
 .field textarea{resize:vertical;min-height:48px}
@@ -152,9 +152,9 @@ strong,b,em,i{font-style:normal;font-weight:var(--w-strong)}
 q{quotes:'\2039' '\203A' '\2039' '\203A'}
 
 /* Ziffern in Tabellen: Versalziffern, dicktengleich, exakt untereinander (G25). */
-table{border-collapse:collapse;font-variant-numeric:tabular-nums lining-nums}
+table{border-collapse:collapse;font-family:var(--font-text);font-variant-numeric:tabular-nums lining-nums}
 th,td{text-align:left;padding:var(--s2) var(--s3);border-bottom:1px solid var(--line-soft)}
-th{font-weight:var(--w-strong);color:var(--ink)}
+th{font-weight:600;color:var(--ink)}
 td.num,th.num,.num{font-variant-numeric:tabular-nums lining-nums;text-align:right;font-feature-settings:"tnum","lnum"}
 
 /* Schnitt-Utilities. */
@@ -192,19 +192,27 @@ td.num,th.num,.num{font-variant-numeric:tabular-nums lining-nums;text-align:righ
 /* Anriss unter dem Titel. */
 .lede{font-size:var(--t-lede);color:var(--muted);line-height:1.45;max-width:54ch}
 
-/* Erklärender Beisatz (Hilfetext, Untertitel eines Abschnitts oder einer Karte).
-   Ein Grad, eine Farbe – egal auf welcher Seite. Löst hint/sub/desc/help ab. */
-.note,.hint,.help,.desc,.subhead{color:var(--muted);font-size:var(--t-small);line-height:1.5;max-width:60ch}
+/* --- Die Schrift-Grenze: Identität vs. Lesbarkeit ----------------------------
+   Goetheanum ist DISPLAY – die STIMME. Sie trägt alles, was als Sprache gelesen
+   wird: Titel, Kicker, Lede, FLIESSTEXT und die erklärenden Hinweise. Lesbarkeit
+   bei normalem Grad kommt dort aus den FAKTOREN (Zeilenhöhe ≥1.6, Mass ~62ch,
+   Schnitt Klar/Betonung Laut), nicht aus einem Schriftwechsel.
+   Die Lese-Grotesk Source Sans 3 (--font-text) übernimmt FUNKTION & DATEN, wo
+   klein & konventionell gelesen wird: Label, Wert, Meta/Legende, Badge/Chip,
+   Formularfelder, Tabellen. Dort geht Lesbarkeit über Identität. */
+
+/* Erklärender Beisatz (Hilfetext, Untertitel) – Sprache, darum Hausschrift. */
+.note,.hint,.help,.desc,.subhead{color:var(--muted);font-size:var(--t-small);line-height:1.6;max-width:62ch}
 
 /* Legende, Bildunterschrift, Datum, Byline – das knappe Beiwerk. */
-.meta,.cap,.caption,.legend,.byline{color:var(--muted);font-size:var(--t-small);line-height:1.45}
+.meta,.cap,.caption,.legend,.byline{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small);line-height:1.45}
 
 /* Aufschrift eines Bedienelements oder Werts – getrackt, nie versal (G05). */
-.lab,.role{color:var(--muted);font-size:var(--t-small);letter-spacing:.01em;line-height:1.35}
-.lab b,.lab strong,.role b,.role strong{color:var(--ink);font-weight:var(--w-strong)}
+.lab,.role{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small);letter-spacing:.01em;line-height:1.35}
+.lab b,.lab strong,.role b,.role strong{color:var(--ink);font-weight:600}
 
 /* Live-Ausgabe / Ableseband – ruhig, Zahlen dicktengleich (G25). */
-.readout{color:var(--ink);font-size:var(--t-small);line-height:1.5;font-variant-numeric:tabular-nums lining-nums}
+.readout{font-family:var(--font-text);color:var(--ink);font-size:var(--t-small);line-height:1.5;font-variant-numeric:tabular-nums lining-nums}
 
 /* Technische Auszeichnung – Monospace. Inline-Chip (.code) = leise getönt;
    Block (.code.block / pre.code) = theme-feste Konsole mit Syntaxpalette. */

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -199,7 +199,7 @@
   <section id="textrollen">
     <div class="shead">
       <h2>Textrollen</h2>
-      <p>Eine gemessene Grundlage für ALLE Texte – jede Seite nutzt diese Klassen statt eigener Grade. Hier live aus <code>base.css</code>, B03-sicher (nichts Lesbares unter 13px).</p>
+      <p>Eine gemessene Grundlage für ALLE Texte – jede Seite nutzt diese Klassen statt eigener Grade. Die Schrift-Grenze: <b>Goetheanum</b> trägt die Sprache (Titel, Kicker, Lede, Fliesstext, Hinweise) – Lesbarkeit aus den Faktoren (Zeilenhöhe, Mass, Schnitt). Die Lese-Grotesk <b>Source Sans 3</b> trägt Funktion &amp; Daten (Label, Wert, Meta, Felder, Tabellen) – dort geht Lesbarkeit über Identität. Live aus <code>base.css</code>, B03-sicher (nichts unter 14px).</p>
     </div>
     <div class="grid cols2">
       <div class="card">

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -108,7 +108,7 @@
   --t-h3:clamp(1.25rem, 1.15rem + 0.45vw, 1.45rem);      /* 20–23px */
   --t-h2:clamp(1.45rem, 1.28rem + 0.8vw, 1.8rem);        /* 23–29px – maßvoll */
   --t-h1:clamp(1.85rem, 1.5rem + 1.55vw, 2.45rem);       /* 30–39px – kein Plakat */
-  --lh-body:1.6; --lh-tight:1.15;
+  --lh-body:1.66; --lh-tight:1.15;   /* Display-als-Fliesstext braucht Luft (Zeilenabstand) */
   --measure:62ch;        /* ~66 Zeichen in Source – lineares Lesemaß (G10) */
 
   /* --- Abstände (4/8/12/16/24/32) ---------------------------------------- */


### PR DESCRIPTION
## Die zweite Groteske endlich im Einsatz — und die Grenze gezogen

Source Sans 3 war geladen, aber nur via `.prose` genutzt. Jetzt im Fundament verdrahtet, entlang einer klaren Grenze: **Identität vs. Lesbarkeit**.

- **Hausschrift (Goetheanum) = Sprache**: Titel, Kicker, Lede, **Fliesstext und erklärende Hinweise**. Lesbarkeit bei normalem Grad kommt aus den **Faktoren**, nicht aus einem Schriftwechsel: `--lh-body` 1.6 → **1.66**, Mass ~62ch, Schnitt Klar, Betonung Laut.
- **Source Sans 3 = Funktion & Daten**: Label, Wert/Readout, Meta/Legende, Badge/Chip, **Formularfelder**, **Tabellen** — klein & konventionell, dort geht Lesbarkeit über Identität.

Die Grenze ist in `CLAUDE.md` und im Schaufenster verankert (nicht je Seite entscheiden).

**Nebenbei:** Regressionen aus #164-Backstage behoben (Logos `#df4164`/conic-gradient → `--sek-*`-Tokens, `.advnote` 12.5px → `--t-small`).

Alle berührten Seiten 100 % konform; Score 76 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_