### PR TITLE
Webfont-Einbindung: zwei saubere Wege statt der phtok.github.io-Falle

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -12,11 +12,11 @@
 <link rel="stylesheet" href="../../design-system/base.css" />
 <link rel="stylesheet" href="../../design-system/nav.css" />
 <style>
-  /* Goetheanum Variable Font – gehostet von GitHub Pages (vgl. schriften.html#web) */
+  /* Goetheanum Variable Font – gleiche Herkunft (relativ), kein Fremd-Host/Redirect. */
   @font-face{
     font-family:"Goetheanum";
-    src:url("https://phtok.github.io/goeloggen/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Variabel-v2.7.woff2") format("woff2"),
-        url("https://phtok.github.io/goeloggen/assets/fonts/goetheanum/Webfonts/woff/Goetheanum-Variabel-v2.7.woff") format("woff");
+    src:url("../../assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Variabel-v2.7.woff2") format("woff2"),
+        url("../../assets/fonts/goetheanum/Webfonts/woff/Goetheanum-Variabel-v2.7.woff") format("woff");
     font-weight:190 725; font-style:normal; font-display:swap;
   }
 

--- a/icons.html
+++ b/icons.html
@@ -163,7 +163,8 @@
         <p class="kbdcap" id="kbdcap"></p>
         <pre class="code"><button class="copybtn" id="copyff">kopieren</button><code id="ffcode">@font-face{
   font-family:"Goetheanum Icons";
-  src:url("https://phtok.github.io/goeloggen/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Icons-v2.7.woff2") format("woff2");
+  /* A · Hausadresse — oder B: url("/fonts/Goetheanum-Icons-v2.7.woff2") */
+  src:url("https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Icons-v2.7.woff2") format("woff2");
   font-display:block;
 }
 .icon{ font-family:"Goetheanum Icons"; }

--- a/schrift-webfont.html
+++ b/schrift-webfont.html
@@ -61,12 +61,20 @@ pre .k{color:var(--code-key)}pre .s{color:var(--code-str)}pre .c{color:var(--cod
   </div>
 </div>
 
+<h2>Zwei Wege, die Schrift zu laden</h2>
+<div class="card">
+  <p class="lead" style="margin-top:0"><b>A · Von der Hausadresse laden.</b> Am schnellsten: die Dateien direkt von <code>werkzeuge.goetheanum.ch</code> ziehen. Die Adresse liefert über <b>https</b> mit <code>access-control-allow-origin: *</code> – lädt also von jeder Domain (kein CORS-Problem). Der Code steht unten.</p>
+  <p class="lead"><b>B · Selbst hosten</b> <span class="tag">für Produktion empfohlen</span><br>Die <code>.woff2</code> aus dem Download-Paket (Ordner <code>Webfonts/woff2/</code>) ins eigene Projekt legen – etwa <code>/fonts/</code> – und die <code>src</code>-URL relativ setzen: <code>url("/fonts/Goetheanum-Variabel-v2.7.woff2")</code>. Kein Fremd-Server, kein CORS, kein Ausfallrisiko – die robusteste Wahl für eine echte Website.</p>
+  <p class="note" style="border-left:3px solid var(--gold);padding-left:12px;margin-top:14px"><b>Nicht</b> <code>phtok.github.io</code> verwenden und <b>nie</b> <code>http://</code>: diese Adresse leitet auf unverschlüsseltes http um, und https-Seiten blockieren das (‹Mixed Content›) – dann lädt die Schrift stumm nicht.</p>
+</div>
+
 <h2>1 · Variable Font einbinden <span class="tag">empfohlen — eine Datei, 66 KB, alle Schnitte</span></h2>
 <div class="card">
 <pre><button class="copy" data-t="v">kopieren</button><code id="code-v"><span class="k">@font-face</span> {
   <span class="k">font-family</span>: <span class="s">"Goetheanum"</span>;
-  <span class="k">src</span>: <span class="k">url</span>(<span class="s">"https://phtok.github.io/goeloggen/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Variabel-v2.7.woff2"</span>) <span class="k">format</span>(<span class="s">"woff2"</span>),
-       <span class="k">url</span>(<span class="s">"https://phtok.github.io/goeloggen/assets/fonts/goetheanum/Webfonts/woff/Goetheanum-Variabel-v2.7.woff"</span>) <span class="k">format</span>(<span class="s">"woff"</span>);
+  <span class="c">/* A · Hausadresse — oder B: url("/fonts/Goetheanum-Variabel-v2.7.woff2") */</span>
+  <span class="k">src</span>: <span class="k">url</span>(<span class="s">"https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Variabel-v2.7.woff2"</span>) <span class="k">format</span>(<span class="s">"woff2"</span>),
+       <span class="k">url</span>(<span class="s">"https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Webfonts/woff/Goetheanum-Variabel-v2.7.woff"</span>) <span class="k">format</span>(<span class="s">"woff"</span>);
   <span class="k">font-weight</span>: 190 725;     <span class="c">/* variable Gewichtsachse */</span>
   <span class="k">font-style</span>: normal;
   <span class="k">font-display</span>: swap;
@@ -85,8 +93,9 @@ pre .k{color:var(--code-key)}pre .s{color:var(--code-str)}pre .c{color:var(--cod
 <h2>2 · Einzelne Schnitte (statisch)</h2>
 <div class="card">
 <pre><button class="copy" data-t="s">kopieren</button><code id="code-s"><span class="k">@font-face</span>{<span class="k">font-family</span>:<span class="s">"Goetheanum Klar"</span>;
-  <span class="k">src</span>:<span class="k">url</span>(<span class="s">"https://phtok.github.io/goeloggen/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.7-Klar.woff2"</span>) <span class="k">format</span>(<span class="s">"woff2"</span>);
+  <span class="k">src</span>:<span class="k">url</span>(<span class="s">"https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.7-Klar.woff2"</span>) <span class="k">format</span>(<span class="s">"woff2"</span>);
   <span class="k">font-weight</span>:400;<span class="k">font-display</span>:swap}
+<span class="c">/* B (selbst hosten): src:url("/fonts/Goetheanum-Schrift-v2.7-Klar.woff2") format("woff2"); */</span>
 <span class="c">/* ebenso: …-Leise.woff2 als "Goetheanum Leise", …-Ruhig.woff2 als "Goetheanum Ruhig", …-Laut.woff2 als "Goetheanum Laut" */</span></code></pre>
 <p class="note">Nutzung: <code>font-family:"Goetheanum Klar"</code>. Verfügbar: <b>Leise · Ruhig · Klar · Deutlich · Laut</b>.</p>
 </div>
@@ -99,7 +108,11 @@ pre .k{color:var(--code-key)}pre .s{color:var(--code-str)}pre .c{color:var(--cod
   <div class="swatch"><span class="tag">Leise 265</span><span class="s" style="font-variation-settings:'wght' 265">geprüft & gefällig</span></div>
 </div>
 
-<p class="note">Hosting: Diese URLs liegen auf GitHub Pages (mit <code>access-control-allow-origin: *</code>, lädt also cross-origin). Für volle Produktionskontrolle die Dateien aus <code>assets/fonts/goetheanum/Webfonts/</code> selbst hosten und die URLs umbiegen — der Code bleibt gleich.</p>
+<h2>Warum überhaupt zwei Wege?</h2>
+<div class="card">
+  <p class="lead" style="margin-top:0"><b>CORS</b> ist die Regel, dass ein Browser eine Schrift von einer fremden Domain nur lädt, wenn diese per Kopfzeile zustimmt (<code>access-control-allow-origin</code>). <code>werkzeuge.goetheanum.ch</code> sendet <code>*</code> – erlaubt also alle. CORS ist hier <b>kein</b> Hindernis.</p>
+  <p class="lead"><b>Mixed Content</b> ist die eigentliche Falle: eine <b>https</b>-Seite darf nichts über <b>http</b> nachladen. Die alte Beispiel-Adresse <code>phtok.github.io</code> leitet intern auf <code>http://…</code> um – der Browser blockiert das, und die Schrift lädt stumm nicht. Darum oben die Hausadresse (durchgehend https) oder – am saubersten – selbst hosten.</p>
+</div>
 
 </div>
 <script>

--- a/schriften.html
+++ b/schriften.html
@@ -269,8 +269,9 @@
     <div class="webgrid">
       <pre class="code"><button class="copybtn" id="copyff">kopieren</button><code id="ffcode">@font-face{
   font-family:"Goetheanum";
-  src:url("https://phtok.github.io/goeloggen/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Variabel-v2.7.woff2") format("woff2"),
-      url("https://phtok.github.io/goeloggen/assets/fonts/goetheanum/Webfonts/woff/Goetheanum-Variabel-v2.7.woff") format("woff");
+  /* A · Hausadresse — oder B: url("/fonts/Goetheanum-Variabel-v2.7.woff2") */
+  src:url("https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Variabel-v2.7.woff2") format("woff2"),
+      url("https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Webfonts/woff/Goetheanum-Variabel-v2.7.woff") format("woff");
   font-weight:190 725; font-style:normal; font-display:swap;
 }
 /* Verwendung */
@@ -279,8 +280,9 @@ body{ font-family:"Goetheanum", system-ui, sans-serif; }
 .frei{ font-variation-settings:"wght" 520 }  /* stufenlos */</code></pre>
       <div class="webaside">
         <p style="margin:0 0 12px">Schnitte über die Achse: <b>Flüstern 190 · Leise 265 · Ruhig 350 · Klar 440 · Deutlich 580 · Laut 680 · Schreien 725</b> – dazwischen alles stufenlos.</p>
-        <p style="margin:0 0 16px;font-size:var(--t-small);color:var(--muted)">Lädt cross-origin von GitHub Pages. Für volle Kontrolle die Dateien aus dem Webfont-Ordner selbst hosten und die URLs umbiegen.</p>
-        <a class="btn primary" href="schrift-webfont.html">Demo &amp; Code-Schnipsel</a>
+        <p style="margin:0 0 8px;font-size:var(--t-small);color:var(--muted)"><b style="color:var(--ink);font-weight:400">A · Hausadresse</b> (oben, durchgehend https) oder <b style="color:var(--ink);font-weight:400">B · selbst hosten</b> (Datei ins Projekt, relative URL – für Produktion empfohlen).</p>
+        <p style="margin:0 0 16px;font-size:var(--t-micro);color:var(--muted)">Nicht <code>phtok.github.io</code> und nie <code>http://</code> – das leitet auf http um, https-Seiten blockieren es (‹Mixed Content›).</p>
+        <a class="btn primary" href="schrift-webfont.html">Beide Wege &amp; Code-Schnipsel</a>
       </div>
     </div>
   </div></section>


### PR DESCRIPTION
## Warum

Die auf der Schriftseite gezeigte Beispiel-URL `phtok.github.io` **liefert die Datei nicht selbst** – sie leitet intern auf `http://…` um. Eine **https**-Seite blockiert das (‹Mixed Content›), und die Schrift lädt **stumm nicht**. Genau das ist einem externen Nutzer (Lovable-Projekt auf goetheanum.online) passiert. `CORS` war dabei nie das Problem – die Hausadresse sendet `access-control-allow-origin: *`.

## `schrift-webfont.html` – der Webfont-Bereich neu

- **„Zwei Wege"** ganz vorn:
  - **A · Von der Hausadresse laden** – `https://werkzeuge.goetheanum.ch/…` (durchgehend https, CORS `*`).
  - **B · Selbst hosten** *(für Produktion empfohlen)* – Datei ins Projekt, relative `src`-URL. Kein Fremd-Server, kein CORS, kein Ausfallrisiko.
- **Warnung**: nicht `phtok.github.io`, nie `http://` – mit Erklärung der Mixed-Content-Falle.
- Abschnitt **„Warum zwei Wege?"** erklärt CORS vs. Mixed Content in Klartext.
- Alle Beispiel-URLs `phtok.github.io` → `werkzeuge.goetheanum.ch`.

## `schriften.html`

Kurzer Webfont-Abschnitt gleich nachgezogen: korrekte URL im Code, A/B-Notiz, Warnung, Button „Beide Wege & Code-Schnipsel".

## Echter Produktions-Bug mitbehoben

- **`apps/signatur-generator/index.html`** lud den Font **live** von `phtok.github.io` – auf der https-Seite blockiert, Preview fiel auf Systemschrift zurück. Auf **relative gleiche-Herkunft-URL** umgestellt.
- **`icons.html`** – das Code-Beispiel von `phtok.github.io` → `werkzeuge.goetheanum.ch`.

## Prüfung

- [x] `typo-check` 0 Fehler · `ds-lint` 4/4 konform (100 %)
- [x] Seite gerendert: Zwei-Wege-Box, Warnung, korrekte URL im Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aSpY9SVm7s2z5dMoG4Cy4

---
_Generated by [Claude Code](https://claude.ai/code/session_017aSpY9SVm7s2z5dMoG4Cy4)_