### PR TITLE
Feedback: aus der Kopfzeile ins Menü (Schubladen-Fuss)

### DIFF
--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -28,8 +28,9 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 - **PowerPoint** (`powerpoint.html`) – Platzhalterseite (Vorlage wird überarbeitet, Datei folgt).
 - **Neue Welt ‹Anwendungen›** (cat `anwendung`) in `nav.js`/`tools.json`/Startseite – für fertige
   Vorlagen (Wallpaper, PowerPoint); **Pantone aus der Farbseite entfernt** (wird nicht mehr verwendet).
-- **Globaler Feedback-Button** (`✉`) in der Kopfzeile (`nav.js`/`nav.css`) – mailto an die Hausgrafik,
-  auf jeder Seite. Ein eigenes Anfrage-/Druckformular bleibt davon getrennt (Todo Druckauftrag).
+- **Globaler Feedback-Link** im Menü (Schubladen-Fuss, `nav.js`) – mailto an die Hausgrafik, auf jeder
+  Seite erreichbar. Bewusst NICHT in der Kopfzeile: dort frass ein Icon die leere Fläche an, über die
+  der (geheime) Dreifach-Klick die Intern-Ansicht schaltet. Anfrage-/Druckformular bleibt getrennt (Todo).
 
 ### Neue Publikumsseite: Farben (Lücke vom alten Auftritt geschlossen)
 - **`farben.html`** – die Identitätsfarben auf einen Blick (Marke · Neutrale ·

--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -46,14 +46,8 @@ html{scrollbar-gutter:stable}
   border-radius:var(--r-control);padding:11px 16px;min-height:40px}
 .dsnav .cta:hover{filter:brightness(1.08)}
 
-/* ✉ Feedback – nur das Icon (mailto, global) */
-.dsnav .feedback{margin-left:18px;display:inline-flex;align-items:center;justify-content:center;
-  color:var(--ink);background:none;border:0;padding:6px;cursor:pointer;line-height:1;text-decoration:none}
-.dsnav .feedback .ic{font-size:18px;line-height:1}
-.dsnav .feedback:hover{color:var(--gold-ink)}
-
 /* ☾/☀ Hell-Dunkel – nur das Icon */
-.dsnav .theme{margin-left:14px;display:inline-flex;align-items:center;justify-content:center;font:inherit;
+.dsnav .theme{margin-left:18px;display:inline-flex;align-items:center;justify-content:center;font:inherit;
   color:var(--ink);background:none;border:0;padding:6px;cursor:pointer;line-height:1}
 .dsnav .theme .ic{font-size:18px;line-height:1}
 .dsnav .theme:hover{color:var(--gold-ink)}
@@ -67,7 +61,7 @@ html{scrollbar-gutter:stable}
 
 @media(max-width:720px){
   .dsnav .worlds{display:none}
-  .dsnav .feedback{margin-left:auto}
+  .dsnav .theme{margin-left:auto}
 }
 
 /* --- Schublade ------------------------------------------------------------- */

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -166,7 +166,6 @@
         '<img class="lockup" src="' + ROOT + 'assets/logos/goetheanum-werkzeuge.svg" alt="Goetheanum Werkzeuge">' +
       '</a>' +
       '<nav class="worlds"></nav>' + ctaHTML +
-      '<a class="feedback" href="mailto:philipp.tok@goetheanum.ch?subject=Feedback%20Goetheanum%20Werkzeuge" aria-label="Feedback geben" title="Feedback geben"><span class="ic">✉</span></a>' +
       '<button class="theme" type="button" aria-label="Dunkel schalten"><span class="ic">☾</span></button>' +
       '<button class="all" type="button" aria-haspopup="dialog" aria-expanded="false" aria-label="Menü">' +
         '<span class="ic">☰</span><span class="idot" hidden></span></button>' +
@@ -181,7 +180,7 @@
     '<div class="dhead"><span class="t">Navigation</span>' +
       '<button class="close" type="button" aria-label="Schliessen">×</button></div>' +
     '<div class="body"></div>' +
-    '<div class="foot">Goetheanum Hausgrafik · <a href="' + ROOT + 'design-system/">Design-System</a></div>';
+    '<div class="foot"><a href="mailto:philipp.tok@goetheanum.ch?subject=Feedback%20Goetheanum%20Werkzeuge">Feedback geben</a> · <a href="' + ROOT + 'design-system/">Design-System</a></div>';
   document.body.appendChild(backdrop);
   document.body.appendChild(drawer);
 


### PR DESCRIPTION
## Worum es geht

Das ✉-Icon in der Kopfzeile war zweifach störend: es wirkte fremd im Bar-Chrome **und** es frass die leere Fläche an, über die der **geheime Dreifach-Klick** die Intern-Ansicht schaltet (Backend ist standardmäßig aus).

## Lösung

- ✉ aus der Bar entfernt (`nav.js`/`nav.css` zurückgebaut, `.theme`-Abstände wiederhergestellt).
- Stattdessen unaufdringlicher **„Feedback geben"-Link im Menü-Fuss** (Schublade) — auf jeder Seite erreichbar, `mailto:philipp.tok@goetheanum.ch` unverändert.
- Die leere Bar-Fläche für den Intern-Schalter ist wieder frei.

## Verifikation

- Menü geöffnet: Fuss zeigt „Feedback geben · Design-System"; Bar enthält kein Feedback-Element mehr (per Headless geprüft).
- `ds-lint`: weiterhin 0 Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_