### PR TITLE
SVG48-Dateiname: Sprachkürzel anhängen

### DIFF
--- a/apps/logos/index.html
+++ b/apps/logos/index.html
@@ -621,7 +621,10 @@
         return;
       }
       if (window.goeStat) window.goeStat("download", sel.fmt);   // Engine-Download selbst melden
-      LogoExport[sel.fmt](currentSVG(), fileBase());
+      // SVG48 dient festen Höhen/Icons; die Sprache im Dateinamen hält Sprachvarianten auseinander.
+      var outBase = fileBase();
+      if (sel.fmt === "svg48") outBase += "-" + sel.lang;
+      LogoExport[sel.fmt](currentSVG(), outBase);
     });
     // Versteckte Profi-Felder verdrahten.
     $("advtext").addEventListener("input", function(){ sel.txt = this.value; render(); });


### PR DESCRIPTION
## Hintergrund

Folge-Feedback aus der Integration: Die SVG48-Variante dient festen Höhen/Icons und wird oft in mehreren Sprachen ins selbe Menü eingebunden. Bisher trug der Dateiname keine Sprache — de/en/fr/es-Exporte hießen identisch und überschrieben sich gegenseitig, was den Überblick erschwert.

## Änderung

`apps/logos/index.html` — Im Export-Pfad für generierte Logos wird für **nur** das Format `svg48` das Sprachkürzel (`sel.lang`) an den Basisnamen gehängt:

```
goetheanum-<org>-<layout>-<mode>-<lang>-48px.svg
```

z. B. `goetheanum-goetheanum-desktop-original-de-48px.svg`.

Die übrigen Formate (`svg`, `png`, `jpg`, `pdf`, `webp`) bleiben unverändert; der Medien-Pfad ist nicht betroffen (dort gibt es kein SVG48).

## Prüfung

- [x] Commit-Hook: `typo-check` 0 Fehler · `ds-lint` 100 %

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWRxJBHxYr143QBxeLrCQ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWRxJBHxYr143QBxeLrCQ9)_