### PR TITLE
Icons: Tippfeld folgt der Ebene – Pfeile & Kompass werden erreichbar

### DIFF
--- a/icons.html
+++ b/icons.html
@@ -86,6 +86,7 @@
   /* Live: tippen → Icons (Webfont per Taste). */
   .try{display:flex;flex-direction:column;gap:10px;margin-top:16px}
   .try .out{font-family:"G Icons";font-size:40px;line-height:1.2;color:var(--ink);min-height:52px;border:1px solid var(--line);border-radius:10px;padding:12px 14px;background:var(--soft);word-break:break-word}
+  .try .out.pf{font-family:"G Pfeile"}   /* Pfeil-/Kompass-Ebene: das Tippfeld zeigt den Pfeile-Font */
   .try input{font:inherit;font-size:16px;color:var(--ink);border:1px solid var(--line);border-radius:var(--r-control);padding:11px 14px;background:var(--field-bg);min-height:var(--tap)}
   /* Ebenen-Umschalter: Grundebene (Buchstaben → Piktogramme) / Pfeile & Kompass (eigener Font, normale Tasten). */
   .kbd-layer{margin:6px 0 12px}
@@ -307,10 +308,26 @@
         ? 'Piktogramme – jede <b style="color:var(--gold-ink);font-weight:400">goldene</b> Taste trägt ein Zeichen; ein Klick kopiert es. Pfeile und Kompass haben einen <b style="color:var(--gold-ink);font-weight:400">eigenen Font</b> (Reiter oben).'
         : 'Pfeile & Kompass – eigener Font <b style="color:var(--gold-ink);font-weight:400">‹Goetheanum Pfeile›</b>: Schrift wählen, Taste tippen (Umschalt = fett) – kein Option nötig. Oder hier per Klick kopieren; Download unten.';
     }
+    // Das Tippfeld folgt der Ebene: auf der Pfeil-/Kompass-Ebene zeigt es den
+    // Pfeile-Font, damit die Grundtasten (6 t u h · y x c v …) wirklich Pfeile und
+    // Kompass ergeben – im Icon-Font lägen dort Piktogramme, die Pfeile wären
+    // unerreichbar. Beispiel und Beschriftung wechseln mit.
+    function syncTry(){
+      var out=document.getElementById('tryout'), inp=document.getElementById('tryin'),
+          lab=document.querySelector('.try .lab');
+      if(!out||!inp) return;
+      var pf = kbdLayer==='pfeile';
+      out.classList.toggle('pf', pf);
+      inp.value = pf ? '6tuh yxcv' : 'heafu';
+      out.textContent = inp.value;
+      if(lab) lab.textContent = pf
+        ? 'Selbst probieren – Pfeil- und Kompass-Tasten tippen (6 t u h · y x c v):'
+        : 'Selbst probieren – Buchstaben tippen:';
+    }
     document.querySelectorAll('.kbd-layer button').forEach(function(b){
       b.addEventListener('click',function(){
         document.querySelectorAll('.kbd-layer button').forEach(function(x){ x.setAttribute('aria-pressed','false'); });
-        b.setAttribute('aria-pressed','true'); kbdLayer=b.dataset.layer; buildKbd();
+        b.setAttribute('aria-pressed','true'); kbdLayer=b.dataset.layer; buildKbd(); syncTry();
       });
     });
     document.querySelectorAll('.tabs button').forEach(function(b){


### PR DESCRIPTION
## Worum es geht

Im „Selbst probieren"-Tippfeld auf `icons.html` waren **Pfeile und Kompass nicht
erreichbar**: das Ausgabefeld war fest auf den **Icon-Font** verdrahtet. Auf der
Ebene *Pfeile & Kompass* liegen die Zeichen aber auf den **Grundtasten**
(6 t u h · y x c v · 2 0 q e o ü s ö) – im Icon-Font tragen diese Tasten jedoch
Piktogramme. Ergebnis: Die Tastatur-Vorschau zeigte Pfeile, das Tippfeld daneben
zeigte weiter Piktogramme. Genau das ist dem Auftraggeber aufgefallen.

## Fix

Das Tippfeld **folgt jetzt der Ebene** (dem Reiter über der Tastatur):

- `.out` bekommt auf der Pfeile-Ebene die Klasse `.pf` → Font
  **‹Goetheanum Pfeile›**; dann ergeben die Grundtasten wirklich **↑ ← → ↓** und
  die vier Kompass-Zeichen.
- `syncTry()` schaltet mit dem Reiter: **Font**, **Beispiel** (‹heafu› ↔
  ‹6tuh yxcv›) und **Beschriftung** wechseln mit.
- Der Piktogramm-Reiter zeigt unverändert die Piktogramme.

## Verifikation (Playwright)

Reiter ‹Pfeile & Kompass› → Tippfeld rendert `↑ ← → ↓` und die vier Kompass-Rosen;
`.out` trägt `.pf`, Font = „G Pfeile", Label und Beispiel umgestellt. Zurück auf
‹Piktogramme› → wieder Piktogramme.

## Regel-Deckung

Reine Verhaltens-/Font-Zuordnung; keine neuen Farb-/Schnitt-Werte. Score 100 %
(Hook grün beim Commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_