### PR TITLE
Sommer-Zähler: Entdopplung, Paperform, Aktionsseiten, Mixed-Content-Fix

### DIFF
--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -18,12 +18,14 @@
 <title>Sommer-Zähler 2026 · Goetheanum</title>
 <meta name="description" content="Aktions-Cockpit der Sommer-Aktion 2026 – neue Abos der Wochenschrift und von goetheanum.tv, live und motivierend." />
 <meta name="robots" content="noindex" />
-<link rel="icon" type="image/svg+xml" href="https://phtok.github.io/goeloggen/assets/logos/goetheanum-mark-blue.svg" />
+<link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
 
-<!-- Das Fundament – eine Quelle der Wahrheit. NICHT kopieren, EINBINDEN. -->
-<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/tokens.css" />
-<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/base.css" />
-<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/nav.css" />
+<!-- Das Fundament – eine Quelle der Wahrheit. NICHT kopieren, EINBINDEN.
+     Relativ (../../) wie die anderen Apps: die absolute phtok-URL leitet auf der
+     Domain per 301 auf http:// um und wird als Mixed Content blockiert. -->
+<link rel="stylesheet" href="../../design-system/tokens.css" />
+<link rel="stylesheet" href="../../design-system/base.css" />
+<link rel="stylesheet" href="../../design-system/nav.css" />
 
 <style>
   /* Nur cockpit-eigene Gestalt. Alles Gemeinsame kommt aus base.css.
@@ -141,8 +143,8 @@
 <body>
 
 <!-- Globale Navigation: Kopfzeile + Menü aus tools.json, mit «← Übersicht». -->
-<script src="https://phtok.github.io/goeloggen/design-system/nav.js"
-        data-root="https://phtok.github.io/goeloggen/"
+<script src="../../design-system/nav.js"
+        data-root="../../"
         data-variant="werkzeug"></script>
 
 <main class="wrap">
@@ -262,7 +264,7 @@
     </div>
     <div class="frow">
       <span><strong>Sommer-Zähler 2026</strong> · live aus dem Werkzeug-Backend · nur Summen, keine Personendaten</span>
-      <span><a href="https://phtok.github.io/goeloggen/design-system/">Design-System</a></span>
+      <span><a href="../../design-system/">Design-System</a></span>
     </div>
   </div>
 </footer>

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -117,6 +117,8 @@
   .provisorisch{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);margin-top:var(--s4);line-height:1.55}
   .empty{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small)}
   .err{font-family:var(--font-text);color:var(--bad);font-size:var(--t-small)}
+  .landing{display:flex;flex-wrap:wrap;gap:var(--s2) var(--s5);align-items:baseline;font-family:var(--font-text);font-size:var(--t-small);margin-bottom:var(--s4)}
+  .landing a{color:var(--blue)}
 
   @media (max-width:720px){
     .tiles{grid-template-columns:1fr} .board{grid-template-columns:1fr} .stay{grid-template-columns:1fr}
@@ -251,9 +253,17 @@
 </main>
 
 <footer class="ds-footer">
-  <div class="wrap frow">
-    <span><strong>Sommer-Zähler 2026</strong> · live aus dem Werkzeug-Backend · nur Summen, keine Personendaten</span>
-    <span><a href="https://phtok.github.io/goeloggen/design-system/">Design-System</a></span>
+  <div class="wrap" style="display:flex;flex-direction:column;gap:var(--s2)">
+    <div class="landing">
+      <span class="meta">Aktionsseiten</span>
+      <a href="https://global-sommer2026.goetheanum.online" target="_blank" rel="noopener">Übersicht · 3 Monate gratis</a>
+      <a href="https://ws-sommer2026.dasgoetheanum.com" target="_blank" rel="noopener">Wochenschrift</a>
+      <a href="https://tv-sommer2026.goetheanum.tv" target="_blank" rel="noopener">goetheanum.tv</a>
+    </div>
+    <div class="frow">
+      <span><strong>Sommer-Zähler 2026</strong> · live aus dem Werkzeug-Backend · nur Summen, keine Personendaten</span>
+      <span><a href="https://phtok.github.io/goeloggen/design-system/">Design-System</a></span>
+    </div>
   </div>
 </footer>
 

--- a/services/sommer-zaehler/README.md
+++ b/services/sommer-zaehler/README.md
@@ -72,12 +72,34 @@ verfeinern.
   (Secret liegt in `sommer2026_config`, nicht im Code/Repo).
 - **In Uscreen:** Settings → Webhooks → obige URL; Events *subscription
   created / canceled* (und *payment/charge* für die Umwandlung `bleibt`).
-- **Attribution:** Settings → User fields → verstecktes Feld `utm_source` am
-  Checkout; die Function mappt es auf `kanal`.
-- **Aktions-Filter (offen):** Damit nur die Sommer-Aktion zählt (nicht das
-  ganze GTV-Geschäft), filtert die Function auf den **Aktions-Plan/-Coupon**.
-  Sobald Plan-Titel bzw. Coupon-Code der «3 Monate gratis»-Aktion bekannt sind,
-  werden sie in der Function hinterlegt.
+- **Attribution:** Settings → Custom user fields → «Wie sind Sie auf uns
+  aufmerksam geworden?»; die Function mappt die Antwort auf `kanal`.
+- **Aktions-Isolierung:** «3 Monate gratis» = Neuzuweisung ohne Sofortzahlung
+  (`transaction_id` leer) → `neu`. Vollzahler-Neukäufe und Verlängerungen
+  (Normalgeschäft) zählen nicht. Zahlung → `bleibt`, Kündigung → `gekuendigt`.
+  Schärfer stellbar über `sommer2026_config.aktion_coupon` / `aktion_plan`.
+- **Scharf/Log:** zählt nur wenn `sommer2026_config.aktion_aktiv = 'true'`,
+  sonst reiner Log-Modus.
+
+## Paperform-Webhook (Wochenschrift, aktiv)
+
+Edge Function [`ingest-paperform/index.ts`](./ingest-paperform/index.ts) nimmt die
+Formular-Einreichungen entgegen (Paperform → After submission → Webhook, **kein
+API-Key nötig**). Das Formular ist die Aktion – jede Einreichung zählt als `neu`
+(`produkt='wos'`). Sprache/Format je Formular über die URL:
+`…/ingest-paperform?key=<secret>&sprache=de` (bzw. `&sprache=en`, optional
+`&format=papier|digital`); Tarif/Intervall werden aus den Feldern erraten und am
+ersten echten Payload verfeinert (Roh-Log).
+
+## Entdopplung (Dupletten filtern)
+
+Strikt über `dedup_key`:
+- Innerhalb einer Quelle: eine Zeile je Abonnent (mehrere Events derselben
+  Person – Anmeldung, Zahlung, Verlängerung, Kündigung – aktualisieren dieselbe
+  Zeile, statt neue anzulegen).
+- Über Quellen hinweg (Paperform **und** Zoho für dieselbe WoS-Person):
+  `dedup_key = <produkt>:<gesalzener E-Mail-Hash>` – E-Mail wird **nur gehasht**
+  gespeichert (Salt in `sommer2026_config.hash_salt`), nie im Klartext.
 
 ## Fest im Cockpit hinterlegt (bis echte Werte vorliegen)
 

--- a/services/sommer-zaehler/ingest-paperform/index.ts
+++ b/services/sommer-zaehler/ingest-paperform/index.ts
@@ -1,0 +1,103 @@
+// =============================================================================
+// ingest-paperform · Supabase Edge Function
+// Nimmt Paperform-Webhooks der Wochenschrift-Aktion entgegen und schreibt jede
+// Einreichung als Aktions-Anmeldung nach public.sommer2026_signups (produkt='wos').
+// Das Formular IST die Aktion – jede Einreichung zählt als 'neu'.
+//
+// Sprache/Format pro Formular über die URL steuerbar:
+//   …/ingest-paperform?key=<secret>&sprache=de&format=papier
+// Tarif/Intervall werden aus den Feldern erraten; jeder Payload wird
+// PII-redigiert (E-Mail/Name/Adresse) in sommer2026_ingest_raw geloggt, um das
+// Mapping am ersten echten Formular zu verfeinern.
+//
+// Entdopplung: dedup_key = wos:<gesalzener E-Mail-Hash> (Person je Produkt, auch
+// über Paperform UND Zoho hinweg), Fallback paperform:<submission_id>.
+//
+// Scharf nur wenn sommer2026_config.aktion_aktiv = 'true'. Auth: ?key=<secret>.
+// =============================================================================
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+const SB = Deno.env.get("SUPABASE_URL")!;
+const KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const H = { "Content-Type": "application/json", apikey: KEY, Authorization: `Bearer ${KEY}` };
+const EMAIL_RE = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i;
+
+async function sha256Hex(s: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(s));
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// PII entfernen: nach Schlüsselname UND E-Mail-artige Werte.
+function redact(o: any): any {
+  if (typeof o === "string") return EMAIL_RE.test(o) ? "***" : o;
+  if (Array.isArray(o)) return o.map(redact);
+  if (o && typeof o === "object") {
+    const r: any = {};
+    for (const k of Object.keys(o)) r[k] = /(email|name|phone|address|\bip\b|vorname|nachname|strasse)/i.test(k) ? "***" : redact(o[k]);
+    return r;
+  }
+  return o;
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") return new Response("ok", { status: 200 });
+
+  const u = new URL(req.url);
+  const key = u.searchParams.get("key") || req.headers.get("x-webhook-key") || "";
+  const cfgRows = await fetch(`${SB}/rest/v1/sommer2026_config?key=in.(webhook_secret,hash_salt,aktion_aktiv)&select=key,value`, { headers: H })
+    .then((r) => r.json()).catch(() => []);
+  const cfg: Record<string, string> = {};
+  if (Array.isArray(cfgRows)) for (const r of cfgRows) cfg[r.key] = r.value;
+  const secret = cfg["webhook_secret"] || null;
+  if (!secret || key !== secret) return new Response("unauthorized", { status: 401 });
+
+  let body: any = {};
+  try { body = await req.json(); } catch { /* leer */ }
+
+  await fetch(`${SB}/rest/v1/sommer2026_ingest_raw`, {
+    method: "POST", headers: { ...H, Prefer: "return=minimal" },
+    body: JSON.stringify({ source: "paperform", event: "submission", ok: true, note: "empfangen", payload: redact(body) }),
+  }).catch(() => {});
+
+  if ((cfg["aktion_aktiv"] || "").toLowerCase() !== "true") return json({ ok: true, mode: "log" });
+
+  const blob = JSON.stringify(body).toLowerCase();
+
+  // Sprache/Format: URL-Vorgabe je Formular hat Vorrang, sonst aus Inhalt geraten.
+  const sprache = (u.searchParams.get("sprache") || (/english|englisch/.test(blob) ? "en" : "de")).toLowerCase() === "en" ? "en" : "de";
+  const formatQ = (u.searchParams.get("format") || "").toLowerCase();
+  const format = formatQ === "papier" || formatQ === "digital" ? formatQ
+    : /digital|online|e-?paper|\bpdf\b/.test(blob) ? "digital"
+    : /papier|print|gedruckt|\bpaper\b|frei haus/.test(blob) ? "papier" : "papier";
+  const tarif = /erm(ä|ae)ss|reduc|student|reduziert/.test(blob) ? "ermaessigt" : "standard";
+  const intervall = /(monat|month|mensuel)/.test(blob) ? "monatlich" : /(jähr|jahr|year|annual)/.test(blob) ? "jaehrlich" : "jaehrlich";
+
+  // E-Mail für Entdopplung (aus rohem Body, vor Redaktion).
+  const emailMatch = JSON.stringify(body).match(EMAIL_RE);
+  const email = emailMatch ? emailMatch[0].toLowerCase() : "";
+  const salt = cfg["hash_salt"] || "";
+  const subId = body?.submission_id || body?.id || body?.data?.submission_id || "";
+  const dedupKey = email ? `wos:${await sha256Hex(salt + email)}` : `paperform:${subId || (await sha256Hex(blob)).slice(0, 24)}`;
+
+  const row = {
+    signed_up_at: new Date().toISOString(), produkt: "wos", sprache, format,
+    tarif, intervall, status: "neu", kanal: "andere", source: "paperform", ext_id: String(subId || ""), dedup_key: dedupKey,
+  };
+  const res = await fetch(`${SB}/rest/v1/sommer2026_signups?on_conflict=dedup_key`, {
+    method: "POST",
+    headers: { ...H, Prefer: "resolution=merge-duplicates,return=minimal" },
+    body: JSON.stringify(row),
+  });
+  if (!res.ok) {
+    await fetch(`${SB}/rest/v1/sommer2026_ingest_raw`, {
+      method: "POST", headers: { ...H, Prefer: "return=minimal" },
+      body: JSON.stringify({ source: "paperform", event: "submission", ok: false, note: `upsert ${res.status}`, payload: redact(body) }),
+    }).catch(() => {});
+    return json({ ok: false }, 200);
+  }
+  return json({ ok: true, produkt: "wos", sprache, format, tarif, intervall });
+});

--- a/services/sommer-zaehler/ingest-uscreen/index.ts
+++ b/services/sommer-zaehler/ingest-uscreen/index.ts
@@ -1,11 +1,19 @@
 // =============================================================================
 // ingest-uscreen · Supabase Edge Function
-// Nimmt Uscreen-Webhooks (goetheanum.tv) entgegen und schreibt sie in
-// public.sommer2026_signups. Loggt jeden Payload PII-redigiert in
-// public.sommer2026_ingest_raw (nur Service-Role liest ihn) – so lässt sich das
-// Mapping am ersten echten Event verfeinern.
+// Nimmt Uscreen-Webhooks (goetheanum.tv) entgegen und schreibt die Sommer-Aktion
+// nach public.sommer2026_signups. Jeder Payload wird PII-redigiert in
+// public.sommer2026_ingest_raw geloggt (nur Service-Role liest ihn).
 //
-// Auth: ?key=<webhook_secret> (liegt in public.sommer2026_config). Kein JWT.
+// Aktions-Isolierung: «3 Monate gratis» = Neuzuweisung OHNE Sofortzahlung
+// (transaction_id leer) → status 'neu'. Vollzahler-Neukäufe und Verlängerungen
+// (Normalgeschäft) werden NICHT gezählt. Zahlung eines Aktions-Users → 'bleibt',
+// Kündigung → 'gekuendigt'. Optional schärfer via aktion_coupon / aktion_plan.
+//
+// Entdopplung: dedup_key = <produkt>:<gesalzener E-Mail-Hash> (Person je Produkt,
+// auch über Quellen hinweg), Fallback <source>:<ext_id>. Upsert/Update laufen
+// über dedup_key – dieselbe Person zählt nie doppelt, auch bei mehreren Events.
+//
+// Scharf nur wenn sommer2026_config.aktion_aktiv = 'true'. Auth: ?key=<secret>.
 // =============================================================================
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 
@@ -21,7 +29,6 @@ function pick(o: any, keys: string[]): any {
   return undefined;
 }
 
-// PII (E-Mail, Name, Telefon, Adresse, IP) vor dem Loggen entfernen.
 function redact(o: any): any {
   if (Array.isArray(o)) return o.map(redact);
   if (o && typeof o === "object") {
@@ -30,6 +37,11 @@ function redact(o: any): any {
     return r;
   }
   return o;
+}
+
+async function sha256Hex(s: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(s));
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
 function mapPlan(title: string) {
@@ -63,74 +75,88 @@ async function log(event: string, ok: boolean, note: string, payload: unknown) {
   }).catch(() => {});
 }
 
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+async function patchStatus(dedupKey: string, status: string) {
+  await fetch(`${SB}/rest/v1/sommer2026_signups?dedup_key=eq.${encodeURIComponent(dedupKey)}`, {
+    method: "PATCH",
+    headers: { ...H, Prefer: "return=minimal" },
+    body: JSON.stringify({ status }),
+  }).catch(() => {});
+}
+
 Deno.serve(async (req) => {
   if (req.method !== "POST") return new Response("ok", { status: 200 });
 
-  // Secret prüfen (Query ?key= oder Header x-webhook-key)
   const u = new URL(req.url);
   const key = u.searchParams.get("key") || req.headers.get("x-webhook-key") || "";
-  const cfgRows = await fetch(`${SB}/rest/v1/sommer2026_config?key=in.(webhook_secret,aktion_coupon,aktion_plan)&select=key,value`, { headers: H })
+  const cfgRows = await fetch(`${SB}/rest/v1/sommer2026_config?key=in.(webhook_secret,hash_salt,aktion_aktiv,aktion_coupon,aktion_plan)&select=key,value`, { headers: H })
     .then((r) => r.json()).catch(() => []);
   const cfg: Record<string, string> = {};
   if (Array.isArray(cfgRows)) for (const r of cfgRows) cfg[r.key] = r.value;
   const secret = cfg["webhook_secret"] || null;
   if (!secret || key !== secret) return new Response("unauthorized", { status: 401 });
-  // Aktions-Filter: nur zählen, was zur Sommer-Aktion gehört. Solange weder
-  // aktion_coupon noch aktion_plan gesetzt ist, läuft die Function im Log-Modus.
+
+  const armed = (cfg["aktion_aktiv"] || "").toLowerCase() === "true";
+  const salt = cfg["hash_salt"] || "";
   const aktionCoupon = (cfg["aktion_coupon"] || "").toLowerCase();
   const aktionPlan = (cfg["aktion_plan"] || "").toLowerCase();
-  const filterConfigured = !!(aktionCoupon || aktionPlan);
 
   let body: any = {};
-  try { body = await req.json(); } catch { /* leerer Body */ }
+  try { body = await req.json(); } catch { /* leer */ }
 
   const event = (pick(body, ["event", "type", "event_type"]) || "").toString();
   const data = body.data && typeof body.data === "object" ? body.data : body;
   await log(event, true, "empfangen", body);
 
-  const ext = pick(data, ["subscription_id", "subscription.id", "transaction_id", "id", "user_id", "user.id"]);
-  if (ext === undefined) {
-    return new Response(JSON.stringify({ ok: true, skipped: "kein subscription_id" }),
-      { status: 200, headers: { "Content-Type": "application/json" } });
-  }
+  if (!armed) return json({ ok: true, mode: "log" });
 
-  const title = (pick(data, ["subscription_title", "plan_title", "plan_name", "subscription.title", "product_title"]) || "").toString();
+  const ext = String(pick(data, ["user_id", "user.id", "subscription_id", "transaction_id", "id"]) ?? "");
+  if (!ext) return json({ ok: true, skipped: "kein user_id" });
 
-  // Log-Modus: ohne Aktions-Filter wird geloggt, aber nichts gezählt.
-  if (!filterConfigured) {
-    return new Response(JSON.stringify({ ok: true, mode: "log" }),
-      { status: 200, headers: { "Content-Type": "application/json" } });
-  }
+  // Entdopplung: Person je Produkt über gesalzenen E-Mail-Hash (Fallback ext_id).
+  const email = (pick(data, ["customer_email", "user_email", "email"]) || "").toString().toLowerCase();
+  const person = email ? await sha256Hex(salt + email) : "";
+  const dedupKey = person ? `gtv:${person}` : `uscreen:${ext}`;
+
+  const title = (pick(data, ["subscription_title", "plan_title", "plan_name", "subscription.title", "product_title", "offer_title", "title"]) || "").toString();
+  const e = event.toLowerCase();
+  const isNew = /(assign|subscribed|created|trial|start)/.test(e);
+  const isPay = /(order_paid|paid|recurring|renew|charge|payment|convert)/.test(e);
+  const isCancel = /(cancel|refund|expire|churn|delet)/.test(e);
+
+  if (isCancel) { await patchStatus(dedupKey, "gekuendigt"); return json({ ok: true, status: "gekuendigt" }); }
+  if (isPay && !isNew) { await patchStatus(dedupKey, "bleibt"); return json({ ok: true, status: "bleibt" }); }
+
+  if (!isNew) return json({ ok: true, skipped: "event ignoriert" });
+
+  const txn = pick(data, ["transaction_id"]);
+  const istTrial = txn === undefined || txn === null || txn === "";
   const coupon = (pick(data, ["coupon_code", "coupon", "discount_code", "code"]) || "").toString().toLowerCase();
-  const matchesAktion = (aktionCoupon && coupon.includes(aktionCoupon)) || (aktionPlan && title.toLowerCase().includes(aktionPlan));
-  if (!matchesAktion) {
-    return new Response(JSON.stringify({ ok: true, skipped: "nicht Aktion" }),
-      { status: 200, headers: { "Content-Type": "application/json" } });
-  }
+  let istAktion: boolean;
+  if (aktionCoupon) istAktion = coupon.includes(aktionCoupon);
+  else if (aktionPlan) istAktion = title.toLowerCase().includes(aktionPlan);
+  else istAktion = istTrial;
+  if (!istAktion) return json({ ok: true, skipped: "Normalgeschäft (kein Gratis-Trial)" });
 
   const { sprache, intervall, tarif } = mapPlan(title);
   const kanal = mapKanal(pick(data, ["utm_source", "source", "custom_fields.utm_source", "referral_source", "user_fields.0.value", "user_field_1"]));
   const when = pick(data, ["created_at", "subscribed_at", "started_at", "date"]) || new Date().toISOString();
 
-  const e = event.toLowerCase();
-  let status = "neu";
-  if (/(cancel|refund|expire|churn|delet)/.test(e)) status = "gekuendigt";       // verlässt vor/bei Umwandlung
-  else if (/(renew|payment|charge|paid|convert)/.test(e)) status = "bleibt";     // erste Abbuchung = umgewandelt
-
   const row = {
     signed_up_at: when, produkt: "gtv", sprache, format: "stream",
-    tarif, intervall, status, kanal, source: "uscreen", ext_id: String(ext),
+    tarif, intervall, status: "neu", kanal, source: "uscreen", ext_id: ext, dedup_key: dedupKey,
   };
-
-  const res = await fetch(`${SB}/rest/v1/sommer2026_signups?on_conflict=source,ext_id`, {
+  const res = await fetch(`${SB}/rest/v1/sommer2026_signups?on_conflict=dedup_key`, {
     method: "POST",
     headers: { ...H, Prefer: "resolution=merge-duplicates,return=minimal" },
     body: JSON.stringify(row),
   });
   if (!res.ok) {
     await log(event, false, `upsert ${res.status} ${(await res.text()).slice(0, 300)}`, row);
-    return new Response(JSON.stringify({ ok: false }), { status: 200, headers: { "Content-Type": "application/json" } });
+    return json({ ok: false }, 200);
   }
-  return new Response(JSON.stringify({ ok: true, status, sprache, tarif, intervall, kanal }),
-    { status: 200, headers: { "Content-Type": "application/json" } });
+  return json({ ok: true, status: "neu", sprache, tarif, intervall, kanal });
 });

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -19,11 +19,13 @@ create table if not exists public.sommer2026_signups (
   tarif         text not null check (tarif   in ('standard','ermaessigt')),
   intervall     text not null check (intervall in ('monatlich','jaehrlich')),
   status        text not null default 'neu'    check (status in ('neu','bleibt','gekuendigt','laeuft-aus')),
-  kanal         text not null default 'andere' check (kanal in ('newsletter','mailer','social','popup','website','empfehlung','andere')),  -- Herkunftsweg (Attribution), aus UTM
+  kanal         text not null default 'andere' check (kanal in ('newsletter','mailer','social','popup','website','empfehlung','andere')),  -- Herkunftsweg (Attribution)
   source        text not null default 'manual' check (source in ('uscreen','zoho','paperform','manual')),
-  ext_id        text,                                 -- Dedup-Schlüssel je Quelle (verhindert Doppelzählung)
-  unique (source, ext_id)
+  ext_id        text,                                 -- Fremd-ID der Quelle (z. B. user_id/submission_id)
+  dedup_key     text                                  -- Entdopplung: <produkt>:<E-Mail-Hash> bzw. <source>:<ext_id>
 );
+-- Entdopplung strikt über dedup_key (Person je Produkt, auch über Quellen hinweg)
+create unique index if not exists sommer2026_signups_dedup_uk on public.sommer2026_signups (dedup_key);
 
 comment on table public.sommer2026_signups is
   'Sommer-Aktion 2026: eine Zeile je Anmeldung im Gratis-Zeitraum. status = Bleibe-Zustand nach 3 Monaten. Nur Aggregate verlassen die DB (RPCs).';
@@ -107,4 +109,9 @@ create table if not exists public.sommer2026_config (
 );
 alter table public.sommer2026_config enable row level security;
 revoke all on table public.sommer2026_config from anon, authenticated;
--- insert into public.sommer2026_config(key,value) values ('webhook_secret','<zufälliger-wert>');
+-- Schlüssel in sommer2026_config:
+--   webhook_secret : Secret für ?key= der Ingestion-Functions
+--   hash_salt      : Salt für den E-Mail-Hash (Entdopplung)
+--   aktion_aktiv   : 'true' = zählen, sonst nur loggen
+--   aktion_coupon  : optional – Aktions-Coupon-Code (statt Trial-Heuristik)
+--   aktion_plan    : optional – Aktions-Plan-Titel (statt Trial-Heuristik)


### PR DESCRIPTION
## Worum es geht

Folgeausbau des Sommer-Zählers: robuste **Entdopplung**, **Paperform**-Anbindung (Wochenschrift), **Aktionsseiten** im Footer — und ein wichtiger **Darstellungs-Fix** für die Live-Domain.

## Änderungen

- **Mixed-Content-Fix (kritisch):** Design-System jetzt **relativ** eingebunden (`../../design-system/…`, `data-root="../../"`) wie die anderen Apps. Die absolute `phtok.github.io`-URL leitet auf `werkzeuge.goetheanum.ch` per **301 auf `http://`** um → Browser blockierte das CSS als Mixed Content → Seite lud **ungestylt**. Behoben.
- **Entdopplung (`dedup_key`):** eine Zeile je Person **und** Produkt, quellenübergreifend, über einen **gesalzenen E-Mail-Hash** (E-Mail nie im Klartext). Mehrere Events derselben Person aktualisieren dieselbe Zeile.
- **`ingest-uscreen` (v5):** Aktions-Isolierung — nur Gratis-Trials (Neuanmeldung ohne Sofortzahlung) zählen; Normalgeschäft (Vollzahler/Verlängerungen) nicht. Zahlung → `bleibt`, Kündigung → `gekuendigt`. Scharf nur bei `aktion_aktiv='true'`.
- **`ingest-paperform` (neu):** Edge Function für die Wochenschrift-Formulare (`produkt=wos`, Sprache/Format je Formular per URL), gleiche Entdopplung.
- **`schema.sql`:** `dedup_key` + Unique-Index, `sommer2026_config`-Schlüssel dokumentiert.
- **Cockpit:** Liste der drei **Aktionsseiten** offen im Footer.

## Geprüft

Live getestet: Dupletten kollabieren zu einer Zeile (case-insensitive), Normalkäufe übersprungen, Status-Übergänge korrekt, 401 bei falschem Secret. ds-lint 100 %, typo-check konform. Ursache der ungestylten Seite reproduziert (301→http) und behoben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_