### PR TITLE
Beta-Einblender + Suche im Menü

### DIFF
--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -18,6 +18,17 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ## [Unveröffentlicht]
 
+### Beta-Einblender + Suche im Menü; Karten-Pillen abgelöst
+- **Beta-Einblender** (`nav.js`/`nav.css`): ein dezenter, schwebender Hinweis unten –
+  ‹Beta – die Werkzeuge wachsen noch. Feedback geben ✕›, wegklickbar (merkt sich
+  ‹gesehen› in localStorage). Löst die per-Karte-Pillen ab; ein Ort statt zwölf Marker.
+- **Suche im Menü**: Tippfeld oben in der Schublade filtert die Werkzeugliste live;
+  leere Bereiche blenden aus, Treffer-Bereiche klappen auf.
+- Startseite: ‹Schon entdeckt?› klein/fein über das Karussell gehoben; Karussell-Inhalt
+  Wallpaper · Schriften · PowerPoint · Icons · Logos; Karten ohne Pillen, eine Fläche.
+- Konsolidiert: Webfont in Schriften (Abschnitt + Sprunglink), Zeichen in Logos (Link) –
+  keine eigenen Karten mehr.
+
 ### Startseite: Entdecker-Karussell + Karten flach nach Priorität
 - **Karussell** oben (rotierend, pausiert bei Hover/Fokus, respektiert
   `prefers-reduced-motion`, Pfeile · Punkte · Wisch): ein **Hinweis auf weniger

--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -93,7 +93,30 @@ html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
 .dsnav-drawer .close{font:inherit;font-size:22px;line-height:1;color:var(--muted);background:none;border:0;cursor:pointer;padding:4px}
 .dsnav-drawer .close:hover{color:var(--ink)}
 
+/* Suche im Menü – filtert die Werkzeugliste live */
+.dsnav-drawer .dsearch{padding:var(--s3) 22px;border-bottom:1px solid var(--line);flex:0 0 auto}
+.dsnav-drawer .dsnav-q{width:100%;font:inherit;font-family:var(--font-text);font-size:16px;
+  color:var(--ink);background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);
+  padding:9px 13px;min-height:var(--tap);outline:none}
+.dsnav-drawer .dsnav-q:focus{border-color:var(--gold)}
+.dsnav-drawer .dsnav-q::placeholder{color:var(--muted)}
+
 .dsnav-drawer .body{overflow:auto;padding:var(--s2) 0 var(--s8)}
+
+/* Globaler Beta-Einblender (unten, dezent, wegklickbar) */
+.dsnav-beta{position:fixed;left:50%;bottom:16px;transform:translateX(-50%);z-index:44;
+  display:flex;align-items:center;gap:14px;max-width:calc(100% - 28px);
+  background:var(--bar-bg);backdrop-filter:saturate(160%) blur(10px);
+  border:1px solid var(--line);border-radius:var(--r-pill);
+  padding:9px 10px 9px 18px;box-shadow:var(--shadow-card);font-size:var(--t-small)}
+.dsnav-beta .t{color:var(--ink)}
+.dsnav-beta .t b{color:var(--gold-ink);font-weight:var(--w-deutlich)}
+.dsnav-beta .fb{color:var(--blue);text-decoration:none;font-weight:var(--w-deutlich);white-space:nowrap}
+.dsnav-beta .fb:hover{text-decoration:underline}
+.dsnav-beta .x{border:0;background:none;color:var(--muted);font-size:18px;line-height:1;cursor:pointer;
+  width:30px;height:30px;border-radius:var(--r-pill);flex:0 0 auto}
+.dsnav-beta .x:hover{color:var(--ink);background:var(--soft)}
+@media(max-width:480px){.dsnav-beta{gap:10px;padding:8px 8px 8px 14px}}
 
 /* Toast für den unsichtbaren Intern-Schalter */
 .dsnav-toast{position:fixed;left:50%;bottom:24px;transform:translateX(-50%);background:var(--ink);color:var(--paper);

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -210,10 +210,26 @@
   drawer.innerHTML =
     '<div class="dhead"><span class="t">Navigation</span>' +
       '<button class="close" type="button" aria-label="Schliessen">×</button></div>' +
+    '<div class="dsearch"><input type="search" class="dsnav-q" placeholder="Werkzeug suchen …" aria-label="Werkzeug suchen" autocomplete="off"></div>' +
     '<div class="body"></div>' +
     '<div class="foot"><a href="mailto:philipp.tok@goetheanum.ch?subject=Feedback%20Goetheanum%20Werkzeuge">Feedback geben</a> · <a href="' + ROOT + 'design-system/">Design-System</a></div>';
   document.body.appendChild(backdrop);
   document.body.appendChild(drawer);
+
+  // Globaler Beta-Einblender (unten, dezent, wegklickbar – merkt sich „gesehen").
+  var BETA_KEY = "goeBetaSeen";
+  var betaSeen = false; try { betaSeen = localStorage.getItem(BETA_KEY) === "1"; } catch (e) {}
+  if (!betaSeen) {
+    var beta = el("div", "dsnav-beta");
+    beta.innerHTML =
+      '<span class="t"><b>Beta</b> – die Werkzeuge wachsen noch.</span>' +
+      '<a class="fb" href="mailto:philipp.tok@goetheanum.ch?subject=Feedback%20Goetheanum%20Werkzeuge">Feedback geben</a>' +
+      '<button class="x" type="button" aria-label="Hinweis schliessen">×</button>';
+    document.body.appendChild(beta);
+    beta.querySelector(".x").addEventListener("click", function () {
+      beta.remove(); try { localStorage.setItem(BETA_KEY, "1"); } catch (e) {}
+    });
+  }
 
   var toast = el("div", "dsnav-toast"); document.body.appendChild(toast);
   function flash(msg) { toast.textContent = msg; toast.classList.add("show"); setTimeout(function () { toast.classList.remove("show"); }, 1400); }
@@ -228,6 +244,24 @@
   var drawerBody = drawer.querySelector(".body");
   var drawerTitle = drawer.querySelector(".dhead .t");
   var idot = btnAll.querySelector(".idot");
+  var searchInput = drawer.querySelector(".dsnav-q");
+
+  // Tippen filtert die Werkzeugliste; leere Bereiche werden ausgeblendet.
+  function applySearch() {
+    var q = (searchInput.value || "").trim().toLowerCase();
+    var groups = drawerBody.querySelectorAll(".dsnav-group");
+    for (var i = 0; i < groups.length; i++) {
+      var g = groups[i], links = g.querySelectorAll(".dsnav-link"), any = false;
+      for (var j = 0; j < links.length; j++) {
+        var hit = !q || links[j].textContent.toLowerCase().indexOf(q) !== -1;
+        links[j].style.display = hit ? "" : "none";
+        if (hit) any = true;
+      }
+      g.style.display = any ? "" : "none";
+      if (q) g.open = true;
+    }
+  }
+  searchInput.addEventListener("input", applySearch);
 
   function openDrawer() { backdrop.classList.add("open"); drawer.classList.add("open"); btnAll.setAttribute("aria-expanded", "true"); }
   function closeDrawer() { backdrop.classList.remove("open"); drawer.classList.remove("open"); btnAll.setAttribute("aria-expanded", "false"); }
@@ -306,6 +340,7 @@
       if (intern) open = (w.id === cur);
       drawerBody.appendChild(groupEl(w, tools, open));
     });
+    applySearch();
   }
 
   // --- Manifest laden --------------------------------------------------------


### PR DESCRIPTION
Teil 2 aus dem Feedback.

## Beta-Einblender
Ein dezenter, schwebender Hinweis unten am Rand: **„Beta – die Werkzeuge wachsen noch · Feedback geben · ✕"**. Wegklickbar, merkt sich „gesehen" (localStorage). Er **löst die per-Karte-Pillen ab** — ein Ort statt zwölf Marker. Trägt den Feedback-mailto.

## Suche im Menü
Tippfeld oben in der Schublade filtert die Werkzeugliste **live**: leere Bereiche blenden aus, Treffer-Bereiche klappen auf. Source-Schrift, ≥16px (kein iOS-Zoom), Fingerziel ≥44px.

## Verifikation
`nav.js` parst; headless: Beta-Einblender erscheint, Suche „sekt" → nur „Sektionsfarben", Leeren stellt alle 11 wieder her. Beide folgen Hell/Dunkel über Tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_