### PR TITLE
PowerPoint: Schrift-Wechsel mitten im Erklärtext raus

### DIFF
--- a/powerpoint.html
+++ b/powerpoint.html
@@ -48,7 +48,7 @@
     <span class="nm">So sitzt die Schrift</span>
     <p>PowerPoint zeigt die Hausschrift zuverlässig nur, wenn sie installiert ist (das Einbetten greift
       auf dem Mac nicht sicher). Darum einmalig:</p>
-    <ol class="prose" style="margin-top:var(--s4);padding-left:1.2em;color:var(--ink)">
+    <ol style="margin-top:var(--s4);padding-left:1.2em;color:var(--ink)">
       <li>Die fünf <b>TrueType</b>-Schriften aus dem Set installieren (Doppelklick → ‹Installieren›).</li>
       <li>PowerPoint komplett schliessen und neu starten.</li>
       <li>Die Vorlage öffnen – Titel in der Hausschrift, Piktogramme als Piktogramme.</li>


### PR DESCRIPTION
## Worum es geht

Auf `powerpoint.html` lag die nummerierte Anleitungsliste in `.prose` (Source Sans 3) — mitten zwischen Hausschrift-Absätzen desselben Erklärblocks. Das wirkte willkürlich (zu Recht bemängelt). Es war die **einzige** `.prose`-Stelle im ganzen Repo.

## Fix

- `class="prose"` von der `<ol>` entfernt → der ganze Erklärblock läuft jetzt in **einer Stimme** (Hausschrift). Kein Wechsel mehr mitten im Text.

## Grundsatz (zur Klarstellung)

Die Schrift-Grenze geht nach **Rolle**, nicht nach Grösse: was als **Sprache** gelesen wird (Titel, Navigation, Lede, Fliesstext, Hinweise) trägt die Hausschrift; was als **Daten** gelesen wird (Tabellenwerte, Eingabefelder, Labels/Readouts, Badges) trägt Source. Ein laufender Anleitungstext ist Sprache — gehört also ganz in die Hausschrift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_