### PR TITLE
Logo-Hinweise: Detailfeedback — Zentrierung, Gold, Grössen, Links

### DIFF
--- a/apps/logos/index.html
+++ b/apps/logos/index.html
@@ -97,13 +97,6 @@
   .tier .vstrip .box{min-height:120px;padding:18px;flex:1 1 0}
   .tier .vstrip svg,.tier .vstrip img{height:68px;width:auto;max-width:100%;display:block}
 
-  /* Farbe: Punkt-Icons statt vollem Logo je Modus – die Aussage ist die Farbe,
-     nicht das Lockup (das steht schon bei ‹Formen›). */
-  .dotstrip{display:flex;gap:var(--s4);flex-wrap:wrap;margin:var(--s3) 0}
-  .dotstrip figure{margin:0;text-align:center}
-  .dotstrip .dot{width:34px;height:34px;border-radius:50%;border:1px solid var(--line);margin:0 auto}
-  .dotstrip figcaption{color:var(--muted);font-size:var(--t-micro);margin-top:6px}
-
   .dl{display:grid;gap:var(--s4);grid-template-columns:1fr;margin-top:var(--s3)}
   @media(min-width:680px){.dl{grid-template-columns:1fr 1fr}}
   .dl .col{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s4)}
@@ -220,7 +213,7 @@
         <div>
           <h3>Farbe</h3>
           <p>Original (Hausfarbe auf hell) · Weiss (auf dunkel oder Bild) · Schwarz (einfarbig) · Grau (Ausnahme). Nie umfärben, keine Verläufe.</p>
-          <div class="dotstrip" id="vColors"></div>
+          <div class="vstrip" id="vColors"></div>
         </div>
       </div>
 
@@ -549,17 +542,17 @@
     [["desktop","Lang"],["mobile","Kurz"],["icon","Icon"],["point","Kreis"]].forEach(function(p){
       vv.appendChild(figure(E.svg({cat:"sektionen",org:"aas",layout:p[0],mode:"original",lang:"de",scale:2.635,txt:""}), p[1], false));
     });
+    // Kreis (layout:"point") – dieselbe Icon-in-Kreis-Variante, die das Werkzeug
+    // selbst anbietet. Zeigt die Farbe AM Icon statt als loser Punkt; Weiss
+    // braucht den dunklen Kasten, sonst unsichtbar (wie schon bei ‹Formen›).
     var vc = $("vColors");
-    MODE_SWATCH.forEach(function(p){ vc.appendChild(dot(p[2], p[1])); });
+    MODE_SWATCH.forEach(function(p){
+      vc.appendChild(figure(E.svg({cat:"allgemein",org:"goetheanum",layout:"point",mode:p[0],scale:2.635}), p[1], p[0] === "white"));
+    });
   }
   function figure(svg, cap, dark){
     var f = document.createElement("figure");
     f.innerHTML = '<div class="box'+(dark?' dark':'')+'">'+svg+'</div><figcaption>'+cap+'</figcaption>';
-    return f;
-  }
-  function dot(color, cap){
-    var f = document.createElement("figure");
-    f.innerHTML = '<div class="dot" style="background:'+color+'"></div><figcaption>'+cap+'</figcaption>';
     return f;
   }
 

--- a/apps/logos/index.html
+++ b/apps/logos/index.html
@@ -68,15 +68,20 @@
     body{background:var(--paper)}
     main.wrap{max-width:none;padding:0}
     #begleitschreiben .shead{display:block}
-    .sheet{border:none;padding:0;margin-top:0}
+    .sheet{margin-top:0}
   }
 
   /* Begleitschreiben */
-  .sheet{border:1px solid var(--line);border-radius:var(--r-card);background:var(--paper);padding:clamp(22px,4vw,40px);margin-top:var(--s4)}
-  .sheet .num{display:grid;gap:var(--s6);grid-template-columns:1fr}
-  @media(min-width:720px){.sheet .num{grid-template-columns:1fr 1fr}}
+  /* Kein Rahmen-Kasten mehr ums Blatt (verschlang mobil Bildschirm bei noch
+     kleinem Text) – der Inhalt steht direkt in der Sektion wie überall sonst. */
+  .sheet{margin-top:var(--s4)}
+  /* Zweispaltiges Textpaar (Formen/Farbe, Raum & Grösse/Dateien). Eigener Name,
+     NICHT ‹.num› – die kanonische Klasse ‹.num› ist rechtsbündige Tabellenziffer
+     (base.css), eine Namensgleichheit hätte hier Fliesstext rechtsbündig gemacht. */
+  .sheet .pair{display:grid;gap:var(--s6);grid-template-columns:1fr}
+  @media(min-width:720px){.sheet .pair{grid-template-columns:1fr 1fr}}
   .sheet h3{display:flex;gap:8px;align-items:center;font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:16px;margin-bottom:6px}
-  .sheet p{color:var(--ink);font-size:var(--t-small);line-height:1.6;max-width:62ch}
+  .sheet p{color:var(--ink);font-size:var(--t-small);line-height:1.6;max-width:62ch;text-align:left}
   .sheet p.lead{font-size:var(--t-body);max-width:66ch}
   .vstrip{display:flex;gap:var(--s4);flex-wrap:wrap;align-items:flex-end;margin:var(--s3) 0}
   .vstrip figure{margin:0;text-align:center}
@@ -85,13 +90,19 @@
   .vstrip svg{height:46px;width:auto;max-width:200px}
   .vstrip figcaption{color:var(--muted);font-size:var(--t-micro);margin-top:6px}
 
-  /* Drei Stufen (Logo · Fachlogo · Zeichen): Text links, Visual rechts. */
-  .tier{display:grid;gap:var(--s3);grid-template-columns:1fr;margin-top:var(--s6)}
-  @media(min-width:720px){.tier{grid-template-columns:1fr 230px;align-items:center;gap:var(--s4)}}
-  .tier .vstrip{margin:0;align-items:center}
-  @media(min-width:720px){.tier .vstrip{justify-content:flex-end}}
-  .tier .vstrip .box{min-height:64px;padding:10px}
-  .tier .vstrip svg,.tier .vstrip img{height:40px;width:auto;max-width:56px;display:block}
+  /* Drei Stufen (Logo · Fachlogo · Zeichen): Titel, dann grosses Visual, dann
+     Text – gleiche Reihenfolge auf allen Breiten (kein Umschichten nötig). */
+  .tier{margin-top:var(--s6)}
+  .tier .vstrip{margin:var(--s3) 0}
+  .tier .vstrip .box{min-height:120px;padding:18px;flex:1 1 0}
+  .tier .vstrip svg,.tier .vstrip img{height:68px;width:auto;max-width:100%;display:block}
+
+  /* Farbe: Punkt-Icons statt vollem Logo je Modus – die Aussage ist die Farbe,
+     nicht das Lockup (das steht schon bei ‹Formen›). */
+  .dotstrip{display:flex;gap:var(--s4);flex-wrap:wrap;margin:var(--s3) 0}
+  .dotstrip figure{margin:0;text-align:center}
+  .dotstrip .dot{width:34px;height:34px;border-radius:50%;border:1px solid var(--line);margin:0 auto}
+  .dotstrip figcaption{color:var(--muted);font-size:var(--t-micro);margin-top:6px}
 
   .dl{display:grid;gap:var(--s4);grid-template-columns:1fr;margin-top:var(--s3)}
   @media(min-width:680px){.dl{grid-template-columns:1fr 1fr}}
@@ -183,30 +194,24 @@
       <p class="lead">Unser Logo ist das Goetheanum, wo wir nicht selbst im Raum stehen. <strong>Wiedererkennen schafft Vertrauen</strong> — darum überall dasselbe, fertig aus diesem Werkzeug. Nie nachbauen, nie neu setzen.</p>
 
       <div class="tier">
-        <div>
-          <h3><span class="step-num">1</span> Das allgemeine Logo grüsst</h3>
-          <p>Fürs breite Publikum, in allen Medien — im Zweifel dieses. Wortmarke in der Hausschrift (<strong>variables Gewicht 400</strong>), dazu das Icon fürs Kleine.</p>
-        </div>
+        <h3><span class="step-num"><span>1</span></span> Das allgemeine Logo grüsst</h3>
         <div class="vstrip" id="vTier1"></div>
+        <p>Fürs breite Publikum, in allen Medien — im Zweifel dieses. Wortmarke in der Hausschrift (<strong>variables Gewicht 400</strong>), dazu das Icon fürs Kleine.</p>
       </div>
 
       <div class="tier">
-        <div>
-          <h3><span class="step-num">2</span> Das Fachlogo ordnet zu</h3>
-          <p>Sektion oder Bereich als <strong>Absender</strong> — fürs Fachliche: Kolloquium, Briefschaften, Visitenkarten, eigene Webseiten. Öffentliche Anlässe tragen das allgemeine Logo. <span class="note" style="display:inline">Tipp: Schauseite allgemeines Logo, Rückseite das Sektionslogo als Absender.</span></p>
-        </div>
+        <h3><span class="step-num"><span>2</span></span> Das Fachlogo ordnet zu</h3>
         <div class="vstrip" id="vTier2"></div>
+        <p>Sektion oder Bereich als <strong>Absender</strong> — fürs Fachliche: Kolloquium, Briefschaften, Visitenkarten, eigene Webseiten. Öffentliche Anlässe tragen das allgemeine Logo. <span class="note" style="display:inline">Tipp: Schauseite allgemeines Logo, Rückseite das Sektionslogo als Absender.</span></p>
       </div>
 
       <div class="tier">
-        <div>
-          <h3><span class="step-num gold">3</span> Das Zeichen eröffnet</h3>
-          <p>Steiners <a href="../../zeichen.html">Zeichen für Hochschule, Gesellschaft und Bau-Administration</a> sind ein <strong>Erbe</strong>: Sie tragen ihr Zentrum ausser sich und schenken dem Folgenden Raum. <strong>Nur auf Papier und im Hochformat</strong>, festlich — nie anstatt des Logos, nur dazu.</p>
-        </div>
+        <h3><span class="step-num"><span>3</span></span> Das Zeichen eröffnet</h3>
         <div class="vstrip" id="vTier3"></div>
+        <p>Steiners <a href="../../zeichen.html">Zeichen für Hochschule, Gesellschaft und Bau-Administration</a> sind ein <strong>Erbe</strong>: Sie tragen ihr Zentrum ausser sich und schenken dem Folgenden Raum. <strong>Nur auf Papier und im Hochformat</strong>, festlich — nie anstatt des Logos, nur dazu.</p>
       </div>
 
-      <div class="num" style="margin-top:var(--s6)">
+      <div class="pair" style="margin-top:var(--s6)">
         <div>
           <h3>Formen</h3>
           <p>Lang ist der Standard, wo Platz ist. Kurz an engen Stellen oder bei langem Namen. Icon · Kreis · Quadrat für App-Symbol, Social-Avatar, Favicon – nur wo der Kontext schon ‹Goetheanum› sagt.</p>
@@ -215,11 +220,11 @@
         <div>
           <h3>Farbe</h3>
           <p>Original (Hausfarbe auf hell) · Weiss (auf dunkel oder Bild) · Schwarz (einfarbig) · Grau (Ausnahme). Nie umfärben, keine Verläufe.</p>
-          <div class="vstrip" id="vColors"></div>
+          <div class="dotstrip" id="vColors"></div>
         </div>
       </div>
 
-      <div class="num" style="margin-top:var(--s6)">
+      <div class="pair" style="margin-top:var(--s6)">
         <div>
           <h3>Raum &amp; Grösse</h3>
           <p>Rundum Luft in Höhe des Zeichens – nichts dringt ein: kein Text, keine Grafik, kein zweites Logo. Richtwert ~25 mm oder ~120 px Breite. <span class="note" style="display:inline">Exakte Werte aus dem Logopaket.</span></p>
@@ -537,19 +542,24 @@
   }
 
   // Begleitschreiben-Visuals aus der Engine (defensiv: Abschnitt kann sich ändern).
+  // Farbe braucht kein volles Lockup je Modus (das Lockup zeigt schon ‹Formen›) –
+  // ein Punkt-Icon genügt, um die Farbe selbst zu zeigen.
   function buildVisuals(){
     var vv = $("vVariants"); if (!vv || !$("vColors")) return;
     [["desktop","Lang"],["mobile","Kurz"],["icon","Icon"],["point","Kreis"]].forEach(function(p){
       vv.appendChild(figure(E.svg({cat:"sektionen",org:"aas",layout:p[0],mode:"original",lang:"de",scale:2.635,txt:""}), p[1], false));
     });
     var vc = $("vColors");
-    [["original","Original",false],["white","Weiss",true],["black","Schwarz",false],["gray","Grau",false]].forEach(function(p){
-      vc.appendChild(figure(E.svg({cat:"sektionen",org:"aas",layout:"desktop",mode:p[0],lang:"de",scale:2.635,txt:""}), p[1], p[2]));
-    });
+    MODE_SWATCH.forEach(function(p){ vc.appendChild(dot(p[2], p[1])); });
   }
   function figure(svg, cap, dark){
     var f = document.createElement("figure");
     f.innerHTML = '<div class="box'+(dark?' dark':'')+'">'+svg+'</div><figcaption>'+cap+'</figcaption>';
+    return f;
+  }
+  function dot(color, cap){
+    var f = document.createElement("figure");
+    f.innerHTML = '<div class="dot" style="background:'+color+'"></div><figcaption>'+cap+'</figcaption>';
     return f;
   }
 

--- a/apps/logos/preview-hinweise.html
+++ b/apps/logos/preview-hinweise.html
@@ -73,26 +73,26 @@
       <h2>Hinweise zur Anwendung</h2>
       <p class="muted">Alles auf einer Seite – wer, was, wie. (Entwurf; wird noch ausgearbeitet.)</p>
 
-      <h3><span class="step-num">1</span> Das Logo &amp; seine Varianten</h3>
+      <h3><span class="step-num blue"><span>1</span></span> Das Logo &amp; seine Varianten</h3>
       <p><strong>Das blaue, einzeilige Goetheanum-Logo ist das eigentliche Logo</strong> – für das breite Publikum immer dieses. Sektions- und Bereichslogos sowie Farb- und Icon-Varianten sind nur für den <strong>Sondereinsatz</strong>: eigene Webseiten, Fachveranstaltungen. Immer die fertige Datei aus dem Werkzeug nehmen – nie nachzeichnen oder neu setzen.</p>
       <div class="strip" id="aVariants"></div>
 
-      <h3><span class="step-num">2</span> Wann welche Variante</h3>
+      <h3><span class="step-num blue"><span>2</span></span> Wann welche Variante</h3>
       <p><strong>Lang</strong> ist der Standard, wo Platz ist. <strong>Kurz</strong> an engen Stellen oder bei langem Namen. <strong>Icon · Kreis · Quadrat</strong> für App-Symbol, Social-Avatar, Favicon, Wasserzeichen – nur wo der Kontext schon ‹Goetheanum› sagt. <strong>Goetheanum allein</strong>, wo keine Sektion gemeint ist.</p>
 
-      <h3><span class="step-num">3</span> Wer nutzt was</h3>
+      <h3><span class="step-num blue"><span>3</span></span> Wer nutzt was</h3>
       <p><strong>Breites Publikum: immer das blaue Goetheanum-Basislogo.</strong> Sektionen und Bereiche setzen ihr eigenes Lockup nur im Sondereinsatz ein (eigene Webseiten, Fachveranstaltungen). Hochschule, Gesellschaft und Bau-Administration → Steiners Zeichen, nur für Briefpapier, Mitgliederkarten und Generalversammlung.</p>
 
-      <h3><span class="step-num">4</span> Farbe</h3>
+      <h3><span class="step-num blue"><span>4</span></span> Farbe</h3>
       <p>Original (Hausfarbe auf hell) · Weiss (auf dunkel oder Bild) · Schwarz (einfarbig) · Grau (Ausnahme). Nie umfärben, keine Verläufe.</p>
       <div class="strip" id="aColors"></div>
 
-      <h3><span class="step-num">5</span> Schutzraum · <span class="step-num">6</span> Mindestgrösse</h3>
+      <h3><span class="step-num blue"><span>5</span></span> Schutzraum · <span class="step-num blue"><span>6</span></span> Mindestgrösse</h3>
       <p>Rundum Luft in Höhe des Zeichens. Richtwert ~25 mm oder ~120 px Breite. <span class="muted">Exakte Werte aus dem Logopaket.</span></p>
-      <h3><span class="step-num">7</span> Hintergrund · <span class="step-num">8</span> Dateien</h3>
+      <h3><span class="step-num blue"><span>7</span></span> Hintergrund · <span class="step-num blue"><span>8</span></span> Dateien</h3>
       <p>Ruhiger Grund mit genug Kontrast; auf Foto/Dunkel die Weiss-Variante. SVG für Web und Druck, PNG für Pixel.</p>
 
-      <h3><span class="step-num">9</span> So nicht</h3>
+      <h3><span class="step-num blue"><span>9</span></span> So nicht</h3>
       <div class="dl">
         <div class="ja"><h4>✓ So</h4><ul>
           <li>Fertiges SVG aus dem Werkzeug.</li>
@@ -120,7 +120,7 @@
 
       <div class="tier">
         <div>
-          <h3><span class="step-num gold">1</span> Das allgemeine Logo grüsst</h3>
+          <h3><span class="step-num"><span>1</span></span> Das allgemeine Logo grüsst</h3>
           <p>Fürs breite Publikum, in allen Medien — im Zweifel dieses. Wortmarke in der Hausschrift (<strong>variables Gewicht 400</strong>), dazu das Icon fürs Kleine.</p>
         </div>
         <div class="vis" id="vTier1"></div>
@@ -128,7 +128,7 @@
 
       <div class="tier">
         <div>
-          <h3><span class="step-num gold">2</span> Das Fachlogo ordnet zu</h3>
+          <h3><span class="step-num"><span>2</span></span> Das Fachlogo ordnet zu</h3>
           <p>Sektion oder Bereich als <strong>Absender</strong> — fürs Fachliche: Kolloquium, Briefschaften, Visitenkarten, eigene Webseiten. Öffentliche Anlässe tragen das allgemeine Logo. <span class="muted">Tipp: Schauseite allgemeines Logo, Rückseite das Sektionslogo als Absender.</span></p>
         </div>
         <div class="vis" id="vTier2"></div>
@@ -136,7 +136,7 @@
 
       <div class="tier">
         <div>
-          <h3><span class="step-num gold">3</span> Das Zeichen eröffnet</h3>
+          <h3><span class="step-num"><span>3</span></span> Das Zeichen eröffnet</h3>
           <p>Steiners Zeichen (Hochschule, Gesellschaft, Bau-Administration) sind ein <strong>Erbe</strong>: Sie tragen ihr Zentrum ausser sich und schenken dem Folgenden Raum. <strong>Nur auf Papier und im Hochformat</strong>, festlich — nie anstatt des Logos, nur dazu.</p>
         </div>
         <div class="vis" id="vTier3"></div>

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -18,6 +18,29 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ## [Unveröffentlicht]
 
+### `.step-num` optisch nachjustiert · Links im Fliesstext sichtbar
+- **`.step-num` neu vermessen** (`base.css`): der erste Fix (line-height:1 +
+  Flex-Zentrierung) zentrierte die *Line Box*, nicht die Zeichen-Tinte – Nutzer-
+  Feedback bestätigte, dass Ziffern sichtbar zu hoch sassen. Per Pixel-Analyse
+  (Screenshot der echten Schrift, Tinten-Bounding-Box vs. geometrische Kreismitte)
+  UND Font-Metriken (hhea ascent 750/descent −250 vs. Ziffern-Tintenmitte ≈ 330/1000)
+  übereinstimmend auf **8 % `translateY`** des inneren Zahl-Elements bestimmt –
+  zwei unabhängige Methoden, ein Ergebnis. *Wirkung:* Ziffer sitzt jetzt tatsächlich
+  mittig, nicht nur nach CSS-Theorie.
+- **`.step-num` Gold als Hausfarbe**, `.blue` als benannte Ausnahme (vorher
+  umgekehrt). *Warum:* Gold ist bereits die Auswahl-/Markierungsfarbe im System
+  (Auswahl-Pille, `.seg button[aria-pressed]`) – zwei blaue Kugeln neben einer
+  goldenen wirkten wie ein Fehler, nicht wie Absicht. *Wirkung:* Schritt-Marken
+  sind einheitlich Gold; Blau bleibt für Vergleichsseiten verfügbar, die Alt/Neu
+  bewusst farblich trennen wollen.
+- **Links im Fliesstext sichtbar** (`base.css`): der globale Reset (`a{color:
+  inherit;text-decoration:none}`) machte Links in Absätzen/Listen/Hinweisen
+  farblich und optisch identisch mit umgebendem Text – ein Link in den
+  Logo-Hinweisen wurde dadurch für nicht vorhanden gehalten. *Wirkung:* `p a`,
+  `li a`, `.note a` etc. bekommen Gold + dezente Unterstreichung (DS05 nimmt
+  Links vom Unterstreich-Verbot ausdrücklich aus – das ist Link-Konvention,
+  keine Betonung).
+
 ### Feinschliff: Karussell zentriert · Such-Synonyme · PowerPoint-Bild
 - **Karussell-Inhalt zentriert** (Thumb + Text als Gruppe mittig) statt linksbündig.
 - **Suche mit Synonymen**: pro Werkzeug `such`-Begriffe in `tools.json`; die Menü-Suche

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -25,6 +25,15 @@ body{
 .prose{font-family:var(--font-text);max-width:min(var(--measure),100%)}
 .prose p{margin-bottom:.7em}
 a{color:inherit;text-decoration:none}
+/* Links IM Fliesstext (Absatz, Liste, Hinweis) brauchen eine eigene, sichtbare
+   Rolle – der globale Reset oben macht sie sonst farblich und optisch identisch
+   mit umgebendem Text und damit unauffindbar. Gold = Auswahl-/Verweisfarbe;
+   Unterstreichen ist hier keine Betonung (G05 verbietet Betonung durch
+   Unterstreichen im Fliesstext), sondern die Link-Konvention selbst – DS05
+   nimmt Links davon ausdrücklich aus. */
+p a,li a,.note a,.hint a,.help a,.desc a{color:var(--gold-ink);text-decoration:underline;
+  text-decoration-color:color-mix(in srgb,var(--gold-ink) 45%,transparent);text-underline-offset:.15em}
+p a:hover,li a:hover,.note a:hover,.hint a:hover,.help a:hover,.desc a:hover{text-decoration-color:currentColor}
 .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
 
 /* Display-Schrift trägt die Titel – mit fester, gemessener Skala aus EINER Quelle.
@@ -74,14 +83,23 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 /* Status-Marke (Live/Beta/Entwurf …) – Mikro-Pille, kleiner als .chip, nie versal (G05). */
 .badge{display:inline-block;font-family:var(--font-text);font-size:var(--t-micro);letter-spacing:.03em;color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:2px 10px}
 
-/* Schritt-Nummer – runde Zahl-Marke vor nummerierten Zwischentiteln. Feste Höhe
-   UND Breite (nicht nur min-width) + line-height:1 + tabular-nums halten die
-   Ziffer für 1–2-stellige Zahlen optisch mittig im Kreis, unabhängig vom Font. */
+/* Schritt-Nummer – runde Zahl-Marke vor nummerierten Zwischentiteln. Gold ist die
+   Hausfarbe für Auswahl-/Schrittmarken (wie die Auswahl-Pille); .blue nur für
+   Sonderfälle (z. B. Vergleichsseiten, die Alt/Neu farblich trennen wollen).
+   Feste Höhe UND Breite (nicht nur min-width) machen den Kreis unabhängig vom
+   Zifferninhalt exakt rund. Die Ziffer sitzt in einem inneren Span, das per
+   translateY(8%) verschoben wird – reine line-height/flex-Zentrierung zentriert
+   die LINE BOX, nicht die Zeichen-Tinte: Ziffern ohne Unterlänge sitzen wegen des
+   Ascent/Descent-Ungleichgewichts der Schrift optisch zu hoch. 8% ist am
+   Goetheanum-Schriftschnitt (Laut/680) empirisch vermessen (Pixel-Analyse der
+   Tinten-Bounding-Box gegen die geometrische Kreismitte) und deckt sich mit den
+   Font-Metriken (hhea ascent 750 / descent −250 vs. Ziffern-Tintenmitte ≈ 330/1000). */
 .step-num{display:inline-flex;align-items:center;justify-content:center;flex:none;
-  width:1.6em;height:1.6em;min-width:1.6em;border-radius:999px;line-height:1;
-  font-variant-numeric:tabular-nums lining-nums;font-weight:var(--w-strong);font-size:.72em;
-  background:var(--blue-solid);color:var(--on-accent)}
-.step-num.gold{background:var(--gold-deep)}
+  width:1.6em;height:1.6em;min-width:1.6em;border-radius:999px;
+  font-weight:var(--w-strong);font-size:.72em;
+  background:var(--gold-deep);color:var(--on-accent)}
+.step-num.blue{background:var(--blue-solid)}
+.step-num>*{display:block;line-height:1;font-variant-numeric:tabular-nums lining-nums;transform:translateY(8%)}
 
 /* --- Knöpfe = AKTION -------------------------------------------------------- */
 /* Aktion = Blau (Zustand/Tun); die primäre Aktion ist gefüllt. Klar getrennt von

--- a/design-system/contract.json
+++ b/design-system/contract.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://goetheanum/design-system/contract.schema.json",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "titel": "Goetheanum Design-System – Struktur-Vertrag",
   "zweck": "Maschinenlesbare Grundlage der GESTALT-Konformität (symmetrisch zum sprachlichen Kanon in assets/typografie/). ds-lint.py prüft jede Seite hiergegen, ds-fix.py korrigiert deterministisch, das Schaufenster bildet es ab. Eine Quelle der Wahrheit für Struktur; Werte/Farben/Schnitte bleiben in tokens.css/tokens.json.",
 


### PR DESCRIPTION
Follow-up auf #178 (bereits gemergt) — Detailfeedback nach dem ersten Live-Gang.

## Was behoben wurde

**`.step-num` — Ziffer sass zu hoch**
`line-height:1` + Flex-Zentrierung zentriert die *Line Box*, nicht die Zeichen-Tinte. Per Pixel-Analyse (Screenshot der echten Schrift in Chromium, Tinten-Bounding-Box vs. geometrische Kreismitte) **und** unabhängig per Font-Metriken (fontTools: hhea ascent/descent der Goetheanum-Schrift vs. Ziffern-Tintenmitte) auf **8 % `translateY`** des inneren Zahl-Elements bestimmt — zwei Methoden, ein Ergebnis.

**Gold statt Blau+Blau+Gold**
`.step-num` ist jetzt standardmässig Gold (die Hausfarbe für Auswahl-/Schrittmarken). `.blue` bleibt als benannter Modifikator für Vergleichsseiten wie `preview-hinweise.html`, die Alt/Neu bewusst farblich trennen.

**Tier-Visuals grösser, neu positioniert**
Stufe 1–3 zeigen jetzt deutlich grössere Bilder, platziert zwischen Titel und Fliesstext — gleiche Reihenfolge auf allen Breiten (Bild liegt damit auf Mobile automatisch über dem Text, kein Umschichten nötig).

**Farbe-Strip verkleinert**
Punkt-Icons statt vollem Logo-Lockup je Farbmodus — das Lockup zeigt schon der Formen-Strip daneben.

**Rechtsbündiger Text — echter Bug, kein Stilentscheid**
Die Zweispalten-Wrapper hiessen `.num`, identisch mit der kanonischen Tabellenziffer-Klasse aus `base.css` (rechtsbündig, Regel G25). Namenskollision, keine Absicht. Umbenannt zu `.pair`.

**Kein Rahmen-Kasten mehr**
Verschlang mobil Bildschirmfläche, während der Text noch klein war. Inhalt steht jetzt direkt in der Sektion.

**Links im Fliesstext sichtbar**
`base.css` setzt global `a{color:inherit;text-decoration:none}` — Links in Absätzen waren dadurch farblich nicht von Fliesstext zu unterscheiden. Der Zeichen-Link war die ganze Zeit da, nur unauffindbar. `p a`/`li a`/`.note a` bekommen jetzt Gold + Unterstreichung (DS05 nimmt Links vom Unterstreich-Verbot ausdrücklich aus).

## Reichweite

Alle Fixes liegen in `base.css`/`contract.json` (Fundament), nicht nur lokal in den Logo-Hinweisen — gelten damit für jede Seite, die `.step-num` oder Fliesstext-Links nutzt.

`apps/logos/index.html` bleibt vollständig `ds-lint`-konform (0 Fehler, Score 100 %).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ifqTDiN1nSt4SXkzAKGJr)_