### PR TITLE
Startseite: neue Reihenfolge der Raster-Karten (Editor vor Design-System)

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,9 +137,9 @@
 (function(){
   // Karten flach nach Priorität (keine Kategorien); Unbekannte ans Ende.
   // Webfont wohnt jetzt in Schriften, Zeichen in Logos – darum keine eigene Karte.
-  var ORDER = ["logo-generator","signatur","editor","visitenkarten","icons","schriften",
-    "sektionsfarben","uebersetzungen","wallpaper","powerpoint",
-    "typografie","design-system"];
+  var ORDER = ["logo-generator","schriften","icons","sektionsfarben",
+    "signatur","visitenkarten","powerpoint","typografie",
+    "uebersetzungen","wallpaper","editor","design-system"];
   // Entdecker-Karussell: ausgewählte Werkzeuge, je ein Teaser.
   // Alle öffentlichen Karten als Reihenfolge des Entdeckens: vom Fundament über die
   // Identität und die Stimme zu den Alltagswerkzeugen und den fertigen Anwendungen.


### PR DESCRIPTION
## Worum es geht

Neue Reihenfolge der **Kacheln im Raster** (ausserhalb des Karussells) nach
Vorgabe. Der Editor war in der Vorgabe-Liste nicht genannt; auf Rückfrage kommt
er **vor Design-System**.

## Neue Reihenfolge

Logos · Schriften · Icons · Sektionsfarben · Signatur · Visitenkarten ·
PowerPoint · Typografie · Übersetzungen · Wallpaper · **Editor** · Design-System

## Was sich ändert

- Nur die `ORDER`-Liste in `index.html` neu sortiert. Der Editor stand vorher an
  Position 3; er schliesst jetzt die Reihe vor dem Fundament (Design-System) ab.
- Auswahl und Filter unverändert (öffentliche `live/beta`-Karten); das Karussell
  bleibt, wie es ist.

## Verifikation (Playwright)

Raster rendert in genau dieser Reihenfolge (12 Kacheln, Editor an Position 11).
Score 100 % (Hook grün beim Commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_