### PR TITLE
Karussell ohne Stations-Kicker & breit→schmal geordnet; Lesemodus ohne Sperr-Reflow

### DIFF
--- a/design-system/base.css
+++ b/design-system/base.css
@@ -300,7 +300,7 @@ img,svg,canvas,video{max-width:100%}
    Spacing. Titel/Kicker/Marke bleiben Goetheanum (Identität); die Chrome-Leiste
    pinnt ihre Schrift ohnehin selbst. Grösse ist über size-adjust (B4) geregelt,
    darum kein Grössensprung; A7 (min-height) fängt den ~7% breiteren Reflow. */
-:root[data-read="easy"] body{font-family:var(--font-text);letter-spacing:.03em;word-spacing:.06em}
+:root[data-read="easy"] body{font-family:var(--font-text)}
 :root[data-read="easy"] .lede{font-family:var(--font-text)}
 /* Titel, Kicker und die Kopfzeile bleiben ausdrücklich Goetheanum (Identität). */
 :root[data-read="easy"] h1,:root[data-read="easy"] h2,:root[data-read="easy"] h3,:root[data-read="easy"] h4,

--- a/index.html
+++ b/index.html
@@ -141,22 +141,23 @@
     "signatur","visitenkarten","powerpoint","typografie",
     "uebersetzungen","wallpaper","editor","design-system"];
   // Entdecker-Karussell: ausgewählte Werkzeuge, je ein Teaser.
-  // Alle öffentlichen Karten als Reihenfolge des Entdeckens: vom Fundament über die
-  // Identität und die Stimme zu den Alltagswerkzeugen und den fertigen Anwendungen.
-  // Der Kicker benennt die Station – gleiche Station = zusammengehörige Karten.
+  // Alle öffentlichen Karten – geordnet von der breitesten Zielgruppe zur kleinsten:
+  // erst die täglichen Werkzeuge für alle (Signatur, Wallpaper, Präsentation, Karte),
+  // dann Hausbild und Nachschlagewerke, zuletzt die Gestaltungs- und Bau-Ebene.
+  // Design-System steht bewusst am Ende (kleinste, spezialisierte Gruppe).
   var DISCOVER = [
-    {slug:"design-system",  kick:"Zuerst · das Fundament", line:"Farben, Schnitte und Regeln aus einer Quelle – hier nachschlagen, von hier aus bauen."},
-    {slug:"logo-generator", kick:"Die Identität",          line:"Das Logo für jede Sektion und jeden Bereich setzen und sauber exportieren."},
-    {slug:"sektionsfarben", kick:"Die Identität",          line:"Die Farben der Schul-Sektionen – Werte, Anwendung und wo Weiss darauf steht."},
-    {slug:"schriften",      kick:"Die Stimme",             line:"Die Hausschrift v2.7: fünf Schnitte von Leise bis Laut, Variable Font und Icon-Satz."},
-    {slug:"icons",          kick:"Die Stimme",             line:"45 Piktogramme, Pfeile und Kompass – als Webfont per Taste oder einzeln als SVG, PNG, PDF."},
-    {slug:"typografie",     kick:"Die Stimme",             line:"Die Satzregeln des Hauses – Auszeichnung, Ziffern, Striche, Anführungen; nachschlagen und prüfen."},
-    {slug:"editor",         kick:"Die Stimme",             line:"Text im Hausbild setzen – die Regeln greifen beim Tippen, fertig zum Übernehmen."},
-    {slug:"visitenkarten",  kick:"Für den Alltag",         line:"Die eigene Visitenkarte im Hausbild – ausfüllen, Vorschau, Druckdatei."},
-    {slug:"signatur",       kick:"Für den Alltag",         line:"Die Mail-Signatur im Hausbild – Angaben eintragen, Block kopieren, einsetzen."},
-    {slug:"uebersetzungen", kick:"Für den Alltag",         line:"Sektionen und Begriffe in vier Sprachen – für Karten, Briefe und die Sekretariate."},
-    {slug:"powerpoint",     kick:"Zum Mitnehmen",          line:"Präsentationsvorlage im Hausbild – mit eingebetteten Schriften, sofort loslegen."},
-    {slug:"wallpaper",      kick:"Zum Mitnehmen",          line:"Elf Goetheanum-Hintergründe für den Desktop, frei zum Herunterladen."}
+    {slug:"signatur",       line:"Die Mail-Signatur im Hausbild – Angaben eintragen, Block kopieren, einsetzen."},
+    {slug:"wallpaper",      line:"Elf Goetheanum-Hintergründe für den Desktop, frei zum Herunterladen."},
+    {slug:"powerpoint",     line:"Präsentationsvorlage im Hausbild – mit eingebetteten Schriften, sofort loslegen."},
+    {slug:"visitenkarten",  line:"Die eigene Visitenkarte im Hausbild – ausfüllen, Vorschau, Druckdatei."},
+    {slug:"logo-generator", line:"Das Logo für jede Sektion und jeden Bereich setzen und sauber exportieren."},
+    {slug:"schriften",      line:"Die Hausschrift v2.7: fünf Schnitte von Leise bis Laut, Variable Font und Icon-Satz."},
+    {slug:"uebersetzungen", line:"Sektionen und Begriffe in vier Sprachen – für Karten, Briefe und die Sekretariate."},
+    {slug:"icons",          line:"45 Piktogramme, Pfeile und Kompass – als Webfont per Taste oder einzeln als SVG, PNG, PDF."},
+    {slug:"sektionsfarben", line:"Die Farben der Schul-Sektionen – Werte, Anwendung und wo Weiss darauf steht."},
+    {slug:"typografie",     line:"Die Satzregeln des Hauses – Auszeichnung, Ziffern, Striche, Anführungen; nachschlagen und prüfen."},
+    {slug:"editor",         line:"Text im Hausbild setzen – die Regeln greifen beim Tippen, fertig zum Übernehmen."},
+    {slug:"design-system",  line:"Farben, Schnitte und Regeln aus einer Quelle – für Gestaltende, die neue Werkzeuge bauen."}
   ];
   // Greifbar: jedes Zeichen zeigt das DING, das das Werkzeug erzeugt.
   var VISUAL = {
@@ -199,8 +200,7 @@
       var a = document.createElement("a"); a.className = "slide"; a.href = x.t.href;
       if (isExt(x.t.href)) { a.target = "_blank"; a.rel = "noopener"; }
       a.innerHTML = visual(x.t) +
-        '<span class="copy">' + (x.d.kick ? '<span class="kick">' + x.d.kick + '</span>' : '') +
-        '<h2>' + x.t.title + '</h2><p>' + x.d.line + '</p>' +
+        '<span class="copy"><h2>' + x.t.title + '</h2><p>' + x.d.line + '</p>' +
         '<span class="go">Ansehen ›</span></span>';
       track.appendChild(a);
     });


### PR DESCRIPTION
## Karussell

- **Stations-Kicker entfernt** (‹Für den Alltag›, ‹Die Stimme› …) – zu viel.
- **Neue Ordnung: breite Zielgruppe → kleinste.** Design-System steht bewusst
  **am Ende** (kleinste, spezialisierte Gruppe), nicht am Anfang:

  Signatur · Wallpaper · PowerPoint · Visitenkarten · Logos · Schriften ·
  Übersetzungen · Icons · Sektionsfarben · Typografie · Editor · Design-System

## Lesemodus (Rückfrage: „springt die Aufteilung?")

Ja, der Umschalter löste einen sichtbaren Reflow aus. Ursache war **neben dem
Schriftwechsel** das zusätzliche `letter-spacing`/`word-spacing` am Textkörper –
das ist zugleich **Sperrung im Lesetext**, was die Hausregeln meiden.

- **Entfernt.** Der Sprung halbiert sich (Messung `uebersetzungen.html`:
  Titel-Versatz **60 → 33 px**, Seitenhöhe **+91 → +32 px**).
- Der Rest (~32 px) ist der **reine Schriftwechsel** (Source läuft etwas breiter,
  die Lede bricht eine Zeile mehr) – ohne Schriftwechsel gäbe es keinen Lesemodus.

Wenn Du **gar keinen** Sprung willst, wäre der nächste Schritt, die Leseschrift
nur auf echten Mengentext (`.prose`) statt global auf den Body zu legen – dann
reflowen UI-lastige Seiten nicht mehr. Sag Bescheid, ob das gewünscht ist.

## Regel-Deckung

- **G05/G23** keine Sperrung mehr im Lesetext.
- Score 100 % (Hook grün), Typo-Sync synchron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_