### PR TITLE
Seiten-Sprungleiste (data-onpage) rendern + Schriften: „Webfont"-Sprunglink

### DIFF
--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -16,6 +16,18 @@ html{scrollbar-gutter:stable}
 
 .dsnav{position:sticky;top:0;z-index:40;background:var(--bar-bg);
   backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--line)}
+
+/* Seiten-Sprungleiste – klebt unter der Kopfzeile, auf jeder Breite sichtbar */
+html{scroll-behavior:smooth;scroll-padding-top:var(--header-h)}
+html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
+.dsnav-onpage{position:sticky;top:var(--header-h);z-index:39;background:var(--bar-bg);
+  backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--line);
+  overflow-x:auto;scrollbar-width:none}
+.dsnav-onpage::-webkit-scrollbar{display:none}
+.dsnav-onpage .row{display:flex;gap:22px;max-width:var(--ds-maxw);margin:0 auto;
+  padding:11px 26px;white-space:nowrap}
+.dsnav-onpage a{font-size:15px;line-height:1;color:var(--muted);text-decoration:none;flex:0 0 auto}
+.dsnav-onpage a:hover{color:var(--gold-ink)}
 .dsnav .bar{display:flex;align-items:center;gap:var(--s4);height:var(--header-h);
   max-width:var(--ds-maxw);margin:0 auto;padding:0 26px}
 

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -176,6 +176,22 @@
     '</div>';
   document.body.insertBefore(header, document.body.firstChild);
 
+  // Optionale Seiten-Sprungleiste unter der Kopfzeile: data-onpage="Label:#anker|…".
+  // Auf jeder Breite sichtbar (auch mobil, wo die Welten-Navigation ausgeblendet ist).
+  var ONPAGE = (s && s.dataset.onpage) || "";
+  if (ONPAGE) {
+    var sub = el("nav", "dsnav-onpage");
+    sub.setAttribute("aria-label", "Auf dieser Seite");
+    sub.innerHTML = '<div class="row">' + ONPAGE.split("|").map(function (pair) {
+      var ci = pair.indexOf(":");
+      var label = ci > 0 ? pair.slice(0, ci) : pair;
+      var anchor = ci > 0 ? pair.slice(ci + 1) : "#";
+      return '<a href="' + anchor + '">' + label + '</a>';
+    }).join("") + '</div>';
+    header.insertAdjacentElement("afterend", sub);
+    document.documentElement.classList.add("has-onpage");
+  }
+
   var backdrop = el("div", "dsnav-backdrop");
   var drawer = el("aside", "dsnav-drawer");
   drawer.setAttribute("role", "dialog");

--- a/schriften.html
+++ b/schriften.html
@@ -114,7 +114,7 @@
 
 <script src="design-system/nav.js" data-root="./" data-section="schrift" data-active="schriften"
         data-cta="Download:#download"
-        data-onpage="Variabel:#variabel|Schnitte:#schnitte|Features:#features|Icons:#icons|Im Web:#web|Download:#download"></script>
+        data-onpage="Variabel:#variabel|Schnitte:#schnitte|Features:#features|Icons:#icons|Webfont:#web|Download:#download"></script>
 
 <main>
   <div class="wrap hero">
@@ -240,7 +240,7 @@
   </div></section>
 
   <section id="web"><div class="wrap">
-    <div class="shead"><h2>Im Web einbinden.</h2>
+    <div class="shead"><h2>Webfont einbinden.</h2>
       <p>Eine Datei, alle sechs Schnitte – der Variable Font ist nur 66&nbsp;KB. Den <code>@font-face</code>-Block kopieren, fertig.</p></div>
     <div class="webgrid">
       <pre class="code"><button class="copybtn" id="copyff">kopieren</button><code id="ffcode">@font-face{


### PR DESCRIPTION
## Befund

`data-onpage="Label:#anker|…"` war auf mehreren Seiten deklariert (Schriften, Sektionsfarben, Übersetzungen) — aber `nav.js` hat es **nie gerendert**. Es gab also gar keine Abschnitts-Sprunglinks; auf dem Handy schon gar nicht (dort ist die Welten-Navigation ausgeblendet).

## Umsetzung

- **Sprungleiste implementiert**: eine schlanke, klebende Leiste **unter der Kopfzeile**, auf jeder Breite sichtbar (mobil horizontal scrollbar). Anker-Sprünge respektieren die klebenden Leisten (`scroll-padding-top`, sanftes Scrollen).
- **Schriften**: der Sprunglink „Im Web" heisst jetzt **„Webfont"** (Abschnitt `#web` ebenso) — so steht die Webfont-Einbindung als eigener Sprungpunkt im Header, wie gewünscht.
- Gilt automatisch auch für **Sektionsfarben** und **Übersetzungen** (haben schon `data-onpage`).

## Verifikation

- Mobil (390px) geprüft: Leiste zeigt „Variabel · Schnitte · Features · Icons · Webfont · Download", Klick springt sauber zum Abschnitt (nicht unter den Leisten versteckt).
- `ds-lint`: 0 Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_