### PR TITLE
Pillen-Buttons: robuste Flex-Zentrierung statt nativer Button-Zentrierung

### DIFF
--- a/design-system/base.css
+++ b/design-system/base.css
@@ -116,9 +116,14 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 /* --- Segmentierte Auswahl (Pillen) = WAHL ---------------------------------- */
 /* Anwahl = Gold/Weiss – der Hausfarbklang für Auswahl. Kapselform, kein Pfeil. */
 .seg{display:flex;flex-wrap:wrap;gap:8px}
-/* line-height:var(--lh-tight) statt geerbtem --lh-body (1.66, für Lesetext) –
-   sonst reisst ein zweizeiliges Pillen-Label (z. B. ‹SVG 48›) weit auseinander. */
-.seg button{font:inherit;font-size:14.5px;line-height:var(--lh-tight);padding:8px 15px;border:1px solid var(--line);border-radius:var(--r-pill);
+/* Wie .btn: display:inline-flex + align-items:center statt nativer Button-
+   Zentrierung über Padding/line-height – native <button>-Vertikalzentrierung
+   ist zwischen Browsern (v. a. iOS Safari vs. Chromium) nicht verlässlich
+   gleich, padding-basiertes Zentrieren zeigte dort sichtbar zu tief sitzende
+   Schrift. line-height:var(--lh-tight) bleibt zusätzlich nötig, sonst reisst
+   ein zweizeiliges Pillen-Label (z. B. ‹SVG 48›) weit auseinander. */
+.seg button{display:inline-flex;align-items:center;justify-content:center;text-align:center;
+  font:inherit;font-size:14.5px;line-height:var(--lh-tight);padding:8px 15px;border:1px solid var(--line);border-radius:var(--r-pill);
   background:var(--field-bg);color:var(--ink);cursor:pointer;transition:border-color .15s,background .15s,color .15s}
 .seg button:hover{border-color:var(--gold-ink)}
 .seg button[aria-pressed="true"]{background:var(--gold-deep);border-color:var(--gold-ink);color:var(--on-accent);font-weight:var(--w-strong)}


### PR DESCRIPTION
Follow-up auf #199 — iPhone-Screenshot zeigte: Schrift sitzt in den Format-Pillen zu tief.

## Ehrlich zur Messung

Ich habe die echten `.seg button`-Elemente in Chromium pixelgenau vermessen (zweifach: eine isolierte Nachbildung und die echten Elemente aus der Live-Seite) — beide zeigten die Zeichen-Tinte eher leicht **über** der geometrischen Mitte, nicht darunter. Das widerspricht dem gemeldeten Bild auf den ersten Blick — aber ich kann in dieser Umgebung nur mit Chromium testen, kein Safari.

## Die wahrscheinlichere Erklärung

Native `<button>`-Elemente zentrieren ihren Inhalt über Padding/line-height, und das ist zwischen Browser-Engines **nicht garantiert gleich** — iOS Safari ist dafür bekannt, das anders zu handhaben als Chromium. Der Beleg direkt im eigenen Code: `.btn` (der "als SVG herunterladen"-Knopf, zu dem es keine Beschwerde gab) zentriert schon lange **nicht** über Padding, sondern über `display:inline-flex;align-items:center;justify-content:center`. `.seg button` (die Pillen, die Beschwerde) tat das bisher nicht.

## Der Fix

`.seg button` bekommt dieselbe Flex-Zentrierung wie `.btn` — robuster als weiteres Nachjustieren der Padding-Werte, das nur für einen Browser richtig gewesen wäre. `line-height:var(--lh-tight)` (aus #199) bleibt zusätzlich bestehen, das zweizeilige Label ("SVG 48") sitzt weiterhin kompakt.

`apps/logos/index.html` bleibt vollständig `ds-lint`-konform (0 Fehler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ifqTDiN1nSt4SXkzAKGJr)_