### PR TITLE
Download-Knopf in der Kopfzeile (Header-CTA im Fundament)

### DIFF
--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -37,6 +37,15 @@ html{scrollbar-gutter:stable}
   background:none;border:0;cursor:pointer;padding:0;text-decoration:none}
 .dsnav .worlds a:hover,.dsnav .worlds button:hover{color:var(--gold-ink)}
 
+/* Seiten-CTA in der Kopfzeile (data-cta) – Aktion = volles Blau + Weiss (B01),
+   immer sichtbar, auch mobil (kein langes Suchen). margin-left:auto hält ihn
+   rechts – auf Desktop hinter den Welten, mobil (Welten ausgeblendet) bündig. */
+.dsnav .cta{margin-left:auto;display:inline-flex;align-items:center;gap:6px;flex:0 0 auto;
+  background:var(--blue-solid);color:var(--on-accent);font-weight:var(--w-strong);
+  font-size:14px;line-height:1;text-decoration:none;white-space:nowrap;
+  border-radius:var(--r-control);padding:11px 16px;min-height:40px}
+.dsnav .cta:hover{filter:brightness(1.08)}
+
 /* ☾/☀ Hell-Dunkel – nur das Icon */
 .dsnav .theme{margin-left:18px;display:inline-flex;align-items:center;justify-content:center;font:inherit;
   color:var(--ink);background:none;border:0;padding:6px;cursor:pointer;line-height:1}

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -147,13 +147,23 @@
   })();
 
   // --- Kopfzeile -------------------------------------------------------------
+  // Optionaler Seiten-CTA in der Kopfzeile: data-cta="Beschriftung:#anker"
+  // (Aktion = volles Blau + Weiss, B01). Immer sichtbar – keine Suchbewegung.
+  var CTA = (s && s.dataset.cta) || "";
+  var ctaHTML = "";
+  if (CTA) {
+    var ci = CTA.indexOf(":");
+    var clabel = ci > 0 ? CTA.slice(0, ci) : CTA;
+    var ctarget = ci > 0 ? CTA.slice(ci + 1) : "#";
+    ctaHTML = '<a class="cta" href="' + ctarget + '">' + clabel + '</a>';
+  }
   var header = el("header", "dsnav");
   header.innerHTML =
     '<div class="bar">' +
       '<a class="brand" href="' + HOME + '" aria-label="Goetheanum Werkzeuge – zur Übersicht">' +
         '<img class="lockup" src="' + ROOT + 'assets/logos/goetheanum-werkzeuge.svg" alt="Goetheanum Werkzeuge">' +
       '</a>' +
-      '<nav class="worlds"></nav>' +
+      '<nav class="worlds"></nav>' + ctaHTML +
       '<button class="theme" type="button" aria-label="Dunkel schalten"><span class="ic">☾</span></button>' +
       '<button class="all" type="button" aria-haspopup="dialog" aria-expanded="false" aria-label="Menü">' +
         '<span class="ic">☰</span><span class="idot" hidden></span></button>' +

--- a/schriften.html
+++ b/schriften.html
@@ -113,6 +113,7 @@
 <body>
 
 <script src="design-system/nav.js" data-root="./" data-section="schrift" data-active="schriften"
+        data-cta="Download:#download"
         data-onpage="Variabel:#variabel|Schnitte:#schnitte|Features:#features|Icons:#icons|Im Web:#web|Download:#download"></script>
 
 <main>


### PR DESCRIPTION
## Was

Auf der Schriftenseite war der Weg zum Download zu lang (scrollen/suchen). Jetzt sitzt ein **Download-Knopf direkt in der Kopfzeile**.

- **Fundament (`nav.js`/`nav.css`):** neuer, wiederverwendbarer Kopfzeilen-CTA über `data-cta="Beschriftung:#anker"`. Volles Blau + Weiss (Aktion, B01), klebt mit der Leiste oben fest, **immer sichtbar – auch mobil** (`margin-left:auto`; die Schnellzugriffe blenden ≤720px aus, der Knopf bleibt). Gehört laut CLAUDE.md ins Fundament, nicht in eine Einzelseite – so kann jede Seite ihn nutzen.
- **`schriften.html`:** `data-cta="Download:#download"` → Knopf springt direkt zum Download-Abschnitt.

## Geprüft (headless Chromium)
- Knopf in der Kopfzeile: Blau `rgb(0,97,169)` + Weiss, Text „Download", Ziel `#download` – Klick springt zum Abschnitt.
- Sichtbar auf Desktop (1200px) und Mobil (390px).
- `schriften.html` 100 % konform (die verbleibenden Hinweise sind die bekannten Demo-Fehlalarme G20/G21).

Nächste Seite, die ihn brauchen könnte: `icons.html` (eine Zeile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aSpY9SVm7s2z5dMoG4Cy4

---
_Generated by [Claude Code](https://claude.ai/code/session_017aSpY9SVm7s2z5dMoG4Cy4)_