### PR TITLE
Visitenkarten: Format-Wähler nur bei Bereichen zeigen

### DIFF
--- a/apps/visitenkarten-generator/index.html
+++ b/apps/visitenkarten-generator/index.html
@@ -2036,6 +2036,10 @@
           refs.cardFormat.value = "portrait";
         }
         refs.cardFormat.disabled = !landscapeAllowed;
+        // Hochschule/Gesellschaft tragen das Zeichen und gibt es nur im Hochformat –
+        // der Format-Wähler ist dort überflüssig. Nur bei Bereichen zeigen.
+        const row = refs.cardFormat.closest(".export-format-row");
+        if (row) row.style.display = landscapeAllowed ? "" : "none";
       }
 
       function cardFormatForModel(model) {


### PR DESCRIPTION
## Bug

Im Visitenkarten-Editor erschien der Quer/Hoch-Format-Wähler auch bei **Hochschule** und **Gesellschaft**. Diese Karten tragen das **Zeichen** und gibt es nur im **Hochformat** — der Wähler war dort überflüssig (bisher nur deaktiviert/ausgegraut).

## Fix

`syncFormatControl` blendet die ganze `.export-format-row` jetzt aus, statt sie nur zu deaktivieren. Sie erscheint **nur bei den Bereichen**, wo das Querformat ein echtes Alternativ-Layout ist.

Headless geprüft: `hochschule → none`, `gesellschaft → none`, `bereiche → flex`. `ds-lint` 0 Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_