### PR TITLE
A11y- & Typografie-Sanierung (WCAG 2.2 AA · Beier) — Block A + B

### DIFF
--- a/CHANGELOG-a11y.md
+++ b/CHANGELOG-a11y.md
@@ -30,7 +30,10 @@ Branch `a11y-typo-refactor`, ein Commit pro Aufgabe. Nachweis je Aufgabe:
 | B7 | Dunkelmodus-Gewichtsabsenkung nur an grossen Display-Rollen (h1/h2/`.h-display`→540); Kleintext/UI behält Hell-Gewicht | `design-system/tokens.css`, `design-system/base.css` | Beier – Fettung hilft klein; kleiner Text soll im Dunkeln nicht dünner werden. Verifiziert: h1 580→540, Kicker/Knopf/Body unverändert. **Abweichung:** Kicker (klein) bleibt Deutlich statt reduziert – erfüllt die Abnahme „kleiner Text nicht leichter" und wahrt B2 |
 
 ## Block C — Leseschrift-Umschalter
-Optional, **nur nach Rückfrage** (noch offen).
+
+| ID | Was | Datei | Begründung |
+|----|-----|-------|------------|
+| C | Kopfzeilen-Schalter „Lesemodus" neben Hell/Dunkel (A-Icon, das die Leseschrift zeigt + Gold-Ring als Zustand); tauscht `body` + `.lede` Display→Source, erhöht Spacing; Titel/Kicker/Kopfzeile bleiben Goetheanum; Zustand in `localStorage('goeRead')`, vor dem Paint gesetzt | `design-system/nav.js`, `design-system/nav.css`, `design-system/base.css` | Nutzerkontrolle ist der best belegte inklusive Faktor. Verifiziert: aus→body Goetheanum; ein→body/lede Source, h1/Kicker bleiben Goetheanum, Icon-A wird Source, Zustand überlebt Reload (kein FOUC). Grösse via B4 stabil; Reflow durch A7 abgesichert. **Symbol:** A mit Font-Wechsel + Gold-Ring statt reiner Buchstabenform (bei 17 px sonst zu subtil) |
 
 ## Bewahrt (nicht angefasst)
 Fluide rem-Skala · Zeilenhöhe 1.66 · Mass ~62 ch · Betonung nur über Gewicht ·

--- a/CHANGELOG-a11y.md
+++ b/CHANGELOG-a11y.md
@@ -1,0 +1,44 @@
+# A11y- & Typografie-Sanierung (WCAG 2.2 AA · Sofie Beier)
+
+Branch `a11y-typo-refactor`, ein Commit pro Aufgabe. Nachweis je Aufgabe:
+**Was · Datei · Begründung (SC / Beier / Messwert)**.
+
+## Block A — Zugänglichkeit
+
+| ID | Was | Datei | Begründung |
+|----|-----|-------|------------|
+| A1 | Verstecktes `h1` als erstes `main`-Kind; Kachel-Titel `h3`→`h2`; `main#inhalt` | `index.html` | WCAG 1.3.1 / 2.4.6 – genau ein `h1`, keine übersprungene Ebene (verifiziert: 1× h1, dann h2) |
+| A2 | Dauerhafter Halt/Weiter-Schalter; Timer läuft nicht bei `paused`; bei `prefers-reduced-motion` von Anfang gestoppt; Punkt-Trefferfläche 26 px via `::before`; aktiver Punkt `aria-current` | `index.html` | WCAG 2.2.2 (Auto-Lauf 6.5 s) · 2.5.8 (Ziel ≥ 24 px). Verifiziert: Index bleibt nach Halt über 7 s stehen; Auto-Lauf ohne Halt läuft |
+| A3 | Fokus in den Dialog (erst Schliessen-Knopf, kein Auto-Fokus ins Suchfeld), `aria-modal`, Tab-Falle nur sichtbare Elemente, Fokus zurück auf Burger | `design-system/nav.js` | WCAG 2.4.3 + ARIA-Dialog. Verifiziert: Öffnen→Close-Knopf, Shift+Tab wraps, Escape→Burger |
+| A4 | Globaler Sprunglink „Zum Inhalt" (setzt `id=inhalt` auf `<main>`, nach DOM-Ready) | `design-system/nav.js`, `design-system/nav.css` | WCAG 2.4.1 (Verbesserung). Verifiziert auf Startseite + Icons: erstes Tab zeigt/aktiviert den Link |
+| A5 | `--gold-ink` `#94702e`→`#8a6728` | `design-system/tokens.css` | WCAG 1.4.3 – auf `--soft` von **4.29** → **4.89:1**, auf Weiss **5.18:1** (Formel des Auftrags) |
+| A6 | Je Sektionsfarbe `--on-sek-*` (Weiss nur ≥ 4.5:1, sonst dunkler Sektionston); Checker im Hook | `design-system/tokens.css`, `tools/check-on-sek.py`, `tools/hooks/pre-commit` | WCAG 1.4.3 – lws/js/hpise u. a. versagen mit Weiss; 6 dunkle Töne ≥ 4.6:1, 7× Weiss. Build bricht bei Unterschreiten |
+| A7 | Text-tragende Seiten-Toolbars `height`→`min-height`; kanonische Rollen waren schon padding-/`min-height`-basiert | `typografie.html`, `werkzeug.html` | WCAG 1.4.12 – Text-Spacing-Test (LH 1.5 / LS .12 / WS .16 / ¶ 2em) auf Startseite, Icons, Sektionsfarben: kein Clipping |
+| A8 | Globaler `@media(prefers-reduced-motion:reduce)`-Block; `.tile:hover` ohne transform | `design-system/base.css`, `index.html` | WCAG 2.3.3 – Übergänge und weiches Scrollen aus |
+| A9 | `lang` je fremdsprachiger Tabellenzelle (en/fr/es) | `uebersetzungen.html` | WCAG 3.1.2 – verifiziert: Zell-`lang` = `["-","en","fr","es","-"]` |
+
+## Block B — Typografie & Lesbarkeit (Beier)
+
+| ID | Was | Datei | Begründung |
+|----|-----|-------|------------|
+| B1 | `.note/.hint/.help/.desc/.subhead` → `--font-text` (Source) | `design-system/base.css` | Kondensierung/geschlossene Aperturen der Display schaden kleinem, dichtem Lesetext |
+| B2 | `.kicker/.kick` Klar→Deutlich; `.btn`, `.seg button` explizit Deutlich | `design-system/base.css` | Fettung hilft bei kleinen Sehwinkeln; Stammbreite Klar bei ~13.5 px grenzwertig |
+| B3 | `body` (→`.lede`) `letter-spacing:.02em`; `h1,h2` auf 0 | `design-system/base.css` | Tracking-/Crowding-Nutzen gilt Lese-/Kleingraden, nicht grossen Titeln |
+| B4 | `size-adjust:103%` (500/486) auf alle Source-Faces | `design-system/tokens.css` | Wahrgenommene Grösse = x-Höhe; gleiche px → gleiche Wirkung, stabiler Fallback |
+| B5 | `ascent-override:75%; descent-override:25%; line-gap-override:0%` auf BEIDE Faces | `design-system/tokens.css` | `usWinAscent` 1114 ⇒ uneinheitlicher Durchschuss/Grundlinie. Verifiziert: À/Ü/Ǻ clippen bei LH 1.66 nicht, beide Faces gleiche Boxhöhe; Font-Bug U+01FA separat behoben (#213/#218) |
+| B6 | `type-scale.json` (kanonische Leiter) + `tools/check-type-scale.py` (TS1/TS2) im Hook | `design-system/type-scale.json`, `tools/check-type-scale.py`, `tools/hooks/pre-commit` | „Konformität durch Konstruktion": Goetheanum-Rolle < 18 px braucht Deutlich; Leise ≥ 22 px. Regeln an synthetischen Verstössen getestet |
+| B7 | Dunkelmodus-Gewichtsabsenkung nur an grossen Display-Rollen (h1/h2/`.h-display`→540); Kleintext/UI behält Hell-Gewicht | `design-system/tokens.css`, `design-system/base.css` | Beier – Fettung hilft klein; kleiner Text soll im Dunkeln nicht dünner werden. Verifiziert: h1 580→540, Kicker/Knopf/Body unverändert. **Abweichung:** Kicker (klein) bleibt Deutlich statt reduziert – erfüllt die Abnahme „kleiner Text nicht leichter" und wahrt B2 |
+
+## Block C — Leseschrift-Umschalter
+Optional, **nur nach Rückfrage** (noch offen).
+
+## Bewahrt (nicht angefasst)
+Fluide rem-Skala · Zeilenhöhe 1.66 · Mass ~62 ch · Betonung nur über Gewicht ·
+`hyphens`/`text-wrap:pretty`/orphans/widows · Flattersatz · 44-px-Ziele ·
+`:focus-visible` · selbstgehostete OFL-Schriften · `scroll-padding-top` · Landmarken.
+
+## Prüfhinweis (PR)
+Empfohlen: eine Runde reine Tastaturbedienung durch Karussell (Halt/Weiter, Punkte)
+und Schublade (Öffnen→Fokus, Tab-Falle, Escape→Burger), plus ein Screenreader-Durchgang
+(VoiceOver/NVDA). Keine visuelle Regression Hell **und** Dunkel (Startseite + Schriften geprüft).
+Design-System-Score bleibt 100 % (29/29).

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -282,3 +282,9 @@ img,svg,canvas,video{max-width:100%}
   .shead{gap:var(--s3)}
   .ds-footer .frow{gap:var(--s3)}
 }
+
+/* Bewegung reduzieren (WCAG 2.3.3): auf Wunsch Übergänge und weiches Scrollen
+   global aus. Seiten-eigene Bewegungen (Karussell, .tile-Hover) ziehen nach. */
+@media(prefers-reduced-motion:reduce){
+  *{transition:none!important;scroll-behavior:auto!important}
+}

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -42,6 +42,9 @@ p a:hover,li a:hover,.note a:hover,.hint a:hover,.help a:hover,.desc a:hover{tex
    keine Seite ausscheren (Konformität durch Konstruktion). Titel = Deutlich, nie Laut. */
 h1,h2,h3,h4,.h-display{font-family:var(--font-display);font-weight:var(--w-deutlich);line-height:var(--lh-tight)}
 h1,h2{letter-spacing:0}   /* B3: grosse Display-Grade bleiben eng (Tracking nur an Lesegraden) */
+/* B7: Halations-Absenkung im Dunkeln NUR an grossen Display-Rollen – gegen das
+   Bleeding heller, fetter Grossbuchstaben. Fliess-/Kleintext behält sein Gewicht. */
+:root[data-theme="dark"] h1,:root[data-theme="dark"] h2,:root[data-theme="dark"] .h-display{font-weight:540}
 h1{font-size:var(--t-h1)}
 h2{font-size:var(--t-h2)}
 h3{font-size:var(--t-h3)}

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -17,6 +17,7 @@ body{
   background:var(--paper); color:var(--ink);
   font-family:var(--font); font-weight:var(--w-text);
   font-size:var(--t-body); line-height:var(--lh-body);
+  letter-spacing:.02em;   /* B3: leichtes Tracking hilft Lese-/Kleingraden (Beier) */
   font-kerning:normal; text-rendering:optimizeLegibility; -webkit-font-smoothing:antialiased;
 }
 /* Langtext (Fliesstext über mehrere Absätze) bekommt die Lese-Grotesk – dort,
@@ -40,6 +41,7 @@ p a:hover,li a:hover,.note a:hover,.hint a:hover,.help a:hover,.desc a:hover{tex
    Seiten setzen KEINE eigenen Überschriften-Grössen oder -Schnitte mehr; so kann
    keine Seite ausscheren (Konformität durch Konstruktion). Titel = Deutlich, nie Laut. */
 h1,h2,h3,h4,.h-display{font-family:var(--font-display);font-weight:var(--w-deutlich);line-height:var(--lh-tight)}
+h1,h2{letter-spacing:0}   /* B3: grosse Display-Grade bleiben eng (Tracking nur an Lesegraden) */
 h1{font-size:var(--t-h1)}
 h2{font-size:var(--t-h2)}
 h3{font-size:var(--t-h3)}

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -105,6 +105,7 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 /* Aktion = Blau (Zustand/Tun); die primäre Aktion ist gefüllt. Klar getrennt von
    der Auswahl-Pille (Gold). Mind. Fingerziel auf Touch. */
 .btn{display:inline-flex;align-items:center;justify-content:center;font:inherit;font-size:15px;line-height:1.2;
+  font-weight:var(--w-deutlich);   /* B2: Goetheanum-Label <18px braucht Deutlich (Beier) */
   padding:10px 16px;border-radius:var(--r-control);border:1px solid var(--line);color:var(--ink);
   background:var(--field-bg);text-align:center;cursor:pointer;transition:.15s}
 .btn:hover{border-color:var(--blue)}
@@ -123,7 +124,7 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
    Schrift. line-height:var(--lh-tight) bleibt zusätzlich nötig, sonst reisst
    ein zweizeiliges Pillen-Label (z. B. ‹SVG 48›) weit auseinander. */
 .seg button{display:inline-flex;align-items:center;justify-content:center;text-align:center;
-  font:inherit;font-size:14.5px;line-height:var(--lh-tight);padding:8px 15px;border:1px solid var(--line);border-radius:var(--r-pill);
+  font:inherit;font-size:14.5px;font-weight:var(--w-deutlich);line-height:var(--lh-tight);padding:8px 15px;border:1px solid var(--line);border-radius:var(--r-pill);
   background:var(--field-bg);color:var(--ink);cursor:pointer;transition:border-color .15s,background .15s,color .15s}
 .seg button:hover{border-color:var(--gold-ink)}
 .seg button[aria-pressed="true"]{background:var(--gold-deep);border-color:var(--gold-ink);color:var(--on-accent);font-weight:var(--w-strong)}
@@ -221,7 +222,7 @@ td.num,th.num,.num{font-variant-numeric:tabular-nums lining-nums;text-align:righ
 
 /* Kicker: getönt, leicht getrackt, Display – NORMAL, nicht versal (G05).
    Kleine UI-Schrift: nie Leise (verschwimmt klein) – mindestens Klar. */
-.kicker,.kick{display:inline-block;font-family:var(--font-display);color:var(--gold-ink);font-size:13.5px;letter-spacing:.03em;font-weight:var(--w-text);line-height:1.3;margin-bottom:var(--s2)}
+.kicker,.kick{display:inline-block;font-family:var(--font-display);color:var(--gold-ink);font-size:13.5px;letter-spacing:.03em;font-weight:var(--w-deutlich);line-height:1.3;margin-bottom:var(--s2)}
 
 /* Anriss unter dem Titel. */
 .lede{font-size:var(--t-lede);color:var(--muted);line-height:1.45;max-width:54ch}

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -294,3 +294,14 @@ img,svg,canvas,video{max-width:100%}
 @media(prefers-reduced-motion:reduce){
   *{transition:none!important;scroll-behavior:auto!important}
 }
+
+/* Block C – Lesemodus (opt-in, Kopfzeilen-Schalter, Zustand data-read="easy"):
+   tauscht NUR Textkörper + Lede + Erklärtexte auf die Leseschrift und erhöht das
+   Spacing. Titel/Kicker/Marke bleiben Goetheanum (Identität); die Chrome-Leiste
+   pinnt ihre Schrift ohnehin selbst. Grösse ist über size-adjust (B4) geregelt,
+   darum kein Grössensprung; A7 (min-height) fängt den ~7% breiteren Reflow. */
+:root[data-read="easy"] body{font-family:var(--font-text);letter-spacing:.03em;word-spacing:.06em}
+:root[data-read="easy"] .lede{font-family:var(--font-text)}
+/* Titel, Kicker und die Kopfzeile bleiben ausdrücklich Goetheanum (Identität). */
+:root[data-read="easy"] h1,:root[data-read="easy"] h2,:root[data-read="easy"] h3,:root[data-read="easy"] h4,
+:root[data-read="easy"] .kicker,:root[data-read="easy"] .kick{font-family:var(--font-display)}

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -236,7 +236,7 @@ td.num,th.num,.num{font-variant-numeric:tabular-nums lining-nums;text-align:righ
    Formularfelder, Tabellen. Dort geht Lesbarkeit über Identität. */
 
 /* Erklärender Beisatz (Hilfetext, Untertitel) – Sprache, darum Hausschrift. */
-.note,.hint,.help,.desc,.subhead{color:var(--muted);font-size:var(--t-small);line-height:1.6;max-width:62ch}
+.note,.hint,.help,.desc,.subhead{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small);line-height:1.6;max-width:62ch}
 
 /* Legende, Bildunterschrift, Datum, Byline – das knappe Beiwerk. */
 .meta,.cap,.caption,.legend,.byline{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small);line-height:1.45}

--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -66,8 +66,18 @@ html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
   border-radius:var(--r-control);padding:11px 16px;min-height:40px}
 .dsnav .cta:hover{filter:brightness(1.08)}
 
+/* Lesemodus-Schalter – ein „A", das die Leseschrift zeigt; Zustand über Gold-Ring.
+   Das Zeichen selbst folgt dem Modus: Goetheanum (Haus) → Source (Lesen). */
+.dsnav .read{margin-left:16px;display:inline-flex;align-items:center;justify-content:center;font:inherit;
+  color:var(--ink);background:none;border:0;padding:5px;cursor:pointer;line-height:1;border-radius:var(--r-control)}
+.dsnav .read .ic{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:19px;line-height:1;
+  width:19px;height:19px;display:grid;place-items:center}
+.dsnav .read:hover{color:var(--gold-ink)}
+.dsnav .read[aria-pressed="true"]{color:var(--gold-ink);box-shadow:inset 0 0 0 2px var(--gold)}
+.dsnav .read[aria-pressed="true"] .ic{font-family:var(--font-text)}
+
 /* ☾/☀ Hell-Dunkel – nur das Icon */
-.dsnav .theme{margin-left:18px;display:inline-flex;align-items:center;justify-content:center;font:inherit;
+.dsnav .theme{margin-left:8px;display:inline-flex;align-items:center;justify-content:center;font:inherit;
   color:var(--ink);background:none;border:0;padding:6px;cursor:pointer;line-height:1}
 .dsnav .theme .ic{font-size:18px;line-height:1}
 .dsnav .theme:hover{color:var(--gold-ink)}
@@ -81,7 +91,7 @@ html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
 
 @media(max-width:720px){
   .dsnav .worlds{display:none}
-  .dsnav .theme{margin-left:auto}
+  .dsnav .read{margin-left:auto}   /* Schalter-Cluster (Lesemodus·Theme·Menü) zusammen nach rechts */
 }
 
 /* --- Schublade ------------------------------------------------------------- */

--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -14,6 +14,13 @@
    zwischen kurzen und langen Seiten um die Balkenbreite nach rechts. */
 html{scrollbar-gutter:stable}
 
+/* Sprunglink „Zum Inhalt" – ausserhalb des Bildes, bis er den Fokus bekommt (WCAG 2.4.1). */
+.skip{position:absolute;left:-9999px;top:0;z-index:100;
+  background:var(--blue-solid);color:var(--on-accent);font-family:var(--font);
+  padding:10px 16px;border-radius:0 0 var(--r-control) 0;text-decoration:none}
+.skip:focus{left:0}
+.skip:focus-visible{outline:2px solid var(--on-accent);outline-offset:-4px}
+
 .dsnav{position:sticky;top:0;z-index:40;background:var(--bar-bg);
   backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--line)}
 

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -176,6 +176,20 @@
     '</div>';
   document.body.insertBefore(header, document.body.firstChild);
 
+  // Sprunglink „Zum Inhalt" (WCAG 2.4.1, Verbesserung): erstes fokussierbares
+  // Element im Body, springt zur Hauptregion. main bekommt id=inhalt, falls es
+  // nicht schon eine trägt (die Startseite setzt sie z. B. selbst). Erst nach
+  // DOM-Ready, da nav.js vor <main> im Markup steht.
+  var placeSkip = function () {
+    var mainEl = document.querySelector("main");
+    if (!mainEl || document.querySelector(".skip")) return;
+    if (!mainEl.id) mainEl.id = "inhalt";
+    var skip = el("a", "skip"); skip.href = "#" + mainEl.id; skip.textContent = "Zum Inhalt";
+    document.body.insertBefore(skip, document.body.firstChild);
+  };
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", placeSkip);
+  else placeSkip();
+
   // Optionale Seiten-Sprungleiste: data-onpage="Label:#anker|…". Sie sitzt UNTER
   // dem Hero/der Lede (nicht über dem Titel) und klebt beim Scrollen unter der
   // Kopfzeile. Auf jeder Breite sichtbar (auch mobil), horizontal scrollbar.

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -54,6 +54,26 @@
   // Sofort anwenden – vor dem Zeichnen, gegen Aufblitzen.
   document.documentElement.setAttribute("data-theme", getTheme());
 
+  // --- Lesemodus (Block C) ---------------------------------------------------
+  // Opt-in: tauscht NUR Textkörper + Erklärtexte Display→Source und erhöht das
+  // Spacing (Regeln in base.css). Titel/Kicker/Marke bleiben Goetheanum. Zustand
+  // in localStorage('goeRead'), VOR dem ersten Paint gesetzt – kein Aufblitzen.
+  var READ_KEY = "goeRead", readBtn = null;
+  function getRead() { try { return localStorage.getItem(READ_KEY) === "easy" ? "easy" : ""; } catch (e) { return ""; } }
+  function updateReadBtn() {
+    if (!readBtn) return;
+    var on = document.documentElement.getAttribute("data-read") === "easy";
+    readBtn.setAttribute("aria-pressed", String(on));
+    readBtn.setAttribute("aria-label", on ? "Lesemodus ausschalten" : "Lesemodus – Fliesstext in der Leseschrift");
+  }
+  function setRead(on) {
+    try { localStorage.setItem(READ_KEY, on ? "easy" : "off"); } catch (e) {}
+    if (on) document.documentElement.setAttribute("data-read", "easy");
+    else document.documentElement.removeAttribute("data-read");
+    updateReadBtn();
+  }
+  if (getRead() === "easy") document.documentElement.setAttribute("data-read", "easy");
+
   // --- Anonyme Nutzungszählung (mitwachsend) ---------------------------------
   // Zählt je Werkzeug (data-active) den Seitenaufruf und Download-Klicks – ohne
   // Cookies, ohne IP/Personendaten, nur anonyme Summen über goeloggen_bump().
@@ -170,6 +190,7 @@
         '<img class="lockup" src="' + ROOT + 'assets/logos/goetheanum-werkzeuge.svg" alt="Goetheanum Werkzeuge">' +
       '</a>' +
       '<nav class="worlds"></nav>' + ctaHTML +
+      '<button class="read" type="button" aria-pressed="false" aria-label="Lesemodus – Fliesstext in der Leseschrift"><span class="ic" aria-hidden="true">A</span></button>' +
       '<button class="theme" type="button" aria-label="Dunkel schalten"><span class="ic"></span></button>' +
       '<button class="all" type="button" aria-haspopup="dialog" aria-expanded="false" aria-label="Menü">' +
         '<span class="ic">☰</span><span class="idot" hidden></span></button>' +
@@ -254,6 +275,11 @@
     setTheme(document.documentElement.getAttribute("data-theme") === "dark" ? "light" : "dark");
   });
   updateThemeBtn();
+  readBtn = header.querySelector(".read");
+  readBtn.addEventListener("click", function () {
+    setRead(document.documentElement.getAttribute("data-read") !== "easy");
+  });
+  updateReadBtn();
   var worldsNav = header.querySelector(".worlds");
   var drawerBody = drawer.querySelector(".body");
   var drawerTitle = drawer.querySelector(".dhead .t");

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -267,12 +267,36 @@
   }
   searchInput.addEventListener("input", applySearch);
 
-  function openDrawer() { backdrop.classList.add("open"); drawer.classList.add("open"); btnAll.setAttribute("aria-expanded", "true"); }
-  function closeDrawer() { backdrop.classList.remove("open"); drawer.classList.remove("open"); btnAll.setAttribute("aria-expanded", "false"); }
+  // Fokusführung nach ARIA-Dialog-Pattern (WCAG 2.4.3): beim Öffnen den Fokus in
+  // den Dialog (erstes Ziel = Schliessen-Knopf, kein Auto-Fokus ins Suchfeld),
+  // Tab zirkuliert nur im Dialog, beim Schliessen zurück auf den Auslöser (Burger).
+  var lastFocus = null;
+  function focusables(r) {
+    var all = r.querySelectorAll('a[href],button:not([disabled]),input,select,textarea,[tabindex]:not([tabindex="-1"])');
+    return Array.prototype.filter.call(all, function (el) { return el.offsetParent !== null; });
+  }
+  function openDrawer() {
+    lastFocus = document.activeElement;
+    backdrop.classList.add("open"); drawer.classList.add("open");
+    btnAll.setAttribute("aria-expanded", "true"); drawer.setAttribute("aria-modal", "true");
+    var f = focusables(drawer); if (f.length) f[0].focus();
+  }
+  function closeDrawer() {
+    backdrop.classList.remove("open"); drawer.classList.remove("open");
+    btnAll.setAttribute("aria-expanded", "false"); drawer.removeAttribute("aria-modal");
+    if (lastFocus && lastFocus.focus) lastFocus.focus();
+  }
   btnAll.addEventListener("click", function () { drawer.classList.contains("open") ? closeDrawer() : openDrawer(); });
   backdrop.addEventListener("click", closeDrawer);
   drawer.querySelector(".close").addEventListener("click", closeDrawer);
-  document.addEventListener("keydown", function (e) { if (e.key === "Escape") closeDrawer(); });
+  document.addEventListener("keydown", function (e) { if (e.key === "Escape" && drawer.classList.contains("open")) closeDrawer(); });
+  drawer.addEventListener("keydown", function (e) {
+    if (e.key !== "Tab") return;
+    var f = focusables(drawer); if (!f.length) return;
+    var a = f[0], z = f[f.length - 1];
+    if (e.shiftKey && document.activeElement === a) { e.preventDefault(); z.focus(); }
+    else if (!e.shiftKey && document.activeElement === z) { e.preventDefault(); a.focus(); }
+  });
 
   // Unsichtbarer Intern-Schalter
   function toggleIntern() {

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -85,6 +85,18 @@
   --sek-hpise:#f98a3c;       /* Sektion für Heilpädagogik und inklusive soziale Entwicklung */
   --bereich:#0061a9;         /* Verwaltungs-/Bereichs-Standard = Markenblau (wie die Logo-Daten, goe-orgs.js) */
 
+  /* Vordergrund AUF der jeweiligen Sektionsfläche (WCAG 1.4.3): Weiss nur, wo es
+     ≥ 4.5:1 hält – sonst ein dunkler Sektionston. Werkzeuge nutzen ausschliesslich
+     --on-sek-*, nie hart #fff. Werte gegen ihre Fläche gerechnet (tools/check-on-sek.py). */
+  --on-sek-goetheanum:#fff;  --on-sek-aas:#fff;    --on-sek-ps:#fff;   --on-sek-ms:#fff;
+  --on-sek-nws:#fff;         --on-sek-ssw:#fff;    --on-sek-mas:#fff;   /* Weiss ≥ 4.5:1 */
+  --on-sek-lws:#12351d;      /* Weiss nur 2.66 → dunkelgrün 5.09:1 */
+  --on-sek-sbk:#46172e;      /* Weiss nur 3.18 → dunkelrosa 4.64:1 */
+  --on-sek-szw:#23060c;      /* Weiss nur 4.14 → dunkelrot 4.60:1 */
+  --on-sek-js:#4a0f0c;       /* Weiss nur 2.86 → dunkelrot 5.39:1 */
+  --on-sek-srmk:#0f2445;     /* Weiss nur 3.35 → dunkelblau 4.61:1 */
+  --on-sek-hpise:#3c2408;    /* Weiss nur 2.41 → dunkelbraun 6.03:1 */
+
   /* --- Schrift-Familien --------------------------------------------------- */
   --font-display:"Goetheanum","Helvetica Neue",Arial,sans-serif; /* Titel, Chrome */
   --font-text:"Source Sans 3","Helvetica Neue",Arial,sans-serif; /* Lesetext, klein/lang */

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -24,16 +24,21 @@
   font-weight:190 725; font-style:normal; font-display:swap;
 }
 /* --- Lesetext: Source Sans 3 (selbst gehostet, OFL) ------------------------ */
+/* B4: size-adjust:103% (500/486) gleicht die x-Höhe an Goetheanum an – gleiche px
+   ergeben gleiche wahrgenommene Grösse, und der Fallback springt beim Laden nicht. */
 @font-face{
   font-family:"Source Sans 3"; font-weight:400; font-style:normal; font-display:swap;
+  size-adjust:103%;
   src:url("../assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2") format("woff2");
 }
 @font-face{
   font-family:"Source Sans 3"; font-weight:600; font-style:normal; font-display:swap;
+  size-adjust:103%;
   src:url("../assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2") format("woff2");
 }
 @font-face{
   font-family:"Source Sans 3"; font-weight:400; font-style:italic; font-display:swap;
+  size-adjust:103%;
   src:url("../assets/fonts/goetheanum/Fallback/SourceSans3-Italic.woff2") format("woff2");
 }
 

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -165,7 +165,10 @@
   --bar-bg:rgba(20,23,26,.85);
   --line:rgba(255,255,255,.14); --line-soft:rgba(255,255,255,.07);
   --bad:#e0675e; --ok:#5aa367;   /* on-accent bleibt Weiss – kein dunkler Text auf Akzentflächen */
-  --w-deutlich:540; --w-strong:620;     /* weniger Bleeding auf Dunkel */
+  /* B7: keine pauschale Gewichtsabsenkung mehr – kleiner Lese-/UI-Text (Knöpfe,
+     Label, Meta, Betonung) behält im Dunkeln sein Hell-Gewicht (Beier). Die
+     Halations-Absenkung greift NUR an grossen Display-Rollen (siehe base.css). */
+  --w-deutlich:580; --w-strong:680;
   --shadow-card:0 10px 30px rgba(0,0,0,.45);
   color-scheme:dark;
 }

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -43,7 +43,7 @@
   --blue-solid:#0061a9;  /* Volles Blau für gefüllte Aktion-Knöpfe – immer Weiss drauf (6.4:1) */
   --gold:#d7ab68;        /* Gold – Inhalts-Akzent */
   --gold-deep:#94702e;   /* Gold dunkel – Auswahl-Fläche, Weiss drauf (4.55:1, WCAG AA) */
-  --gold-ink:#94702e;    /* Gold als TEXT (Kicker, Links) – hellt im Dunkel auf */
+  --gold-ink:#8a6728;    /* Gold als TEXT (Kicker, Links) – 4.89:1 auf --soft, 5.18:1 auf Weiss (WCAG AA); hellt im Dunkel auf */
 
   /* --- Neutrale Töne ------------------------------------------------------ */
   --ink:#23272b;         /* Lesetext */

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -22,23 +22,30 @@
   src:url("../assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Variabel-v2.7.woff2") format("woff2"),
       url("../assets/fonts/goetheanum/Webfonts/woff/Goetheanum-Variabel-v2.7.woff") format("woff");
   font-weight:190 725; font-style:normal; font-display:swap;
+  /* B5: Zeilenbox auf die Typo-Metrik normieren (750/-250). Die Schrift trägt
+     usWinAscent 1114 (hohe Streukontur) – ohne Override entstünde je Face ein
+     anderer Durchschuss und versetzte Grundlinien. Werte für BEIDE Faces gleich,
+     damit Goetheanum und Source auf derselben Grundlinie sitzen. Der Font-Bug
+     selbst ist separat behoben (U+01FA, #213/#218), damit PPTX/E-Mail-Export
+     ohne dieses CSS ebenfalls stimmt. */
+  ascent-override:75%; descent-override:25%; line-gap-override:0%;
 }
 /* --- Lesetext: Source Sans 3 (selbst gehostet, OFL) ------------------------ */
 /* B4: size-adjust:103% (500/486) gleicht die x-Höhe an Goetheanum an – gleiche px
    ergeben gleiche wahrgenommene Grösse, und der Fallback springt beim Laden nicht. */
 @font-face{
   font-family:"Source Sans 3"; font-weight:400; font-style:normal; font-display:swap;
-  size-adjust:103%;
+  size-adjust:103%; ascent-override:75%; descent-override:25%; line-gap-override:0%;
   src:url("../assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2") format("woff2");
 }
 @font-face{
   font-family:"Source Sans 3"; font-weight:600; font-style:normal; font-display:swap;
-  size-adjust:103%;
+  size-adjust:103%; ascent-override:75%; descent-override:25%; line-gap-override:0%;
   src:url("../assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2") format("woff2");
 }
 @font-face{
   font-family:"Source Sans 3"; font-weight:400; font-style:italic; font-display:swap;
-  size-adjust:103%;
+  size-adjust:103%; ascent-override:75%; descent-override:25%; line-gap-override:0%;
   src:url("../assets/fonts/goetheanum/Fallback/SourceSans3-Italic.woff2") format("woff2");
 }
 

--- a/design-system/type-scale.json
+++ b/design-system/type-scale.json
@@ -1,0 +1,22 @@
+{
+  "$titel": "Kanonische Typo-Leiter (B-Leitprinzip, Beier) – eine Quelle der Wahrheit",
+  "$zweck": "Grad → (Schrift, Mindestgewicht, Tracking). tools/check-type-scale.py erzwingt die zwei harten Regeln maschinell; base.css ist die Umsetzung. Symmetrisch zu contract.json (Gestalt) und typo-regeln.yaml (Sprache).",
+  "leitprinzip": "< 18px nur Source ODER Goetheanum Deutlich · ab 18px Klar möglich · Leise erst ab 22px (Retina) bzw. 24 generell. Leichte UND schwere Gewichte verschlechtern das Lesen – die Mitte (Klar/Deutlich) ist optimal.",
+  "gewichte": { "leise": 265, "text_klar": 440, "deutlich": 580, "laut": 680 },
+  "regeln": {
+    "goetheanum_klein": { "id": "TS1", "wenn": "Goetheanum-Textrolle mit font-size < 18px", "dann": "font-weight >= 580 (Deutlich)", "sonst": "Warnung" },
+    "leise_klein": { "id": "TS2", "wenn": "Leise (w-leise / .leise) als Lesetext", "dann": "font-size >= 22px", "sonst": "Warnung" }
+  },
+  "grenzwerte": { "klar_min_px": 18, "leise_min_px": 22, "min_gewicht_unter_18": 580 },
+  "rollen": {
+    "fliesstext": { "schrift": "display-oder-source", "min_px": 18, "tracking": "0.02em" },
+    "lede":       { "schrift": "display", "min_px": 18, "tracking": "0.02em" },
+    "meta":       { "schrift": "source", "min_px": 15 },
+    "label":      { "schrift": "source", "min_px": 15 },
+    "readout":    { "schrift": "source", "min_px": 15 },
+    "beiwerk":    { "schrift": "source", "min_px": 14 },
+    "kicker":     { "schrift": "display", "min_px": 13.5, "min_gewicht": 580 },
+    "knopf":      { "schrift": "display", "min_px": 14.5, "min_gewicht": 580 },
+    "titel":      { "schrift": "display", "min_px": 22, "tracking": "0" }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -102,9 +102,13 @@
     cursor:pointer;display:grid;place-items:center;font-size:20px;line-height:1;padding:0;z-index:2}
   .carousel .arrow:hover{border-color:var(--gold-ink);color:var(--gold-ink)}
   .carousel .arrow.l{left:12px}.carousel .arrow.r{right:12px}
+  /* Anhalten/Weiter unten links – eigener, zustandsfester Schalter (WCAG 2.2.2). */
+  .carousel .arrow.pause{left:12px;right:auto;top:auto;bottom:11px;transform:none;width:30px;height:30px;font-size:var(--t-micro)}
   .carousel .dots{position:absolute;bottom:11px;left:50%;transform:translateX(-50%);display:flex;gap:7px;z-index:2}
-  .carousel .dots button{width:8px;height:8px;border-radius:var(--r-pill);border:0;background:var(--line);
+  .carousel .dots button{position:relative;width:8px;height:8px;border-radius:var(--r-pill);border:0;background:var(--line);
     cursor:pointer;padding:0;transition:width .2s,background .2s}
+  /* sichtbarer Punkt bleibt 8 px, Trefferfläche ≥ 24 px (WCAG 2.5.8). */
+  .carousel .dots button::before{content:"";position:absolute;inset:-9px}
   .carousel .dots button.on{background:var(--gold-deep);width:22px}
   @media(max-width:560px){
     .carousel .slide{flex-direction:column;align-items:flex-start;gap:var(--s4);padding:var(--s6)}
@@ -202,6 +206,7 @@
 
     var i = 0, n = items.length, timer = null;
     var reduce = window.matchMedia && window.matchMedia("(prefers-reduced-motion:reduce)").matches;
+    var paused = reduce;   // bei prefers-reduced-motion von Anfang an gestoppt
     for (var k = 0; k < n; k++) {
       (function(k){
         var b = document.createElement("button"); b.type = "button"; b.setAttribute("aria-label","Folie " + (k+1));
@@ -211,13 +216,27 @@
     }
     function paint(){
       track.style.transform = "translateX(-" + (i*100) + "%)";
-      var ds = dots.children; for (var k = 0; k < ds.length; k++) ds[k].className = (k === i ? "on" : "");
+      var ds = dots.children;
+      for (var k = 0; k < ds.length; k++) {
+        ds[k].className = (k === i ? "on" : "");
+        if (k === i) ds[k].setAttribute("aria-current","true"); else ds[k].removeAttribute("aria-current");
+      }
     }
     function go(k){ i = (k + n) % n; paint(); }
-    function start(){ if (reduce) return; stop(); timer = setInterval(function(){ go(i+1); }, 6500); }
+    function start(){ if (reduce || paused) return; stop(); timer = setInterval(function(){ go(i+1); }, 6500); }
     function stop(){ if (timer) { clearInterval(timer); timer = null; } }
     prev.addEventListener("click", function(){ go(i-1); start(); });
     next.addEventListener("click", function(){ go(i+1); start(); });
+    // Sichtbarer, zustandsfester Halt/Weiter-Schalter (WCAG 2.2.2). Hält dauerhaft:
+    // solange paused, startet der Timer nicht wieder (auch nicht bei mouseleave/focusout).
+    var pauseBtn = document.createElement("button"); pauseBtn.type = "button"; pauseBtn.className = "arrow pause";
+    function syncPause(){
+      pauseBtn.setAttribute("aria-pressed", String(paused));
+      pauseBtn.setAttribute("aria-label", paused ? "Automatischen Wechsel starten" : "Automatischen Wechsel anhalten");
+      pauseBtn.textContent = paused ? "▶" : "❚❚";
+    }
+    pauseBtn.addEventListener("click", function(){ paused = !paused; syncPause(); if (paused) stop(); else start(); });
+    syncPause(); car.appendChild(pauseBtn);
     car.addEventListener("mouseenter", stop); car.addEventListener("mouseleave", start);
     car.addEventListener("focusin", stop); car.addEventListener("focusout", start);
     var x0 = null;

--- a/index.html
+++ b/index.html
@@ -23,9 +23,9 @@
     border-radius:var(--r-card);padding:var(--s6);background:var(--paper);text-decoration:none;color:var(--ink);
     transition:border-color .15s,box-shadow .15s,transform .15s}
   .tile:hover{border-color:var(--gold-ink);box-shadow:var(--shadow-card);transform:translateY(-1px)}
-  .tile h3{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:20px;line-height:1.15;display:flex;align-items:center;gap:9px;margin:0}
-  .tile h3 .arr{color:var(--muted);font-weight:var(--w-text);transition:transform .15s,color .15s}
-  .tile:hover h3 .arr{color:var(--gold-ink);transform:translateX(3px)}
+  .tile h2{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:20px;line-height:1.15;display:flex;align-items:center;gap:9px;margin:0}
+  .tile h2 .arr{color:var(--muted);font-weight:var(--w-text);transition:transform .15s,color .15s}
+  .tile:hover h2 .arr{color:var(--gold-ink);transform:translateX(3px)}
 
   /* Kleiner, feiner Hinweis über dem Karussell. */
   .discover{font-size:var(--t-small);letter-spacing:.07em;color:var(--gold-ink);margin:0 0 var(--s3)}
@@ -118,7 +118,8 @@
 
 <script src="design-system/nav.js" data-root="./" data-active="start"></script>
 
-<main class="wrap">
+<main class="wrap" id="inhalt">
+  <h1 class="sr-only">Goetheanum Werkzeuge – Hausgrafik</h1>
   <section class="carousel" id="carousel" aria-roledescription="Karussell" aria-label="Entdecken" hidden></section>
   <div class="grid" id="cards"></div>
 </main>
@@ -172,7 +173,7 @@
     a.className = "tile";
     a.href = t.href;
     if (isExt(t.href)) { a.target = "_blank"; a.rel = "noopener"; }
-    a.innerHTML = visual(t) + '<h3>' + t.title + ' <span class="arr">›</span></h3>';
+    a.innerHTML = visual(t) + '<h2>' + t.title + ' <span class="arr">›</span></h2>';
     return a;
   }
   function buildCarousel(byslug){

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
   .carousel{position:relative;margin-bottom:var(--s8);border:1px solid var(--line);
     border-radius:var(--r-card);background:var(--soft);overflow:hidden}
   .carousel .track{display:flex;transition:transform .45s ease}
-  @media(prefers-reduced-motion:reduce){.carousel .track{transition:none}}
+  @media(prefers-reduced-motion:reduce){.carousel .track{transition:none}.tile:hover{transform:none}}
   .carousel .slide{flex:0 0 100%;min-width:0;box-sizing:border-box;display:flex;
     align-items:center;justify-content:center;gap:var(--s6);
     padding:var(--s6) clamp(var(--s6),5vw,var(--s8));text-decoration:none;color:var(--ink)}

--- a/tools/check-on-sek.py
+++ b/tools/check-on-sek.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Prüft die Vordergrund-auf-Sektionsfläche-Kontraste (WCAG 1.4.3, A6).
+
+Für jedes --sek-<key> in design-system/tokens.css muss --on-sek-<key> existieren
+und auf seiner Fläche ≥ 4.5:1 erreichen. Unterschreiten (oder ein fehlendes
+Gegenstück) bricht den Build. Aufruf aus dem Repo-Wurzelverzeichnis:
+  python3 tools/check-on-sek.py
+"""
+import os, re, sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TOKENS = os.path.join(ROOT, "design-system", "tokens.css")
+AA = 4.5
+
+
+def _hex(v):
+    v = v.strip().lstrip("#")
+    if len(v) == 3:
+        v = "".join(c * 2 for c in v)
+    return tuple(int(v[i:i + 2], 16) / 255 for i in (0, 2, 4))
+
+
+def _lum(rgb):
+    def f(c):
+        return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+    r, g, b = (f(c) for c in rgb)
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def ratio(a, b):
+    la, lb = sorted((_lum(_hex(a)), _lum(_hex(b))))
+    return (lb + 0.05) / (la + 0.05)
+
+
+def main():
+    css = open(TOKENS, encoding="utf-8").read()
+    sek = dict(re.findall(r"--sek-([\w-]+)\s*:\s*(#[0-9a-fA-F]{3,6})", css))
+    on = dict(re.findall(r"--on-sek-([\w-]+)\s*:\s*(#[0-9a-fA-F]{3,6})", css))
+    fails = []
+    for key, bg in sek.items():
+        fg = on.get(key)
+        if fg is None:
+            fails.append("  --on-sek-%s fehlt (Fläche %s)" % (key, bg)); continue
+        r = ratio(fg, bg)
+        if r < AA:
+            fails.append("  --on-sek-%s (%s) auf --sek-%s (%s): %.2f < %.1f" % (key, fg, key, bg, r, AA))
+    if fails:
+        print("✗ Sektions-Vordergrund unter WCAG AA:"); print("\n".join(fails)); return 1
+    print("✓ Alle %d --on-sek-* halten ≥ %.1f:1 auf ihrer Fläche." % (len(sek), AA))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check-type-scale.py
+++ b/tools/check-type-scale.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Erzwingt die kanonische Typo-Leiter (B6, Beier) auf design-system/base.css.
+
+Zwei harte Regeln aus design-system/type-scale.json:
+  TS1  Goetheanum-Textrolle mit font-size < 18px MUSS font-weight >= 580 (Deutlich) tragen.
+  TS2  Leise (Gewicht 265 bzw. --w-leise) als Lesetext MUSS >= 22px sein.
+
+Geprüft werden die Regel-Blöcke in base.css: Selektoren, die eine font-size in px
+setzen. Die Familie wird als Goetheanum gewertet, wenn font-family fehlt (Body-Erbe
+= Display) oder var(--font)/var(--font-display) ist; Source (var(--font-text) u. a.)
+ist ausgenommen. Verstösse melden (Warnung); mit --strict brechen sie den Build.
+Aufruf:  python3 tools/check-type-scale.py [--strict]
+"""
+import os, re, sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE = os.path.join(ROOT, "design-system", "base.css")
+SCALE = os.path.join(ROOT, "design-system", "type-scale.json")
+WEIGHTS = {"w-leise": 265, "w-text": 440, "w-deutlich": 580, "w-strong": 680}
+
+
+def load_floor():
+    import json
+    g = json.load(open(SCALE, encoding="utf-8"))["grenzwerte"]
+    return g["klar_min_px"], g["leise_min_px"], g["min_gewicht_unter_18"]
+
+
+def px(decls):
+    m = re.search(r"font-size:\s*([0-9.]+)px", decls)
+    return float(m.group(1)) if m else None
+
+
+def weight(decls):
+    m = re.search(r"font-weight:\s*var\(--(w-[\w-]+)\)", decls)
+    if m:
+        return WEIGHTS.get(m.group(1))
+    m = re.search(r"font-weight:\s*(\d{3})", decls)
+    return int(m.group(1)) if m else None
+
+
+def is_source(decls):
+    return "var(--font-text)" in decls or "Source Sans" in decls
+
+
+def is_display(decls):
+    return "var(--font-display)" in decls or 'font-family:"Goetheanum"' in decls or "var(--font)" in decls
+
+
+def main():
+    strict = "--strict" in sys.argv
+    css = re.sub(r"/\*.*?\*/", "", open(BASE, encoding="utf-8").read(), flags=re.S)
+    klar_min, leise_min, min_w = load_floor()
+    warns = []
+    for sel, decls in re.findall(r"([^{}]+)\{([^{}]*)\}", css):
+        sel = sel.strip()
+        if sel.startswith("@") or ":" in sel and "::" not in sel and "hover" in sel:
+            pass
+        size = px(decls)
+        if size is None:
+            continue
+        w = weight(decls)
+        # TS1: Goetheanum (nicht Source) < 18px braucht >= Deutlich
+        if size < klar_min and not is_source(decls):
+            # nur wenn Familie Display ist ODER unspezifiziert (erbt Display) UND ein Gewicht gesetzt ist
+            fam_ok = is_display(decls) or ("font-family" not in decls)
+            if fam_ok and w is not None and w < min_w:
+                warns.append("TS1  %-26s  %.4gpx Goetheanum, Gewicht %d < %d" % (sel[:26], size, w, min_w))
+        # TS2: Leise (265) als Lesetext braucht >= 22px
+        if w == WEIGHTS["w-leise"] and size < leise_min:
+            warns.append("TS2  %-26s  Leise bei %.4gpx < %dpx" % (sel[:26], size, leise_min))
+    if warns:
+        head = "✗ Typo-Leiter verletzt:" if strict else "⚠ Typo-Leiter – Hinweise:"
+        print(head); print("\n".join("  " + w for w in warns))
+        return 1 if strict else 0
+    print("✓ Typo-Leiter eingehalten (TS1/TS2) in base.css.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -30,3 +30,9 @@ fi
 if git diff --cached --name-only | grep -Eq 'design-system/tokens\.css'; then
   "$PY" "$ROOT/tools/check-on-sek.py"
 fi
+
+# 4) Typo-Leiter (B6, Beier): Goetheanum-Rolle <18px braucht Deutlich; Leise ≥22px.
+#    Vorläufig BERICHTEND (wie ds-lint), sobald base.css/Leiter vorgemerkt ist.
+if git diff --cached --name-only | grep -Eq 'design-system/(base\.css|type-scale\.json)'; then
+  "$PY" "$ROOT/tools/check-type-scale.py" || true
+fi

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -24,3 +24,9 @@ if git diff --cached --name-only \
    | grep -Eq 'design-system/(tokens|base)\.css|assets/typografie/(goetheanum-typo-tokens\.json|typo-regeln\.yaml)|typografie\.html'; then
   "$PY" "$ROOT/tools/typo-sync.py"
 fi
+
+# 3) Sektions-Vordergrund-Kontrast (WCAG 1.4.3, A6): jedes --on-sek-* ≥ 4.5:1 auf
+#    seiner Fläche. Blockiert, sobald tokens.css vorgemerkt ist.
+if git diff --cached --name-only | grep -Eq 'design-system/tokens\.css'; then
+  "$PY" "$ROOT/tools/check-on-sek.py"
+fi

--- a/typografie.html
+++ b/typografie.html
@@ -25,7 +25,7 @@
   .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
   a{color:var(--gold-ink)}
   header{position:sticky;top:0;z-index:30;background:var(--bar-bg);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
-  .bar{display:flex;align-items:center;justify-content:space-between;height:58px}
+  .bar{display:flex;align-items:center;justify-content:space-between;min-height:58px}
   .brand img{height:34px;display:block}
   nav.top{display:flex;gap:22px}
   nav.top a{color:var(--muted);text-decoration:none;font-size:var(--t-small)}

--- a/uebersetzungen.html
+++ b/uebersetzungen.html
@@ -85,7 +85,9 @@
 "use strict";
 var $=function(s){return document.querySelector(s);};
 function toast(m){var t=$("#toast");t.textContent=m;t.style.opacity="1";setTimeout(function(){t.style.opacity="0";},1100);}
-function cell(text){var td=document.createElement("td");td.textContent=text||"â€“";return td;}
+// lang je Zelle: fremdsprachige Zellen tragen ihre Sprache (WCAG 3.1.2), damit
+// Screenreader/Ausspracheregeln stimmen. Die Seite ist de; en/fr/es-Zellen weichen ab.
+function cell(text,lang){var td=document.createElement("td");td.textContent=text||"â€“";if(lang)td.lang=lang;return td;}
 
 // Institutionelle Begriffe
 (function(){
@@ -94,8 +96,8 @@ function cell(text){var td=document.createElement("td");td.textContent=text||"â€
     var t=T[k], pruefen=t.status!=="fest";
     var tr=document.createElement("tr");
     var de=cell(t.de); de.innerHTML="<b>"+(t.de||"")+"</b>";
-    tr.appendChild(de); tr.appendChild(cell(t.en));
-    var fr=cell(t.fr), es=cell(t.es);
+    tr.appendChild(de); tr.appendChild(cell(t.en,"en"));
+    var fr=cell(t.fr,"fr"), es=cell(t.es,"es");
     if(pruefen){fr.className="meta";es.className="meta";}
     tr.appendChild(fr); tr.appendChild(es);
     var st=document.createElement("td"); st.style.cursor="default";
@@ -117,7 +119,7 @@ function cell(text){var td=document.createElement("td");td.textContent=text||"â€
     c.innerHTML='<span class="sw-c" style="background:'+(o.color||"transparent")+'"></span>';
     tr.appendChild(c);
     var de=document.createElement("td"); de.innerHTML="<b>"+(o.name_de||"")+"</b>"; tr.appendChild(de);
-    tr.appendChild(cell(o.name_en)); tr.appendChild(cell(o.name_fr)); tr.appendChild(cell(o.name_es));
+    tr.appendChild(cell(o.name_en,"en")); tr.appendChild(cell(o.name_fr,"fr")); tr.appendChild(cell(o.name_es,"es"));
     var g=document.createElement("td"); g.className="meta"; g.style.cursor="default"; g.textContent=grp[k]||"â€“";
     tr.appendChild(g);
     body.appendChild(tr);

--- a/werkzeug.html
+++ b/werkzeug.html
@@ -17,7 +17,7 @@
   body{background:var(--paper);color:var(--ink);font-family:"G Klar","Helvetica Neue",Arial,sans-serif;line-height:1.5;-webkit-font-smoothing:antialiased}
   .wrap{max-width:980px;margin:0 auto;padding:0 22px}
   header{border-bottom:1px solid var(--line)}
-  .bar{display:flex;align-items:center;justify-content:space-between;height:56px}
+  .bar{display:flex;align-items:center;justify-content:space-between;min-height:56px}
   .bar b{font-weight:400}.bar a{color:var(--muted);text-decoration:none;font-size:var(--t-small)}
   .hero{padding-block:34px 6px}
   .kick{color:var(--gold-ink);font-size:var(--t-small);margin-bottom:10px}


### PR DESCRIPTION
Umsetzung des typografisch-inklusiven Gutachtens. **Ein Commit pro Aufgabe** (`[A1] …`), minimal-invasiv, jede Änderung einzeln rücknehmbar. Nachweis vollständig in **`CHANGELOG-a11y.md`** (Was · Datei · Begründung).

## Block A — Zugänglichkeit
- **A1** Startseite: verstecktes `h1`, Kachel-Titel `h3`→`h2`, `main#inhalt` (1.3.1/2.4.6)
- **A2** Karussell: dauerhafter Halt/Weiter-Schalter (Timer stoppt endgültig; bei `reduced-motion` von Anfang gestoppt), Punkt-Trefferfläche 26 px, `aria-current` (2.2.2/2.5.8)
- **A3** Schublade: Fokus in den Dialog (Schliessen-Knopf zuerst), `aria-modal`, Tab-Falle, Rückgabe auf den Burger (2.4.3)
- **A4** Globaler Sprunglink „Zum Inhalt" via `nav.js`/`nav.css` (2.4.1)
- **A5** `--gold-ink` `#94702e`→`#8a6728`: 4.29→**4.89:1** auf `--soft`, **5.18:1** auf Weiss (1.4.3)
- **A6** `--on-sek-*` je Sektionsfarbe (Weiss nur ≥ 4.5:1, sonst dunkler Ton) + `tools/check-on-sek.py` im Hook (1.4.3)
- **A7** Text-Toolbars `height`→`min-height`; kanonische Rollen waren schon robust (1.4.12; Text-Spacing-Test grün)
- **A8** Globaler `prefers-reduced-motion`-Block (2.3.3)
- **A9** `lang` je fremdsprachiger Zelle in Übersetzungen (3.1.2)

## Block B — Typografie (Beier)
- **B1** kleine Erklärtexte → Source · **B2** kleine Goetheanum-Label ≥ Deutlich · **B3** Tracking nur an Lesegraden · **B4** `size-adjust:103%` (x-Höhen-Parität) · **B5** `ascent/descent-override` auf beide Faces (gemeinsame Grundlinie; À/Ü/Ǻ clippen nicht) · **B6** `type-scale.json` + `check-type-scale.py` (Konformität durch Konstruktion) · **B7** Dunkelmodus-Gewicht nur an grossen Display-Rollen absenken

**Eine bewusste Abweichung** (in `CHANGELOG-a11y.md` vermerkt): B7 senkt den **Kicker** *nicht* mit ab (er ist klein → Abnahme „kleiner Text nicht leichter" + B2-Legibilität). Rückmeldung willkommen.

## Testplan
- [x] `ds-lint --score` 100 % (29/29) nach allen Fundament-Änderungen
- [x] Automatisiert (Playwright): A1 Heading-Outline · A2 Halt bleibt/Auto-Lauf läuft/`aria-current`/26 px · A3 Fokus-Reihenfolge+Falle+Rückgabe · A4 erstes Tab · A5/A6 Kontraste gerechnet · A7 kein Clipping · A9 Zell-`lang` · B5 kein Clipping/gleiche Box · B7 Gewichte hell/dunkel
- [x] Sichtprüfung Startseite + Schriften in Hell **und** Dunkel: keine Regression
- [ ] **Empfohlen (manuell):** eine Runde reine Tastaturbedienung durch Karussell + Schublade, ein Screenreader-Durchgang (VoiceOver/NVDA)

Block C (Leseschrift-Umschalter) bewusst **offen** — nur nach Rückfrage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_