### PR TITLE
Schliff: Sektionsfarben-Seite · eigenes DS-Bild · Theme-Icon ohne Emoji

### DIFF
--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -18,6 +18,16 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ## [Unveröffentlicht]
 
+### Schliff: Sektionsfarben-Seite · Design-System-Bild · Theme-Icon ohne Emoji
+- **Farben → Sektionsfarben**: die Sonderseite trägt jetzt **nur Sektions- und Bereichsfarben**
+  (datengetrieben aus `goe-orgs.js`: 12 Sektionen + 6 Bereiche). Marken- und Neutralfarben wohnen
+  im **Design-System** (Schaufenster `#swatches`) – keine Doppelpflege. Datei, Karte und Slug heissen
+  jetzt `sektionsfarben`. Pantone war schon raus.
+- **Startkarte Design-System** bekommt ein **eigenes Bild**: ein Mini-Bauplan (Leiste + Textzeilen +
+  Farb-Chips = Struktur **und** Farbe) statt der Farbfelder – klar unterscheidbar von den Sektionsfarben.
+- **Theme-Schalter ohne Emoji**: Sonne/Mond sind jetzt **Inline-SVG** (currentColor) statt der
+  Unicode-Glyphen ☀/☾, die iOS zu Emoji umfärbte. Deterministisch in Hell wie Dunkel.
+
 ### Weitere Lücken vom alten Auftritt geschlossen: Zeichen · Wallpaper · PowerPoint · Feedback
 - **Zeichen** (`zeichen.html`) – die Zeichen von Rudolf Steiner (Hochschule, Gesellschaft,
   Bau-Administration) als Vorschau + Anwendungshinweis + Zugang zu den vollständigen Paketen.

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -35,10 +35,14 @@
     try { var t = localStorage.getItem(THEME_KEY); if (t === "light" || t === "dark") return t; } catch (e) {}
     return prefersDark() ? "dark" : "light";
   }
+  // Sonne/Mond als Inline-SVG (currentColor) – NICHT als Unicode, das iOS sonst
+  // zu Emoji umfärbt. Deterministisch in Hell wie Dunkel.
+  var MOON_SVG = '<svg viewBox="0 0 24 24" width="17" height="17" aria-hidden="true" style="display:block" fill="currentColor"><path d="M20.7 13.3A8 8 0 1 1 10.7 3.3a6.3 6.3 0 1 0 10 10Z"/></svg>';
+  var SUN_SVG = '<svg viewBox="0 0 24 24" width="17" height="17" aria-hidden="true" style="display:block" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4.2"/><path d="M12 2.6v2.1M12 19.3v2.1M2.6 12h2.1M19.3 12h2.1M5.2 5.2l1.5 1.5M17.3 17.3l1.5 1.5M18.8 5.2l-1.5 1.5M6.7 17.3l-1.5 1.5"/></svg>';
   function updateThemeBtn() {
     if (!themeBtn) return;
     var dark = document.documentElement.getAttribute("data-theme") === "dark";
-    themeBtn.querySelector(".ic").textContent = dark ? "☀" : "☾";  // ☀ U+2600 / ☾ U+263E
+    themeBtn.querySelector(".ic").innerHTML = dark ? SUN_SVG : MOON_SVG;
     themeBtn.setAttribute("aria-label", dark ? "Hell schalten" : "Dunkel schalten");
     themeBtn.setAttribute("aria-pressed", String(dark));
   }
@@ -166,7 +170,7 @@
         '<img class="lockup" src="' + ROOT + 'assets/logos/goetheanum-werkzeuge.svg" alt="Goetheanum Werkzeuge">' +
       '</a>' +
       '<nav class="worlds"></nav>' + ctaHTML +
-      '<button class="theme" type="button" aria-label="Dunkel schalten"><span class="ic">☾</span></button>' +
+      '<button class="theme" type="button" aria-label="Dunkel schalten"><span class="ic"></span></button>' +
       '<button class="all" type="button" aria-haspopup="dialog" aria-expanded="false" aria-label="Menü">' +
         '<span class="ic">☰</span><span class="idot" hidden></span></button>' +
     '</div>';

--- a/index.html
+++ b/index.html
@@ -58,6 +58,13 @@
   /* Design-System: Farbfelder */
   .tile .sw{display:flex;gap:9px}
   .tile .sw i{width:20px;height:20px;border-radius:5px;display:block}
+  /* Design-System: Mini-Bauplan – Struktur (Leiste, Zeilen) + Farbe (Chips) */
+  .tile .sys{display:grid;gap:6px;width:122px}
+  .tile .sys .bar{height:13px;border-radius:4px;background:var(--blue)}
+  .tile .sys .ln{height:7px;border-radius:3px;background:var(--line)}
+  .tile .sys .ln.s{width:60%}
+  .tile .sys .chips{display:flex;gap:6px;margin-top:3px}
+  .tile .sys .chips i{width:18px;height:18px;border-radius:5px;display:block}
   /* Icons: drei Piktogramme aus dem Icon-Webfont (currentColor – folgt Hell/Dunkel) */
   .tile .icons{font-family:"G Icons";font-size:36px;line-height:1;color:var(--ink);display:flex;gap:14px}
   /* Übersetzungen: vier Sprach-Marken */
@@ -95,8 +102,8 @@
     "icons":           '<span class="icons" aria-hidden="true">gfx</span>',                     // drei Piktogramme (WLAN · Garderobe · Rollstuhl)
     "schrift-webfont": '<span class="win"><b></b><em>Aa</em></span>',                          // Schrift im Browser-Fenster
     "typografie":      '<span class="para"><i></i><i></i><i></i><i></i></span>',               // gesetzter Absatz
-    "design-system":   '<span class="sw"><i style="background:var(--blue)"></i><i style="background:var(--gold-deep)"></i><i style="background:var(--ink)"></i></span>', // Farbfelder
-    "farben":          '<span class="sw"><i style="background:var(--blue)"></i><i style="background:var(--gold)"></i><i style="background:var(--sek-lws)"></i><i style="background:var(--sek-szw)"></i></span>', // Identitätsfarben
+    "design-system":   '<span class="sys"><i class="bar"></i><i class="ln"></i><i class="ln s"></i><span class="chips"><i style="background:var(--gold)"></i><i style="background:var(--sek-ms)"></i><i style="background:var(--gold-deep)"></i></span></span>', // Mini-Bauplan: Struktur + Farbe
+    "sektionsfarben":  '<span class="sw"><i style="background:var(--sek-szw)"></i><i style="background:var(--sek-lws)"></i><i style="background:var(--sek-ms)"></i><i style="background:var(--sek-js)"></i></span>', // vier Sektionsfarben
     "zeichen":         '<span style="background:#fff;border-radius:8px;width:100%;height:100%;display:grid;place-items:center"><img src="assets/zeichen/hochschulzeichen.png" alt="" style="max-height:66px;max-width:78%"></span>', // Rudolf-Steiner-Zeichen auf weissem Papier
     "wallpaper":       '<img src="assets/wallpaper/goetheanum-wallpaper-48.jpg" alt="" style="width:100%;height:100%;object-fit:cover;border-radius:8px">', // ein Motiv
     "uebersetzungen":  '<span class="tr"><i>DE</i><i>EN</i><i>FR</i><i>ES</i></span>' // vier Sprachen

--- a/sektionsfarben.html
+++ b/sektionsfarben.html
@@ -4,8 +4,8 @@
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Goetheanum – Farben</title>
-<meta name="description" content="Die Identitätsfarben des Goetheanum auf einen Blick: Markenfarben, Neutrale und Sektionsfarben mit Hex, RGB, HSB und CMYK (Richtwert) – klick-kopierbar." />
+<title>Goetheanum – Sektionsfarben</title>
+<meta name="description" content="Die Identitätsfarben der Schul-Sektionen und der Bereiche mit Hex, RGB, HSB und CMYK (Richtwert) – klick-kopierbar. Marken- und Neutralfarben wohnen im Design-System." />
 <link rel="stylesheet" href="design-system/tokens.css" />
 <link rel="stylesheet" href="design-system/base.css" />
 <link rel="stylesheet" href="design-system/nav.css" />
@@ -27,7 +27,6 @@
   td.val{cursor:copy;font-variant-numeric:tabular-nums;white-space:nowrap}
   td.val:hover{background:var(--soft)}
   .name{font-family:var(--font);font-weight:var(--w-deutlich);font-size:var(--t-body)}
-  .cdesc{color:var(--muted);font-size:var(--t-small)}
   .pend{color:var(--muted)}
 
   .sw{width:42px;height:42px;border-radius:var(--r-control);border:1px solid var(--line);display:inline-block;vertical-align:middle}
@@ -38,50 +37,42 @@
 </style>
 </head>
 <body>
-<script src="design-system/nav.js" data-root="./" data-section="system" data-active="farben"
-        data-onpage="Marke:#marke|Neutrale:#neutrale|Sektionen:#sektionen"></script>
+<script src="design-system/nav.js" data-root="./" data-section="system" data-active="sektionsfarben"
+        data-onpage="Sektionen:#sektionen|Bereiche:#bereiche"></script>
 
 <main class="wrap">
   <div class="hero">
     <div class="kicker">Hausgrafik · Elemente</div>
-    <h1>Farben</h1>
-    <p class="lede">Die Identitätsfarben auf einen Blick. Hex, RGB und HSB sind exakt aus dem
-      Design-System abgeleitet (eine Quelle der Wahrheit: <code>design-system/tokens.css</code>).
-      Jede Zelle ist klick-kopierbar.</p>
+    <h1>Sektionsfarben</h1>
+    <p class="lede">Die Identitätsfarben der Schul-Sektionen und der Bereiche – Hex, RGB und HSB exakt
+      aus der Quelle (<code>assets/goe-orgs.js</code>, speist die Logo-Engine). Jede Zelle ist
+      klick-kopierbar. Marken- und Neutralfarben wohnen im
+      <a href="design-system/">Design-System</a>.</p>
   </div>
 
-  <section class="grp" id="marke">
-    <h2>Markenfarben</h2>
-    <p>Blau trägt Zustand, Verweis und Aktion; Gold den Inhalts-Akzent. Auf Farbflächen steht Weiss (B01).</p>
-    <div class="tablecard"><table><thead><tr>
-      <th></th><th>Name</th><th>Hex</th><th>RGB</th><th>HSB</th><th>CMYK<span class="pend"> ·&nbsp;Richtwert</span></th>
-    </tr></thead><tbody id="marke-body"></tbody></table></div>
-  </section>
-
-  <section class="grp" id="neutrale">
-    <h2>Neutrale</h2>
-    <p>Tinte, Sekundärton und die Flächen. Hell/Dunkel kommt aus den Tokens – hier stehen die hellen Grundwerte.</p>
-    <div class="tablecard"><table><thead><tr>
-      <th></th><th>Name</th><th>Hex</th><th>RGB</th><th>HSB</th><th>CMYK<span class="pend"> ·&nbsp;Richtwert</span></th>
-    </tr></thead><tbody id="neutrale-body"></tbody></table></div>
-  </section>
-
   <section class="grp" id="sektionen">
-    <h2>Sektionsfarben</h2>
-    <p>Die Identitätsfarben der Schul-Sektionen. Quelle: <code>assets/goe-orgs.js</code> (speist die Logo-Engine).
-      Markenfest – sie kippen nicht mit Hell/Dunkel.</p>
+    <h2>Sektionen</h2>
+    <p>Die Identitätsfarben der Sektionen der Freien Hochschule für Geisteswissenschaft. Markenfest –
+      sie kippen nicht mit Hell/Dunkel.</p>
     <div class="tablecard"><table><thead><tr>
       <th></th><th>Sektion</th><th>Hex</th><th>RGB</th><th>HSB</th><th>CMYK<span class="pend"> ·&nbsp;Richtwert</span></th>
     </tr></thead><tbody id="sektionen-body"></tbody></table></div>
   </section>
 
+  <section class="grp" id="bereiche">
+    <h2>Bereiche</h2>
+    <p>Die Bereiche tragen den Standard – Markenblau – oder eine eigene Bereichsfarbe.</p>
+    <div class="tablecard"><table><thead><tr>
+      <th></th><th>Bereich</th><th>Hex</th><th>RGB</th><th>HSB</th><th>CMYK<span class="pend"> ·&nbsp;Richtwert</span></th>
+    </tr></thead><tbody id="bereiche-body"></tbody></table></div>
+  </section>
+
   <p class="fineprint">
-    <b>Hex · RGB · HSB</b> sind aus den Tokens errechnet und verbindlich für Bildschirm/Web.
+    <b>Hex · RGB · HSB</b> sind aus der Quelle errechnet und verbindlich für Bildschirm/Web.
     <b>CMYK</b> ist ein <b>rechnerischer Richtwert</b> (sRGB→CMYK, geräteabhängig) – <b>nicht</b> der
     verbindliche Druckwert; die offiziellen Druck-CMYK-Werte folgen aus dem Marken-Handbuch.
     Korrigieren = die Quelle bearbeiten
-    (<a href="https://github.com/phtok/goeloggen/blob/main/design-system/tokens.css">tokens.css</a> ·
-    <a href="https://github.com/phtok/goeloggen/blob/main/assets/goe-orgs.js">goe-orgs.js</a>).
+    (<a href="https://github.com/phtok/goeloggen/blob/main/assets/goe-orgs.js">goe-orgs.js</a>).
   </p>
 </main>
 
@@ -93,7 +84,7 @@
   "use strict";
   function $(s,r){return (r||document).querySelector(s);}
 
-  // --- Farbwert-Umrechnung aus dem Hex (eine Quelle: der Token-Hex) ----------
+  // --- Farbwert-Umrechnung aus dem Hex (eine Quelle: der goe-orgs-Hex) -------
   function hexToRgb(hex){
     var h=hex.replace("#","");
     if(h.length===3) h=h[0]+h[0]+h[1]+h[1]+h[2]+h[2];
@@ -131,16 +122,14 @@
     return td;
   }
 
-  function row(tbody, hex, name, role){
+  function row(tbody, hex, name){
     var rgb=hexToRgb(hex), hsb=rgbToHsb(rgb.r,rgb.g,rgb.b), cmyk=rgbToCmyk(rgb.r,rgb.g,rgb.b);
     var tr=document.createElement("tr");
     var swc=document.createElement("td"); swc.className="swc";
     var sw=document.createElement("span"); sw.className="sw"; sw.style.background=hex; swc.appendChild(sw);
     tr.appendChild(swc);
     var nc=document.createElement("td");
-    nc.innerHTML='<div class="name"></div>'+(role?'<div class="cdesc"></div>':"");
-    nc.querySelector(".name").textContent=name;
-    if(role) nc.querySelector(".cdesc").textContent=role;
+    nc.innerHTML='<span class="name"></span>'; nc.querySelector(".name").textContent=name;
     tr.appendChild(nc);
     tr.appendChild(valCell(hex.toUpperCase()));
     tr.appendChild(valCell(rgb.r+", "+rgb.g+", "+rgb.b));
@@ -149,30 +138,17 @@
     tbody.appendChild(tr);
   }
 
-  var MARKE=[
-    {hex:"#0061a9", name:"Markenblau", role:"Zustand · Verweis · Aktion"},
-    {hex:"#d7ab68", name:"Gold", role:"Inhalts-Akzent"},
-    {hex:"#94702e", name:"Gold dunkel", role:"Auswahl-Fläche (Weiss drauf, ≥4.5:1)"}
-  ];
-  var NEUTRAL=[
-    {hex:"#23272b", name:"Tinte", role:"Lesetext"},
-    {hex:"#6b7177", name:"Sekundär", role:"gedämpfter Text (4.9:1)"},
-    {hex:"#faf8f4", name:"Sanft", role:"gedämpfte Fläche, Karten"},
-    {hex:"#ffffff", name:"Papier", role:"Grund"}
-  ];
-  // Reihenfolge der Schul-Sektionen (Schlüssel in goe-orgs.js)
-  var SEK_KEYS=["aas","ps","ms","nws","lws","sbk","ssw","szw","js","srmk","mas","hpise"];
-
+  function renderGroup(catKey, bodyId){
+    var O=window.GOE_GCI_ORGS, C=window.GOE_GCI_CATS, body=$("#"+bodyId);
+    if(!O||!C||!C[catKey]||!body) return;
+    C[catKey].items.forEach(function(k){
+      var o=O[k]; if(!o||!o.color) return;
+      row(body, o.color, o.name_de);
+    });
+  }
   function render(){
-    MARKE.forEach(function(c){row($("#marke-body"),c.hex,c.name,c.role);});
-    NEUTRAL.forEach(function(c){row($("#neutrale-body"),c.hex,c.name,c.role);});
-    var O=window.GOE_GCI_ORGS;
-    if(O){
-      SEK_KEYS.forEach(function(k){
-        var o=O[k]; if(!o||!o.color) return;
-        row($("#sektionen-body"), o.color, o.name_de, "");
-      });
-    }
+    renderGroup("sektionen","sektionen-body");
+    renderGroup("bereiche","bereiche-body");
   }
   if(document.readyState!=="loading") render();
   else document.addEventListener("DOMContentLoaded", render);

--- a/tools.json
+++ b/tools.json
@@ -74,13 +74,13 @@
       "desc": "Farben, Schnitte, Typografie-Regeln und Komponenten – die lebende Schauseite, aus einer Quelle gerendert. Mit Starter und Bau-Workflow."
     },
     {
-      "slug": "farben",
+      "slug": "sektionsfarben",
       "cat": "system",
       "status": "beta",
       "tag": "Elemente",
-      "title": "Farben",
-      "href": "farben.html",
-      "desc": "Alle Identitätsfarben auf einen Blick – Marke, Neutrale, Sektionen – mit Hex, RGB, HSB und CMYK (Richtwert), klick-kopierbar."
+      "title": "Sektionsfarben",
+      "href": "sektionsfarben.html",
+      "desc": "Die Identitätsfarben der Sektionen und Bereiche – mit Hex, RGB, HSB und CMYK (Richtwert), klick-kopierbar. Marken- und Neutralfarben wohnen im Design-System."
     },
     {
       "slug": "zeichen",


### PR DESCRIPTION
Drei Korrekturen aus dem Feedback.

## 1 · Farben → Sektionsfarben

Die Sonderseite trägt jetzt **nur Sektions- und Bereichsfarben** (datengetrieben aus `goe-orgs.js`: 12 Sektionen + 6 Bereiche, je mit Hex/RGB/HSB/CMYK, klick-kopierbar). **Marken- und Neutralfarben wohnen im Design-System** (Schaufenster rendert sie bereits unter `#swatches`) — keine Doppelpflege. Datei, Karte und Slug heissen jetzt `sektionsfarben` (`farben.html → sektionsfarben.html` per `git mv`).

## 2 · Design-System-Karte: eigenes Bild

Vorher zu nah an „Farben" (beides Farbfelder). Jetzt ein **Mini-Bauplan** — eine Leiste + Textzeilen + eine Reihe Farb-Chips = **Struktur und Farbe**. Klar unterscheidbar.

## 3 · Theme-Schalter ohne Emoji

Sonne/Mond sind jetzt **Inline-SVG** (`currentColor`) statt der Unicode-Glyphen `☀`/`☾`, die iOS zu Emoji umfärbte. Deterministisch in Hell wie Dunkel.

## Verifikation

- `ds-lint`: 0 Fehler. Keine toten `farben.html`-Links.
- Beide Themes per Screenshot geprüft; Toggle Mond↔Sonne über echten Klick verifiziert (light→Mond, dark→Sonne, beide SVG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_