### PR TITLE
Karussell: alle öffentlichen Karten als Reihenfolge des Entdeckens

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,11 +141,22 @@
     "sektionsfarben","uebersetzungen","wallpaper","powerpoint",
     "typografie","design-system"];
   // Entdecker-Karussell: ausgewählte Werkzeuge, je ein Teaser.
+  // Alle öffentlichen Karten als Reihenfolge des Entdeckens: vom Fundament über die
+  // Identität und die Stimme zu den Alltagswerkzeugen und den fertigen Anwendungen.
+  // Der Kicker benennt die Station – gleiche Station = zusammengehörige Karten.
   var DISCOVER = [
-    {slug:"wallpaper",      line:"Elf Goetheanum-Hintergründe für den Desktop, frei zum Herunterladen."},
-    {slug:"schriften",      line:"Sechs Schnitte von Flüstern bis Schreien, Variable Font und Icon-Satz."},
-    {slug:"powerpoint",     line:"Präsentationsvorlage im Hausbild – mit eingebetteten Schriften."},
-    {slug:"icons",          line:"45 Piktogramme als Webfont oder einzeln – per Taste gesetzt."}
+    {slug:"design-system",  kick:"Zuerst · das Fundament", line:"Farben, Schnitte und Regeln aus einer Quelle – hier nachschlagen, von hier aus bauen."},
+    {slug:"logo-generator", kick:"Die Identität",          line:"Das Logo für jede Sektion und jeden Bereich setzen und sauber exportieren."},
+    {slug:"sektionsfarben", kick:"Die Identität",          line:"Die Farben der Schul-Sektionen – Werte, Anwendung und wo Weiss darauf steht."},
+    {slug:"schriften",      kick:"Die Stimme",             line:"Die Hausschrift v2.7: fünf Schnitte von Leise bis Laut, Variable Font und Icon-Satz."},
+    {slug:"icons",          kick:"Die Stimme",             line:"45 Piktogramme, Pfeile und Kompass – als Webfont per Taste oder einzeln als SVG, PNG, PDF."},
+    {slug:"typografie",     kick:"Die Stimme",             line:"Die Satzregeln des Hauses – Auszeichnung, Ziffern, Striche, Anführungen; nachschlagen und prüfen."},
+    {slug:"editor",         kick:"Die Stimme",             line:"Text im Hausbild setzen – die Regeln greifen beim Tippen, fertig zum Übernehmen."},
+    {slug:"visitenkarten",  kick:"Für den Alltag",         line:"Die eigene Visitenkarte im Hausbild – ausfüllen, Vorschau, Druckdatei."},
+    {slug:"signatur",       kick:"Für den Alltag",         line:"Die Mail-Signatur im Hausbild – Angaben eintragen, Block kopieren, einsetzen."},
+    {slug:"uebersetzungen", kick:"Für den Alltag",         line:"Sektionen und Begriffe in vier Sprachen – für Karten, Briefe und die Sekretariate."},
+    {slug:"powerpoint",     kick:"Zum Mitnehmen",          line:"Präsentationsvorlage im Hausbild – mit eingebetteten Schriften, sofort loslegen."},
+    {slug:"wallpaper",      kick:"Zum Mitnehmen",          line:"Elf Goetheanum-Hintergründe für den Desktop, frei zum Herunterladen."}
   ];
   // Greifbar: jedes Zeichen zeigt das DING, das das Werkzeug erzeugt.
   var VISUAL = {
@@ -188,7 +199,8 @@
       var a = document.createElement("a"); a.className = "slide"; a.href = x.t.href;
       if (isExt(x.t.href)) { a.target = "_blank"; a.rel = "noopener"; }
       a.innerHTML = visual(x.t) +
-        '<span class="copy"><h2>' + x.t.title + '</h2><p>' + x.d.line + '</p>' +
+        '<span class="copy">' + (x.d.kick ? '<span class="kick">' + x.d.kick + '</span>' : '') +
+        '<h2>' + x.t.title + '</h2><p>' + x.d.line + '</p>' +
         '<span class="go">Ansehen ›</span></span>';
       track.appendChild(a);
     });


### PR DESCRIPTION
## Worum es geht

Das Entdecken-Karussell auf der Startseite zeigte nur **vier** handverlesene
Folien. Jetzt trägt es **alle zwölf öffentlichen Karten** (Status live/beta aus
den Welten `system · generatoren · schrift · anwendung`) – und zwar in einer
**Reihenfolge des Entdeckens**, nicht bloss aufgereiht.

## Die Dramaturgie

**Fundament → Identität → Stimme → Alltag → Anwendung**

| # | Station | Karten |
|---|---|---|
| 1 | Zuerst · das Fundament | Design-System |
| 2–3 | Die Identität | Logos · Sektionsfarben |
| 4–7 | Die Stimme | Schriften · Icons · Typografie · Editor |
| 8–10 | Für den Alltag | Visitenkarten · Signatur · Übersetzungen |
| 11–12 | Zum Mitnehmen | PowerPoint · Wallpaper |

Man beginnt beim Fundament, lernt die Marke und die Farben, dann die Stimme
(Schrift, Icons, Satzregeln, Editor), greift zu den Alltagswerkzeugen und nimmt
am Ende die fertigen Anwendungen mit.

## Was sich ändert

- **`DISCOVER`** von vier auf zwölf Einträge, je mit kurzer, einladender Zeile.
- Jede Folie trägt einen **Stations-Kicker** – gleiche Station = zusammengehörige
  Karten, so wird die Reihenfolge sichtbar. Kicker normal gesetzt, Gold
  (**G05**: Betonung nicht per Versal).
- `buildCarousel` rendert den Kicker über die bestehende `.kick`-Rolle; alles
  andere unverändert – Halt/Weiter-Schalter (WCAG 2.2.2), Punkte mit
  `aria-current`, Wischgesten, reduzierte Bewegung bleiben.

## Regel-Deckung

- **G05** Kicker als Laut/Farbe, nicht Versal.
- Auswahl folgt der bestehenden `PUBLIC`-Logik (Backstage bleibt draussen);
  Score 100 % (Hook grün).

## Verifikation (Playwright)

12 Folien + 12 Punkte in der genannten Reihenfolge; Desktop und Mobil (360 px)
geprüft – Punkte passen (187/301 px), Folie stapelt sauber, Kicker sitzt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_