### PR TITLE
Goetheanum Editor v1: Typografie-Engine im Browser

### DIFF
--- a/apps/editor/index.html
+++ b/apps/editor/index.html
@@ -1,0 +1,267 @@
+<!doctype html>
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Goetheanum Editor</title>
+<meta name="description" content="Text einfügen, prüfen lassen: die eindeutigen Hausregeln der Typografie werden automatisch gesetzt, offene Fragen erscheinen in der Marginalspalte zur Bestätigung." />
+<link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
+<link rel="stylesheet" href="../../design-system/tokens.css" />
+<link rel="stylesheet" href="../../design-system/base.css" />
+<link rel="stylesheet" href="../../design-system/nav.css" />
+<style>
+  /* Nur seiten-eigenes Layout – Farben/Schrift/Abstände kommen aus tokens.css/base.css. */
+  .hero{padding-block:clamp(36px,6vw,60px) var(--s6)}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(28px,4.6vw,44px);line-height:1.08;letter-spacing:-.01em;max-width:20ch}
+  .hero .lede{margin-top:var(--s4);color:var(--muted);font-size:var(--t-body);line-height:1.55;max-width:60ch}
+
+  .work{display:grid;grid-template-columns:1fr;gap:var(--s6);align-items:start;padding-bottom:var(--s8)}
+  @media(min-width:960px){.work{grid-template-columns:minmax(0,1fr) minmax(280px,340px)}}
+
+  .stage{border:1px solid var(--line);border-radius:var(--r-card);background:var(--paper);padding:var(--s6)}
+  .stage .toolbar{display:flex;align-items:center;justify-content:space-between;gap:var(--s4);flex-wrap:wrap;margin-bottom:var(--s4)}
+  .stage .toolbar .count{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small);font-variant-numeric:tabular-nums}
+  .stage .toolbar .btns{display:flex;gap:var(--s2);flex-wrap:wrap}
+
+  .edit{min-height:320px;max-width:var(--measure);outline:none;font-size:var(--t-body);line-height:var(--lh-body);white-space:pre-wrap;word-break:break-word}
+  .edit:empty::before{content:attr(data-placeholder);color:var(--muted)}
+  .edit mark.goe-mark{background:color-mix(in srgb, var(--gold) 26%, transparent);border-radius:3px;padding:0 1px;cursor:pointer}
+  .edit mark.goe-mark.is-active{background:color-mix(in srgb, var(--gold) 48%, transparent)}
+
+  .margin{display:grid;gap:var(--s6);position:sticky;top:calc(var(--header-h) + var(--s4))}
+  .margin .lab{margin-bottom:var(--s2);display:flex;align-items:center;gap:var(--s2)}
+  .margin .empty{color:var(--muted);font-size:var(--t-small)}
+
+  .qitem{border:1px solid var(--line);border-radius:var(--r-control);padding:var(--s3);margin-bottom:var(--s2);background:var(--soft)}
+  .qitem .id{font-family:var(--font-text);font-size:var(--t-micro);color:var(--gold-ink);letter-spacing:.02em}
+  .qitem p{font-size:var(--t-small);color:var(--ink);margin:var(--s1) 0 var(--s2)}
+  .qitem .diff{font-family:var(--font-text);font-size:var(--t-small);line-height:1.5;word-break:break-word}
+  .qitem .diff .von{color:var(--muted)}
+  .qitem .diff .nach{color:var(--ok);font-weight:600}
+  .qitem .row{display:flex;gap:var(--s2);margin-top:var(--s2)}
+  .qitem .row button{flex:1 1 auto}
+
+  .aitem{border-bottom:1px solid var(--line-soft);padding:var(--s2) 0;font-size:var(--t-small)}
+  .aitem:last-child{border-bottom:0}
+  .aitem .id{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);letter-spacing:.02em;display:block;margin-bottom:2px}
+  .aitem .diff{font-family:var(--font-text);line-height:1.5;word-break:break-word}
+  .aitem .diff .von{color:var(--muted)}
+  .aitem .diff .nach{color:var(--ink);font-weight:600}
+
+  .lm-note{margin-top:var(--s2);color:var(--muted);font-size:var(--t-small);max-width:64ch}
+  .lm-note b{color:var(--ink);font-weight:var(--w-deutlich)}
+  .lm-note .ids{font-family:var(--font-text);font-size:var(--t-micro);letter-spacing:.02em}
+
+  @media(max-width:560px){
+    .stage{padding:var(--s4)}
+    .margin{position:static}
+  }
+</style>
+</head>
+<body>
+
+<script src="../../design-system/nav.js" data-root="../../" data-section="generatoren" data-active="editor"></script>
+
+<main class="wrap">
+
+  <section class="hero">
+    <span class="kicker">Werkzeug</span>
+    <h1>Goetheanum Editor</h1>
+    <p class="lede">Text einfügen, <q>Prüfen</q> klicken: Eindeutiges wird automatisch nach den Hausregeln korrigiert, offene Fragen erscheinen in der Marginalspalte zur Bestätigung.</p>
+  </section>
+
+  <section class="work">
+    <div class="stage">
+      <div class="toolbar">
+        <div class="btns">
+          <button class="btn primary" type="button" id="btn-pruefen">Prüfen</button>
+          <button class="btn" type="button" id="btn-kopieren">Kopieren</button>
+          <button class="btn" type="button" id="btn-datei">Als Datei</button>
+        </div>
+        <span class="count" id="zaehler">0 Zeichen · 0 Wörter</span>
+      </div>
+      <div class="edit lese" id="edit" contenteditable="true" data-placeholder="Text einfügen oder schreiben …" role="textbox" aria-multiline="true" aria-label="Text"></div>
+    </div>
+
+    <aside class="margin">
+      <div>
+        <span class="lab">Offene Fragen <span id="offen-zahl" class="chip" style="display:none"></span></span>
+        <div id="offen-liste"><p class="empty">Noch nichts geprüft.</p></div>
+        <button class="btn ghost" type="button" id="btn-alle" style="display:none;width:100%;margin-top:var(--s2)">Alle übernehmen</button>
+      </div>
+      <div>
+        <span class="lab">Angewandt</span>
+        <div id="angewandt-liste"><p class="empty">–</p></div>
+      </div>
+    </aside>
+  </section>
+
+  <p class="lm-note">Diese Prüfung deckt die eindeutigen Regeln ab (Anführung, Striche, Auslassung, Ziffern-Gruppierung, Leerzeichen). Fragen aus Urteil und Lektorat – Schriftwahl, Auszeichnung, Zeilenmass, Kontrast – <b>folgen mit dem nächsten Schritt</b>: <span class="ids">S01 · G01 · G03 · G04 · G05 · G09 · G10 · G25 · G27 · G28</span>.</p>
+
+</main>
+
+<footer class="ds-footer">
+  <div class="wrap frow">
+    <span><strong>Goetheanum</strong> · Werkzeuge für die Hausgrafik</span>
+    <span>Allgemeine Anthroposophische Gesellschaft · <a href="https://www.goetheanum.ch">goetheanum.ch</a></span>
+  </div>
+</footer>
+
+<script src="../../assets/typografie/goe-typo.js"></script>
+<script>
+"use strict";
+(function(){
+  var RULES_URL = "../../assets/typografie/typo-regeln.yaml";
+  var edit = document.getElementById("edit");
+  var zaehlerEl = document.getElementById("zaehler");
+  var offenListe = document.getElementById("offen-liste");
+  var offenZahl = document.getElementById("offen-zahl");
+  var angewandtListe = document.getElementById("angewandt-liste");
+  var btnPruefen = document.getElementById("btn-pruefen");
+  var btnAlle = document.getElementById("btn-alle");
+  var btnKopieren = document.getElementById("btn-kopieren");
+  var btnDatei = document.getElementById("btn-datei");
+
+  var rules = null;
+  var angewandtLog = []; // {ruleId, regel, vorher, nachher}
+
+  function escapeHtml(s){
+    return s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
+  }
+
+  // Baut die Diff-Zeile mit Satzkontext: „…Kontext {alt} → {neu} Kontext…"
+  function diffHtml(kontextVor, von, nach, kontextNach){
+    return escapeHtml(kontextVor||"")+'<span class="von">'+escapeHtml(von)+'</span> → '+
+      '<span class="nach">'+escapeHtml(nach)+'</span>'+escapeHtml(kontextNach||"");
+  }
+
+  function zaehlen(){
+    var z = window.GoeTypo.zeichenzahl(edit.innerText || "");
+    zaehlerEl.textContent = z.zeichen + " Zeichen · " + z.woerter + " Wörter";
+  }
+
+  function renderAngewandt(){
+    if(!angewandtLog.length){ angewandtListe.innerHTML = '<p class="empty">–</p>'; return; }
+    angewandtListe.innerHTML = angewandtLog.map(function(a){
+      return '<div class="aitem"><span class="id">'+escapeHtml(a.ruleId)+'</span>'+
+        '<span class="diff">'+diffHtml(a.kontextVor, a.vorher, a.nachher, a.kontextNach)+'</span></div>';
+    }).join("");
+  }
+
+  function offeneMarks(){
+    return Array.prototype.slice.call(edit.querySelectorAll("mark.goe-mark"));
+  }
+
+  function renderOffenListe(){
+    var marks = offeneMarks();
+    if(!marks.length){
+      offenListe.innerHTML = '<p class="empty">Keine offenen Fragen.</p>';
+      offenZahl.style.display = "none";
+      btnAlle.style.display = "none";
+      return;
+    }
+    offenZahl.style.display = "";
+    offenZahl.textContent = String(marks.length);
+    btnAlle.style.display = "";
+    offenListe.innerHTML = "";
+    marks.forEach(function(markEl){
+      var item = document.createElement("div");
+      item.className = "qitem";
+      item.dataset.goeIdx = markEl.dataset.goeIdx;
+      item.innerHTML = '<span class="id">'+escapeHtml(markEl.dataset.goeRule)+'</span>'+
+        '<p>'+escapeHtml(markEl.dataset.goeRegel)+'</p>'+
+        '<div class="diff">'+diffHtml(markEl.dataset.goeKontextVor, markEl.dataset.goeOriginal, markEl.dataset.goeKorrektur, markEl.dataset.goeKontextNach)+'</div>'+
+        '<div class="row"><button class="btn ok" type="button" data-aktion="uebernehmen">Übernehmen</button>'+
+        '<button class="btn ghost" type="button" data-aktion="lassen">Lassen</button></div>';
+      item.addEventListener("mouseenter", function(){ markEl.classList.add("is-active"); });
+      item.addEventListener("mouseleave", function(){ markEl.classList.remove("is-active"); });
+      offenListe.appendChild(item);
+    });
+  }
+
+  function loeseMark(markEl, uebernehmen){
+    var vorher = markEl.dataset.goeOriginal;
+    var nachher = uebernehmen ? markEl.dataset.goeKorrektur : vorher;
+    if(uebernehmen){
+      angewandtLog.push({ruleId:markEl.dataset.goeRule, regel:markEl.dataset.goeRegel, vorher:vorher, nachher:nachher,
+        kontextVor:markEl.dataset.goeKontextVor, kontextNach:markEl.dataset.goeKontextNach});
+    }
+    markEl.replaceWith(document.createTextNode(nachher));
+    edit.normalize();
+    renderAngewandt();
+    renderOffenListe();
+    zaehlen();
+  }
+
+  offenListe.addEventListener("click", function(ev){
+    var btn = ev.target.closest("button[data-aktion]");
+    if(!btn) return;
+    var item = btn.closest(".qitem");
+    var markEl = edit.querySelector('mark.goe-mark[data-goe-idx="'+item.dataset.goeIdx+'"]');
+    if(!markEl) return;
+    loeseMark(markEl, btn.dataset.aktion === "uebernehmen");
+  });
+
+  btnAlle.addEventListener("click", function(){
+    offeneMarks().forEach(function(markEl){ loeseMark(markEl, true); });
+  });
+
+  function pruefen(){
+    if(!rules || !rules.length) return;
+    var roh = edit.innerText || "";
+    if(!roh.trim()) return;
+
+    var fehlerErgebnis = window.GoeTypo.pruefeFehler(roh, rules);
+    angewandtLog = angewandtLog.concat(fehlerErgebnis.log);
+
+    var text = fehlerErgebnis.text;
+    var funde = window.GoeTypo.findeEmpfehlungen(text, rules);
+    if(!funde.length){
+      edit.textContent = text;
+    } else {
+      var html = "", pos = 0;
+      funde.forEach(function(f, i){
+        html += escapeHtml(text.slice(pos, f.start));
+        html += '<mark class="goe-mark" data-goe-idx="'+i+'" data-goe-rule="'+escapeHtml(f.ruleId)+'" '+
+          'data-goe-regel="'+escapeHtml(f.regel)+'" data-goe-original="'+escapeHtml(f.original)+'" '+
+          'data-goe-korrektur="'+escapeHtml(f.korrektur)+'" data-goe-kontext-vor="'+escapeHtml(f.kontextVor)+'" '+
+          'data-goe-kontext-nach="'+escapeHtml(f.kontextNach)+'">'+escapeHtml(f.original)+'</mark>';
+        pos = f.end;
+      });
+      html += escapeHtml(text.slice(pos));
+      edit.innerHTML = html;
+    }
+    renderAngewandt();
+    renderOffenListe();
+    zaehlen();
+  }
+
+  btnPruefen.addEventListener("click", pruefen);
+
+  btnKopieren.addEventListener("click", function(){
+    navigator.clipboard.writeText(edit.innerText || "").then(function(){
+      var alt = btnKopieren.textContent;
+      btnKopieren.textContent = "Kopiert";
+      setTimeout(function(){ btnKopieren.textContent = alt; }, 1500);
+    });
+  });
+
+  btnDatei.addEventListener("click", function(){
+    var blob = new Blob([edit.innerText || ""], {type:"text/plain;charset=utf-8"});
+    var a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = "text.txt";
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+
+  edit.addEventListener("input", zaehlen);
+
+  window.GoeTypo.laden(RULES_URL).then(function(r){ rules = r; });
+
+  zaehlen();
+})();
+</script>
+
+</body>
+</html>

--- a/assets/typografie/goe-typo.js
+++ b/assets/typografie/goe-typo.js
@@ -1,0 +1,123 @@
+/* =============================================================================
+   goe-typo.js – Typografie-Engine der Hausregeln, wiederverwendbar.
+   -----------------------------------------------------------------------------
+   Quelle der Wahrheit bleibt assets/typografie/typo-regeln.yaml. Diese Datei
+   liest nichts Eigenes hinein, sie führt nur aus: laden() holt die Regeln,
+   pruefeFehler() behebt Eindeutiges automatisch, findeEmpfehlungen() markiert
+   Urteilsfragen. Kein Rendering, kein DOM – das bleibt Sache der Seite, die
+   diese Bibliothek einbindet (z. B. apps/editor/).
+   ============================================================================= */
+(function (root) {
+  "use strict";
+
+  function scalar(v) {
+    v = v.trim();
+    if (v.length >= 2 && v[0] === v[v.length - 1] && (v[0] === "'" || v[0] === '"')) {
+      var inner = v.slice(1, -1);
+      return v[0] === "'" ? inner.split("''").join("'") : inner;
+    }
+    return v;
+  }
+
+  // Mini-Parser für die flache Regelliste – spiegelt tools/typo-check.py, damit
+  // beide Seiten (Hook und Browser) exakt dieselbe Datei ohne Bibliothek lesen.
+  function parseYaml(text) {
+    var lines = text.split(/\r?\n/), rules = [], cur = null;
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      if (/^\s*#/.test(line) || !line.trim()) continue;
+      var m = line.match(/^-\s+(\w+):\s*(.*)$/);
+      if (m) {
+        if (cur) rules.push(cur);
+        cur = {};
+        cur[m[1]] = scalar(m[2]);
+        continue;
+      }
+      m = line.match(/^\s+(\w+):\s*(.*)$/);
+      if (m && cur) cur[m[1]] = scalar(m[2]);
+    }
+    if (cur) rules.push(cur);
+    return rules;
+  }
+
+  function laden(url) {
+    return fetch(url).then(function (r) { return r.text(); }).then(parseYaml);
+  }
+
+  // Wendet eine einzelne Regel auf einen bereits gefundenen Treffer an –
+  // dieselbe Regex noch einmal auf den Treffer selbst, damit $1/$2 stimmen.
+  function korrigiereTreffer(rule, treffer) {
+    return treffer.replace(new RegExp(rule.erkennen), rule.korrektur);
+  }
+
+  // Umgebung eines Treffers fürs Verständnis in der Marginalspalte – der Treffer
+  // selbst bleibt exakt (er wird programmatisch ersetzt), nur die Anzeige bekommt
+  // ein paar Zeichen mehr Satz drumherum, an der nächsten Wortgrenze gekappt.
+  var KONTEXT_PAD = 18;
+  function kontext(text, start, end) {
+    var vor = text.slice(Math.max(0, start - KONTEXT_PAD), start);
+    var nach = text.slice(end, Math.min(text.length, end + KONTEXT_PAD));
+    if (start - KONTEXT_PAD > 0) vor = "…" + vor.replace(/^\S*\s?/, "");
+    if (end + KONTEXT_PAD < text.length) nach = nach.replace(/\s?\S*$/, "") + "…";
+    return { vor: vor, nach: nach };
+  }
+
+  // Behebt alle ‹fehler›-Regeln automatisch, protokolliert jede Änderung mit Kontext.
+  function pruefeFehler(text, rules) {
+    var log = [], out = text;
+    rules.filter(function (r) { return r.schwere === "fehler" && r.erkennen && r.korrektur; })
+      .forEach(function (rule) {
+        var re = new RegExp(rule.erkennen, "g"), m, stueckchen = [], pos = 0;
+        while ((m = re.exec(out))) {
+          if (m[0].length === 0) { re.lastIndex++; continue; }
+          var korrigiert = korrigiereTreffer(rule, m[0]);
+          if (korrigiert !== m[0]) {
+            var k = kontext(out, m.index, m.index + m[0].length);
+            log.push({ ruleId: rule.id, regel: rule.regel, vorher: m[0], nachher: korrigiert, kontextVor: k.vor, kontextNach: k.nach });
+          }
+          stueckchen.push(out.slice(pos, m.index), korrigiert);
+          pos = m.index + m[0].length;
+        }
+        stueckchen.push(out.slice(pos));
+        out = stueckchen.join("");
+      });
+    return { text: out, log: log };
+  }
+
+  // Findet ‹empfehlung›-Regeln als offene Fragen (nicht automatisch verändert).
+  // Überlappende Treffer verschiedener Regeln: der frühere gewinnt.
+  function findeEmpfehlungen(text, rules) {
+    var funde = [];
+    rules.filter(function (r) { return r.schwere === "empfehlung" && r.erkennen && r.korrektur; })
+      .forEach(function (rule) {
+        var re = new RegExp(rule.erkennen, "g"), m;
+        while ((m = re.exec(text))) {
+          if (m[0].length === 0) { re.lastIndex++; continue; }
+          var korrektur = korrigiereTreffer(rule, m[0]);
+          if (korrektur !== m[0]) {
+            var k = kontext(text, m.index, m.index + m[0].length);
+            funde.push({ ruleId: rule.id, regel: rule.regel, start: m.index, end: m.index + m[0].length, original: m[0], korrektur: korrektur, kontextVor: k.vor, kontextNach: k.nach });
+          }
+        }
+      });
+    funde.sort(function (a, b) { return a.start - b.start; });
+    var kept = [], lastEnd = -1;
+    funde.forEach(function (f) {
+      if (f.start >= lastEnd) { kept.push(f); lastEnd = f.end; }
+    });
+    return kept;
+  }
+
+  // Urteils-Regeln (pruefung: lm) – (noch) kein Regex, brauchen ein Sprachmodell.
+  function lmRegeln(rules) {
+    return rules.filter(function (r) { return r.pruefung === "lm"; });
+  }
+
+  function zeichenzahl(text) {
+    var ohneLeerzeichen = text.replace(/\s/g, "").length;
+    var woerter = (text.trim().match(/\S+/g) || []).length;
+    return { zeichen: text.length, ohneLeerzeichen: ohneLeerzeichen, woerter: woerter };
+  }
+
+  root.GoeTypo = { laden: laden, parseYaml: parseYaml, pruefeFehler: pruefeFehler, findeEmpfehlungen: findeEmpfehlungen, lmRegeln: lmRegeln, zeichenzahl: zeichenzahl };
+})(window);

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -18,6 +18,30 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ## [Unveröffentlicht]
 
+### Neues Werkzeug: Goetheanum Editor (v1) – die Typografie-Engine läuft im Browser
+- **`assets/typografie/goe-typo.js`** (neu, wiederverwendbar): führt
+  `typo-regeln.yaml` clientseitig aus – lädt und parst die Regeln (derselbe
+  Mini-Parser wie `tools/typo-check.py`, eine Quelle der Wahrheit), behebt
+  ‹fehler›-Regeln automatisch und findet ‹empfehlung›-Regeln als offene Fragen
+  mit Kontext-Ausschnitt fürs Verständnis. Kein Rendering/DOM – reine Engine,
+  gedacht als Baustein fürs Backend weiterer Goe-Webseiten (v3-Ziel).
+- **`apps/editor/`**: Text einfügen, ‹Prüfen› klicken – Eindeutiges (Anführung,
+  Striche, Auslassung, Ziffern-Gruppierung, Leerzeichen) wird sofort gesetzt und
+  im Protokoll ‹Angewandt› nachvollziehbar; offene Fragen (Abkürzungs-Spatium,
+  Prozent/Einheiten-Spatium, Uhrzeit, Minus) erscheinen als Marginal-Karten mit
+  Übernehmen/Lassen und Sammel-Übernahme. Die 10 Urteils-Regeln (`pruefung: lm`
+  – Schriftwahl, Auszeichnung, Zeilenmass, Kontrast …) sind ausgewiesen, aber
+  noch nicht automatisiert (kein LLM in v1) – folgt als Lektorat-Pass (v2).
+- Eintrag in `tools.json`/Startseite/Menü (Kategorie Werkzeuge, Priorität nach
+  Signatur). Score bleibt 100 % (konform).
+
+### Icons-Tastatur: das Piktogramm wird zum Held der Taste
+- Die Icons standen mit 26px verloren in 48px-Tasten, der Buchstabe konkurrierte
+  darunter. Jetzt: ruhigere Tasten (62px), Icon mittig bei 40px, Buchstabe als
+  kleine Legende in der unteren rechten Ecke (wie das Zweitzeichen echter Tasten),
+  leere Tasten treten zurück (`opacity`). *Wirkung:* die Piktogramme führen den
+  Blick statt zu verschwimmen; hell/dunkel bleibt tokengetrieben (`--ink`).
+
 ### `.step-num` optisch nachjustiert · Links im Fliesstext sichtbar
 - **`.step-num` neu vermessen** (`base.css`): der erste Fix (line-height:1 +
   Flex-Zentrierung) zentrierte die *Line Box*, nicht die Zeichen-Tinte – Nutzer-

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -332,7 +332,7 @@
   }
 
   // Öffentliche Reihenfolge (flach) – wie die Startseite. Unbekannte ans Ende.
-  var FLAT_ORDER = ["logo-generator", "signatur", "visitenkarten", "icons", "schriften",
+  var FLAT_ORDER = ["logo-generator", "signatur", "editor", "visitenkarten", "icons", "schriften",
     "sektionsfarben", "uebersetzungen", "wallpaper", "powerpoint", "typografie", "design-system"];
   var PUBLIC_CATS = WORLDS.reduce(function (a, w) { return a.concat(w.cats); }, []);
 

--- a/icons.html
+++ b/icons.html
@@ -63,15 +63,23 @@
   pre.code{position:relative;margin:0 0 14px;border-radius:12px;padding:16px}
   .copybtn{position:absolute;top:10px;right:10px;font:inherit;font-size:var(--t-micro);border:1px solid var(--code-bg2);background:var(--code-bg2);color:var(--code-ink);border-radius:8px;padding:6px 11px;cursor:pointer;min-height:32px}
   .copybtn:hover{filter:brightness(1.25)}
-  /* Tastatur-Belegung: jede markierte Taste trägt ein Icon (wie im Beipackzettel). */
-  .kbd{display:flex;flex-direction:column;gap:6px;margin:2px 0 8px;overflow-x:auto;padding-bottom:6px}
-  .krow{display:flex;gap:6px}
-  .keycap{flex:0 0 auto;width:48px;height:52px;border:1px solid var(--line);border-radius:8px;background:var(--soft);
-    display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2px}
-  .keycap .lk{font-family:var(--font-mono);font-size:14px;color:var(--muted)}
-  .keycap.has{border-color:var(--gold);background:var(--paper)}
-  .keycap.has .gl{font-family:"G Icons";font-size:26px;line-height:1;color:var(--ink);height:26px}
-  .keycap.has .lk{color:var(--gold-ink)}
+  /* Tastatur-Belegung: das Icon ist der Held der Taste, der Buchstabe nur die
+     kleine Legende in der Ecke (wie das Zweitzeichen auf einer echten Taste).
+     Leere Tasten treten zurück, damit die Piktogramme den Blick führen. */
+  .kbd{display:flex;flex-direction:column;gap:8px;margin:6px 0 12px;overflow-x:auto;padding-bottom:8px}
+  .krow{display:flex;gap:8px}
+  .keycap{position:relative;flex:0 0 auto;width:62px;height:62px;border:1px solid var(--line);border-radius:12px;
+    background:var(--soft);display:flex;align-items:center;justify-content:center}
+  .keycap .lk{font-family:var(--font-mono);font-size:var(--t-micro);line-height:1;color:var(--muted)}
+  .keycap:not(.has){opacity:.5}
+  .keycap.has{border-color:var(--gold);background:var(--paper);box-shadow:0 1px 2px rgba(20,24,28,.05)}
+  .keycap.has .gl{font-family:"G Icons";font-size:40px;line-height:1;color:var(--ink)}
+  /* Buchstaben-Legende: auf belegten Tasten klein in die untere rechte Ecke. */
+  .keycap.has .lk{position:absolute;right:7px;bottom:5px;color:var(--gold-ink)}
+  @media(max-width:560px){
+    .keycap{width:52px;height:52px;border-radius:10px}
+    .keycap.has .gl{font-size:33px}
+  }
   .kbdcap{color:var(--muted);font-size:var(--t-small);line-height:1.6;margin:2px 0 0;max-width:60ch}
   /* Live: tippen → Icons (Webfont per Taste). */
   .try{display:flex;flex-direction:column;gap:10px;margin-top:16px}

--- a/index.html
+++ b/index.html
@@ -75,6 +75,12 @@
   /* Übersetzungen: vier Sprach-Marken */
   .thumb .tr{display:flex;gap:6px;flex-wrap:wrap;justify-content:center}
   .thumb .tr i{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:15px;font-style:normal;color:var(--ink);border:1px solid var(--line);border-radius:6px;padding:3px 9px}
+  /* Editor: Text mit einer offenen Frage (Gold-Markierung), wie in der Marginalspalte */
+  .thumb .ed{display:grid;gap:6px;width:66px}
+  .thumb .ed i{display:block;height:3px;border-radius:2px;background:var(--muted)}
+  .thumb .ed i:nth-child(1){width:100%}
+  .thumb .ed i.mk{background:var(--gold-ink);width:44%}
+  .thumb .ed i:nth-child(3){width:82%}
 
   /* Entdecker-Karussell – Hinweis auf weniger Bekanntes, oben über den Karten. */
   .carousel{position:relative;margin-bottom:var(--s8);border:1px solid var(--line);
@@ -129,7 +135,7 @@
 (function(){
   // Karten flach nach Priorität (keine Kategorien); Unbekannte ans Ende.
   // Webfont wohnt jetzt in Schriften, Zeichen in Logos – darum keine eigene Karte.
-  var ORDER = ["logo-generator","signatur","visitenkarten","icons","schriften",
+  var ORDER = ["logo-generator","signatur","editor","visitenkarten","icons","schriften",
     "sektionsfarben","uebersetzungen","wallpaper","powerpoint",
     "typografie","design-system"];
   // Entdecker-Karussell: ausgewählte Werkzeuge, je ein Teaser.
@@ -153,7 +159,8 @@
     "zeichen":         '<span style="background:#fff;border-radius:8px;width:100%;height:100%;display:grid;place-items:center"><img src="assets/zeichen/hochschulzeichen.png" alt="" style="max-height:66px;max-width:78%"></span>', // Rudolf-Steiner-Zeichen auf weissem Papier
     "wallpaper":       '<img src="assets/wallpaper/goetheanum-wallpaper-48.jpg" alt="" style="width:100%;height:100%;object-fit:cover;border-radius:8px">', // ein Motiv
     "powerpoint":      '<span class="ppt"><b></b><i></i><i></i></span>', // eine Folie mit Titel
-    "uebersetzungen":  '<span class="tr"><i>DE</i><i>EN</i><i>FR</i><i>ES</i></span>' // vier Sprachen
+    "uebersetzungen":  '<span class="tr"><i>DE</i><i>EN</i><i>FR</i><i>ES</i></span>', // vier Sprachen
+    "editor":          '<span class="ed"><i></i><i class="mk"></i><i></i></span>' // Text mit offener Frage
   };
   function visual(t){
     var v = VISUAL[t.slug] || ('<span class="spec">' + (t.title || "?").slice(0, 1) + '</span>');

--- a/tools.json
+++ b/tools.json
@@ -138,6 +138,17 @@
       "such": "E-Mail Mail Outlook Signatur Fusszeile"
     },
     {
+      "slug": "editor",
+      "cat": "generatoren",
+      "status": "beta",
+      "tag": "Lektorat",
+      "title": "Goetheanum Editor",
+      "short": "Editor",
+      "href": "apps/editor/",
+      "desc": "Text einfügen, prüfen lassen: Eindeutiges wird automatisch nach den Hausregeln korrigiert, offene Fragen erscheinen zur Bestätigung.",
+      "such": "Editor Lektorat Korrektur Korrekturmaschine Typografie Text Schreiben Prüfung Regeln"
+    },
+    {
       "slug": "uebersetzungen",
       "cat": "generatoren",
       "status": "beta",


### PR DESCRIPTION
## Summary
- Erste Umsetzung der Korrekturmaschine-Idee als **Goetheanum Editor**: `assets/typografie/goe-typo.js` führt die bestehenden Hausregeln aus `typo-regeln.yaml` clientseitig aus (einzige Quelle der Wahrheit, gleicher Mini-Parser wie `tools/typo-check.py`) — `fehler`-Regeln werden automatisch angewandt, `empfehlung`-Regeln erscheinen als offene Fragen mit Satzkontext.
- Neues Werkzeug `apps/editor/`: Text einfügen, «Prüfen» klicken — editierbare Textfläche, Marginalspalte mit «Angewandt»-Protokoll und «Offene Fragen» (einzeln oder per Sammel-Übernahme), Zeichenzähler, Export als Kopieren/Datei. Die 10 Urteils-Regeln (`pruefung: lm`) sind sichtbar ausgewiesen, aber bewusst noch nicht automatisiert (kein LLM in v1 — folgt als Lektorat-Pass v2).
- Registriert in `tools.json`, Startseiten-Karten (`ORDER`) und Menü (`FLAT_ORDER`), Such-Synonyme ergänzt.
- `design-system/CHANGELOG.md` (Beschluss-Ledger) um den Eintrag ergänzt.

## Test plan
- [x] `python3 tools/typo-check.py --all` → 0 Fehler
- [x] `python3 tools/ds-lint.py --score` → 100 % (28/28 konform)
- [x] Playwright: Regeln laden, Prüfen-Lauf korrigiert Anführung/Striche/Auslassung/Leerzeichen automatisch, offene Fragen (Abkürzungs-/Prozent-/Einheiten-Spatium) einzeln und per Sammel-Übernahme bestätigt, geschützte/ schmale Leerzeichen (U+00A0/U+202F) korrekt gesetzt
- [x] Kopieren-/Datei-Export geprüft
- [x] Sichtgeprüft hell/dunkel/mobil
- [x] Startseiten-Suche findet den Editor über Synonyme («Lektorat»)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_