### PR TITLE
Sommer-Zähler: Aktionsstart als harte Zeitgrenze (3. Juli)

### DIFF
--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -275,7 +275,7 @@
      Bleibe-Quote werden hier gesetzt – sobald die echten Werte vorliegen, nur
      diese Werte anpassen. */
   var CONFIG = {
-    start: '2026-06-24',            // Aktionsstart (für den Fortschritts-Balken)
+    start: '2026-07-03',            // Aktionsstart (Nachmittag 3. Juli 2026)
     ende:  '2026-08-08',            // Aktionsende
     bleibeQuote: 0.62,             // Annahme, bis Erfahrungswerte vorliegen
     meilensteine: [100, 250, 500, 1000],

--- a/services/sommer-zaehler/ingest-uscreen/index.ts
+++ b/services/sommer-zaehler/ingest-uscreen/index.ts
@@ -92,7 +92,7 @@ Deno.serve(async (req) => {
 
   const u = new URL(req.url);
   const key = u.searchParams.get("key") || req.headers.get("x-webhook-key") || "";
-  const cfgRows = await fetch(`${SB}/rest/v1/sommer2026_config?key=in.(webhook_secret,hash_salt,aktion_aktiv,aktion_coupon,aktion_plan)&select=key,value`, { headers: H })
+  const cfgRows = await fetch(`${SB}/rest/v1/sommer2026_config?key=in.(webhook_secret,hash_salt,aktion_aktiv,aktion_start,aktion_coupon,aktion_plan)&select=key,value`, { headers: H })
     .then((r) => r.json()).catch(() => []);
   const cfg: Record<string, string> = {};
   if (Array.isArray(cfgRows)) for (const r of cfgRows) cfg[r.key] = r.value;
@@ -101,6 +101,7 @@ Deno.serve(async (req) => {
 
   const armed = (cfg["aktion_aktiv"] || "").toLowerCase() === "true";
   const salt = cfg["hash_salt"] || "";
+  const aktionStart = cfg["aktion_start"] || "";
   const aktionCoupon = (cfg["aktion_coupon"] || "").toLowerCase();
   const aktionPlan = (cfg["aktion_plan"] || "").toLowerCase();
 
@@ -144,6 +145,11 @@ Deno.serve(async (req) => {
   const { sprache, intervall, tarif } = mapPlan(title);
   const kanal = mapKanal(pick(data, ["utm_source", "source", "custom_fields.utm_source", "referral_source", "user_fields.0.value", "user_field_1"]));
   const when = pick(data, ["created_at", "subscribed_at", "started_at", "date"]) || new Date().toISOString();
+
+  // Aktions-Grenze: Anmeldungen vor dem Start (Nachmittag 3. Juli) zählen nicht.
+  if (aktionStart && !isNaN(Date.parse(when)) && new Date(when) < new Date(aktionStart)) {
+    return json({ ok: true, skipped: "vor Aktionsstart" });
+  }
 
   const row = {
     signed_up_at: when, produkt: "gtv", sprache, format: "stream",

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -113,5 +113,7 @@ revoke all on table public.sommer2026_config from anon, authenticated;
 --   webhook_secret : Secret für ?key= der Ingestion-Functions
 --   hash_salt      : Salt für den E-Mail-Hash (Entdopplung)
 --   aktion_aktiv   : 'true' = zählen, sonst nur loggen
+--   aktion_start   : Zeitgrenze (Anmeldungen davor zählen nicht), z. B.
+--                    '2026-07-03T12:00:00+02:00'
 --   aktion_coupon  : optional – Aktions-Coupon-Code (statt Trial-Heuristik)
 --   aktion_plan    : optional – Aktions-Plan-Titel (statt Trial-Heuristik)


### PR DESCRIPTION
## Worum es geht

Die Sommer-Aktion startete am **Nachmittag des 3. Juli 2026** — alles davor gehört nicht dazu. Das wird jetzt als harte Zeitgrenze verankert.

## Änderungen

- **`sommer2026_config.aktion_start`** (`2026-07-03T12:00:00+02:00`): `ingest-uscreen` überspringt Neuanmeldungen **vor** diesem Zeitpunkt. Wichtig für einen späteren historischen Nachtrag aus Uscreen — Normalgeschäft vor Aktionsstart bleibt aussen vor.
- **Cockpit:** Fortschritts-Balken/Start ab 3. Juli.
- **`schema.sql`:** Config-Schlüssel `aktion_start` dokumentiert.

## Geprüft

Live getestet: Event vom 2. Juli → **übersprungen** («vor Aktionsstart»), 3. Juli abends → **gezählt**. ds-lint 100 %, typo-check konform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_