### PR TITLE
Sommer-Zähler: Uscreen-Zählung korrigiert (Trials haben Kreditkarte)

### DIFF
--- a/services/sommer-zaehler/README.md
+++ b/services/sommer-zaehler/README.md
@@ -74,10 +74,12 @@ verfeinern.
   created / canceled* (und *payment/charge* für die Umwandlung `bleibt`).
 - **Attribution:** Settings → Custom user fields → «Wie sind Sie auf uns
   aufmerksam geworden?»; die Function mappt die Antwort auf `kanal`.
-- **Aktions-Isolierung:** «3 Monate gratis» = Neuzuweisung ohne Sofortzahlung
-  (`transaction_id` leer) → `neu`. Vollzahler-Neukäufe und Verlängerungen
-  (Normalgeschäft) zählen nicht. Zahlung → `bleibt`, Kündigung → `gekuendigt`.
-  Schärfer stellbar über `sommer2026_config.aktion_coupon` / `aktion_plan`.
+- **Aktions-Isolierung:** jede Neuanmeldung (`subscription_assigned` u. ä.) im
+  Aktionszeitraum zählt als `neu`. Trials hinterlegen eine Kreditkarte, darum ist
+  `transaction_id` **kein** Unterscheidungsmerkmal. Verlängerungen legen nichts an
+  (nur Neuanmeldungen). Kündigung → `gekuendigt`. **Zahlungen setzen vorerst kein
+  `bleibt`** – die Umwandlung wird erst nach der 3-Monats-Frist bestimmt. Zeitlich
+  begrenzt durch `aktion_start`; schärfer stellbar über `aktion_coupon` / `aktion_plan`.
 - **Scharf/Log:** zählt nur wenn `sommer2026_config.aktion_aktiv = 'true'`,
   sonst reiner Log-Modus.
 

--- a/services/sommer-zaehler/ingest-uscreen/index.ts
+++ b/services/sommer-zaehler/ingest-uscreen/index.ts
@@ -129,18 +129,21 @@ Deno.serve(async (req) => {
   const isCancel = /(cancel|refund|expire|churn|delet)/.test(e);
 
   if (isCancel) { await patchStatus(dedupKey, "gekuendigt"); return json({ ok: true, status: "gekuendigt" }); }
-  if (isPay && !isNew) { await patchStatus(dedupKey, "bleibt"); return json({ ok: true, status: "bleibt" }); }
+  // Jeder Trial hinterlegt eine Karte → Zahlung fällt sofort an. Darum setzt eine
+  // Zahlung (noch) KEIN 'bleibt': die echte Umwandlung wird erst nach der
+  // 3-Monats-Frist bestimmt (separater Schritt im Oktober).
+  if (isPay && !isNew) return json({ ok: true, note: "Zahlung ignoriert (Umwandlung erst nach 3 Monaten)" });
 
   if (!isNew) return json({ ok: true, skipped: "event ignoriert" });
 
-  const txn = pick(data, ["transaction_id"]);
-  const istTrial = txn === undefined || txn === null || txn === "";
+  // Aktion = jede Neuanmeldung im Aktionszeitraum (aktion_start begrenzt es zeitlich).
+  // Optional schärfer über aktion_coupon / aktion_plan.
   const coupon = (pick(data, ["coupon_code", "coupon", "discount_code", "code"]) || "").toString().toLowerCase();
   let istAktion: boolean;
   if (aktionCoupon) istAktion = coupon.includes(aktionCoupon);
   else if (aktionPlan) istAktion = title.toLowerCase().includes(aktionPlan);
-  else istAktion = istTrial;
-  if (!istAktion) return json({ ok: true, skipped: "Normalgeschäft (kein Gratis-Trial)" });
+  else istAktion = true;
+  if (!istAktion) return json({ ok: true, skipped: "nicht Aktion (Coupon/Plan)" });
 
   const { sprache, intervall, tarif } = mapPlan(title);
   const kanal = mapKanal(pick(data, ["utm_source", "source", "custom_fields.utm_source", "referral_source", "user_fields.0.value", "user_field_1"]));


### PR DESCRIPTION
## Worum es geht

Drei neue GTV-Abos vom Vormittag tauchten nicht im Cockpit auf. Der Webhook war funktional — der Fehler lag in der Filterlogik.

## Ursache

Ich hatte angenommen, Aktions-Anmeldungen seien Gratis-Trials **ohne** `transaction_id`. Tatsächlich **hinterlegt jeder Trial eine Kreditkarte**, darum setzt Uscreen immer eine Transaktions-ID. Die echten Anmeldungen wurden so als „Normalgeschäft" verworfen.

## Änderungen

- **`ingest-uscreen`:** jede Neuanmeldung (`subscription_assigned`) im Aktionszeitraum zählt jetzt als `neu`. `transaction_id` ist kein Unterscheidungsmerkmal mehr. Zeitgrenze `aktion_start` und optionale `aktion_coupon`/`aktion_plan` bleiben.
- **Zahlungen setzen vorerst kein `bleibt`:** weil beim Trial sofort eine Zahlung anfällt, würde sonst eine frische Anmeldung fälschlich als umgewandelt gelten. Die Umwandlung wird erst nach der 3-Monats-Frist bestimmt.
- **README** angepasst.

## Geprüft

Live getestet: Neuanmeldung **mit** `transaction_id` wird jetzt gezählt (`status: neu`). Die drei verpassten Vormittags-Abos wurden aus dem Roh-Log nachgetragen. Keine fälschlichen `bleibt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_