### PR TITLE
Sommer-Zähler: Uscreen-Webhook-Ingestion (goetheanum.tv)

### DIFF
--- a/services/sommer-zaehler/README.md
+++ b/services/sommer-zaehler/README.md
@@ -59,6 +59,26 @@ Geplant je Quelle eine Ingestion (Supabase Edge Function + `pg_cron`), die nach
 - **Paperform:** API-Key **oder** Webhook je Formular (DE/EN) — nur als
   Echtzeitpuls «gerade angemeldet»; entprellt gegen Zoho.
 
+## Uscreen-Webhook (aktiv)
+
+Edge Function [`ingest-uscreen/index.ts`](./ingest-uscreen/index.ts) nimmt
+Uscreen-Webhooks entgegen (kein API-Key nötig) und upsertet nach
+`sommer2026_signups` (`source='uscreen'`, Dedup über `ext_id` =
+`subscription_id`). Jeder Payload wird PII-redigiert (E-Mail/Name → `***`) in
+`sommer2026_ingest_raw` geloggt, um das Mapping am ersten echten Event zu
+verfeinern.
+
+- **URL:** `…/functions/v1/ingest-uscreen?key=<webhook_secret>`
+  (Secret liegt in `sommer2026_config`, nicht im Code/Repo).
+- **In Uscreen:** Settings → Webhooks → obige URL; Events *subscription
+  created / canceled* (und *payment/charge* für die Umwandlung `bleibt`).
+- **Attribution:** Settings → User fields → verstecktes Feld `utm_source` am
+  Checkout; die Function mappt es auf `kanal`.
+- **Aktions-Filter (offen):** Damit nur die Sommer-Aktion zählt (nicht das
+  ganze GTV-Geschäft), filtert die Function auf den **Aktions-Plan/-Coupon**.
+  Sobald Plan-Titel bzw. Coupon-Code der «3 Monate gratis»-Aktion bekannt sind,
+  werden sie in der Function hinterlegt.
+
 ## Fest im Cockpit hinterlegt (bis echte Werte vorliegen)
 
 In `apps/sommer-zaehler/index.html` im `CONFIG`-Block: Zielmarken je Strom,

--- a/services/sommer-zaehler/ingest-uscreen/index.ts
+++ b/services/sommer-zaehler/ingest-uscreen/index.ts
@@ -1,0 +1,136 @@
+// =============================================================================
+// ingest-uscreen · Supabase Edge Function
+// Nimmt Uscreen-Webhooks (goetheanum.tv) entgegen und schreibt sie in
+// public.sommer2026_signups. Loggt jeden Payload PII-redigiert in
+// public.sommer2026_ingest_raw (nur Service-Role liest ihn) – so lässt sich das
+// Mapping am ersten echten Event verfeinern.
+//
+// Auth: ?key=<webhook_secret> (liegt in public.sommer2026_config). Kein JWT.
+// =============================================================================
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+const SB = Deno.env.get("SUPABASE_URL")!;
+const KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const H = { "Content-Type": "application/json", apikey: KEY, Authorization: `Bearer ${KEY}` };
+
+function pick(o: any, keys: string[]): any {
+  for (const k of keys) {
+    const v = k.split(".").reduce((a: any, p: string) => (a == null ? a : a[p]), o);
+    if (v !== undefined && v !== null && v !== "") return v;
+  }
+  return undefined;
+}
+
+// PII (E-Mail, Name, Telefon, Adresse, IP) vor dem Loggen entfernen.
+function redact(o: any): any {
+  if (Array.isArray(o)) return o.map(redact);
+  if (o && typeof o === "object") {
+    const r: any = {};
+    for (const k of Object.keys(o)) r[k] = /(email|name|phone|address|\bip\b)/i.test(k) ? "***" : redact(o[k]);
+    return r;
+  }
+  return o;
+}
+
+function mapPlan(title: string) {
+  const t = (title || "").toLowerCase();
+  const sprache = /\b(en|eng|english|englisch)\b/.test(t) ? "en" : "de";
+  const intervall = /(year|annual|annum|jahr|jähr|yearly)/.test(t) ? "jaehrlich"
+    : /(month|monat|mensile|mensuel)/.test(t) ? "monatlich" : "monatlich";
+  const tarif = /(reduc|ermäss|ermaess|student|conc)/.test(t) ? "ermaessigt" : "standard";
+  return { sprache, intervall, tarif };
+}
+
+const KANAELE = ["newsletter", "mailer", "social", "popup", "website", "empfehlung", "andere"];
+function mapKanal(v: any): string {
+  const s = (v ?? "").toString().toLowerCase();
+  if (!s) return "andere";
+  if (KANAELE.includes(s)) return s;
+  if (/(news|\bnl\b)/.test(s)) return "newsletter";
+  if (/(mail|post|brief)/.test(s)) return "mailer";
+  if (/(insta|face|\bfb\b|social|linkedin|youtube|twitter|tiktok)/.test(s)) return "social";
+  if (/(popup|pop-up|overlay)/.test(s)) return "popup";
+  if (/(web|site|direct|organic)/.test(s)) return "website";
+  if (/(refer|empfehl|friend)/.test(s)) return "empfehlung";
+  return "andere";
+}
+
+async function log(event: string, ok: boolean, note: string, payload: unknown) {
+  await fetch(`${SB}/rest/v1/sommer2026_ingest_raw`, {
+    method: "POST",
+    headers: { ...H, Prefer: "return=minimal" },
+    body: JSON.stringify({ source: "uscreen", event, ok, note, payload: redact(payload) }),
+  }).catch(() => {});
+}
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") return new Response("ok", { status: 200 });
+
+  // Secret prüfen (Query ?key= oder Header x-webhook-key)
+  const u = new URL(req.url);
+  const key = u.searchParams.get("key") || req.headers.get("x-webhook-key") || "";
+  const cfgRows = await fetch(`${SB}/rest/v1/sommer2026_config?key=in.(webhook_secret,aktion_coupon,aktion_plan)&select=key,value`, { headers: H })
+    .then((r) => r.json()).catch(() => []);
+  const cfg: Record<string, string> = {};
+  if (Array.isArray(cfgRows)) for (const r of cfgRows) cfg[r.key] = r.value;
+  const secret = cfg["webhook_secret"] || null;
+  if (!secret || key !== secret) return new Response("unauthorized", { status: 401 });
+  // Aktions-Filter: nur zählen, was zur Sommer-Aktion gehört. Solange weder
+  // aktion_coupon noch aktion_plan gesetzt ist, läuft die Function im Log-Modus.
+  const aktionCoupon = (cfg["aktion_coupon"] || "").toLowerCase();
+  const aktionPlan = (cfg["aktion_plan"] || "").toLowerCase();
+  const filterConfigured = !!(aktionCoupon || aktionPlan);
+
+  let body: any = {};
+  try { body = await req.json(); } catch { /* leerer Body */ }
+
+  const event = (pick(body, ["event", "type", "event_type"]) || "").toString();
+  const data = body.data && typeof body.data === "object" ? body.data : body;
+  await log(event, true, "empfangen", body);
+
+  const ext = pick(data, ["subscription_id", "subscription.id", "transaction_id", "id", "user_id", "user.id"]);
+  if (ext === undefined) {
+    return new Response(JSON.stringify({ ok: true, skipped: "kein subscription_id" }),
+      { status: 200, headers: { "Content-Type": "application/json" } });
+  }
+
+  const title = (pick(data, ["subscription_title", "plan_title", "plan_name", "subscription.title", "product_title"]) || "").toString();
+
+  // Log-Modus: ohne Aktions-Filter wird geloggt, aber nichts gezählt.
+  if (!filterConfigured) {
+    return new Response(JSON.stringify({ ok: true, mode: "log" }),
+      { status: 200, headers: { "Content-Type": "application/json" } });
+  }
+  const coupon = (pick(data, ["coupon_code", "coupon", "discount_code", "code"]) || "").toString().toLowerCase();
+  const matchesAktion = (aktionCoupon && coupon.includes(aktionCoupon)) || (aktionPlan && title.toLowerCase().includes(aktionPlan));
+  if (!matchesAktion) {
+    return new Response(JSON.stringify({ ok: true, skipped: "nicht Aktion" }),
+      { status: 200, headers: { "Content-Type": "application/json" } });
+  }
+
+  const { sprache, intervall, tarif } = mapPlan(title);
+  const kanal = mapKanal(pick(data, ["utm_source", "source", "custom_fields.utm_source", "referral_source", "user_fields.0.value", "user_field_1"]));
+  const when = pick(data, ["created_at", "subscribed_at", "started_at", "date"]) || new Date().toISOString();
+
+  const e = event.toLowerCase();
+  let status = "neu";
+  if (/(cancel|refund|expire|churn|delet)/.test(e)) status = "gekuendigt";       // verlässt vor/bei Umwandlung
+  else if (/(renew|payment|charge|paid|convert)/.test(e)) status = "bleibt";     // erste Abbuchung = umgewandelt
+
+  const row = {
+    signed_up_at: when, produkt: "gtv", sprache, format: "stream",
+    tarif, intervall, status, kanal, source: "uscreen", ext_id: String(ext),
+  };
+
+  const res = await fetch(`${SB}/rest/v1/sommer2026_signups?on_conflict=source,ext_id`, {
+    method: "POST",
+    headers: { ...H, Prefer: "resolution=merge-duplicates,return=minimal" },
+    body: JSON.stringify(row),
+  });
+  if (!res.ok) {
+    await log(event, false, `upsert ${res.status} ${(await res.text()).slice(0, 300)}`, row);
+    return new Response(JSON.stringify({ ok: false }), { status: 200, headers: { "Content-Type": "application/json" } });
+  }
+  return new Response(JSON.stringify({ ok: true, status, sprache, tarif, intervall, kanal }),
+    { status: 200, headers: { "Content-Type": "application/json" } });
+});

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -82,3 +82,29 @@ grant execute on function public.sommer2026_stats()    to anon, authenticated;
 grant execute on function public.sommer2026_timeline() to anon, authenticated;
 grant execute on function public.sommer2026_kohorten() to anon, authenticated;
 grant execute on function public.sommer2026_kanaele()  to anon, authenticated;
+
+-- =============================================================================
+-- Ingestion (Webhooks) – siehe ingest-uscreen/index.ts
+-- =============================================================================
+
+-- Roh-Log jedes eingehenden Webhooks (PII-redigiert), nur Service-Role liest ihn
+create table if not exists public.sommer2026_ingest_raw (
+  id          bigint generated always as identity primary key,
+  received_at timestamptz not null default now(),
+  source      text not null default 'uscreen',
+  event       text,
+  ok          boolean not null default true,
+  note        text,
+  payload     jsonb
+);
+alter table public.sommer2026_ingest_raw enable row level security;
+revoke all on table public.sommer2026_ingest_raw from anon, authenticated;
+
+-- Konfig-Speicher (u. a. webhook_secret) – nur Service-Role
+create table if not exists public.sommer2026_config (
+  key   text primary key,
+  value text not null
+);
+alter table public.sommer2026_config enable row level security;
+revoke all on table public.sommer2026_config from anon, authenticated;
+-- insert into public.sommer2026_config(key,value) values ('webhook_secret','<zufälliger-wert>');


### PR DESCRIPTION
## Worum es geht

Live-Anbindung von **goetheanum.tv (Uscreen)** an den Sommer-Zähler über Webhooks — **ohne API-Key**. Uscreen sendet Anmeldungen/Zahlungen/Kündigungen an eine Supabase-Edge-Function, die sie nach `sommer2026_signups` schreibt.

## Was drin ist

- **`services/sommer-zaehler/ingest-uscreen/index.ts`** — Edge Function (Secret-geschützt via `?key=`, kein JWT). Mappt Plan-Titel → Sprache/Tarif/Intervall, Herkunftsfeld → `kanal`, Events (`Subscription Assigned` / `Order Paid` / `Recurring Payment Successful` / `Access canceled`) → Status (`neu` / `bleibt` / `gekuendigt`). Dedup über `subscription_id`.
- **Log-Modus:** solange kein Aktions-Filter (`sommer2026_config.aktion_coupon` / `aktion_plan`) gesetzt ist, wird **nur geloggt, nichts gezählt** — damit später ausschliesslich die Sommer-Aktion zählt, nicht das gesamte GTV-Geschäft. Umschalten ohne Redeploy über die Config.
- **Datenschutz:** jeder Payload wird **PII-redigiert** (E-Mail/Name → `***`) in `sommer2026_ingest_raw` geloggt; Hilfstabellen `sommer2026_ingest_raw` + `sommer2026_config` in `schema.sql`, beide für `anon` gesperrt. Das Secret liegt in der DB, nicht im Repo.
- **README:** Webhook-Einrichtung, Attribution über Uscreen-User-Field („How did you hear about us?"), offener Aktions-Filter.

## Geprüft

Live getestet (Function v3): `subscription.created` und `canceled` mappen korrekt, falsches Secret → 401, Rohtabelle für `anon` verweigert, Log-Modus zählt nichts. Aktuell 0 gezählte Uscreen-Zeilen (wartet auf erstes echtes Event).

## Offen

Aktions-Kennung (Coupon-Code oder Plan-Titel der „3 Monate gratis"-Aktion) setzen, dann schaltet der Zähler von Log- auf Zähl-Modus. Bis dahin sammelt die Function Roh-Events zur Verfeinerung des Mappings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_