### PR TITLE
Kopfzeile-Feinschliff: Lesemodus-Schalter als Minuskel-a, an Theme ausgerichtet; „Schon entdeckt?" raus

### DIFF
--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -66,12 +66,13 @@ html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
   border-radius:var(--r-control);padding:11px 16px;min-height:40px}
 .dsnav .cta:hover{filter:brightness(1.08)}
 
-/* Lesemodus-Schalter – ein „A", das die Leseschrift zeigt; Zustand über Gold-Ring.
-   Das Zeichen selbst folgt dem Modus: Goetheanum (Haus) → Source (Lesen). */
+/* Lesemodus-Schalter – ein „a", das die Leseschrift zeigt; Zustand über Gold-Ring.
+   Das Zeichen selbst folgt dem Modus: Goetheanum (Haus) → Source (Lesen). Minuskel,
+   weil sich die beiden Schriften am Klein-a deutlicher unterscheiden als an der Versal.
+   Optische Mitte an den Theme-Schalter angeglichen (kein fixes Kästchen, gleiche Höhe). */
 .dsnav .read{margin-left:16px;display:inline-flex;align-items:center;justify-content:center;font:inherit;
-  color:var(--ink);background:none;border:0;padding:5px;cursor:pointer;line-height:1;border-radius:var(--r-control)}
-.dsnav .read .ic{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:19px;line-height:1;
-  width:19px;height:19px;display:grid;place-items:center}
+  color:var(--ink);background:none;border:0;padding:6px;cursor:pointer;line-height:1;border-radius:var(--r-control)}
+.dsnav .read .ic{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:22px;line-height:1;display:block}
 .dsnav .read:hover{color:var(--gold-ink)}
 .dsnav .read[aria-pressed="true"]{color:var(--gold-ink);box-shadow:inset 0 0 0 2px var(--gold)}
 .dsnav .read[aria-pressed="true"] .ic{font-family:var(--font-text)}

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -190,7 +190,7 @@
         '<img class="lockup" src="' + ROOT + 'assets/logos/goetheanum-werkzeuge.svg" alt="Goetheanum Werkzeuge">' +
       '</a>' +
       '<nav class="worlds"></nav>' + ctaHTML +
-      '<button class="read" type="button" aria-pressed="false" aria-label="Lesemodus – Fliesstext in der Leseschrift"><span class="ic" aria-hidden="true">A</span></button>' +
+      '<button class="read" type="button" aria-pressed="false" aria-label="Lesemodus – Fliesstext in der Leseschrift"><span class="ic" aria-hidden="true">a</span></button>' +
       '<button class="theme" type="button" aria-label="Dunkel schalten"><span class="ic"></span></button>' +
       '<button class="all" type="button" aria-haspopup="dialog" aria-expanded="false" aria-label="Menü">' +
         '<span class="ic">☰</span><span class="idot" hidden></span></button>' +

--- a/index.html
+++ b/index.html
@@ -27,9 +27,6 @@
   .tile h2 .arr{color:var(--muted);font-weight:var(--w-text);transition:transform .15s,color .15s}
   .tile:hover h2 .arr{color:var(--gold-ink);transform:translateX(3px)}
 
-  /* Kleiner, feiner Hinweis über dem Karussell. */
-  .discover{font-size:var(--t-small);letter-spacing:.07em;color:var(--gold-ink);margin:0 0 var(--s3)}
-
   /* Greifbare Mini-Werkzeuge je Karte – das Erzeugnis als Erkennungszeichen. */
   .thumb{height:96px;display:grid;place-items:center;border-radius:10px;background:var(--paper);
     border:1px solid var(--line-soft);overflow:hidden}
@@ -185,9 +182,6 @@
     var items = DISCOVER.map(function(d){ return { d:d, t:byslug[d.slug] }; })
                         .filter(function(x){ return x.t; });
     if (items.length < 2) { car.remove(); return; }   // Karussell erst ab zwei Folien
-
-    // Kleiner, feiner Hinweis ÜBER dem Karussell (nicht je Folie).
-    car.insertAdjacentHTML("beforebegin", '<p class="discover">Schon entdeckt?</p>');
 
     var track = document.createElement("div"); track.className = "track";
     items.forEach(function(x){


### PR DESCRIPTION
## Worum es geht

Drei Feinschliffe nach dem Praxisblick auf dem Telefon (Screenshots vom
Auftraggeber):

1. **Lese-Schalter ‹A› → ‹a›.** Die beiden Versal-A (Goetheanum vs. Source)
   waren im Wechsel zu ähnlich. Am **Klein-a** ist der Unterschied sofort
   lesbar: Goetheanum/Titillium ist **einstöckig**, Source **zweistöckig** –
   der Buchstabe zeigt jetzt selbst, in welche Schrift geschaltet wird.
2. **Vertikale Ausrichtung.** Das feste 19-px-Kästchen (`display:grid`) setzte
   die Versal zu hoch gegenüber dem Hell/Dunkel-Schalter. Kästchen raus, gleiche
   Polsterung wie `.theme` – Lese- und Theme-Zeichen sitzen jetzt auf einer Höhe
   (per Screenshot in Hell, Dunkel, an/aus geprüft).
3. **‹Schon entdeckt?› entfernt.** Die gesperrt gesetzte Überzeile über dem
   Karussell war entbehrlich (**G03 Weglassen**); die zugehörige `.discover`-Regel
   ist mit weg.

## Vorher / Nachher

| | vorher | nachher |
|---|---|---|
| Symbol | Versal **A** (beide Zustände ähnlich) | Minuskel **a** (ein-/zweistöckig, klar verschieden) |
| Höhe | A saß über der Sonne/Mond | auf gleicher Mitte wie Theme |
| Karussell | „Schon entdeckt?" (gesperrt) | ohne Überzeile |

## Regel-Deckung

- **G03** entbehrliche Auszeichnung entfällt (Überzeile).
- **G05** Betonung nie über Versalien – die Minuskel ist auch hier die ruhigere
  Wahl.
- Ausrichtung = Gestalt; Score 100 % (Hook grün beim Commit).

Verifikation: Playwright-Screenshots der Kopfzeile in Hell/Dunkel und im
An/Aus-Zustand des Schalters; Box-Mitten von Lese- und Theme-Zeichen deckungsgleich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_