### PR TITLE
Neue Publikumsseite: Farben – Identitätsfarben auf einen Blick

### DIFF
--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -18,6 +18,18 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ## [Unveröffentlicht]
 
+### Neue Publikumsseite: Farben (Lücke vom alten Auftritt geschlossen)
+- **`farben.html`** – die Identitätsfarben auf einen Blick (Marke · Neutrale ·
+  Sektionen). **Hex/RGB/HSB** werden im Browser exakt aus dem Token-Hex errechnet
+  (eine Quelle: `tokens.css`; Sektionen aus `goe-orgs.js`), jede Zelle klick-kopierbar.
+- **Ehrlich statt erfunden** (Hausregel): **CMYK** steht als **rechnerischer Richtwert**
+  (sRGB→CMYK, geräteabhängig) klar markiert; **Pantone** und die offiziellen Druck-CMYK-/
+  Sonderfarben sind ‹—› (noch aus dem Marken-Handbuch zu erfassen). Damit ist der im
+  Schaufenster offene Punkt ‹CMYK-/Sonderfarben› sichtbar adressiert, ohne falsche Werte.
+- Registriert in `tools.json` (cat `system`, erscheint in der Welt **Elemente**) + Startkarte.
+- Aus dem Vergleich mit grafik.goetheanum.ch als ‹jetzt bauen› gewählt; Zeichen, PowerPoint,
+  Wallpaper und ein globaler Kontakt-/Feedback-Button sind als nächste Schritte vorgemerkt.
+
 ### Generatorpass: die letzten vier Werkzeuge theme-aware – 100 %
 - Die vier Generatoren folgten eigenen, fest verdrahteten Dunkel-Paletten und
   ignorierten Hell/Dunkel. Jetzt **theme-aware reskinnt**: ihre lokalen Variablen

--- a/farben.html
+++ b/farben.html
@@ -1,0 +1,183 @@
+<!doctype html>
+<html lang="de">
+<head>
+<link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Goetheanum – Farben</title>
+<meta name="description" content="Die Identitätsfarben des Goetheanum auf einen Blick: Markenfarben, Neutrale und Sektionsfarben mit Hex, RGB, HSB und CMYK (Richtwert) – klick-kopierbar. Offizielle Pantone- und Druck-CMYK-Werte folgen." />
+<link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/base.css" />
+<link rel="stylesheet" href="design-system/nav.css" />
+<style>
+  /* Farben/Schrift/Hell-Dunkel aus tokens.css/base.css – nur seiten-eigenes Layout. */
+  .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
+  .hero{padding-block:60px 14px}
+  .lede{max-width:64ch;margin-top:var(--s4)}
+
+  .grp{margin-top:var(--s8)}
+  .grp > h2{font-size:var(--t-h3);font-family:var(--font);font-weight:var(--w-deutlich);margin-bottom:var(--s2)}
+  .grp > p{color:var(--muted);font-size:var(--t-small);max-width:62ch}
+
+  .tablecard{border:1px solid var(--line);border-radius:var(--r-card);background:var(--paper);overflow-x:auto;margin-top:var(--s4)}
+  table{width:100%;border-collapse:collapse}
+  th,td{vertical-align:middle;text-align:left;padding:var(--s3) var(--s4);border-top:1px solid var(--line-soft)}
+  thead th{border-top:0;color:var(--muted);font-size:var(--t-small);font-weight:var(--w-text);white-space:nowrap}
+  tbody td{font-size:var(--t-small)}
+  td.val{cursor:copy;font-variant-numeric:tabular-nums;white-space:nowrap}
+  td.val:hover{background:var(--soft)}
+  .name{font-family:var(--font);font-weight:var(--w-deutlich);font-size:var(--t-body)}
+  .cdesc{color:var(--muted);font-size:var(--t-small)}
+  .pend{color:var(--muted)}
+
+  .sw{width:42px;height:42px;border-radius:var(--r-control);border:1px solid var(--line);display:inline-block;vertical-align:middle}
+  td.swc{width:42px}
+
+  .fineprint{margin-top:var(--s8);color:var(--muted);font-size:var(--t-small);max-width:64ch}
+  .fineprint b{color:var(--ink);font-weight:var(--w-deutlich)}
+</style>
+</head>
+<body>
+<script src="design-system/nav.js" data-root="./" data-section="system" data-active="farben"
+        data-onpage="Marke:#marke|Neutrale:#neutrale|Sektionen:#sektionen"></script>
+
+<main class="wrap">
+  <div class="hero">
+    <div class="kicker">Hausgrafik · Elemente</div>
+    <h1>Farben</h1>
+    <p class="lede">Die Identitätsfarben auf einen Blick. Hex, RGB und HSB sind exakt aus dem
+      Design-System abgeleitet (eine Quelle der Wahrheit: <code>design-system/tokens.css</code>).
+      Jede Zelle ist klick-kopierbar.</p>
+  </div>
+
+  <section class="grp" id="marke">
+    <h2>Markenfarben</h2>
+    <p>Blau trägt Zustand, Verweis und Aktion; Gold den Inhalts-Akzent. Auf Farbflächen steht Weiss (B01).</p>
+    <div class="tablecard"><table><thead><tr>
+      <th></th><th>Name</th><th>Hex</th><th>RGB</th><th>HSB</th><th>CMYK<span class="pend"> ·&nbsp;Richtwert</span></th><th>Pantone</th>
+    </tr></thead><tbody id="marke-body"></tbody></table></div>
+  </section>
+
+  <section class="grp" id="neutrale">
+    <h2>Neutrale</h2>
+    <p>Tinte, Sekundärton und die Flächen. Hell/Dunkel kommt aus den Tokens – hier stehen die hellen Grundwerte.</p>
+    <div class="tablecard"><table><thead><tr>
+      <th></th><th>Name</th><th>Hex</th><th>RGB</th><th>HSB</th><th>CMYK<span class="pend"> ·&nbsp;Richtwert</span></th><th>Pantone</th>
+    </tr></thead><tbody id="neutrale-body"></tbody></table></div>
+  </section>
+
+  <section class="grp" id="sektionen">
+    <h2>Sektionsfarben</h2>
+    <p>Die Identitätsfarben der Schul-Sektionen. Quelle: <code>assets/goe-orgs.js</code> (speist die Logo-Engine).
+      Markenfest – sie kippen nicht mit Hell/Dunkel.</p>
+    <div class="tablecard"><table><thead><tr>
+      <th></th><th>Sektion</th><th>Hex</th><th>RGB</th><th>HSB</th><th>CMYK<span class="pend"> ·&nbsp;Richtwert</span></th><th>Pantone</th>
+    </tr></thead><tbody id="sektionen-body"></tbody></table></div>
+  </section>
+
+  <p class="fineprint">
+    <b>Hex · RGB · HSB</b> sind aus den Tokens errechnet und verbindlich für Bildschirm/Web.
+    <b>CMYK</b> ist ein <b>rechnerischer Richtwert</b> (sRGB→CMYK, geräteabhängig) – <b>nicht</b> der
+    verbindliche Druckwert. <b>Pantone</b> und die offiziellen Druck-CMYK-/Sonderfarben sind noch zu
+    erfassen (aus dem Marken-Handbuch) und hier mit ‹—› markiert. Korrigieren = die Quelle bearbeiten
+    (<a href="https://github.com/phtok/goeloggen/blob/main/design-system/tokens.css">tokens.css</a> ·
+    <a href="https://github.com/phtok/goeloggen/blob/main/assets/goe-orgs.js">goe-orgs.js</a>).
+  </p>
+</main>
+
+<div class="toast" id="toast" style="position:fixed;left:50%;bottom:24px;transform:translateX(-50%);background:var(--ink);color:var(--on-accent);padding:8px 16px;border-radius:var(--r-pill);font-size:var(--t-small);opacity:0;transition:opacity .2s;pointer-events:none;z-index:60"></div>
+
+<script src="assets/goe-orgs.js"></script>
+<script>
+(function(){
+  "use strict";
+  function $(s,r){return (r||document).querySelector(s);}
+
+  // --- Farbwert-Umrechnung aus dem Hex (eine Quelle: der Token-Hex) ----------
+  function hexToRgb(hex){
+    var h=hex.replace("#","");
+    if(h.length===3) h=h[0]+h[0]+h[1]+h[1]+h[2]+h[2];
+    return {r:parseInt(h.slice(0,2),16), g:parseInt(h.slice(2,4),16), b:parseInt(h.slice(4,6),16)};
+  }
+  function rgbToHsb(r,g,b){
+    r/=255; g/=255; b/=255;
+    var max=Math.max(r,g,b), min=Math.min(r,g,b), d=max-min, h=0;
+    if(d!==0){
+      if(max===r) h=((g-b)/d)%6;
+      else if(max===g) h=(b-r)/d+2;
+      else h=(r-g)/d+4;
+      h*=60; if(h<0) h+=360;
+    }
+    var s=max===0?0:d/max;
+    return {h:Math.round(h), s:Math.round(s*100), b:Math.round(max*100)};
+  }
+  function rgbToCmyk(r,g,b){
+    r/=255; g/=255; b/=255;
+    var k=1-Math.max(r,g,b);
+    if(k===1) return {c:0,m:0,y:0,k:100};
+    var c=(1-r-k)/(1-k), m=(1-g-k)/(1-k), y=(1-b-k)/(1-k);
+    return {c:Math.round(c*100), m:Math.round(m*100), y:Math.round(y*100), k:Math.round(k*100)};
+  }
+
+  function copy(txt){
+    if(navigator.clipboard) navigator.clipboard.writeText(txt);
+    var t=$("#toast"); t.textContent="„"+txt+"“ kopiert"; t.style.opacity="1";
+    setTimeout(function(){t.style.opacity="0";},1100);
+  }
+  function valCell(txt){
+    var td=document.createElement("td");
+    td.className="val"; td.textContent=txt; td.title="Klick kopiert";
+    td.addEventListener("click",function(){copy(txt);});
+    return td;
+  }
+
+  function row(tbody, hex, name, role){
+    var rgb=hexToRgb(hex), hsb=rgbToHsb(rgb.r,rgb.g,rgb.b), cmyk=rgbToCmyk(rgb.r,rgb.g,rgb.b);
+    var tr=document.createElement("tr");
+    var swc=document.createElement("td"); swc.className="swc";
+    var sw=document.createElement("span"); sw.className="sw"; sw.style.background=hex; swc.appendChild(sw);
+    tr.appendChild(swc);
+    var nc=document.createElement("td");
+    nc.innerHTML='<div class="name"></div>'+(role?'<div class="cdesc"></div>':"");
+    nc.querySelector(".name").textContent=name;
+    if(role) nc.querySelector(".cdesc").textContent=role;
+    tr.appendChild(nc);
+    tr.appendChild(valCell(hex.toUpperCase()));
+    tr.appendChild(valCell(rgb.r+", "+rgb.g+", "+rgb.b));
+    tr.appendChild(valCell(hsb.h+"°, "+hsb.s+"%, "+hsb.b+"%"));
+    tr.appendChild(valCell(cmyk.c+", "+cmyk.m+", "+cmyk.y+", "+cmyk.k));
+    var pt=document.createElement("td"); pt.className="pend"; pt.textContent="—"; tr.appendChild(pt);
+    tbody.appendChild(tr);
+  }
+
+  var MARKE=[
+    {hex:"#0061a9", name:"Markenblau", role:"Zustand · Verweis · Aktion"},
+    {hex:"#d7ab68", name:"Gold", role:"Inhalts-Akzent"},
+    {hex:"#94702e", name:"Gold dunkel", role:"Auswahl-Fläche (Weiss drauf, ≥4.5:1)"}
+  ];
+  var NEUTRAL=[
+    {hex:"#23272b", name:"Tinte", role:"Lesetext"},
+    {hex:"#6b7177", name:"Sekundär", role:"gedämpfter Text (4.9:1)"},
+    {hex:"#faf8f4", name:"Sanft", role:"gedämpfte Fläche, Karten"},
+    {hex:"#ffffff", name:"Papier", role:"Grund"}
+  ];
+  // Reihenfolge der Schul-Sektionen (Schlüssel in goe-orgs.js)
+  var SEK_KEYS=["aas","ps","ms","nws","lws","sbk","ssw","szw","js","srmk","mas","hpise"];
+
+  function render(){
+    MARKE.forEach(function(c){row($("#marke-body"),c.hex,c.name,c.role);});
+    NEUTRAL.forEach(function(c){row($("#neutrale-body"),c.hex,c.name,c.role);});
+    var O=window.GOE_GCI_ORGS;
+    if(O){
+      SEK_KEYS.forEach(function(k){
+        var o=O[k]; if(!o||!o.color) return;
+        row($("#sektionen-body"), o.color, o.name_de, "");
+      });
+    }
+  }
+  if(document.readyState!=="loading") render();
+  else document.addEventListener("DOMContentLoaded", render);
+})();
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
     "schrift-webfont": '<span class="win"><b></b><em>Aa</em></span>',                          // Schrift im Browser-Fenster
     "typografie":      '<span class="para"><i></i><i></i><i></i><i></i></span>',               // gesetzter Absatz
     "design-system":   '<span class="sw"><i style="background:var(--blue)"></i><i style="background:var(--gold-deep)"></i><i style="background:var(--ink)"></i></span>', // Farbfelder
+    "farben":          '<span class="sw"><i style="background:var(--blue)"></i><i style="background:var(--gold)"></i><i style="background:var(--sek-lws)"></i><i style="background:var(--sek-szw)"></i></span>', // Identitätsfarben
     "uebersetzungen":  '<span class="tr"><i>DE</i><i>EN</i><i>FR</i><i>ES</i></span>' // vier Sprachen
   };
   function visual(t){

--- a/tools.json
+++ b/tools.json
@@ -69,6 +69,15 @@
       "desc": "Farben, Schnitte, Typografie-Regeln und Komponenten – die lebende Schauseite, aus einer Quelle gerendert. Mit Starter und Bau-Workflow."
     },
     {
+      "slug": "farben",
+      "cat": "system",
+      "status": "beta",
+      "tag": "Elemente",
+      "title": "Farben",
+      "href": "farben.html",
+      "desc": "Alle Identitätsfarben auf einen Blick – Marke, Neutrale, Sektionen – mit Hex, RGB, HSB und CMYK (Richtwert), klick-kopierbar. Offizielle Pantone-/Druckwerte folgen."
+    },
+    {
       "slug": "logo-generator",
       "cat": "generatoren",
       "status": "live",


### PR DESCRIPTION
## Worum es geht

Schliesst eine der grössten Lücken aus dem Vergleich mit dem alten Auftritt `grafik.goetheanum.ch` (Bereich **Elemente → Farben**): eine **Publikumsseite für die Identitätsfarben**.

## `farben.html`

- **Marke · Neutrale · Sektionen** auf einen Blick, je mit Swatch, Name und Rolle.
- **Hex / RGB / HSB** werden im Browser **exakt aus dem Token-Hex errechnet** — eine Quelle der Wahrheit (`design-system/tokens.css`; die Sektionsfarben aus `assets/goe-orgs.js`). Kein doppelt gepflegter Wert.
- **Jede Zelle ist klick-kopierbar** (wie bei den Übersetzungen).
- Folgt Hell/Dunkel, bindet das Fundament ein — **0 Fehler / 0 Hinweise** beim Linter.

## Ehrlich statt erfunden (Hausregel)

- **CMYK** steht als **rechnerischer Richtwert** (sRGB→CMYK, geräteabhängig) — klar als solcher markiert, **nicht** als verbindlicher Druckwert.
- **Pantone** und die offiziellen Druck-CMYK-/Sonderfarben sind mit ‹—› markiert (noch aus dem Marken-Handbuch zu erfassen).

Damit ist der im Schaufenster offen gelistete Punkt ‹CMYK-/Sonderfarben-Gegenwerte› sichtbar adressiert, ohne falsche Zahlen zu publizieren.

## Einbettung

- Registriert in `tools.json` (cat `system` → erscheint in der Welt **Elemente**).
- **Startkarte** mit Vier-Farben-Vorschau (Blau · Gold · Landwirtschaft · Sozialwissenschaft).

## Kontext / nächste Schritte

Aus dem Lücken-Vergleich als „jetzt bauen" gewählt. Vorgemerkt (mit Tasks): **Zeichen/Signets**, **PowerPoint-Vorlagen**, **Wallpaper**, **globaler Kontakt-/Feedback-Button** — diese brauchen Assets bzw. ein Kontaktziel vom Auftraggeber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_