### PR TITLE
Goe-Editor: Einfügen auf Klartext normalisieren – &lt;q&gt; wird zu echten ‹…›

### DIFF
--- a/apps/editor/index.html
+++ b/apps/editor/index.html
@@ -255,6 +255,58 @@
     URL.revokeObjectURL(a.href);
   });
 
+  // Einfügen normalisiert auf echten Klartext: der Editor arbeitet mit Text,
+  // nicht mit Fremd-Markup. Ein <q> aus der Zwischenablage wird zu ECHTEN
+  // ‹…›-Zeichen materialisiert – sonst ist die Hausanführung nur CSS (base.css
+  // rendert <q> über die quotes-Eigenschaft, G16) und verschwindet beim ersten
+  // Prüfen spurlos, ohne dass am Klartext etwas geschieht. Blockgrenzen werden
+  // zu Zeilenumbrüchen, sonst fiele der ganze Satzbau zu einer Zeile zusammen.
+  function htmlZuText(html){
+    var tpl = document.createElement("template");
+    tpl.innerHTML = html;
+    var root = tpl.content;
+    var q;
+    while((q = root.querySelector("q"))){
+      var innerst = q, tiefer; // innerste Anführung zuerst, damit Verschachtelung ‹‹…›› erhalten bleibt
+      while((tiefer = innerst.querySelector("q"))) innerst = tiefer;
+      innerst.replaceWith(document.createTextNode("‹" + innerst.textContent + "›"));
+    }
+    Array.prototype.forEach.call(root.querySelectorAll("br"), function(br){
+      br.replaceWith(document.createTextNode("\n"));
+    });
+    Array.prototype.forEach.call(root.querySelectorAll("p,div,li,tr,h1,h2,h3,h4,h5,h6,blockquote"), function(b){
+      b.appendChild(document.createTextNode("\n"));
+    });
+    return (root.textContent || "").replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n").replace(/^\n+|\n+$/g, "");
+  }
+
+  function textEinfuegen(text){
+    if(!text) return;
+    // insertText hält Cursor und Undo-Verlauf und erzeugt reinen Text.
+    if(document.execCommand && document.execCommand("insertText", false, text)) return;
+    var sel = window.getSelection();
+    if(sel && sel.rangeCount){
+      var range = sel.getRangeAt(0);
+      range.deleteContents();
+      var node = document.createTextNode(text);
+      range.insertNode(node);
+      range.setStartAfter(node); range.setEndAfter(node);
+      sel.removeAllRanges(); sel.addRange(range);
+    } else {
+      edit.appendChild(document.createTextNode(text));
+    }
+  }
+
+  edit.addEventListener("paste", function(ev){
+    var cd = ev.clipboardData || window.clipboardData;
+    if(!cd) return;
+    ev.preventDefault();
+    var html = cd.getData("text/html");
+    var text = html ? htmlZuText(html) : (cd.getData("text/plain") || "");
+    textEinfuegen(text);
+    zaehlen();
+  });
+
   edit.addEventListener("input", zaehlen);
 
   window.GoeTypo.laden(RULES_URL).then(function(r){ rules = r; });


### PR DESCRIPTION
## Beobachtung

Ein kleiner Text wurde geprüft. Der Editor hat **saubere Anführungen gelöscht** und **nicht gesagt, was er geändert hat** (Angewandt: –, Zähler unverändert).

## Ursache

Der Test-Text war die gesetzte Lede der Seite, die `<q>Prüfen</q>` enthält. Beim Einfügen landete das **Markup** im Feld. Die ‹…› der Hausanführung sind aber **CSS-generiert** (`base.css:186` — `q{quotes:'‹' '›' …}`, G16), **keine echten Zeichen**:

1. Nach dem Einfügen zeigt CSS `‹Prüfen›` — im DOM steht `<q>Prüfen</q>`.
2. `edit.innerText` liest CSS-generierte Zeichen **nicht** mit → die Engine sieht nur `…Prüfen…` (darum blieb der Zähler bei 155, ohne die ‹›).
3. „Prüfen" findet am Klartext nichts → `edit.textContent = text` **plättet das `<q>` zu reinem Text** → die sichtbaren ‹› verschwinden spurlos.
4. Am Klartext geschah wirklich nichts → **Angewandt: –**, keine offene Frage. Von aussen: stilles Löschen.

## Änderung

Ein `paste`-Handler normalisiert Eingefügtes auf **echten Klartext**:

- `<q>` aus der Zwischenablage wird zu **materiellen `‹…›`-Zeichen** (verschachtelt `‹‹…››` bleibt erhalten).
- Blockgrenzen (`p`, `div`, `li`, `br`, …) werden zu Zeilenumbrüchen, sonst fiele der Satzbau zu einer Zeile zusammen.
- Sonstiges Markup fällt sauber weg; eingefügt wird über `insertText` (Cursor/Undo bleiben erhalten).

Damit ist WYSIWYG wieder konsistent: was im Feld steht, wird geprüft, kopiert und gespeichert — und materialisierte Anführungen **überleben** das Prüfen, statt unbemerkt zu verschwinden.

## Verifiziert (Chromium/Playwright)

- Einfügen von `<q>Prüfen</q>` → echtes `‹Prüfen›`; überlebt „Prüfen" ohne falschen Log.
- Gerade `"Hallo"` → `‹Hallo›`, weiterhin korrigiert **und** korrekt protokolliert (`Angewandt: G16 … "Hallo" → ‹Hallo›`).
- Keine JS-Fehler. Haus-Linter: Typo konform, DS-Score 100 %.

## Betroffene Regel-IDs

- **G16** (Hausanführung ‹…›) — der reklamierte Fall.
- **B05** (Flächen/Tokens) unberührt; nur seiten-eigene JS-Logik in `apps/editor/index.html`.

## Offen (separat, nicht in diesem PR)

Die Auto-Korrektur `G16-anfuehrung` paart bei **unpaarigen** geraden Zeichen (Zoll/Prime, z. B. `5"`) über das eigentliche Zitat hinweg und kann so ein echtes Anführungspaar zerreissen. Eigener Befund — auf Wunsch als nächster Schritt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EemaEtz2DK971VAL727yYK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EemaEtz2DK971VAL727yYK)_