### PR TITLE
Sprungleiste unter die Lede · Schein-Button-Pillen raus

### DIFF
--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -17,15 +17,16 @@ html{scrollbar-gutter:stable}
 .dsnav{position:sticky;top:0;z-index:40;background:var(--bar-bg);
   backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--line)}
 
-/* Seiten-Sprungleiste – klebt unter der Kopfzeile, auf jeder Breite sichtbar */
+/* Seiten-Sprungleiste – sitzt UNTER dem Hero/der Lede, klebt beim Scrollen unter
+   der Kopfzeile. Inhaltsbreit (gleich, egal ob die Seite full-bleed oder .wrap ist). */
 html{scroll-behavior:smooth;scroll-padding-top:var(--header-h)}
 html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
-.dsnav-onpage{position:sticky;top:var(--header-h);z-index:39;background:var(--bar-bg);
-  backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--line);
-  overflow-x:auto;scrollbar-width:none}
+.dsnav-onpage{position:sticky;top:var(--header-h);z-index:39;
+  max-width:var(--ds-maxw);margin:0 auto;
+  background:var(--bar-bg);backdrop-filter:saturate(160%) blur(8px);
+  border-bottom:1px solid var(--line);overflow-x:auto;scrollbar-width:none}
 .dsnav-onpage::-webkit-scrollbar{display:none}
-.dsnav-onpage .row{display:flex;gap:22px;max-width:var(--ds-maxw);margin:0 auto;
-  padding:11px 26px;white-space:nowrap}
+.dsnav-onpage .row{display:flex;gap:22px;padding:11px 26px;white-space:nowrap}
 .dsnav-onpage a{font-size:15px;line-height:1;color:var(--muted);text-decoration:none;flex:0 0 auto}
 .dsnav-onpage a:hover{color:var(--gold-ink)}
 .dsnav .bar{display:flex;align-items:center;gap:var(--s4);height:var(--header-h);

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -176,8 +176,9 @@
     '</div>';
   document.body.insertBefore(header, document.body.firstChild);
 
-  // Optionale Seiten-Sprungleiste unter der Kopfzeile: data-onpage="Label:#anker|…".
-  // Auf jeder Breite sichtbar (auch mobil, wo die Welten-Navigation ausgeblendet ist).
+  // Optionale Seiten-Sprungleiste: data-onpage="Label:#anker|…". Sie sitzt UNTER
+  // dem Hero/der Lede (nicht über dem Titel) und klebt beim Scrollen unter der
+  // Kopfzeile. Auf jeder Breite sichtbar (auch mobil), horizontal scrollbar.
   var ONPAGE = (s && s.dataset.onpage) || "";
   if (ONPAGE) {
     var sub = el("nav", "dsnav-onpage");
@@ -188,7 +189,17 @@
       var anchor = ci > 0 ? pair.slice(ci + 1) : "#";
       return '<a href="' + anchor + '">' + label + '</a>';
     }).join("") + '</div>';
-    header.insertAdjacentElement("afterend", sub);
+    // Unter den Hero/die Lede hängen; wenn es keinen gibt, direkt unter die Kopfzeile.
+    // nav.js läuft oft VOR <main> – darum die Platzierung bis DOM-ready aufschieben.
+    var placeOnpage = function () {
+      var heroEl = document.querySelector("main .hero, .hero, main .lede");
+      (heroEl || header).insertAdjacentElement("afterend", sub);
+    };
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", placeOnpage);
+    } else {
+      placeOnpage();
+    }
     document.documentElement.classList.add("has-onpage");
   }
 

--- a/schriften.html
+++ b/schriften.html
@@ -121,12 +121,6 @@
     <div class="kick">Hausschrift · Version 2.6</div>
     <h1>Goetheanum Schriften</h1>
     <p class="lede">Sechs Schnitte von Flüstern bis Schreien – dazu ein Variable Font und ein Icon-Satz. Repariert, vervollständigt, sauber gesetzt.</p>
-    <div class="meta">
-      <span class="chip"><b>4</b> Schnitte + Variabel</span>
-      <span class="chip"><b>Variabel</b> 190–725</span>
-      <span class="chip"><b>81</b> Icons</span>
-      <span class="chip">⌘B im Office</span>
-    </div>
   </div>
 
   <section id="variabel"><div class="wrap">


### PR DESCRIPTION
Zwei Korrekturen aus dem Feedback.

## Sprungleiste tiefer

Die Seiten-Sprungleiste sitzt jetzt **unter dem Hero/der Lede** (nicht mehr über dem Titel) und klebt **erst beim Scrollen** unter der Kopfzeile. Die Platzierung wird bis DOM-ready aufgeschoben (`nav.js` läuft vor `<main>`, sonst landet die Leiste oben). Inhaltsbreit, damit sie über full-bleed- und `.wrap`-Seiten gleich aussieht.

## Schein-Buttons raus

In Schriften flogen die vier Hero-„Pillen" (`4 Schnitte + Variabel`, `Variabel 190–725`, `81 Icons`, `⌘B im Office`) raus — sie sahen aus wie Buttons, taten aber nichts. Die **echten Abschnitts-Sprunglinks** darunter ersetzen sie an gleicher Stelle.

## Verifikation

Mobil (390px): Leiste liegt unter der Lede (top 349 vs. Lede-Ende 335), beim Scrollen klebt sie bei 74 (= Kopfzeilenhöhe). Pillen entfernt. `ds-lint` 0 Fehler. Gilt auch für Sektionsfarben/Übersetzungen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_