### PR TITLE
Icons: alle Pfeile und die mit-Text-Piktogramme sichtbar & katalogisiert

### DIFF
--- a/assets/fonts/goetheanum/Icons-Einzeldateien/icons.json
+++ b/assets/fonts/goetheanum/Icons-Einzeldateien/icons.json
@@ -1,488 +1,510 @@
 [
- {
-  "slug": "bioabfall",
-  "label": "Bioabfall",
-  "codepoint": "U+0068",
-  "group": "piktogramm"
- },
- {
-  "slug": "bitte-anfassen",
-  "label": "Bitte anfassen",
-  "codepoint": "U+0071",
-  "group": "piktogramm"
- },
- {
-  "slug": "draussen-essen",
-  "label": "Draussen essen",
-  "codepoint": "U+0075",
-  "group": "piktogramm"
- },
- {
-  "slug": "eintritt",
-  "label": "Eintritt",
-  "codepoint": "U+0065",
-  "group": "piktogramm"
- },
- {
-  "slug": "fahrstuhl",
-  "label": "Fahrstuhl",
-  "codepoint": "U+0061",
-  "group": "piktogramm"
- },
- {
-  "slug": "garderobe",
-  "label": "Garderobe",
-  "codepoint": "U+0066",
-  "group": "piktogramm"
- },
- {
-  "slug": "geraete-abschalten",
-  "label": "Geräte abschalten",
-  "codepoint": "U+006F",
-  "group": "piktogramm"
- },
- {
-  "slug": "goetheanum-badge",
-  "label": "Goetheanum Badge",
-  "codepoint": "U+0032",
-  "group": "piktogramm"
- },
- {
-  "slug": "goetheanum-badge-invers",
-  "label": "Goetheanum Badge invers",
-  "codepoint": "U+0031",
-  "group": "piktogramm"
- },
- {
-  "slug": "hunde-anleinen",
-  "label": "Hunde anleinen",
-  "codepoint": "U+0072",
-  "group": "piktogramm"
- },
- {
-  "slug": "icon-0021",
-  "label": "U+0021",
-  "codepoint": "U+0021",
-  "group": "weitere"
- },
- {
-  "slug": "icon-003e",
-  "label": "U+003E",
-  "codepoint": "U+003E",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0041",
-  "label": "U+0041",
-  "codepoint": "U+0041",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0042",
-  "label": "U+0042",
-  "codepoint": "U+0042",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0043",
-  "label": "U+0043",
-  "codepoint": "U+0043",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0044",
-  "label": "U+0044",
-  "codepoint": "U+0044",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0045",
-  "label": "U+0045",
-  "codepoint": "U+0045",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0046",
-  "label": "U+0046",
-  "codepoint": "U+0046",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0047",
-  "label": "U+0047",
-  "codepoint": "U+0047",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0048",
-  "label": "U+0048",
-  "codepoint": "U+0048",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0049",
-  "label": "U+0049",
-  "codepoint": "U+0049",
-  "group": "weitere"
- },
- {
-  "slug": "icon-004a",
-  "label": "U+004A",
-  "codepoint": "U+004A",
-  "group": "weitere"
- },
- {
-  "slug": "icon-004b",
-  "label": "U+004B",
-  "codepoint": "U+004B",
-  "group": "weitere"
- },
- {
-  "slug": "icon-004f",
-  "label": "U+004F",
-  "codepoint": "U+004F",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0051",
-  "label": "U+0051",
-  "codepoint": "U+0051",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0052",
-  "label": "U+0052",
-  "codepoint": "U+0052",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0053",
-  "label": "U+0053",
-  "codepoint": "U+0053",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0054",
-  "label": "U+0054",
-  "codepoint": "U+0054",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0055",
-  "label": "U+0055",
-  "codepoint": "U+0055",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0056",
-  "label": "U+0056",
-  "codepoint": "U+0056",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0057",
-  "label": "U+0057",
-  "codepoint": "U+0057",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0058",
-  "label": "U+0058",
-  "codepoint": "U+0058",
-  "group": "weitere"
- },
- {
-  "slug": "icon-0059",
-  "label": "U+0059",
-  "codepoint": "U+0059",
-  "group": "weitere"
- },
- {
-  "slug": "icon-005a",
-  "label": "U+005A",
-  "codepoint": "U+005A",
-  "group": "weitere"
- },
- {
-  "slug": "icon-e200",
-  "label": "U+E200",
-  "codepoint": "U+E200",
-  "group": "weitere"
- },
- {
-  "slug": "icon-e201",
-  "label": "U+E201",
-  "codepoint": "U+E201",
-  "group": "weitere"
- },
- {
-  "slug": "icon-e202",
-  "label": "U+E202",
-  "codepoint": "U+E202",
-  "group": "weitere"
- },
- {
-  "slug": "icon-e203",
-  "label": "U+E203",
-  "codepoint": "U+E203",
-  "group": "weitere"
- },
- {
-  "slug": "icon-e204",
-  "label": "U+E204",
-  "codepoint": "U+E204",
-  "group": "weitere"
- },
- {
-  "slug": "icon-e205",
-  "label": "U+E205",
-  "codepoint": "U+E205",
-  "group": "weitere"
- },
- {
-  "slug": "icon-e206",
-  "label": "U+E206",
-  "codepoint": "U+E206",
-  "group": "weitere"
- },
- {
-  "slug": "icon-e21d",
-  "label": "U+E21D",
-  "codepoint": "U+E21D",
-  "group": "weitere"
- },
- {
-  "slug": "icon-e240",
-  "label": "U+E240",
-  "codepoint": "U+E240",
-  "group": "weitere"
- },
- {
-  "slug": "icon-e241",
-  "label": "U+E241",
-  "codepoint": "U+E241",
-  "group": "weitere"
- },
- {
-  "slug": "icon-e242",
-  "label": "U+E242",
-  "codepoint": "U+E242",
-  "group": "weitere"
- },
- {
-  "slug": "icon-e25d",
-  "label": "U+E25D",
-  "codepoint": "U+E25D",
-  "group": "weitere"
- },
- {
-  "slug": "keine-fotos",
-  "label": "Keine Fotos",
-  "codepoint": "U+007A",
-  "group": "piktogramm"
- },
- {
-  "slug": "keine-hunde",
-  "label": "Keine Hunde",
-  "codepoint": "U+0074",
-  "group": "piktogramm"
- },
- {
-  "slug": "keine-taschen",
-  "label": "Keine Taschen",
-  "codepoint": "U+0069",
-  "group": "piktogramm"
- },
- {
-  "slug": "kompass-1",
-  "label": "Kompass",
-  "codepoint": "U+E243",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "kompass-2",
-  "label": "Kompass",
-  "codepoint": "U+E244",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "kompass-3",
-  "label": "Kompass",
-  "codepoint": "U+E245",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "kompass-4",
-  "label": "Kompass",
-  "codepoint": "U+E246",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "nur-mit-augen",
-  "label": "Nur mit den Augen",
-  "codepoint": "U+0077",
-  "group": "piktogramm"
- },
- {
-  "slug": "papier",
-  "label": "Papier",
-  "codepoint": "U+006A",
-  "group": "piktogramm"
- },
- {
-  "slug": "pfeil-gebogen-1",
-  "label": "Pfeil gebogen",
-  "codepoint": "U+E260",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "pfeil-gebogen-2",
-  "label": "Pfeil gebogen",
-  "codepoint": "U+E261",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "pfeil-gebogen-3",
-  "label": "Pfeil gebogen",
-  "codepoint": "U+E262",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "pfeil-gebogen-4",
-  "label": "Pfeil gebogen",
-  "codepoint": "U+E263",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "pfeil-gebogen-5",
-  "label": "Pfeil gebogen",
-  "codepoint": "U+E26C",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "pfeil-gebogen-6",
-  "label": "Pfeil gebogen",
-  "codepoint": "U+E26D",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "pfeil-gebogen-7",
-  "label": "Pfeil gebogen",
-  "codepoint": "U+E26E",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "pfeil-gebogen-8",
-  "label": "Pfeil gebogen",
-  "codepoint": "U+E26F",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "pfeil-hoch",
-  "label": "Pfeil hoch",
-  "codepoint": "U+E264",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "pfeil-hoch-fett",
-  "label": "Pfeil hoch (fett)",
-  "codepoint": "U+E268",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "pfeil-links",
-  "label": "Pfeil links",
-  "codepoint": "U+E267",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "pfeil-links-fett",
-  "label": "Pfeil links (fett)",
-  "codepoint": "U+E26B",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "pfeil-rechts",
-  "label": "Pfeil rechts",
-  "codepoint": "U+E265",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "pfeil-rechts-fett",
-  "label": "Pfeil rechts (fett)",
-  "codepoint": "U+E269",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "pfeil-runter",
-  "label": "Pfeil runter",
-  "codepoint": "U+E266",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "pfeil-runter-fett",
-  "label": "Pfeil runter (fett)",
-  "codepoint": "U+E26A",
-  "group": "pfeil-kompass"
- },
- {
-  "slug": "restmuell",
-  "label": "Restmüll",
-  "codepoint": "U+006B",
-  "group": "piktogramm"
- },
- {
-  "slug": "schliessfaecher",
-  "label": "Schliessfächer",
-  "codepoint": "U+0064",
-  "group": "piktogramm"
- },
- {
-  "slug": "treppe",
-  "label": "Treppe",
-  "codepoint": "U+0073",
-  "group": "piktogramm"
- },
- {
-  "slug": "wc-damen",
-  "label": "WC Damen",
-  "codepoint": "U+0079",
-  "group": "piktogramm"
- },
- {
-  "slug": "wc-familie",
-  "label": "WC Familie",
-  "codepoint": "U+0062",
-  "group": "piktogramm"
- },
- {
-  "slug": "wc-gruppe",
-  "label": "WC Gruppe",
-  "codepoint": "U+0076",
-  "group": "piktogramm"
- },
- {
-  "slug": "wc-herren",
-  "label": "WC Herren",
-  "codepoint": "U+003C",
-  "group": "piktogramm"
- },
- {
-  "slug": "wc-rollstuhl",
-  "label": "WC Rollstuhl",
-  "codepoint": "U+0078",
-  "group": "piktogramm"
- },
- {
-  "slug": "wickelraum",
-  "label": "Wickelraum",
-  "codepoint": "U+0063",
-  "group": "piktogramm"
- },
- {
-  "slug": "wlan",
-  "label": "WLAN",
-  "codepoint": "U+0067",
-  "group": "piktogramm"
- }
+  {
+    "slug": "bioabfall",
+    "label": "Bioabfall",
+    "codepoint": "U+0068",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "bitte-anfassen",
+    "label": "Bitte anfassen",
+    "codepoint": "U+0071",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "draussen-essen",
+    "label": "Draussen essen",
+    "codepoint": "U+0075",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "eintritt",
+    "label": "Eintritt",
+    "codepoint": "U+0065",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "fahrstuhl",
+    "label": "Fahrstuhl",
+    "codepoint": "U+0061",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "garderobe",
+    "label": "Garderobe",
+    "codepoint": "U+0066",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "geraete-abschalten",
+    "label": "Geräte abschalten",
+    "codepoint": "U+006F",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "goetheanum-badge",
+    "label": "Goetheanum Badge",
+    "codepoint": "U+0032",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "goetheanum-badge-invers",
+    "label": "Goetheanum Badge invers",
+    "codepoint": "U+0031",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "hunde-anleinen",
+    "label": "Hunde anleinen",
+    "codepoint": "U+0072",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "icon-0021",
+    "label": "U+0021",
+    "codepoint": "U+0021",
+    "group": "weitere"
+  },
+  {
+    "slug": "icon-003e",
+    "label": "U+003E",
+    "codepoint": "U+003E",
+    "group": "weitere"
+  },
+  {
+    "slug": "fahrstuhl-text",
+    "label": "Fahrstuhl · mit Text",
+    "codepoint": "U+0041",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "wc-familie-text",
+    "label": "WC Familie · mit Text",
+    "codepoint": "U+0042",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "wickelraum-text",
+    "label": "Wickelraum · mit Text",
+    "codepoint": "U+0043",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "schliessfaecher-text",
+    "label": "Schliessfächer · mit Text",
+    "codepoint": "U+0044",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "eintritt-text",
+    "label": "Eintritt · mit Text",
+    "codepoint": "U+0045",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "garderobe-text",
+    "label": "Garderobe · mit Text",
+    "codepoint": "U+0046",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "wlan-text",
+    "label": "WLAN · mit Text",
+    "codepoint": "U+0047",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "bioabfall-text",
+    "label": "Bioabfall · mit Text",
+    "codepoint": "U+0048",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "keine-taschen-text",
+    "label": "Keine Taschen · mit Text",
+    "codepoint": "U+0049",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "papier-text",
+    "label": "Papier · mit Text",
+    "codepoint": "U+004A",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "restmuell-text",
+    "label": "Restmüll · mit Text",
+    "codepoint": "U+004B",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "geraete-abschalten-text",
+    "label": "Geräte abschalten · mit Text",
+    "codepoint": "U+004F",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "bitte-anfassen-text",
+    "label": "Bitte anfassen · mit Text",
+    "codepoint": "U+0051",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "hunde-anleinen-text",
+    "label": "Hunde anleinen · mit Text",
+    "codepoint": "U+0052",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "treppe-text",
+    "label": "Treppe · mit Text",
+    "codepoint": "U+0053",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "keine-hunde-text",
+    "label": "Keine Hunde · mit Text",
+    "codepoint": "U+0054",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "draussen-essen-text",
+    "label": "Draussen essen · mit Text",
+    "codepoint": "U+0055",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "wc-gruppe-text",
+    "label": "WC Gruppe · mit Text",
+    "codepoint": "U+0056",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "nur-mit-augen-text",
+    "label": "Nur mit den Augen · mit Text",
+    "codepoint": "U+0057",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "wc-rollstuhl-text",
+    "label": "WC Rollstuhl · mit Text",
+    "codepoint": "U+0058",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "wc-damen-text",
+    "label": "WC Damen · mit Text",
+    "codepoint": "U+0059",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "keine-fotos-text",
+    "label": "Keine Fotos · mit Text",
+    "codepoint": "U+005A",
+    "group": "piktogramm-text",
+    "fontonly": true
+  },
+  {
+    "slug": "icon-e200",
+    "label": "U+E200",
+    "codepoint": "U+E200",
+    "group": "weitere"
+  },
+  {
+    "slug": "icon-e201",
+    "label": "U+E201",
+    "codepoint": "U+E201",
+    "group": "weitere"
+  },
+  {
+    "slug": "icon-e202",
+    "label": "U+E202",
+    "codepoint": "U+E202",
+    "group": "weitere"
+  },
+  {
+    "slug": "icon-e203",
+    "label": "U+E203",
+    "codepoint": "U+E203",
+    "group": "weitere"
+  },
+  {
+    "slug": "icon-e204",
+    "label": "U+E204",
+    "codepoint": "U+E204",
+    "group": "weitere"
+  },
+  {
+    "slug": "icon-e205",
+    "label": "U+E205",
+    "codepoint": "U+E205",
+    "group": "weitere"
+  },
+  {
+    "slug": "icon-e206",
+    "label": "U+E206",
+    "codepoint": "U+E206",
+    "group": "weitere"
+  },
+  {
+    "slug": "icon-e21d",
+    "label": "U+E21D",
+    "codepoint": "U+E21D",
+    "group": "weitere"
+  },
+  {
+    "slug": "icon-e240",
+    "label": "U+E240",
+    "codepoint": "U+E240",
+    "group": "weitere"
+  },
+  {
+    "slug": "icon-e241",
+    "label": "U+E241",
+    "codepoint": "U+E241",
+    "group": "weitere"
+  },
+  {
+    "slug": "icon-e242",
+    "label": "U+E242",
+    "codepoint": "U+E242",
+    "group": "weitere"
+  },
+  {
+    "slug": "icon-e25d",
+    "label": "U+E25D",
+    "codepoint": "U+E25D",
+    "group": "weitere"
+  },
+  {
+    "slug": "keine-fotos",
+    "label": "Keine Fotos",
+    "codepoint": "U+007A",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "keine-hunde",
+    "label": "Keine Hunde",
+    "codepoint": "U+0074",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "keine-taschen",
+    "label": "Keine Taschen",
+    "codepoint": "U+0069",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "kompass-1",
+    "label": "Kompass",
+    "codepoint": "U+E243",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "kompass-2",
+    "label": "Kompass",
+    "codepoint": "U+E244",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "kompass-3",
+    "label": "Kompass",
+    "codepoint": "U+E245",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "kompass-4",
+    "label": "Kompass",
+    "codepoint": "U+E246",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "nur-mit-augen",
+    "label": "Nur mit den Augen",
+    "codepoint": "U+0077",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "papier",
+    "label": "Papier",
+    "codepoint": "U+006A",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "pfeil-gebogen-1",
+    "label": "Pfeil gebogen",
+    "codepoint": "U+E260",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "pfeil-gebogen-2",
+    "label": "Pfeil gebogen",
+    "codepoint": "U+E261",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "pfeil-gebogen-3",
+    "label": "Pfeil gebogen",
+    "codepoint": "U+E262",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "pfeil-gebogen-4",
+    "label": "Pfeil gebogen",
+    "codepoint": "U+E263",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "pfeil-gebogen-5",
+    "label": "Pfeil gebogen",
+    "codepoint": "U+E26C",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "pfeil-gebogen-6",
+    "label": "Pfeil gebogen",
+    "codepoint": "U+E26D",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "pfeil-gebogen-7",
+    "label": "Pfeil gebogen",
+    "codepoint": "U+E26E",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "pfeil-gebogen-8",
+    "label": "Pfeil gebogen",
+    "codepoint": "U+E26F",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "pfeil-hoch",
+    "label": "Pfeil hoch",
+    "codepoint": "U+E264",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "pfeil-hoch-fett",
+    "label": "Pfeil hoch (fett)",
+    "codepoint": "U+E268",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "pfeil-links",
+    "label": "Pfeil links",
+    "codepoint": "U+E267",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "pfeil-links-fett",
+    "label": "Pfeil links (fett)",
+    "codepoint": "U+E26B",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "pfeil-rechts",
+    "label": "Pfeil rechts",
+    "codepoint": "U+E265",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "pfeil-rechts-fett",
+    "label": "Pfeil rechts (fett)",
+    "codepoint": "U+E269",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "pfeil-runter",
+    "label": "Pfeil runter",
+    "codepoint": "U+E266",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "pfeil-runter-fett",
+    "label": "Pfeil runter (fett)",
+    "codepoint": "U+E26A",
+    "group": "pfeil-kompass"
+  },
+  {
+    "slug": "restmuell",
+    "label": "Restmüll",
+    "codepoint": "U+006B",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "schliessfaecher",
+    "label": "Schliessfächer",
+    "codepoint": "U+0064",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "treppe",
+    "label": "Treppe",
+    "codepoint": "U+0073",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "wc-damen",
+    "label": "WC Damen",
+    "codepoint": "U+0079",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "wc-familie",
+    "label": "WC Familie",
+    "codepoint": "U+0062",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "wc-gruppe",
+    "label": "WC Gruppe",
+    "codepoint": "U+0076",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "wc-herren",
+    "label": "WC Herren",
+    "codepoint": "U+003C",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "wc-rollstuhl",
+    "label": "WC Rollstuhl",
+    "codepoint": "U+0078",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "wickelraum",
+    "label": "Wickelraum",
+    "codepoint": "U+0063",
+    "group": "piktogramm"
+  },
+  {
+    "slug": "wlan",
+    "label": "WLAN",
+    "codepoint": "U+0067",
+    "group": "piktogramm"
+  }
 ]

--- a/icons.html
+++ b/icons.html
@@ -78,6 +78,14 @@
   .keycap.has .gl.pf{font-family:"G Pfeile"}  /* Pfeile-Ebene: eigener Font, Grundtaste getippt */
   /* Buchstaben-Legende: auf belegten Tasten klein in die untere rechte Ecke. */
   .keycap.has .lk{position:absolute;right:7px;bottom:5px;color:var(--gold-ink)}
+  /* Zweitzeichen oben rechts: der fette Pfeil (Umschalt) – wie „&“ über „6“.
+     Nichts unter dem Lesbarkeits-Floor (B03): ⇧ auf --t-micro, Pfeil knapp grösser. */
+  .keycap .sh{position:absolute;right:6px;top:4px;display:flex;align-items:center;gap:1px;line-height:1}
+  .keycap .sh .up{font-size:var(--t-micro);line-height:1;color:var(--gold-ink)}
+  .keycap .sh .fg{font-family:"G Pfeile";font-size:15px;line-height:1;color:var(--gold-ink)}
+  /* Unter-Umschalter ‹ohne/mit Text› – nur unter Piktogramme sichtbar. */
+  .kbd-sub{margin:-2px 0 12px;font-size:var(--t-small)}
+  .kbd-sub[hidden]{display:none}
   @media(max-width:560px){
     .keycap{width:52px;height:52px;border-radius:10px}
     .keycap.has .gl{font-size:33px}
@@ -161,6 +169,10 @@
           <button type="button" data-layer="base" aria-pressed="true">Piktogramme</button>
           <button type="button" data-layer="pfeile" aria-pressed="false">Pfeile &amp; Kompass</button>
         </div>
+        <div class="seg kbd-sub" id="kbdsub" role="tablist" aria-label="Piktogramm-Ebene">
+          <button type="button" data-sub="ohne" aria-pressed="true">ohne Text</button>
+          <button type="button" data-sub="mit" aria-pressed="false">mit Text</button>
+        </div>
         <div class="kbd" id="kbd"></div>
         <span class="kbd-toast" id="kbdtoast" aria-live="polite"></span>
         <p class="kbdcap" id="kbdcap"></p>
@@ -237,7 +249,7 @@
       var rows=DATA.filter(function(it){
         var inTab = tab==="alle" || it.group===tab;
         var inTerm = !term || it.label.toLowerCase().indexOf(term)!==-1 || it.slug.indexOf(term)!==-1;
-        return inTab && inTerm;
+        return inTab && inTerm && !it.fontonly;   // ‹mit Text› ist Font-only (keine Einzeldatei) – nur auf der Tastatur
       });
       grid.innerHTML="";
       rows.forEach(function(it){
@@ -267,21 +279,24 @@
       });
       empty.hidden = rows.length>0;
     }
-    // Zwei Ebenen: Piktogramme (Icon-Font, Buchstaben → Zeichen) und Pfeile & Kompass.
-    // Die Pfeile haben einen EIGENEN Font «Goetheanum Pfeile»: dieselben Zeichen auf
-    // normalen Tasten – tippen, kein Option, kein PUA. Belegung A (Beipackzettel-treu),
-    // Umschalt = fett. Die Tasten hier zeigen die Zeichen aus dem Pfeile-Webfont.
+    // Drei Ebenen, aber nur zwei Fonts – wie auf einer echten Tastatur zwei Zeichen
+    // je Taste liegen (unten tippen, oben mit ⇧):
+    //  • Piktogramme  ‹ohne Text›  – Grundtaste, Icon-Font
+    //  • Piktogramme  ‹mit Text›   – Umschalt-Glyphe (Grosstaste), Icon-Font
+    //  • Pfeile & Kompass          – eigener Font «Goetheanum Pfeile»; die vier
+    //    Richtungspfeile tragen den fetten Pfeil als ⇧-Zweitzeichen oben rechts.
     var PFEIL_KEYS={ '6':'pfeil-hoch','t':'pfeil-links','u':'pfeil-rechts','h':'pfeil-runter',
       'y':'kompass-1','x':'kompass-2','c':'kompass-3','v':'kompass-4',
       '2':'pfeil-gebogen-1','0':'pfeil-gebogen-2','q':'pfeil-gebogen-3','e':'pfeil-gebogen-4',
       'o':'pfeil-gebogen-5','ü':'pfeil-gebogen-6','s':'pfeil-gebogen-7','ö':'pfeil-gebogen-8' };
     // Umkehrung slug → Taste, für die Kachel-Anzeige im Reiter «Pfeile & Kompass».
     var PFEIL_REV={}; Object.keys(PFEIL_KEYS).forEach(function(t){ PFEIL_REV[PFEIL_KEYS[t]]=t; });
+    var FAT_SHIFT={ '6':'&','t':'T','u':'U','h':'H' };   // fette Richtungspfeile (Umschalt)
     var ROWS=[['1','2','3','4','5','6','7','8','9','0','ß'],
               ['q','w','e','r','t','z','u','i','o','p','ü'],
               ['a','s','d','f','g','h','j','k','l','ö','ä'],
               ['<','y','x','c','v','b','n','m']];
-    var kbdLayer='base', copyTimer;
+    var kbdLayer='base', mainLayer='pikto', subText=false, copyTimer;
     function copyGlyph(g,label){
       if(navigator.clipboard) navigator.clipboard.writeText(g);
       var t=document.getElementById('kbdtoast'); if(!t) return;
@@ -293,18 +308,27 @@
       var byChar={}, bySlug={};
       DATA.forEach(function(it){ var k=key(it.codepoint); if(k) byChar[k]=it; bySlug[it.slug]=it; });
       box.innerHTML="";
+      var pfeile = kbdLayer==='pfeile', text = kbdLayer==='text';
       ROWS.forEach(function(r){
         var row=document.createElement('div'); row.className='krow';
         r.forEach(function(ch){
-          var pfeile = kbdLayer==='pfeile';
-          var it = pfeile ? bySlug[PFEIL_KEYS[ch]] : byChar[ch];
+          var it=null, glClass='gl', glChar=ch, shHTML='';
+          if(pfeile){
+            it = bySlug[PFEIL_KEYS[ch]];
+            if(it){ glClass='gl pf'; glChar=ch;
+              if(FAT_SHIFT[ch]) shHTML='<span class="sh" aria-hidden="true"><span class="up">⇧</span><span class="fg">'+esc(FAT_SHIFT[ch])+'</span></span>';
+            }
+          } else if(text){
+            var up=ch.toUpperCase(); var t=byChar[up];
+            if(t && t.group==='piktogramm-text'){ it=t; glChar=up; }
+          } else {
+            it = byChar[ch]; glChar=ch;
+          }
           if(it){
             var g=key(it.codepoint), legend=ch.toUpperCase();
-            // Piktogramme: Zeichen aus dem Icon-Font. Pfeile: die GRUNDTASTE im Pfeile-Font.
-            var glClass = pfeile ? 'gl pf' : 'gl', glChar = pfeile ? ch : g;
             var b=document.createElement('button'); b.type='button'; b.className='keycap has';
             b.title=it.label+' – kopieren'; b.setAttribute('aria-label',it.label+' kopieren');
-            b.innerHTML='<span class="'+glClass+'" aria-hidden="true">'+esc(glChar)+'</span><span class="lk">'+esc(legend)+'</span>';
+            b.innerHTML='<span class="'+glClass+'" aria-hidden="true">'+esc(glChar)+'</span>'+shHTML+'<span class="lk">'+esc(legend)+'</span>';
             b.addEventListener('click',(function(gg,lab){ return function(){ copyGlyph(gg,lab); }; })(g,it.label));
             row.appendChild(b);
           } else {
@@ -315,31 +339,48 @@
         });
         box.appendChild(row);
       });
+      var sub=document.getElementById('kbdsub'); if(sub) sub.hidden = pfeile;
+      var G='<b style="color:var(--gold-ink);font-weight:400">';
       var cap=document.getElementById('kbdcap');
-      if(cap) cap.innerHTML = kbdLayer==='base'
-        ? 'Piktogramme – jede <b style="color:var(--gold-ink);font-weight:400">goldene</b> Taste trägt ein Zeichen; ein Klick kopiert es. Pfeile und Kompass haben einen <b style="color:var(--gold-ink);font-weight:400">eigenen Font</b> (Reiter oben).'
-        : 'Pfeile & Kompass – eigener Font <b style="color:var(--gold-ink);font-weight:400">‹Goetheanum Pfeile›</b>: Schrift wählen, Taste tippen (Umschalt = fett) – kein Option nötig. Oder hier per Klick kopieren; Download unten.';
+      if(cap) cap.innerHTML = pfeile
+        ? 'Pfeile & Kompass – eigener Font '+G+'‹Goetheanum Pfeile›</b>: Taste tippen. Das kleine Zeichen oben rechts mit '+G+'⇧ (Umschalt)</b> ist der fette Pfeil. Ein Klick kopiert.'
+        : text
+          ? 'Piktogramme '+G+'mit Text</b> – dieselben Zeichen mit eingeprägter Beschriftung, auf der '+G+'Umschalt-Taste (⇧)</b>. Ein Klick kopiert.'
+          : 'Piktogramme – jede '+G+'goldene</b> Taste trägt ein Zeichen; ein Klick kopiert es. Über '+G+'‹mit Text›</b> die beschrifteten Varianten (Umschalt), rechts der Pfeile-Font.';
     }
-    // Das Tippfeld folgt der Ebene: auf der Pfeil-/Kompass-Ebene zeigt es den
-    // Pfeile-Font, damit die Grundtasten (6 t u h · y x c v …) wirklich Pfeile und
-    // Kompass ergeben – im Icon-Font lägen dort Piktogramme, die Pfeile wären
-    // unerreichbar. Beispiel und Beschriftung wechseln mit.
+    // Das Tippfeld folgt der Ebene: Pfeile → Pfeile-Font (6 t u h · y x c v),
+    // ‹mit Text› → Grosstasten im Icon-Font, sonst die Grund-Piktogramme.
     function syncTry(){
       var out=document.getElementById('tryout'), inp=document.getElementById('tryin'),
           lab=document.querySelector('.try .lab');
       if(!out||!inp) return;
-      var pf = kbdLayer==='pfeile';
+      var pf = kbdLayer==='pfeile', tx = kbdLayer==='text';
       out.classList.toggle('pf', pf);
-      inp.value = pf ? '6tuh yxcv' : 'heafu';
+      inp.value = pf ? '6tuh yxcv' : (tx ? 'HEAFU' : 'heafu');
       out.textContent = inp.value;
       if(lab) lab.textContent = pf
         ? 'Selbst probieren – Pfeil- und Kompass-Tasten tippen (6 t u h · y x c v):'
+        : tx ? 'Selbst probieren – Grosstasten tippen (Umschalt = mit Text):'
         : 'Selbst probieren – Buchstaben tippen:';
+    }
+    function applyLayer(){
+      kbdLayer = mainLayer==='pfeile' ? 'pfeile' : (subText ? 'text' : 'base');
+      buildKbd(); syncTry();
     }
     document.querySelectorAll('.kbd-layer button').forEach(function(b){
       b.addEventListener('click',function(){
         document.querySelectorAll('.kbd-layer button').forEach(function(x){ x.setAttribute('aria-pressed','false'); });
-        b.setAttribute('aria-pressed','true'); kbdLayer=b.dataset.layer; buildKbd(); syncTry();
+        b.setAttribute('aria-pressed','true');
+        mainLayer = b.dataset.layer==='pfeile' ? 'pfeile' : 'pikto';
+        applyLayer();
+      });
+    });
+    document.querySelectorAll('.kbd-sub button').forEach(function(b){
+      b.addEventListener('click',function(){
+        document.querySelectorAll('.kbd-sub button').forEach(function(x){ x.setAttribute('aria-pressed','false'); });
+        b.setAttribute('aria-pressed','true');
+        subText = b.dataset.sub==='mit';
+        if(mainLayer==='pikto') applyLayer();
       });
     });
     document.querySelectorAll('.tabs button').forEach(function(b){


### PR DESCRIPTION
## Worum es geht

Zwei Unklarheiten der Icon-Tastatur (`icons.html`), nach dem Vorbild **echter
Tasten** gelöst: zwei Zeichen je Taste – unten tippen, oben mit **⇧**.

## 1 · Pfeile: Doppelbeschriftung (eine Tastatur, alles sichtbar)

- Die vier Richtungstasten (6 t u h) tragen den **dünnen Pfeil gross** und den
  **fetten Pfeil klein oben rechts mit ⇧**. Damit sind **alle 20 Pfeil-/Kompass-
  Zeichen auf einer Tastatur** sichtbar, und „⇧ = fett" erklärt sich selbst.
- Kein z7ij-Kreuz, keine vierte Tastatur – die echte Font-Belegung (Umschalt =
  fett) wird einfach sichtbar gemacht.

## 2 · Piktogramme „mit Text": eigene Ansicht + Katalog

Befund: die 22 „mit Text"-Glyphen lagen **im Font, aber unbenannt** in
`icons.json` (`icon-0041` …). Darum unsichtbar und, klein auf die Taste
gequetscht, wäre es Matsch.

- **Katalogisiert:** 22 Einträge benannt (`slug: <grund>-text`, `group:
  piktogramm-text`, `fontonly: true`, jeweils dem Grund-Piktogramm zugeordnet).
- **Zweite Ansicht:** neuer Unter-Umschalter **‹ohne Text / mit Text›** unter
  *Piktogramme* zeigt sie in **voller Grösse** (lesbar, kein Matsch). Nur unter
  Piktogramme sichtbar; bei den Pfeilen ausgeblendet.
- **Download-Raster** blendet `fontonly` aus – keine toten Einzeldatei-Links;
  die mit-Text-Varianten sind bewusst nur auf der Tastatur.
- **Tippfeld** folgt der Ebene: `heafu` / `HEAFU` / `6tuh yxcv`.

## Regel-Deckung

- **B03/DS03:** der ⇧-Hinweis sitzt auf dem `--t-micro`-Floor (14px), nichts
  darunter. Score 100 % (Hook grün).
- **G05:** Betonung/Hinweis per Laut/Farbe (Gold), keine Versal-Auszeichnung.

## Verifikation (Playwright)

- ohne Text: 25 belegte Tasten · mit Text: 22 (voll gross) · Pfeile: 16 belegt,
  4 fette ⇧-Ecken · Download-Raster ‹alle›: 45 Kacheln, **0** mit-Text (keine
  toten Links). Screenshots aller drei Zustände gesichtet.

## Folgeschritt

Beipackzettel-Seiten 3–5 ziehen im selben Stil nach (Doppelbeschriftung / mit-
Text-Ansicht), damit Web und PDF gleich sprechen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_