### PR TITLE
Feedback-Button vereinfachen: einladende Frage statt Beta-Hinweis

### DIFF
--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -103,20 +103,21 @@ html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
 
 .dsnav-drawer .body{overflow:auto;padding:var(--s2) 0 var(--s8)}
 
-/* Globaler Beta-Einblender (unten, dezent, wegklickbar) */
-.dsnav-beta{position:fixed;left:50%;bottom:16px;transform:translateX(-50%);z-index:44;
-  display:flex;align-items:center;gap:14px;max-width:calc(100% - 28px);
+/* Globaler Feedback-Einblender (unten, dezent, wegklickbar) – eine einladende Frage.
+   Die ganze Pille ist der Aufruf; ein Klick öffnet die Mail. Kein Beta-Hinweis mehr. */
+.dsnav-invite{position:fixed;left:50%;bottom:16px;transform:translateX(-50%);z-index:44;
+  display:flex;align-items:center;gap:4px;max-width:calc(100% - 28px);
   background:var(--bar-bg);backdrop-filter:saturate(160%) blur(10px);
   border:1px solid var(--line);border-radius:var(--r-pill);
-  padding:9px 10px 9px 18px;box-shadow:var(--shadow-card);font-size:var(--t-small)}
-.dsnav-beta .t{color:var(--ink)}
-.dsnav-beta .t b{color:var(--gold-ink);font-weight:var(--w-deutlich)}
-.dsnav-beta .fb{color:var(--blue);text-decoration:none;font-weight:var(--w-deutlich);white-space:nowrap}
-.dsnav-beta .fb:hover{text-decoration:underline}
-.dsnav-beta .x{border:0;background:none;color:var(--muted);font-size:18px;line-height:1;cursor:pointer;
+  padding:5px 6px;box-shadow:var(--shadow-card);font-size:var(--t-small)}
+.dsnav-invite .ask{display:inline-flex;align-items:center;gap:7px;color:var(--ink);text-decoration:none;
+  white-space:nowrap;padding:7px 14px;border-radius:var(--r-pill)}
+.dsnav-invite .ask b{color:var(--gold-ink);font-weight:var(--w-deutlich)}
+.dsnav-invite .ask:hover{background:var(--soft)}
+.dsnav-invite .x{border:0;background:none;color:var(--muted);font-size:18px;line-height:1;cursor:pointer;
   width:30px;height:30px;border-radius:var(--r-pill);flex:0 0 auto}
-.dsnav-beta .x:hover{color:var(--ink);background:var(--soft)}
-@media(max-width:480px){.dsnav-beta{gap:10px;padding:8px 8px 8px 14px}}
+.dsnav-invite .x:hover{color:var(--ink);background:var(--soft)}
+@media(max-width:480px){.dsnav-invite .ask{padding:7px 12px}}
 
 /* Toast für den unsichtbaren Intern-Schalter */
 .dsnav-toast{position:fixed;left:50%;bottom:24px;transform:translateX(-50%);background:var(--ink);color:var(--paper);

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -216,18 +216,20 @@
   document.body.appendChild(backdrop);
   document.body.appendChild(drawer);
 
-  // Globaler Beta-Einblender (unten, dezent, wegklickbar – merkt sich „gesehen").
-  var BETA_KEY = "goeBetaSeen";
-  var betaSeen = false; try { betaSeen = localStorage.getItem(BETA_KEY) === "1"; } catch (e) {}
-  if (!betaSeen) {
-    var beta = el("div", "dsnav-beta");
-    beta.innerHTML =
-      '<span class="t"><b>Beta</b> – die Werkzeuge wachsen noch.</span>' +
-      '<a class="fb" href="mailto:philipp.tok@goetheanum.ch?subject=Feedback%20Goetheanum%20Werkzeuge">Feedback geben</a>' +
-      '<button class="x" type="button" aria-label="Hinweis schliessen">×</button>';
-    document.body.appendChild(beta);
-    beta.querySelector(".x").addEventListener("click", function () {
-      beta.remove(); try { localStorage.setItem(BETA_KEY, "1"); } catch (e) {}
+  // Globaler Feedback-Einblender (unten, dezent, wegklickbar). Eine einladende
+  // Frage statt Beta-Hinweis: motiviert zur Rückmeldung und öffnet die Mail mit
+  // vorbereitetem Betreff samt aktueller Seite – niedrige Schwelle.
+  var INVITE_KEY = "goeInviteSeen";
+  var inviteSeen = false; try { inviteSeen = localStorage.getItem(INVITE_KEY) === "1"; } catch (e) {}
+  if (!inviteSeen) {
+    var subj = encodeURIComponent("Rückmeldung – " + (document.title || "Goetheanum Werkzeuge"));
+    var invite = el("div", "dsnav-invite");
+    invite.innerHTML =
+      '<a class="ask" href="mailto:philipp.tok@goetheanum.ch?subject=' + subj + '">Fehlt Dir etwas? <b>Sag es uns</b></a>' +
+      '<button class="x" type="button" aria-label="Ausblenden">×</button>';
+    document.body.appendChild(invite);
+    invite.querySelector(".x").addEventListener("click", function () {
+      invite.remove(); try { localStorage.setItem(INVITE_KEY, "1"); } catch (e) {}
     });
   }
 


### PR DESCRIPTION
## Worum es geht

Der globale Einblender am unteren Rand war ein Beta-Hinweis mit separatem
„Feedback geben"-Link. Auftrag: **Beta-Zeile raus** und den Knopf so gestalten,
dass er **mehr zur Nutzung motiviert**.

## Was sich ändert

- **nav.js** — `BETA_KEY` / „Beta – die Werkzeuge wachsen noch" ersetzt durch
  `INVITE_KEY` / eine warme, direkte Frage: **„Fehlt Dir etwas? Sag es uns"**.
  Die ganze Pille ist jetzt der Aufruf (ein Klick öffnet die Mail), Betreff
  dynamisch mit der aktuellen Seite (`document.title`) — niedrige Schwelle.
- **nav.css** — `.dsnav-beta` → `.dsnav-invite`. Die ganze Pille ist ein
  `.ask`-Link (Hover = `--soft`), „Sag es uns" in Gold (`--gold-ink`,
  `--w-deutlich`). Kein getrennter blauer Link mehr.

## Warum diese Formulierung

Ein Beta-Etikett bittet nicht um etwas — es entschuldigt sich. Eine kurze,
zugewandte Frage lädt ein und benennt den Nutzen (deine Rückmeldung zählt).
„Sag es uns" ist der einzige betonte Teil (G01/G05: Betonung per Laut/Gold,
kein Versal, kein Unterstreichen).

## Regel-Deckung

- **G01/G05** Betonung „Sag es uns" nur über Gewicht/Farbe (Gold), ein Merkmal.
- **B01** kein dunkler Text auf Farbe — Pille auf `--bar-bg`, Text `--ink`/Gold.
- **B04** `.x`-Ziel 30px + `.ask` mit Polsterung; Fingerziel gewahrt.
- Score bleibt 100 % (Hook grün beim Commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_