### PR TITLE
Startseite: Entdecker-Karussell + Karten flach nach Priorität

### DIFF
--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -18,6 +18,17 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ## [Unveröffentlicht]
 
+### Startseite: Entdecker-Karussell + Karten flach nach Priorität
+- **Karussell** oben (rotierend, pausiert bei Hover/Fokus, respektiert
+  `prefers-reduced-motion`, Pfeile · Punkte · Wisch): ein **Hinweis auf weniger
+  Bekanntes** (Sektionsfarben, Zeichen, Übersetzungen, Wallpaper, Typografie,
+  Design-System) – ‹Schon entdeckt?›.
+- **Karten flach nach Priorität** statt nach Kategorien gruppiert (Logos · Signatur
+  · Visitenkarten · Icons · Schriften · …). Backstage-Welten bleiben draussen
+  (öffentliche Kategorien-Schranke beibehalten).
+- Die Mini-Visuals der Karten von `.tile .x` auf `.thumb .x` generalisiert, damit
+  das Karussell dieselben Erkennungszeichen nutzt – eine Quelle, kein Duplikat.
+
 ### Schliff: Sektionsfarben-Seite · Design-System-Bild · Theme-Icon ohne Emoji
 - **Farben → Sektionsfarben**: die Sonderseite trägt jetzt **nur Sektions- und Bereichsfarben**
   (datengetrieben aus `goe-orgs.js`: 12 Sektionen + 6 Bereiche). Marken- und Neutralfarben wohnen

--- a/index.html
+++ b/index.html
@@ -31,45 +31,75 @@
   .badge{position:absolute;top:var(--s4);right:var(--s4)}
 
   /* Greifbare Mini-Werkzeuge je Karte – das Erzeugnis als Erkennungszeichen. */
-  .tile .thumb{height:96px;display:grid;place-items:center;border-radius:10px;background:var(--paper);
+  .thumb{height:96px;display:grid;place-items:center;border-radius:10px;background:var(--paper);
     border:1px solid var(--line-soft);overflow:hidden}
-  .tile .thumb img{height:46px;width:auto;display:block}
+  .thumb img{height:46px;width:auto;display:block}
   /* Buchstaben-Probe (Schriften) */
-  .tile .spec{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:46px;line-height:1;color:var(--ink);letter-spacing:.02em}
+  .thumb .spec{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:46px;line-height:1;color:var(--ink);letter-spacing:.02em}
   /* Visitenkarte */
-  .tile .vk{width:58px;height:37px;border:1.6px solid var(--muted);border-radius:4px;display:grid;align-content:center;gap:5px;padding:8px}
-  .tile .vk i{display:block;height:2px;background:var(--muted);border-radius:2px}
-  .tile .vk i:nth-child(1){width:64%}.tile .vk i:nth-child(2){width:42%}
+  .thumb .vk{width:58px;height:37px;border:1.6px solid var(--muted);border-radius:4px;display:grid;align-content:center;gap:5px;padding:8px}
+  .thumb .vk i{display:block;height:2px;background:var(--muted);border-radius:2px}
+  .thumb .vk i:nth-child(1){width:64%}.thumb .vk i:nth-child(2){width:42%}
   /* Signatur-Block: blaue Kante + Zeilen (wie die echte Trennlinie) */
-  .tile .sig{display:flex;gap:10px;align-items:center}
-  .tile .sig>b{width:3px;height:40px;background:var(--blue);border-radius:2px;display:block}
-  .tile .sig>span{display:grid;gap:6px}
-  .tile .sig i{display:block;height:2.5px;background:var(--muted);border-radius:2px}
-  .tile .sig i:nth-child(1){width:56px}.tile .sig i:nth-child(2){width:40px}.tile .sig i:nth-child(3){width:48px}
+  .thumb .sig{display:flex;gap:10px;align-items:center}
+  .thumb .sig>b{width:3px;height:40px;background:var(--blue);border-radius:2px;display:block}
+  .thumb .sig>span{display:grid;gap:6px}
+  .thumb .sig i{display:block;height:2.5px;background:var(--muted);border-radius:2px}
+  .thumb .sig i:nth-child(1){width:56px}.thumb .sig i:nth-child(2){width:40px}.thumb .sig i:nth-child(3){width:48px}
   /* Webfont: Schrift im Browser-Fenster */
-  .tile .win{width:78px;height:58px;border:1.6px solid var(--muted);border-radius:6px;position:relative;display:grid;place-items:center;overflow:hidden}
-  .tile .win>b{position:absolute;top:0;left:0;right:0;height:14px;background:var(--line-soft);border-bottom:1.4px solid var(--muted)}
-  .tile .win>em{font-family:var(--font-display);font-weight:var(--w-deutlich);font-style:normal;font-size:26px;color:var(--ink);margin-top:11px}
+  .thumb .win{width:78px;height:58px;border:1.6px solid var(--muted);border-radius:6px;position:relative;display:grid;place-items:center;overflow:hidden}
+  .thumb .win>b{position:absolute;top:0;left:0;right:0;height:14px;background:var(--line-soft);border-bottom:1.4px solid var(--muted)}
+  .thumb .win>em{font-family:var(--font-display);font-weight:var(--w-deutlich);font-style:normal;font-size:26px;color:var(--ink);margin-top:11px}
   /* Typografie: gesetzter Absatz, erste Zeile als goldene Überschrift */
-  .tile .para{display:grid;gap:6px;width:66px}
-  .tile .para i{display:block;height:3px;border-radius:2px;background:var(--muted)}
-  .tile .para i:nth-child(1){background:var(--gold-ink);width:72%;height:4.5px}
-  .tile .para i:nth-child(2){width:100%}.tile .para i:nth-child(3){width:100%}.tile .para i:nth-child(4){width:60%}
+  .thumb .para{display:grid;gap:6px;width:66px}
+  .thumb .para i{display:block;height:3px;border-radius:2px;background:var(--muted)}
+  .thumb .para i:nth-child(1){background:var(--gold-ink);width:72%;height:4.5px}
+  .thumb .para i:nth-child(2){width:100%}.thumb .para i:nth-child(3){width:100%}.thumb .para i:nth-child(4){width:60%}
   /* Design-System: Farbfelder */
-  .tile .sw{display:flex;gap:9px}
-  .tile .sw i{width:20px;height:20px;border-radius:5px;display:block}
+  .thumb .sw{display:flex;gap:9px}
+  .thumb .sw i{width:20px;height:20px;border-radius:5px;display:block}
   /* Design-System: Mini-Bauplan – Struktur (Leiste, Zeilen) + Farbe (Chips) */
-  .tile .sys{display:grid;gap:6px;width:122px}
-  .tile .sys .bar{height:13px;border-radius:4px;background:var(--blue)}
-  .tile .sys .ln{height:7px;border-radius:3px;background:var(--line)}
-  .tile .sys .ln.s{width:60%}
-  .tile .sys .chips{display:flex;gap:6px;margin-top:3px}
-  .tile .sys .chips i{width:18px;height:18px;border-radius:5px;display:block}
+  .thumb .sys{display:grid;gap:6px;width:122px}
+  .thumb .sys .bar{height:13px;border-radius:4px;background:var(--blue)}
+  .thumb .sys .ln{height:7px;border-radius:3px;background:var(--line)}
+  .thumb .sys .ln.s{width:60%}
+  .thumb .sys .chips{display:flex;gap:6px;margin-top:3px}
+  .thumb .sys .chips i{width:18px;height:18px;border-radius:5px;display:block}
   /* Icons: drei Piktogramme aus dem Icon-Webfont (currentColor – folgt Hell/Dunkel) */
-  .tile .icons{font-family:"G Icons";font-size:36px;line-height:1;color:var(--ink);display:flex;gap:14px}
+  .thumb .icons{font-family:"G Icons";font-size:36px;line-height:1;color:var(--ink);display:flex;gap:14px}
   /* Übersetzungen: vier Sprach-Marken */
-  .tile .tr{display:flex;gap:6px;flex-wrap:wrap;justify-content:center}
-  .tile .tr i{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:15px;font-style:normal;color:var(--ink);border:1px solid var(--line);border-radius:6px;padding:3px 9px}
+  .thumb .tr{display:flex;gap:6px;flex-wrap:wrap;justify-content:center}
+  .thumb .tr i{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:15px;font-style:normal;color:var(--ink);border:1px solid var(--line);border-radius:6px;padding:3px 9px}
+
+  /* Entdecker-Karussell – Hinweis auf weniger Bekanntes, oben über den Karten. */
+  .carousel{position:relative;margin-bottom:var(--s8);border:1px solid var(--line);
+    border-radius:var(--r-card);background:var(--soft);overflow:hidden}
+  .carousel .track{display:flex;transition:transform .45s ease}
+  @media(prefers-reduced-motion:reduce){.carousel .track{transition:none}}
+  .carousel .slide{flex:0 0 100%;min-width:0;box-sizing:border-box;display:grid;
+    grid-template-columns:auto 1fr;gap:var(--s6);align-items:center;
+    padding:var(--s6) clamp(var(--s6),5vw,var(--s8));text-decoration:none;color:var(--ink)}
+  .carousel .slide .thumb{width:132px;height:104px}
+  .carousel .slide .copy{min-width:0}
+  .carousel .slide .kick{color:var(--gold-ink);font-size:var(--t-small);letter-spacing:.04em}
+  .carousel .slide h2{font-family:var(--font-display);font-weight:var(--w-deutlich);
+    font-size:clamp(21px,3vw,29px);line-height:1.1;margin:2px 0 0}
+  .carousel .slide p{color:var(--muted);max-width:54ch;margin:6px 0 0;line-height:1.5}
+  .carousel .slide .go{display:inline-block;margin-top:10px;color:var(--gold-ink);font-weight:var(--w-deutlich)}
+  .carousel .arrow{position:absolute;top:50%;transform:translateY(-50%);width:40px;height:40px;
+    border-radius:var(--r-pill);border:1px solid var(--line);background:var(--paper);color:var(--ink);
+    cursor:pointer;display:grid;place-items:center;font-size:20px;line-height:1;padding:0;z-index:2}
+  .carousel .arrow:hover{border-color:var(--gold-ink);color:var(--gold-ink)}
+  .carousel .arrow.l{left:12px}.carousel .arrow.r{right:12px}
+  .carousel .dots{position:absolute;bottom:11px;left:50%;transform:translateX(-50%);display:flex;gap:7px;z-index:2}
+  .carousel .dots button{width:8px;height:8px;border-radius:var(--r-pill);border:0;background:var(--line);
+    cursor:pointer;padding:0;transition:width .2s,background .2s}
+  .carousel .dots button.on{background:var(--gold-deep);width:22px}
+  @media(max-width:560px){
+    .carousel .slide{grid-template-columns:1fr;gap:var(--s4);padding:var(--s6)}
+    .carousel .slide .thumb{width:100%;height:120px}
+    .carousel .arrow{display:none}
+  }
 </style>
 </head>
 <body>
@@ -77,6 +107,7 @@
 <script src="design-system/nav.js" data-root="./" data-active="start"></script>
 
 <main class="wrap">
+  <section class="carousel" id="carousel" aria-roledescription="Karussell" aria-label="Entdecken" hidden></section>
   <div class="grid" id="cards"></div>
 </main>
 
@@ -90,8 +121,19 @@
 <script>
 "use strict";
 (function(){
-  // Öffentliche Werkzeuge, in Welt-Reihenfolge; live vor beta. Nur die Karten.
-  var CATS = ["generatoren", "schrift", "system", "anwendung"];
+  // Karten flach nach Priorität (keine Kategorien); Unbekannte ans Ende.
+  var ORDER = ["logo-generator","signatur","visitenkarten","icons","schriften",
+    "sektionsfarben","uebersetzungen","zeichen","wallpaper","powerpoint",
+    "typografie","design-system","schrift-webfont"];
+  // Entdecker-Karussell: weniger bekannte Werkzeuge, je ein Teaser.
+  var DISCOVER = [
+    {slug:"sektionsfarben", line:"Alle Identitätsfarben der Sektionen und Bereiche – Hex, RGB, HSB, klick-kopierbar."},
+    {slug:"zeichen",        line:"Die Zeichen von Rudolf Steiner – Hochschule, Gesellschaft, Bau-Administration."},
+    {slug:"uebersetzungen", line:"Sektionen und Begriffe in vier Sprachen – auf goetheanum.ch geprüft, für die Sekretariate."},
+    {slug:"wallpaper",      line:"Elf Goetheanum-Hintergründe für den Desktop, frei zum Herunterladen."},
+    {slug:"typografie",     line:"Die Hausregeln des Satzes – wenige Mittel, präzise gesetzt."},
+    {slug:"design-system",  line:"Das Fundament: Farben, Schnitte und Komponenten aus einer Quelle."}
+  ];
   var STATUS_LABEL = { beta:"in Überarbeitung" };
   // Greifbar: jedes Zeichen zeigt das DING, das das Werkzeug erzeugt.
   var VISUAL = {
@@ -122,14 +164,70 @@
     a.innerHTML = badge + visual(t) + '<h3>' + t.title + ' <span class="arr">›</span></h3>';
     return a;
   }
-  function render(man){
-    var grid = document.getElementById("cards");
-    var tools = [];
-    CATS.forEach(function(cat){
-      (man.tools || []).filter(function(t){ return t.cat === cat && (t.status === "live" || t.status === "beta"); })
-        .sort(function(a,b){ return (a.status === "live" ? 0 : 1) - (b.status === "live" ? 0 : 1); })
-        .forEach(function(t){ tools.push(t); });
+  function buildCarousel(byslug){
+    var car = document.getElementById("carousel");
+    var items = DISCOVER.map(function(d){ return { d:d, t:byslug[d.slug] }; })
+                        .filter(function(x){ return x.t; });
+    if (items.length < 2) { car.remove(); return; }   // Karussell erst ab zwei Folien
+
+    var track = document.createElement("div"); track.className = "track";
+    items.forEach(function(x){
+      var a = document.createElement("a"); a.className = "slide"; a.href = x.t.href;
+      if (isExt(x.t.href)) { a.target = "_blank"; a.rel = "noopener"; }
+      a.innerHTML = visual(x.t) +
+        '<span class="copy"><span class="kick">Schon entdeckt?</span>' +
+        '<h2>' + x.t.title + '</h2><p>' + x.d.line + '</p>' +
+        '<span class="go">Ansehen ›</span></span>';
+      track.appendChild(a);
     });
+    var prev = document.createElement("button"); prev.className = "arrow l"; prev.type = "button"; prev.setAttribute("aria-label","Zurück"); prev.textContent = "‹";
+    var next = document.createElement("button"); next.className = "arrow r"; next.type = "button"; next.setAttribute("aria-label","Weiter"); next.textContent = "›";
+    var dots = document.createElement("div"); dots.className = "dots";
+    car.appendChild(track); car.appendChild(prev); car.appendChild(next); car.appendChild(dots);
+    car.hidden = false;
+
+    var i = 0, n = items.length, timer = null;
+    var reduce = window.matchMedia && window.matchMedia("(prefers-reduced-motion:reduce)").matches;
+    for (var k = 0; k < n; k++) {
+      (function(k){
+        var b = document.createElement("button"); b.type = "button"; b.setAttribute("aria-label","Folie " + (k+1));
+        b.addEventListener("click", function(){ go(k); start(); });
+        dots.appendChild(b);
+      })(k);
+    }
+    function paint(){
+      track.style.transform = "translateX(-" + (i*100) + "%)";
+      var ds = dots.children; for (var k = 0; k < ds.length; k++) ds[k].className = (k === i ? "on" : "");
+    }
+    function go(k){ i = (k + n) % n; paint(); }
+    function start(){ if (reduce) return; stop(); timer = setInterval(function(){ go(i+1); }, 6500); }
+    function stop(){ if (timer) { clearInterval(timer); timer = null; } }
+    prev.addEventListener("click", function(){ go(i-1); start(); });
+    next.addEventListener("click", function(){ go(i+1); start(); });
+    car.addEventListener("mouseenter", stop); car.addEventListener("mouseleave", start);
+    car.addEventListener("focusin", stop); car.addEventListener("focusout", start);
+    var x0 = null;
+    car.addEventListener("touchstart", function(e){ x0 = e.touches[0].clientX; stop(); }, {passive:true});
+    car.addEventListener("touchend", function(e){
+      if (x0 === null) return;
+      var dx = e.changedTouches[0].clientX - x0;
+      if (Math.abs(dx) > 40) go(i + (dx < 0 ? 1 : -1));
+      x0 = null; start();
+    }, {passive:true});
+    paint(); start();
+  }
+
+  function render(man){
+    // Öffentliche Welten (Backstage wie schau/schriftpflege/statistik bleibt draussen).
+    var PUBLIC = ["generatoren", "schrift", "system", "anwendung"];
+    var tools = (man.tools || []).filter(function(t){
+      return PUBLIC.indexOf(t.cat) >= 0 && (t.status === "live" || t.status === "beta");
+    });
+    var byslug = {}; tools.forEach(function(t){ byslug[t.slug] = t; });
+    buildCarousel(byslug);
+    var rank = function(t){ var k = ORDER.indexOf(t.slug); return k < 0 ? 999 : k; };
+    tools.sort(function(a,b){ return rank(a) - rank(b); });
+    var grid = document.getElementById("cards");
     tools.forEach(function(t){ grid.appendChild(tile(t)); });
   }
   fetch("tools.json").then(function(r){ return r.json(); }).then(render).catch(function(){


### PR DESCRIPTION
Erste Fassung nach deiner Wahl: **rotierendes Karussell als Hinweis aufs Unbekannte, darunter alle Cards durchpriorisiert.**

## Karussell (Entdecken)

- Oben über den Karten, rotierend mit ‹Schon entdeckt?›-Auftakt; zeigt **weniger Bekanntes**: Sektionsfarben · Zeichen · Übersetzungen · Wallpaper · Typografie · Design-System.
- Pfeile · Punkte · **Wisch** (Touch); **pausiert bei Hover/Fokus**; respektiert `prefers-reduced-motion` (keine Auto-Rotation).
- Jede Folie ist ein Link zum Werkzeug, mit seinem Erkennungs-Visual.

## Karten flach nach Priorität

- Keine Kategorie-Gruppierung mehr auf der Startseite — eine Liste in Reihenfolge: **Logos · Signatur · Visitenkarten · Icons · Schriften · Sektionsfarben · Übersetzungen · Zeichen · Wallpaper · PowerPoint · Typografie · Design-System · Webfont**.
- Reihenfolge steckt in einem `ORDER`-Array (leicht zu ändern). **Backstage-Welten** (Mockups, Schriftpflege, Statistik) bleiben wie zuvor draussen.

## Technik

- Die Karten-Mini-Visuals von `.tile .x` auf `.thumb .x` generalisiert, damit Karten **und** Karussell dieselben Erkennungszeichen aus einer Quelle nutzen.

## Verifikation

Desktop + Mobil (390px) geprüft; `ds-lint` 0 Fehler. Reihenfolge und Karussell-Folien headless bestätigt.

Reihenfolge/Karussell-Auswahl sind bewusst leicht justierbar — sag, was du verschieben willst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_