### PR TITLE
Pillen-Buttons: engen Zeilenabstand für zweizeilige Labels

### DIFF
--- a/design-system/base.css
+++ b/design-system/base.css
@@ -116,7 +116,9 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 /* --- Segmentierte Auswahl (Pillen) = WAHL ---------------------------------- */
 /* Anwahl = Gold/Weiss – der Hausfarbklang für Auswahl. Kapselform, kein Pfeil. */
 .seg{display:flex;flex-wrap:wrap;gap:8px}
-.seg button{font:inherit;font-size:14.5px;padding:8px 15px;border:1px solid var(--line);border-radius:var(--r-pill);
+/* line-height:var(--lh-tight) statt geerbtem --lh-body (1.66, für Lesetext) –
+   sonst reisst ein zweizeiliges Pillen-Label (z. B. ‹SVG 48›) weit auseinander. */
+.seg button{font:inherit;font-size:14.5px;line-height:var(--lh-tight);padding:8px 15px;border:1px solid var(--line);border-radius:var(--r-pill);
   background:var(--field-bg);color:var(--ink);cursor:pointer;transition:border-color .15s,background .15s,color .15s}
 .seg button:hover{border-color:var(--gold-ink)}
 .seg button[aria-pressed="true"]{background:var(--gold-deep);border-color:var(--gold-ink);color:var(--on-accent);font-weight:var(--w-strong)}


### PR DESCRIPTION
Follow-up auf #178/#198 — Feedback zu einem Mobile-Screenshot (Dark Mode, Format-Pillen im Logo-Generator).

## Das Problem

`.seg button` (die Pillen-Auswahl, z. B. PNG/JPG/PDF/SVG/SVG 48/WebP) setzt kein eigenes `line-height` und erbt damit `--lh-body` (1.66) — die Zeilenhöhe für Lesetext. Bei einem einzeiligen Label fällt das kaum auf, aber "SVG 48" bricht auf Schmalbreite in zwei Zeilen um und wird durch den ererbten Lesetext-Abstand unnötig hoch und auseinandergezogen.

## Der Fix

`line-height:var(--lh-tight)` (1.15, existierendes Token) auf `.seg button` in `base.css` — Fundament-Fix, gilt für jede Segment-Pille im System, nicht nur diese eine.

Vorher/Nachher (Dark Mode, Mobile-Breite): die "SVG 48"-Pille ist jetzt genauso kompakt wie ihre Nachbarn.

`apps/logos/index.html` bleibt vollständig `ds-lint`-konform (0 Fehler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ifqTDiN1nSt4SXkzAKGJr)_