### PR TITLE
Sommer-Zähler: Währung (EUR/CHF) für die vier Paperform-Formulare

### DIFF
--- a/services/sommer-zaehler/README.md
+++ b/services/sommer-zaehler/README.md
@@ -86,10 +86,11 @@ verfeinern.
 Edge Function [`ingest-paperform/index.ts`](./ingest-paperform/index.ts) nimmt die
 Formular-Einreichungen entgegen (Paperform → After submission → Webhook, **kein
 API-Key nötig**). Das Formular ist die Aktion – jede Einreichung zählt als `neu`
-(`produkt='wos'`). Sprache/Format je Formular über die URL:
-`…/ingest-paperform?key=<secret>&sprache=de` (bzw. `&sprache=en`, optional
-`&format=papier|digital`); Tarif/Intervall werden aus den Feldern erraten und am
-ersten echten Payload verfeinert (Roh-Log).
+(`produkt='wos'`). Es gibt **vier Formulare** (Währung EUR/CHF × Sprache DE/EN);
+Sprache, Währung und Format je Formular über die URL:
+`…/ingest-paperform?key=<secret>&sprache=de&waehrung=eur` (bzw. `&sprache=en`,
+`&waehrung=chf`, optional `&format=papier|digital`). Tarif/Intervall werden aus
+den Feldern erraten und am ersten echten Payload verfeinert (Roh-Log).
 
 ## Entdopplung (Dupletten filtern)
 

--- a/services/sommer-zaehler/ingest-paperform/index.ts
+++ b/services/sommer-zaehler/ingest-paperform/index.ts
@@ -75,6 +75,8 @@ Deno.serve(async (req) => {
     : /papier|print|gedruckt|\bpaper\b|frei haus/.test(blob) ? "papier" : "papier";
   const tarif = /erm(ä|ae)ss|reduc|student|reduziert/.test(blob) ? "ermaessigt" : "standard";
   const intervall = /(monat|month|mensuel)/.test(blob) ? "monatlich" : /(jähr|jahr|year|annual)/.test(blob) ? "jaehrlich" : "jaehrlich";
+  const waehrungQ = (u.searchParams.get("waehrung") || "").toLowerCase();
+  const waehrung = waehrungQ === "eur" || waehrungQ === "chf" ? waehrungQ : (/\bchf\b|fr\.?\b/.test(blob) ? "chf" : /\beur\b|€/.test(blob) ? "eur" : null);
 
   // E-Mail für Entdopplung (aus rohem Body, vor Redaktion).
   const emailMatch = JSON.stringify(body).match(EMAIL_RE);
@@ -85,7 +87,7 @@ Deno.serve(async (req) => {
 
   const row = {
     signed_up_at: new Date().toISOString(), produkt: "wos", sprache, format,
-    tarif, intervall, status: "neu", kanal: "andere", source: "paperform", ext_id: String(subId || ""), dedup_key: dedupKey,
+    tarif, intervall, waehrung, status: "neu", kanal: "andere", source: "paperform", ext_id: String(subId || ""), dedup_key: dedupKey,
   };
   const res = await fetch(`${SB}/rest/v1/sommer2026_signups?on_conflict=dedup_key`, {
     method: "POST",
@@ -99,5 +101,5 @@ Deno.serve(async (req) => {
     }).catch(() => {});
     return json({ ok: false }, 200);
   }
-  return json({ ok: true, produkt: "wos", sprache, format, tarif, intervall });
+  return json({ ok: true, produkt: "wos", sprache, format, tarif, intervall, waehrung });
 });

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -18,6 +18,7 @@ create table if not exists public.sommer2026_signups (
   format        text not null check (format  in ('papier','digital','stream')),   -- WoS: papier/digital · GTV: stream
   tarif         text not null check (tarif   in ('standard','ermaessigt')),
   intervall     text not null check (intervall in ('monatlich','jaehrlich')),
+  waehrung      text check (waehrung in ('eur','chf')),  -- Zahlungswährung (für Umsatz)
   status        text not null default 'neu'    check (status in ('neu','bleibt','gekuendigt','laeuft-aus')),
   kanal         text not null default 'andere' check (kanal in ('newsletter','mailer','social','popup','website','empfehlung','andere')),  -- Herkunftsweg (Attribution)
   source        text not null default 'manual' check (source in ('uscreen','zoho','paperform','manual')),


### PR DESCRIPTION
## Worum es geht

Es gibt vier Paperform-Formulare (Währung EUR/CHF × Sprache DE/EN). Die Währung wird jetzt mitgeführt (für den Umsatz).

## Änderungen

- **`sommer2026_signups.waehrung`** (`eur`/`chf`).
- **`ingest-paperform`:** Währung je Formular über die URL (`&waehrung=eur|chf`), sonst aus dem Inhalt erraten. Sprache/Format wie gehabt per URL.
- **`schema.sql` + README** ergänzt (vier Formulare, Währungs-Parameter).

## Geprüft

Live getestet: `CHF·DE` → de/digital/chf, `EUR·EN` → en/digital/eur. Dedup unverändert (E-Mail-Hash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_