### PR TITLE
Footer: goetheanum.org → goetheanum.ch (aktuelle Adresse)

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
 <footer class="ds-footer">
   <div class="wrap frow">
     <span><strong>Goetheanum</strong> · Werkzeuge für die Hausgrafik</span>
-    <span>Allgemeine Anthroposophische Gesellschaft · <a href="https://www.goetheanum.org">goetheanum.org</a></span>
+    <span>Allgemeine Anthroposophische Gesellschaft · <a href="https://www.goetheanum.ch">goetheanum.ch</a></span>
   </div>
 </footer>
 

--- a/start/index.html
+++ b/start/index.html
@@ -68,7 +68,7 @@
 
 <footer class="ds-footer"><div class="wrap frow">
   <span><strong>Goetheanum Grafik</strong> · Werkzeuge für die Hausgrafik</span>
-  <span>Allgemeine Anthroposophische Gesellschaft · <a href="https://www.goetheanum.org">goetheanum.org</a></span>
+  <span>Allgemeine Anthroposophische Gesellschaft · <a href="https://www.goetheanum.ch">goetheanum.ch</a></span>
 </div></footer>
 
 <script>


### PR DESCRIPTION
## Worum es geht

Der Footer der Startseiten (`index.html`, `start/index.html`) verwies auf die alte Adresse `goetheanum.org`. Aktuell ist **`goetheanum.ch`** — korrigiert.

## Umfang

- Nur die beiden Footer-Links geändert (`https://www.goetheanum.org` → `https://www.goetheanum.ch`, Anzeigetext `goetheanum.ch`). Ziel mit `curl` geprüft: **HTTP 200**.
- **Bewusst unverändert:** die `*.goetheanum.org`-Einträge in `assets/goe-orgs.js` (`mas.goetheanum.org`, `medsektion-goetheanum.org` …) — das sind **echte Sektions-Webadressen**, keine Tippfehler. Ebenso Font-Lizenz/Metadaten (anderer Kontext).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_