### PR TITLE
Feinschliff: Karussell zentriert · Such-Synonyme · PowerPoint-Bild

### DIFF
--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -18,6 +18,14 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ## [Unveröffentlicht]
 
+### Feinschliff: Karussell zentriert · Such-Synonyme · PowerPoint-Bild
+- **Karussell-Inhalt zentriert** (Thumb + Text als Gruppe mittig) statt linksbündig.
+- **Suche mit Synonymen**: pro Werkzeug `such`-Begriffe in `tools.json`; die Menü-Suche
+  matcht Titel **und** Synonyme. So findet ‹Farben› jetzt Sektionsfarben **und**
+  Design-System (wo Marken-/Neutralfarben wohnen).
+- **PowerPoint** bekommt ein eindeutiges Bild (Mini-Folie mit Titelzeile) statt des
+  mehrdeutigen ‹P›.
+
 ### Burger flach (Modell B) – keine Kategorien öffentlich
 - Das Menü zeigt öffentlich **eine priorisierte Liste** (wie die Startseite), mit
   ‹Startseite› oben – keine aufklappbaren Welten mehr. Die Suche übernimmt das Finden.

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -252,7 +252,8 @@
     // Werkzeug-Links filtern (Startseite bleibt immer sichtbar).
     var links = drawerBody.querySelectorAll(".dsnav-link:not(.dsnav-home)");
     for (var j = 0; j < links.length; j++) {
-      var hit = !q || links[j].textContent.toLowerCase().indexOf(q) !== -1;
+      var hay = (links[j].textContent + " " + (links[j].dataset.such || "")).toLowerCase();
+      var hit = !q || hay.indexOf(q) !== -1;
       links[j].style.display = hit ? "" : "none";
     }
     // Bereiche (intern) ohne Treffer ausblenden, Treffer aufklappen.
@@ -313,6 +314,8 @@
     a.href = resolveHref(t.href);
     if (isExternal(t.href)) { a.target = "_blank"; a.rel = "noopener"; }
     if (active) a.setAttribute("aria-current", "page");
+    // Suchbegriffe (Synonyme) fürs Filtern – „Farben" findet so auch das Design-System.
+    if (t.such) a.dataset.such = t.such;
     a.innerHTML = '<span class="tt">' + t.title + '</span>';
     return a;
   }

--- a/index.html
+++ b/index.html
@@ -67,6 +67,11 @@
   .thumb .sys .chips i{width:18px;height:18px;border-radius:5px;display:block}
   /* Icons: drei Piktogramme aus dem Icon-Webfont (currentColor – folgt Hell/Dunkel) */
   .thumb .icons{font-family:"G Icons";font-size:36px;line-height:1;color:var(--ink);display:flex;gap:14px}
+  /* PowerPoint: eine Folie mit Titelzeile (statt mehrdeutigem „P") */
+  .thumb .ppt{width:76px;height:56px;border:1.6px solid var(--muted);border-radius:5px;display:grid;align-content:start;gap:6px;padding:9px}
+  .thumb .ppt b{display:block;height:7px;width:62%;background:var(--gold-ink);border-radius:2px}
+  .thumb .ppt i{display:block;height:3px;background:var(--muted);border-radius:2px}
+  .thumb .ppt i:nth-child(2){width:100%}.thumb .ppt i:nth-child(3){width:76%}
   /* Übersetzungen: vier Sprach-Marken */
   .thumb .tr{display:flex;gap:6px;flex-wrap:wrap;justify-content:center}
   .thumb .tr i{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:15px;font-style:normal;color:var(--ink);border:1px solid var(--line);border-radius:6px;padding:3px 9px}
@@ -76,11 +81,11 @@
     border-radius:var(--r-card);background:var(--soft);overflow:hidden}
   .carousel .track{display:flex;transition:transform .45s ease}
   @media(prefers-reduced-motion:reduce){.carousel .track{transition:none}}
-  .carousel .slide{flex:0 0 100%;min-width:0;box-sizing:border-box;display:grid;
-    grid-template-columns:auto 1fr;gap:var(--s6);align-items:center;
+  .carousel .slide{flex:0 0 100%;min-width:0;box-sizing:border-box;display:flex;
+    align-items:center;justify-content:center;gap:var(--s6);
     padding:var(--s6) clamp(var(--s6),5vw,var(--s8));text-decoration:none;color:var(--ink)}
-  .carousel .slide .thumb{width:132px;height:104px}
-  .carousel .slide .copy{min-width:0}
+  .carousel .slide .thumb{width:132px;height:104px;flex:0 0 auto}
+  .carousel .slide .copy{min-width:0;max-width:520px}
   .carousel .slide .kick{color:var(--gold-ink);font-size:var(--t-small);letter-spacing:.04em}
   .carousel .slide h2{font-family:var(--font-display);font-weight:var(--w-deutlich);
     font-size:clamp(21px,3vw,29px);line-height:1.1;margin:2px 0 0}
@@ -96,8 +101,9 @@
     cursor:pointer;padding:0;transition:width .2s,background .2s}
   .carousel .dots button.on{background:var(--gold-deep);width:22px}
   @media(max-width:560px){
-    .carousel .slide{grid-template-columns:1fr;gap:var(--s4);padding:var(--s6)}
+    .carousel .slide{flex-direction:column;align-items:flex-start;gap:var(--s4);padding:var(--s6)}
     .carousel .slide .thumb{width:100%;height:120px}
+    .carousel .slide .copy{max-width:none}
     .carousel .arrow{display:none}
   }
 </style>
@@ -147,6 +153,7 @@
     "sektionsfarben":  '<span class="sw"><i style="background:var(--sek-szw)"></i><i style="background:var(--sek-lws)"></i><i style="background:var(--sek-ms)"></i><i style="background:var(--sek-js)"></i></span>', // vier Sektionsfarben
     "zeichen":         '<span style="background:#fff;border-radius:8px;width:100%;height:100%;display:grid;place-items:center"><img src="assets/zeichen/hochschulzeichen.png" alt="" style="max-height:66px;max-width:78%"></span>', // Rudolf-Steiner-Zeichen auf weissem Papier
     "wallpaper":       '<img src="assets/wallpaper/goetheanum-wallpaper-48.jpg" alt="" style="width:100%;height:100%;object-fit:cover;border-radius:8px">', // ein Motiv
+    "powerpoint":      '<span class="ppt"><b></b><i></i><i></i></span>', // eine Folie mit Titel
     "uebersetzungen":  '<span class="tr"><i>DE</i><i>EN</i><i>FR</i><i>ES</i></span>' // vier Sprachen
   };
   function visual(t){

--- a/tools.json
+++ b/tools.json
@@ -71,7 +71,8 @@
       "tag": "Fundament",
       "title": "Design-System",
       "href": "design-system/",
-      "desc": "Farben, Schnitte, Typografie-Regeln und Komponenten – die lebende Schauseite, aus einer Quelle gerendert. Mit Starter und Bau-Workflow."
+      "desc": "Farben, Schnitte, Typografie-Regeln und Komponenten – die lebende Schauseite, aus einer Quelle gerendert. Mit Starter und Bau-Workflow.",
+      "such": "Farben Palette Tokens Hex RGB CMYK Markenfarben Neutrale Komponenten Fundament"
     },
     {
       "slug": "sektionsfarben",
@@ -80,7 +81,8 @@
       "tag": "Elemente",
       "title": "Sektionsfarben",
       "href": "sektionsfarben.html",
-      "desc": "Die Identitätsfarben der Sektionen und Bereiche – mit Hex, RGB, HSB und CMYK (Richtwert), klick-kopierbar. Marken- und Neutralfarben wohnen im Design-System."
+      "desc": "Die Identitätsfarben der Sektionen und Bereiche – mit Hex, RGB, HSB und CMYK (Richtwert), klick-kopierbar. Marken- und Neutralfarben wohnen im Design-System.",
+      "such": "Farben Identitätsfarben Sektionsfarben Bereichsfarben Hex RGB HSB CMYK Palette"
     },
     {
       "slug": "wallpaper",
@@ -89,7 +91,8 @@
       "tag": "Anwendungen",
       "title": "Wallpaper",
       "href": "wallpaper.html",
-      "desc": "Elf Desktop-Hintergründe des Goetheanum (2500 × 1406) zum Herunterladen."
+      "desc": "Elf Desktop-Hintergründe des Goetheanum (2500 × 1406) zum Herunterladen.",
+      "such": "Wallpaper Hintergrund Desktop Bild"
     },
     {
       "slug": "powerpoint",
@@ -98,7 +101,8 @@
       "tag": "Anwendungen",
       "title": "PowerPoint-Vorlagen",
       "href": "powerpoint.html",
-      "desc": "Präsentationsvorlage (A4) im Hausbild mit eingebetteten Schriften – plus die TrueType-Schriften fürs Office zum Installieren."
+      "desc": "Präsentationsvorlage (A4) im Hausbild mit eingebetteten Schriften – plus die TrueType-Schriften fürs Office zum Installieren.",
+      "such": "PowerPoint Präsentation Folien PPT Vorlage Keynote"
     },
     {
       "slug": "logo-generator",
@@ -108,7 +112,8 @@
       "title": "Logos",
       "short": "Logos",
       "href": "apps/logos/",
-      "desc": "Sektions-, Bereichs- und Medienlogos in der Hausschrift – erklärt, mit Regeln, korrekt gesetzt und zum Herunterladen."
+      "desc": "Sektions-, Bereichs- und Medienlogos in der Hausschrift – erklärt, mit Regeln, korrekt gesetzt und zum Herunterladen.",
+      "such": "Logo Marke Sektionslogo Bereichslogo Medienlogo Zeichen"
     },
     {
       "slug": "visitenkarten",
@@ -118,7 +123,8 @@
       "title": "Visitenkarten",
       "short": "Visitenkarten",
       "href": "apps/visitenkarten-generator/",
-      "desc": "Einheitliche Visitenkarten aus den eigenen Angaben – druckfertig, ohne Layoutprogramm."
+      "desc": "Einheitliche Visitenkarten aus den eigenen Angaben – druckfertig, ohne Layoutprogramm.",
+      "such": "Visitenkarte Karte Kontakt Druck"
     },
     {
       "slug": "signatur",
@@ -128,7 +134,8 @@
       "title": "Signatur",
       "short": "Signatur",
       "href": "apps/signatur-generator/",
-      "desc": "Outlook-robuste E-Mail-Signatur nach gemeinsamer Vorlage – kopieren und einsetzen."
+      "desc": "Outlook-robuste E-Mail-Signatur nach gemeinsamer Vorlage – kopieren und einsetzen.",
+      "such": "E-Mail Mail Outlook Signatur Fusszeile"
     },
     {
       "slug": "uebersetzungen",
@@ -138,7 +145,8 @@
       "title": "Übersetzungen",
       "short": "Übersetzungen",
       "href": "uebersetzungen.html",
-      "desc": "Sektionen, Bereiche und institutionelle Begriffe in vier Sprachen – geprüft auf goetheanum.ch, durchsuchbar, klick-kopierbar. Für die Sekretariate."
+      "desc": "Sektionen, Bereiche und institutionelle Begriffe in vier Sprachen – geprüft auf goetheanum.ch, durchsuchbar, klick-kopierbar. Für die Sekretariate.",
+      "such": "Übersetzung Sprachen Englisch Französisch Spanisch Begriffe Sektionen"
     },
     {
       "slug": "gtv-naming",
@@ -188,7 +196,8 @@
       "title": "Schriften",
       "short": "Überblick",
       "href": "schriften.html",
-      "desc": "Sechs Schnitte von Leise bis Laut, Variable Font und Icon-Satz – mit Download."
+      "desc": "Sechs Schnitte von Leise bis Laut, Variable Font und Icon-Satz – mit Download.",
+      "such": "Schrift Font Hausschrift Variable Webfont Gewichte Icons"
     },
     {
       "slug": "icons",
@@ -198,7 +207,8 @@
       "title": "Icons",
       "short": "Icons",
       "href": "icons.html",
-      "desc": "45 benannte Piktogramme, Pfeile und Kompass – als Webfont per Taste oder einzeln als SVG, PNG und PDF."
+      "desc": "45 benannte Piktogramme, Pfeile und Kompass – als Webfont per Taste oder einzeln als SVG, PNG und PDF.",
+      "such": "Icon Piktogramme Symbole Webfont Zeichen"
     },
     {
       "slug": "typografie",
@@ -208,7 +218,8 @@
       "title": "Typografie",
       "short": "Typografie",
       "href": "typografie.html",
-      "desc": "Wenige Mittel, präzise gesetzt – als Handbuch und maschinenlesbares Token-System."
+      "desc": "Wenige Mittel, präzise gesetzt – als Handbuch und maschinenlesbares Token-System.",
+      "such": "Typografie Satz Regeln Hausregeln Mikrotypografie"
     },
     {
       "slug": "schrift-vergleich",


### PR DESCRIPTION
Drei kleine Korrekturen aus dem Feedback.

- **Karussell zentriert**: Thumb + Text sitzen jetzt als Gruppe mittig statt linkslastig (Flexbox, `justify-content:center`). Mobil weiterhin gestapelt.
- **Suche mit Synonymen**: jedes Werkzeug bekommt in `tools.json` ein `such`-Feld; die Menü-Suche matcht **Titel und Synonyme**. So findet **„Farben"** jetzt **Sektionsfarben *und* Design-System** (wo die Marken-/Neutralfarben wohnen) — nicht nur den Titel-Treffer.
- **PowerPoint-Bild**: eine eindeutige **Mini-Folie mit Titelzeile** statt des mehrdeutigen „P" (Karte und Karussell).

Headless geprüft: Suche „farben" → Sektionsfarben + Design-System; `ds-lint` 0 Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_