### PR TITLE
Icons-Seite: „Taste" für Pfeile korrekt + Einbinden-Anleitung ergänzt

### DIFF
--- a/icons.html
+++ b/icons.html
@@ -241,12 +241,22 @@
       grid.innerHTML="";
       rows.forEach(function(it){
         var k=key(it.codepoint);
+        // Pfeile/Kompass liegen im EIGENEN Font «Goetheanum Pfeile» auf Buchstaben-
+        // tasten (nicht auf dem PUA-Codepoint). Darum dort die echte Pfeile-Taste
+        // zeigen – sonst stünde das untypbare PUA-Zeichen (Tofu) im Feld.
+        var pf = it.group==='pfeil-kompass';
+        var taste = k, fett = false;
+        if (pf) {
+          var base = it.slug.replace(/-fett$/,''); fett = /-fett$/.test(it.slug);
+          var bk = PFEIL_REV[base];
+          taste = bk ? (fett ? '⇧'+bk : bk) : '';
+        }
         var cell=document.createElement('div'); cell.className='icell';
         cell.setAttribute('role','group'); cell.setAttribute('aria-label',it.label);
         cell.innerHTML=
           '<span class="ico" aria-hidden="true">'+esc(k)+'</span>'+
           '<div class="nm">'+esc(it.label)+'</div>'+
-          (k ? '<div class="key">Taste <b>'+esc(k)+'</b></div>' : '')+
+          (taste ? '<div class="key">'+(pf?'Pfeile-Taste':'Taste')+' <b>'+esc(taste)+'</b></div>' : '')+
           '<div class="dl">'+
             '<a download href="'+BASE+'svg/'+it.slug+'.svg">SVG</a>'+
             '<a download href="'+BASE+'png/'+it.slug+'.png">PNG</a>'+
@@ -264,6 +274,8 @@
       'y':'kompass-1','x':'kompass-2','c':'kompass-3','v':'kompass-4',
       '2':'pfeil-gebogen-1','0':'pfeil-gebogen-2','q':'pfeil-gebogen-3','e':'pfeil-gebogen-4',
       'o':'pfeil-gebogen-5','ü':'pfeil-gebogen-6','s':'pfeil-gebogen-7','ö':'pfeil-gebogen-8' };
+    // Umkehrung slug → Taste, für die Kachel-Anzeige im Reiter «Pfeile & Kompass».
+    var PFEIL_REV={}; Object.keys(PFEIL_KEYS).forEach(function(t){ PFEIL_REV[PFEIL_KEYS[t]]=t; });
     var ROWS=[['1','2','3','4','5','6','7','8','9','0','ß'],
               ['q','w','e','r','t','z','u','i','o','p','ü'],
               ['a','s','d','f','g','h','j','k','l','ö','ä'],

--- a/schrift-webfont.html
+++ b/schrift-webfont.html
@@ -107,6 +107,20 @@ pre .k{color:var(--code-key)}pre .s{color:var(--code-str)}pre .c{color:var(--cod
   <div class="swatch"><span class="tag">Leise 265</span><span class="s" style="font-variation-settings:'wght' 265">geprüft & gefällig</span></div>
 </div>
 
+<h2>4 · Icons &amp; Pfeile <span class="tag">zwei eigene Fonts, per Taste</span></h2>
+<div class="card">
+<p class="lead" style="margin-top:0">Piktogramme und Pfeile liegen in <b>zwei eigenen Fonts</b> – nicht im Textfont. Man setzt sie nicht über ein Gewicht, sondern indem man einer Fläche die Icon- oder Pfeile-Schrift gibt und die passende <b>Taste</b> tippt. Welche Taste welches Zeichen ergibt (und jedes einzeln als SVG/PNG/PDF), zeigt die <a href="icons.html">Icon-Seite</a>.</p>
+<pre><button class="copy" data-t="i">kopieren</button><code id="code-i"><span class="k">@font-face</span>{ <span class="k">font-family</span>:<span class="s">"Goetheanum Icons"</span>;
+  <span class="k">src</span>:<span class="k">url</span>(<span class="s">"https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Icons-v2.7.woff2"</span>) <span class="k">format</span>(<span class="s">"woff2"</span>); <span class="k">font-display</span>:block }
+<span class="k">@font-face</span>{ <span class="k">font-family</span>:<span class="s">"Goetheanum Pfeile"</span>;
+  <span class="k">src</span>:<span class="k">url</span>(<span class="s">"https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Pfeile-v2.7.woff2"</span>) <span class="k">format</span>(<span class="s">"woff2"</span>); <span class="k">font-display</span>:block }
+
+<span class="c">/* Verwendung – Zeichen per Taste, nicht per Gewicht */</span>
+.icon  { <span class="k">font-family</span>:<span class="s">"Goetheanum Icons"</span>; }   <span class="c">/* &lt;span class="icon"&gt;h&lt;/span&gt;  → Piktogramm */</span>
+.pfeil { <span class="k">font-family</span>:<span class="s">"Goetheanum Pfeile"</span>; }  <span class="c">/* &lt;span class="pfeil"&gt;u&lt;/span&gt; → Pfeil (Grossbuchstabe = fett) */</span></code></pre>
+<p class="note">Beide Wege gelten auch hier: von der Hausadresse laden (oben) oder <b>selbst hosten</b> – Dateien ins Projekt, <code>src</code>-URL relativ.</p>
+</div>
+
 </div>
 <script>
 var w=document.getElementById("w"),wv=document.getElementById("wv"),hero=document.getElementById("hero");


### PR DESCRIPTION
## 1 · „Taste"-Glitch behoben (`icons.html`)

Im Reiter **Pfeile & Kompass** stand im Feld „Taste" ein Tofu-Kästchen. Grund: die Pfeile liegen im **eigenen Font „Goetheanum Pfeile" auf Buchstabentasten**, aber die Kachel zeigte den (untypbaren) PUA-Codepoint. Jetzt zeigt sie die **echte Pfeile-Taste** (aus der Belegung rückwärts), **⇧** für die fetten Varianten, und labelt sie **„Pfeile-Taste"** (disambiguiert im Reiter „Alle").

## 2 · Einbinden-Anleitung ergänzt (`schrift-webfont.html`)

Die Seite kannte nur den Textfont. Neuer Abschnitt **„4 · Icons & Pfeile"**: beide eigenen Fonts als **zweiter `@font-face`-Schnipsel** (Icons + Pfeile), mit Verwendung (Zeichen **per Taste**, nicht per Gewicht) und Verweis auf die Icon-Seite für die Tastenbelegung.

> **Zweiter Schnipsel statt Integration** – bewusst: die Nutzung ist grundlegend anders (Zeichen wählen statt Gewicht), das in den Text-Schnipsel zu mischen würde verwirren.

## Prüfung

- [x] `typo-check` konform · `ds-lint` 2/2 konform
- [x] Pfeile-Reiter gerendert: echte Tasten (y/x/c/v, 6/t/u/h, ⇧-Varianten), kein Tofu
- [x] Abschnitt 4 mit funktionierendem Kopier-Knopf verdrahtet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aSpY9SVm7s2z5dMoG4Cy4

---
_Generated by [Claude Code](https://claude.ai/code/session_017aSpY9SVm7s2z5dMoG4Cy4)_