### PR TITLE
Karussell: Logos raus (vier Folien)

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,8 +137,7 @@
     {slug:"wallpaper",      line:"Elf Goetheanum-Hintergründe für den Desktop, frei zum Herunterladen."},
     {slug:"schriften",      line:"Sechs Schnitte von Flüstern bis Schreien, Variable Font und Icon-Satz."},
     {slug:"powerpoint",     line:"Präsentationsvorlage im Hausbild – mit eingebetteten Schriften."},
-    {slug:"icons",          line:"45 Piktogramme als Webfont oder einzeln – per Taste gesetzt."},
-    {slug:"logo-generator", line:"Sektions-, Bereichs- und Medienlogos in der Hausschrift, korrekt gesetzt."}
+    {slug:"icons",          line:"45 Piktogramme als Webfont oder einzeln – per Taste gesetzt."}
   ];
   // Greifbar: jedes Zeichen zeigt das DING, das das Werkzeug erzeugt.
   var VISUAL = {


### PR DESCRIPTION
Logos ist das bekannteste Werkzeug — im **Entdecker**-Karussell (Hinweis auf weniger Bekanntes) hat es nichts verloren. Bleiben vier Folien: Wallpaper · Schriften · PowerPoint · Icons.

`ds-lint` 0 Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_