### PR TITLE
G20-abkuerzung idempotent machen + geschützte Spatien auf der Logo-Seite

### DIFF
--- a/apps/logos/index.html
+++ b/apps/logos/index.html
@@ -220,7 +220,7 @@
       <div class="pair" style="margin-top:var(--s6)">
         <div>
           <h3>Raum &amp; Grösse</h3>
-          <p>Rundum Luft in Höhe des Zeichens – nichts dringt ein: kein Text, keine Grafik, kein zweites Logo. Richtwert ~25 mm oder ~120 px Breite. <span class="note" style="display:inline">Exakte Werte aus dem Logopaket.</span></p>
+          <p>Rundum Luft in Höhe des Zeichens – nichts dringt ein: kein Text, keine Grafik, kein zweites Logo. Richtwert ~25 mm oder ~120 px Breite. <span class="note" style="display:inline">Exakte Werte aus dem Logopaket.</span></p>
         </div>
         <div>
           <h3>Dateien</h3>
@@ -248,7 +248,7 @@
         </div>
       </div>
 
-      <p class="note" style="margin-top:var(--s4)">Holen: oben Sektion wählen und herunterladen. Die Zeichen liegen als <a href="../../zeichen.html">eigene Seite</a> (Vorschau und Pakete). · Grundlage: Werkstatt-Artikel und Leitsystem-Grundsätze auf grafik.goetheanum.ch; Struktur nach gängigen Logo-Richtlinien (u. a. Smithsonian, UC Santa Barbara, Mailchimp).</p>
+      <p class="note" style="margin-top:var(--s4)">Holen: oben Sektion wählen und herunterladen. Die Zeichen liegen als <a href="../../zeichen.html">eigene Seite</a> (Vorschau und Pakete). · Grundlage: Werkstatt-Artikel und Leitsystem-Grundsätze auf grafik.goetheanum.ch; Struktur nach gängigen Logo-Richtlinien (u. a. Smithsonian, UC Santa Barbara, Mailchimp).</p>
     </div>
   </section>
 

--- a/assets/typografie/typo-regeln.yaml
+++ b/assets/typografie/typo-regeln.yaml
@@ -33,7 +33,7 @@
   schwere: fehler
 - id: G20-abkuerzung
   regel: In mehrgliedrigen Abkürzungen schmales geschütztes Spatium (z. B., d. h., u. a.)
-  erkennen: '\b(z|d|u)\.\s?(B|h|a)\.'
+  erkennen: '\b(z|d|u)\.[  ]?(B|h|a)\.'
   korrektur: '$1. $2.'
   schwere: empfehlung
 - id: G20-prozent


### PR DESCRIPTION
## Hintergrund

Aus dem geschlossenen Audit-PR #108 blieb der Befund „G20/G22 melden teils korrekten Text". Byte-genaue Prüfung zeigt genau **einen** echten Defekt:

**`G20-abkuerzung`** nutzte `\s?` im `erkennen`-Muster. `\s` matcht auch das **korrekte** schmale geschützte Spatium (U+202F). Folge: Sobald „u. a." richtig gesetzt ist (mit U+202F), meldet die Regel den Text **trotzdem endlos weiter** — sie ist nicht idempotent.

`G20-prozent` und `G22-uhrzeit` sind dagegen sauber (ASCII-basiertes `erkennen`, Korrektur mit geschütztem Spatium → stabil); sie melden nur echten ASCII-Space und werden hier nicht angefasst.

## Änderung

- **`assets/typografie/typo-regeln.yaml`** — `G20-abkuerzung` `erkennen`: `\s?` → `[ · U+00A0]?` (ASCII-Space oder geschütztes Spatium **ja**, schmales NBSP **nein**). Fehlender/falscher Abstand wird weiter erkannt, korrekt gesetzter Text bleibt in Ruhe.
- **`apps/logos/index.html`** — die zwei **legitim** gemeldeten Stellen gesetzt: `25 mm`/`120 px` mit geschütztem Spatium, `u. a.` mit schmalem geschütztem Spatium. Seite ist damit typo-konform.

## Prüfung

- [x] `typo-check` auf der Logo-Seite: 0 Hinweise
- [x] Idempotenz-Beweis: neue Regel matcht korrektes „u.<U+202F>a." nicht mehr, ASCII „u. a." weiterhin
- [x] Commit-Hook grün (typo-check + ds-lint), Typo-Sync „synchron"

_Hinweis: Die Regeln sind einzige Quelle der Wahrheit (`typo-check.py` **und** `goe-typo.js` lesen dieselbe YAML) — der Fix wirkt in Checker, Hook und Browser-Editor gleichermaßen. Vorbestehende Treffer auf anderen Seiten (schriften/uebersetzungen …) sind unabhängig und nicht Teil dieses PR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWRxJBHxYr143QBxeLrCQ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWRxJBHxYr143QBxeLrCQ9)_