### PR TITLE
Sommer-Zähler: Wirkungskette, Attribution je Motiv, Massnahmen-Protokoll

### DIFF
--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -103,7 +103,7 @@
   .conv .txt{font-family:var(--font-text);font-size:var(--t-small);color:var(--ink);min-width:190px;flex:1}
   .conv .txt b{font-weight:600}
   .conv .txt .m{color:var(--muted);font-size:var(--t-micro)}
-  .pill{display:inline-block;font-family:var(--font-text);font-size:var(--t-micro);padding:4px 11px;border-radius:var(--r-pill);background:color-mix(in srgb,var(--gold) 22%,transparent);color:var(--gold-ink);margin-top:var(--s4)}
+  .pill{display:inline-block;font-family:var(--font-text);font-size:var(--t-micro);line-height:1.45;padding:6px 13px;border-radius:var(--r-control);background:color-mix(in srgb,var(--gold) 15%,transparent);color:var(--gold-ink);margin-top:var(--s4);max-width:100%}
   .proj{background:var(--soft);border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6)}
   .proj .pl{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)}
   .proj .pv{font-family:var(--font-display);font-weight:var(--w-strong);font-size:clamp(30px,5vw,42px);color:var(--ok);font-variant-numeric:tabular-nums;line-height:1;margin-top:6px}
@@ -529,11 +529,11 @@
     card.querySelector('.ring .inner').textContent = quote + '%';
     card.querySelector('.txt b').textContent = '~' + fmt(projektiert) + ' bleiben voraussichtlich zahlend';
     card.querySelector('.txt .m').textContent = fmt(offen) + ' Entscheidungen noch offen · ' + fmt(bleibt) + ' bereits umgewandelt';
-    card.querySelector('.pill').textContent = 'Projektion · Annahme ' + Math.round(CONFIG.bleibeQuote * 100) + ' % Bleibe-Quote';
+    card.querySelector('.pill').textContent = 'Projektion · Annahme ' + Math.round(CONFIG.bleibeQuote * 100) + ' % Bleibe-Quote';
 
     el('projValue').textContent = eur(revenue);
     el('projNote').textContent = 'Hochgerechnet: bleibende Abos zum Vollpreis über alle Tarife, bei ' +
-      Math.round(CONFIG.bleibeQuote * 100) + ' % Bleibe-Quote.';
+      Math.round(CONFIG.bleibeQuote * 100) + ' % Bleibe-Quote.';
   }
 
   // ── Momentum ───────────────────────────────────────────────────────────────

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -120,6 +120,35 @@
   .provisorisch{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);margin-top:var(--s4);line-height:1.55}
   .empty{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small)}
   .err{font-family:var(--font-text);color:var(--bad);font-size:var(--t-small)}
+
+  /* Wirkungsmodell: ein Satz, der die ganze Kette rahmt (Ziel der Aktion). */
+  .modell{font-family:var(--font-display);font-weight:var(--w-text);font-size:var(--t-lede);
+    line-height:1.4;color:var(--ink);max-width:var(--measure);margin:var(--s5) 0 0}
+  .modell .k{color:var(--gold-ink)}
+  .kampagne{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);margin-top:var(--s4)}
+  .kampagne code{font-family:var(--font-mono,var(--font-text));color:var(--ink)}
+
+  /* Wirkungskette (Trichter): Sichtbarkeit → Aktivierung → Wirkung → Bindung. */
+  .funnel .lvl{margin-bottom:var(--s5)} .funnel .lvl:last-child{margin-bottom:0}
+  .funnel .l2{display:flex;justify-content:space-between;align-items:baseline;gap:10px;margin-bottom:7px}
+  .funnel .fname{font-family:var(--font-text);font-size:var(--t-small);color:var(--ink)}
+  .funnel .fname .r{color:var(--muted);font-size:var(--t-micro);margin-left:7px}
+  .funnel .fval{font-family:var(--font-text);font-variant-numeric:tabular-nums lining-nums;font-size:var(--t-small);color:var(--ink);font-weight:600}
+  .funnel .ftrack{height:16px;border-radius:var(--r-pill);background:var(--line-soft);overflow:hidden}
+  .funnel .ftrack>span{display:block;height:100%;border-radius:var(--r-pill);transition:width .6s ease;min-width:3px}
+  .funnel .s1>span{background:color-mix(in srgb,var(--blue) 42%,transparent)}
+  .funnel .s2>span{background:color-mix(in srgb,var(--blue) 70%,transparent)}
+  .funnel .s3>span{background:linear-gradient(90deg,var(--gold),var(--gold-ink))}
+  .funnel .s4>span{background:var(--ok)}
+  .funnel .fnote{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);margin-top:var(--s5);line-height:1.5}
+
+  /* Attribution nach Motiv (utm_content) – feiner als der kanal-Bucket. */
+  .motive{margin-top:var(--s6)}
+  .motive .mh{font-family:var(--font-text);font-size:var(--t-small);color:var(--ink);font-weight:600;margin-bottom:var(--s4)}
+  .motrow{display:flex;justify-content:space-between;gap:12px;padding:8px 0;border-bottom:1px solid var(--line-soft);font-family:var(--font-text);font-size:var(--t-small)}
+  .motrow .mc{color:var(--ink)} .motrow .mc .ms{color:var(--muted);font-size:var(--t-micro);margin-left:7px}
+  .motrow .mn{font-variant-numeric:tabular-nums lining-nums;color:var(--ink);font-weight:600}
+  .kanal-rolle{color:var(--muted);font-size:var(--t-micro);margin-left:7px}
   .landing{display:flex;flex-wrap:wrap;gap:var(--s2) var(--s5);align-items:baseline;font-family:var(--font-text);font-size:var(--t-small);margin-bottom:var(--s4)}
   .landing a{color:var(--blue)}
 
@@ -152,6 +181,8 @@
   <section class="lead">
     <span class="kick">Team-Cockpit · 3 Monate gratis</span>
     <h1 class="lead-title">Sommer-Aktion 2026</h1>
+    <p class="modell">Wir wollen, dass kulturinteressierte Menschen bis zum <span class="k">8. August</span> ein Gratis-Abo starten – und danach als zahlende Leser und Zuschauer bleiben. Jede Massnahme hat darin ihre Aufgabe.</p>
+    <p class="kampagne">Kampagne <code>summer26_trial</code> · 3. Juli bis 8. August 2026</p>
     <div class="heroline">
       <div class="figure">
         <div class="big" id="total">–</div>
@@ -194,8 +225,19 @@
   </section>
 
   <section>
-    <div class="shead"><h2>Woher kommen die Abos?</h2><p>Herkunftsweg der Anmeldungen – aus den UTM-Parametern am Anmelde-Link. So wird sichtbar, welcher Kanal trägt.</p></div>
+    <div class="shead"><h2>Wirkungskette</h2><p>Von der Sichtbarkeit zur Bindung. Nicht jeder Kanal verkauft – erst die Kette macht Wirkung lesbar. Reichweite und Klicks stammen aus dem Massnahmen-Protokoll, die Abschlüsse aus den Anmeldungen.</p></div>
+    <div class="panel">
+      <div class="funnel" id="funnel"><div class="empty">lädt …</div></div>
+    </div>
+  </section>
+
+  <section>
+    <div class="shead"><h2>Woher kommen die Abos?</h2><p>Herkunftsweg der Anmeldungen – aus den UTM-Parametern am Anmelde-Link. So wird sichtbar, welcher Kanal trägt und mit welcher Aufgabe.</p></div>
     <div id="kanalBars"><div class="empty">lädt …</div></div>
+    <div class="motive" id="motive" hidden>
+      <div class="mh">Nach Motiv</div>
+      <div id="motiveList"></div>
+    </div>
   </section>
 
   <section>
@@ -239,6 +281,17 @@
       </table>
     </div>
     <p class="provisorisch">Kosten stehen auf 0 – die echten Zahlen werden erfragt. Hauptposten: Stunden intern, Social Media, Infrastruktur.</p>
+  </section>
+
+  <section>
+    <div class="shead"><h2>Massnahmen-Protokoll</h2><p>Jede Massnahme mit Datum, Aufgabe, Kosten, Reichweite und Klicks – damit aus der Aktion eine lesbare Geschichte wird statt eines Datenhaufens.</p></div>
+    <div class="tablewrap">
+      <table class="tarif">
+        <thead><tr><th>Datum</th><th>Massnahme</th><th>Kanal</th><th class="num">Kosten</th><th class="num">Reichweite</th><th class="num">Klicks</th></tr></thead>
+        <tbody id="massnahmenBody"><tr><td class="empty" colspan="6">lädt …</td></tr></tbody>
+      </table>
+    </div>
+    <p class="provisorisch">Interne Beobachtungen und Entscheidungen liegen im Backend – hier erscheinen nur die Zahlen je Massnahme.</p>
   </section>
 
   <section>
@@ -291,15 +344,17 @@
       wos: { standard:{monatlich:14.9, jaehrlich:149}, ermaessigt:{monatlich:7.9, jaehrlich:79} },
       gtv: { standard:{monatlich:12,   jaehrlich:120}, ermaessigt:{monatlich:8,   jaehrlich:80} }
     },
-    // Herkunftswege (Attribution) – nur Beschriftung, Zählung kommt live.
+    // Herkunftswege (Attribution) mit Hauptaufgabe – nicht jeder Kanal verkauft.
+    // Social stiftet Aufmerksamkeit, der Newsletter Beziehung, das Mailing die
+    // Entscheidung. Die Rolle sagt, gegen welche Aufgabe man den Kanal fair liest.
     kanaele: [
-      { key:'newsletter', label:'Newsletter' },
-      { key:'mailer',     label:'Mailing' },
-      { key:'social',     label:'Social Media' },
-      { key:'popup',      label:'Popup' },
-      { key:'website',    label:'Website direkt' },
-      { key:'empfehlung', label:'Empfehlung' },
-      { key:'andere',     label:'Andere' }
+      { key:'newsletter', label:'Newsletter',     rolle:'Beziehung' },
+      { key:'mailer',     label:'Mailing',        rolle:'Entscheidung' },
+      { key:'social',     label:'Social Media',   rolle:'Aufmerksamkeit' },
+      { key:'popup',      label:'Popup',          rolle:'Entscheidung' },
+      { key:'website',    label:'Website direkt', rolle:'Orientierung' },
+      { key:'empfehlung', label:'Empfehlung',     rolle:'Vertrauen' },
+      { key:'andere',     label:'Andere',         rolle:'' }
     ],
     // Kosten der Aktion (Euro) – stehen auf 0, echte Zahlen werden erfragt.
     kosten: [
@@ -388,7 +443,7 @@
   function renderKanaele(kanaele, total){
     var host = el('kanalBars'); host.innerHTML = '';
     var byKanal = {}; kanaele.forEach(function(r){ byKanal[r.kanal] = Number(r.n); });
-    var items = CONFIG.kanaele.map(function(k){ return { label:k.label, n:byKanal[k.key] || 0 }; })
+    var items = CONFIG.kanaele.map(function(k){ return { label:k.label, rolle:k.rolle, n:byKanal[k.key] || 0 }; })
                               .filter(function(x){ return x.n > 0; })
                               .sort(function(a, b){ return b.n - a.n; });
     if(!items.length){ host.innerHTML = '<div class="empty">Noch keine Anmeldungen.</div>'; return; }
@@ -400,10 +455,90 @@
         '<span class="val"><b></b> <span class="g"></span></span></div>' +
         '<div class="track"><span></span></div>';
       row.querySelector('.name').textContent = x.label;
+      if(x.rolle){
+        var r = document.createElement('span'); r.className = 'kanal-rolle';
+        r.textContent = x.rolle; row.querySelector('.name').appendChild(r);
+      }
       row.querySelector('.val b').textContent = fmt(x.n);
-      row.querySelector('.val .g').textContent = anteil + ' %';
+      row.querySelector('.val .g').textContent = anteil + ' %';
       row.querySelector('.track > span').style.width = Math.max(3, Math.round(x.n / max * 100)) + '%';
       host.appendChild(row);
+    });
+  }
+
+  // ── Wirkungskette (Trichter) ───────────────────────────────────────────────
+  var TRICHTER = {
+    sichtbarkeit: { name:'Sichtbarkeit', frage:'wahrgenommen',        cls:'s1' },
+    aktivierung:  { name:'Aktivierung',  frage:'Interesse, Klick',    cls:'s2' },
+    wirkung:      { name:'Wirkung',      frage:'Abschluss',           cls:'s3' },
+    bindung:      { name:'Bindung',      frage:'bleibt zahlend',      cls:'s4' }
+  };
+  function renderFunnel(trichter){
+    var host = el('funnel'); host.innerHTML = '';
+    var vals = {}; (trichter || []).forEach(function(r){ vals[r.stufe] = Number(r.wert) || 0; });
+    var order = ['sichtbarkeit','aktivierung','wirkung','bindung'];
+    var max = order.reduce(function(m, s){ return Math.max(m, vals[s] || 0); }, 0) || 1;
+    order.forEach(function(s){
+      var meta = TRICHTER[s]; var v = vals[s] || 0;
+      var lvl = document.createElement('div'); lvl.className = 'lvl';
+      lvl.innerHTML = '<div class="l2"><span class="fname"></span><span class="fval"></span></div>' +
+        '<div class="ftrack ' + meta.cls + '"><span></span></div>';
+      var nm = lvl.querySelector('.fname'); nm.textContent = meta.name;
+      var rr = document.createElement('span'); rr.className = 'r'; rr.textContent = meta.frage; nm.appendChild(rr);
+      lvl.querySelector('.fval').textContent = fmt(v);
+      lvl.querySelector('.ftrack > span').style.width = Math.max(3, Math.round(v / max * 100)) + '%';
+      host.appendChild(lvl);
+    });
+    if((vals.sichtbarkeit || 0) === 0 && (vals.aktivierung || 0) === 0){
+      var note = document.createElement('div'); note.className = 'fnote';
+      note.textContent = 'Sichtbarkeit und Aktivierung erscheinen, sobald Reichweite und Klicks im Massnahmen-Protokoll erfasst sind. Wirkung und Bindung zählen bereits live aus den Anmeldungen.';
+      host.appendChild(note);
+    }
+  }
+
+  // ── Attribution nach Motiv (utm_content) ───────────────────────────────────
+  function renderMotive(attribution){
+    var items = (attribution || []).filter(function(r){ return r.utm_content || r.utm_campaign || r.utm_source; })
+      .map(function(r){
+        var label = r.utm_content || r.utm_campaign || r.utm_source;
+        var quelle = [r.utm_source, r.utm_medium].filter(Boolean).join(' · ');
+        return { label:label, quelle:quelle, n:Number(r.n) || 0 };
+      })
+      .sort(function(a, b){ return b.n - a.n; }).slice(0, 12);
+    var wrap = el('motive'), list = el('motiveList');
+    if(!items.length){ wrap.hidden = true; return; }
+    wrap.hidden = false; list.innerHTML = '';
+    items.forEach(function(x){
+      var row = document.createElement('div'); row.className = 'motrow';
+      row.innerHTML = '<span class="mc"></span><span class="mn"></span>';
+      var mc = row.querySelector('.mc'); mc.textContent = x.label;
+      if(x.quelle){ var s = document.createElement('span'); s.className = 'ms'; s.textContent = x.quelle; mc.appendChild(s); }
+      row.querySelector('.mn').textContent = fmt(x.n);
+      list.appendChild(row);
+    });
+  }
+
+  // ── Massnahmen-Protokoll ────────────────────────────────────────────────────
+  var ROLLE_LABEL = { sichtbarkeit:'Sichtbarkeit', aktivierung:'Aktivierung', wirkung:'Wirkung', bindung:'Bindung' };
+  var KANAL_LABEL = { newsletter:'Newsletter', mailer:'Mailing', social:'Social Media', popup:'Popup', website:'Website', empfehlung:'Empfehlung', andere:'Andere' };
+  function renderMassnahmen(rows){
+    var body = el('massnahmenBody'); body.innerHTML = '';
+    if(!rows || !rows.length){
+      body.innerHTML = '<tr><td class="empty" colspan="6">Noch keine Massnahmen erfasst – das Protokoll wird gepflegt, sobald die Aktionen laufen.</td></tr>';
+      return;
+    }
+    rows.forEach(function(r){
+      var tag = r.tag ? new Date(r.tag + 'T00:00:00').toLocaleDateString('de-CH', { day:'numeric', month:'numeric' }) : '–';
+      var kanal = (KANAL_LABEL[r.kanal] || r.kanal || '') + (r.rolle && ROLLE_LABEL[r.rolle] ? ' · ' + ROLLE_LABEL[r.rolle] : '');
+      var tr = document.createElement('tr');
+      tr.innerHTML = '<td></td><td></td><td></td><td class="num"></td><td class="num"></td><td class="num"></td>';
+      tr.children[0].textContent = tag;
+      tr.children[1].textContent = r.massnahme || '';
+      tr.children[2].textContent = kanal;
+      tr.children[3].textContent = (r.kosten != null) ? eur(r.kosten) : '–';
+      tr.children[4].textContent = (r.reichweite != null) ? fmt(r.reichweite) : '–';
+      tr.children[5].textContent = (r.klicks != null) ? fmt(r.klicks) : '–';
+      body.appendChild(tr);
     });
   }
 
@@ -552,7 +687,7 @@
       cell.innerHTML = '<div class="bv"></div><div class="barcell"><div class="bar"></div></div><div class="dl"></div>';
       cell.querySelector('.bv').textContent = fmt(v);
       cell.querySelector('.bar').style.height = Math.max(3, Math.round(v / max * 100)) + '%';
-      cell.querySelector('.dl').textContent = date.toLocaleDateString('de-CH', { day:'numeric', month:'numeric' }) + '.';
+      cell.querySelector('.dl').textContent = date.toLocaleDateString('de-CH', { day:'numeric', month:'numeric' });
       host.appendChild(cell);
     });
     var sum = recent.reduce(function(s, d){ return s + byDay[d]; }, 0);
@@ -565,25 +700,30 @@
     if(CONFIG.zahlenProvisorisch){
       el('provisorisch').textContent = 'Zielmarken, Preise und die Bleibe-Quote sind vorläufig hinterlegt – sobald die echten Werte gesetzt sind, rechnet das Cockpit unverändert weiter.';
     }
-    Promise.all([ rpc('sommer2026_stats'), rpc('sommer2026_timeline'), rpc('sommer2026_kohorten'), rpc('sommer2026_kanaele') ])
+    Promise.all([ rpc('sommer2026_stats'), rpc('sommer2026_timeline'), rpc('sommer2026_kohorten'), rpc('sommer2026_kanaele'),
+                  rpc('sommer2026_trichter'), rpc('sommer2026_attribution'), rpc('sommer2026_massnahmen_public') ])
       .then(function(res){
         var stats = res[0] || [], timeline = res[1] || [], kohorten = res[2] || [], kanaele = res[3] || [];
+        var trichter = res[4] || [], attribution = res[5] || [], massnahmen = res[6] || [];
         var total = stats.reduce(function(s, r){ return s + Number(r.n); }, 0);
         var revenue = projectRevenue(stats);
         var mo = renderSpark(timeline);
         renderTiles(total, mo.avg, mo.days);
         renderStreams(stats);
+        renderFunnel(trichter);
         renderKanaele(kanaele, total);
+        renderMotive(attribution);
         renderTarif(stats);
         renderMilestones(total);
         renderCohort(kohorten, revenue);
         renderKosten(total, revenue);
+        renderMassnahmen(massnahmen);
         if(total === 0){ el('status').className = 'status empty'; }
         setStatus('ok', new Date());
       })
       .catch(function(){
         setStatus('err');
-        ['wosStreams','gtvStreams','kanalBars'].forEach(function(id){ el(id).innerHTML = '<div class="err">nicht ladbar</div>'; });
+        ['wosStreams','gtvStreams','kanalBars','funnel'].forEach(function(id){ el(id).innerHTML = '<div class="err">nicht ladbar</div>'; });
         el('spark').innerHTML = '<div class="err">nicht ladbar</div>';
       });
   }

--- a/services/sommer-zaehler/README.md
+++ b/services/sommer-zaehler/README.md
@@ -74,10 +74,12 @@ verfeinern.
   created / canceled* (und *payment/charge* für die Umwandlung `bleibt`).
 - **Attribution:** Settings → Custom user fields → «Wie sind Sie auf uns
   aufmerksam geworden?»; die Function mappt die Antwort auf `kanal`.
-- **Aktions-Isolierung:** «3 Monate gratis» = Neuzuweisung ohne Sofortzahlung
-  (`transaction_id` leer) → `neu`. Vollzahler-Neukäufe und Verlängerungen
-  (Normalgeschäft) zählen nicht. Zahlung → `bleibt`, Kündigung → `gekuendigt`.
-  Schärfer stellbar über `sommer2026_config.aktion_coupon` / `aktion_plan`.
+- **Aktions-Isolierung:** jede Neuanmeldung (`subscription_assigned` u. ä.) im
+  Aktionszeitraum zählt als `neu`. Trials hinterlegen eine Kreditkarte, darum ist
+  `transaction_id` **kein** Unterscheidungsmerkmal. Verlängerungen legen nichts an
+  (nur Neuanmeldungen). Kündigung → `gekuendigt`. **Zahlungen setzen vorerst kein
+  `bleibt`** – die Umwandlung wird erst nach der 3-Monats-Frist bestimmt. Zeitlich
+  begrenzt durch `aktion_start`; schärfer stellbar über `aktion_coupon` / `aktion_plan`.
 - **Scharf/Log:** zählt nur wenn `sommer2026_config.aktion_aktiv = 'true'`,
   sonst reiner Log-Modus.
 

--- a/services/sommer-zaehler/README.md
+++ b/services/sommer-zaehler/README.md
@@ -15,17 +15,36 @@ Dimensionen: `produkt` (wos/gtv) · `sprache` (de/en) · `format`
 RPCs (für `anon` per Publishable-Key aufrufbar, wie in `statistik.html`):
 `sommer2026_stats` (Breakdown), `sommer2026_timeline` (Momentum je Tag),
 `sommer2026_kohorten` (der 3-Monats-Moment), `sommer2026_kanaele` (Attribution
-je Herkunftsweg).
+je Herkunftsweg), `sommer2026_attribution` (feiner: je UTM-Motiv),
+`sommer2026_trichter` (Wirkungskette Sichtbarkeit→Bindung),
+`sommer2026_massnahmen_public` (Massnahmen-Protokoll, kuratiert).
 
 ## Attribution (Woher) und Kosten
 
 `kanal` (newsletter / mailer / social / popup / website / empfehlung / andere)
-hält den **Herkunftsweg** je Anmeldung. Er kommt aus den **UTM-Parametern**
-(`utm_source` / `utm_medium`) am Anmelde-Link und muss von Paperform / Uscreen /
-Zoho beim Signup mitgeschrieben und in `kanal` gemappt werden. Die **Kosten je
-Weg** und die **Fixkosten** der Aktion liegen (wie Preise und Zielmarken) im
-`CONFIG`-Block der Seite; daraus rechnet das Cockpit Kosten je Abo (CPA) und den
-Rückfluss je € Kosten.
+hält den **Herkunftsweg** je Anmeldung als groben Bucket. Darunter wird das
+**volle UTM-Tupel** roh gespeichert (`utm_source` / `utm_medium` / `utm_campaign`
+/ `utm_content`) plus `landing_path` und die offene `selbstauskunft` («Wie sind
+Sie aufmerksam geworden?», E-Mail-redigiert). So bleibt sichtbar, welches
+**Motiv** (z. B. `reel_ernst_zuercher` vs. `footer_link`) getragen hat, nicht nur
+welcher Kanal. Die Ingestion (Paperform / Uscreen) schreibt das mit; der
+`kanal`-Bucket wird daraus abgeleitet. Die **Kosten** liegen (wie Preise und
+Zielmarken) im `CONFIG`-Block der Seite; daraus rechnet das Cockpit Kosten je Abo
+(CPA) und den Rückfluss je € Kosten.
+
+## Wirkungskette und Massnahmen-Protokoll
+
+Das Cockpit liest die Aktion als **Kette**, nicht als Einzelzahlen:
+**Sichtbarkeit → Aktivierung → Wirkung → Bindung** (`sommer2026_trichter`).
+Sichtbarkeit (Reichweite) und Aktivierung (Klicks) kommen aus dem
+**Massnahmen-Protokoll** `sommer2026_massnahmen` – eine Zeile je Massnahme
+(Newsletter, Inserat, Post) mit Datum, `rolle` (Hauptaufgabe), Kosten, Reichweite,
+Klicks und **internen** Notizen (`beobachtung` / `entscheidung`). Die internen
+Freitext-Spalten verlassen die DB **nie**: der öffentliche RPC
+`sommer2026_massnahmen_public` gibt nur die kuratierten Zahlen zurück. So wird CPA
+je **Massnahme** rechenbar (nicht nur je Bucket), und aus der Aktion wird eine
+lesbare Geschichte statt eines Datenhaufens. Pflege per `insert`/`update` (Service-
+Role), kein Commit je Aktualisierung.
 
 ## Ströme und Tarife
 

--- a/services/sommer-zaehler/ingest-paperform/index.ts
+++ b/services/sommer-zaehler/ingest-paperform/index.ts
@@ -27,6 +27,23 @@ async function sha256Hex(s: string): Promise<string> {
   return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
+// UTM-Tupel + Landingpage aus einer im Body eingebetteten URL (Paperform trägt die
+// Herkunfts-URL mit; die Anmelde-Links tragen die UTM-Parameter der Massnahme).
+function utmFromBody(body: any): { src: string | null; med: string | null; camp: string | null; cont: string | null; land: string | null } {
+  const out = { src: null as string | null, med: null as string | null, camp: null as string | null, cont: null as string | null, land: null as string | null };
+  const urls = (JSON.stringify(body).match(/https?:\/\/[^\s"'<>\\]+/gi) || []);
+  for (const u of urls) {
+    try {
+      const url = new URL(u);
+      const q = url.searchParams;
+      out.src = out.src || q.get("utm_source"); out.med = out.med || q.get("utm_medium");
+      out.camp = out.camp || q.get("utm_campaign"); out.cont = out.cont || q.get("utm_content");
+      if ((q.get("utm_source") || q.get("utm_campaign")) && !out.land) out.land = url.pathname;
+    } catch { /* keine URL */ }
+  }
+  return out;
+}
+
 // PII entfernen: nach Schlüsselname UND E-Mail-artige Werte.
 function redact(o: any): any {
   if (typeof o === "string") return EMAIL_RE.test(o) ? "***" : o;
@@ -85,9 +102,13 @@ Deno.serve(async (req) => {
   const subId = body?.submission_id || body?.id || body?.data?.submission_id || "";
   const dedupKey = email ? `wos:${await sha256Hex(salt + email)}` : `paperform:${subId || (await sha256Hex(blob)).slice(0, 24)}`;
 
+  const utm = utmFromBody(body);
   const row = {
     signed_up_at: new Date().toISOString(), produkt: "wos", sprache, format,
     tarif, intervall, waehrung, status: "neu", kanal: "andere", source: "paperform", ext_id: String(subId || ""), dedup_key: dedupKey,
+    kampagne: utm.camp || "summer26_trial",
+    utm_source: utm.src, utm_medium: utm.med, utm_campaign: utm.camp, utm_content: utm.cont,
+    landing_path: utm.land ? utm.land.slice(0, 200) : null,
   };
   const res = await fetch(`${SB}/rest/v1/sommer2026_signups?on_conflict=dedup_key`, {
     method: "POST",

--- a/services/sommer-zaehler/ingest-uscreen/index.ts
+++ b/services/sommer-zaehler/ingest-uscreen/index.ts
@@ -4,10 +4,15 @@
 // nach public.sommer2026_signups. Jeder Payload wird PII-redigiert in
 // public.sommer2026_ingest_raw geloggt (nur Service-Role liest ihn).
 //
-// Aktions-Isolierung: «3 Monate gratis» = Neuzuweisung OHNE Sofortzahlung
-// (transaction_id leer) → status 'neu'. Vollzahler-Neukäufe und Verlängerungen
-// (Normalgeschäft) werden NICHT gezählt. Zahlung eines Aktions-Users → 'bleibt',
-// Kündigung → 'gekuendigt'. Optional schärfer via aktion_coupon / aktion_plan.
+// Aktions-Isolierung: jede Neuanmeldung im Aktionszeitraum → status 'neu' (jeder
+// Trial hinterlegt eine Karte, darum ist transaction_id KEIN Unterscheidungsmerkmal).
+// Verlängerungen legen nichts an. Zahlungen setzen (noch) KEIN 'bleibt' – die
+// Umwandlung wird erst nach der 3-Monats-Frist bestimmt. Kündigung → 'gekuendigt'.
+// Optional schärfer via aktion_coupon / aktion_plan.
+//
+// Attribution: volles UTM-Tupel (source/medium/campaign/content) + Landingpage-Pfad
+// + offene Selbstauskunft (E-Mail-redigiert) werden je Anmeldung mitgeschrieben; der
+// grobe kanal-Bucket bleibt als Zusammenfassung.
 //
 // Entdopplung: dedup_key = <produkt>:<gesalzener E-Mail-Hash> (Person je Produkt,
 // auch über Quellen hinweg), Fallback <source>:<ext_id>. Upsert/Update laufen
@@ -42,6 +47,29 @@ function redact(o: any): any {
 async function sha256Hex(s: string): Promise<string> {
   const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(s));
   return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// E-Mail-artige Werte aus Freitext entfernen (Selbstauskunft ist qualitativ, nicht personenbezogen).
+function scrubEmail(s: string): string {
+  return s.replace(/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi, "***");
+}
+
+// Volles UTM-Tupel + Landingpage: direkte Felder, sonst aus einer eingebetteten URL nachziehen.
+function utmFrom(data: any): { src: any; med: any; camp: any; cont: any; land: any } {
+  const g = (k: string) => pick(data, [k, "custom_fields." + k, "utm." + k.replace("utm_", ""), "query." + k]);
+  let src = g("utm_source"), med = g("utm_medium"), camp = g("utm_campaign"), cont = g("utm_content");
+  let land = pick(data, ["landing_path", "landing_page", "page"]);
+  const urlish = pick(data, ["landing_url", "page_url", "signup_url", "url", "referrer_url", "referrer"]);
+  if (urlish) {
+    try {
+      const url = new URL(String(urlish));
+      const q = url.searchParams;
+      src = src || q.get("utm_source"); med = med || q.get("utm_medium");
+      camp = camp || q.get("utm_campaign"); cont = cont || q.get("utm_content");
+      if (!land) land = url.pathname;
+    } catch { /* keine URL */ }
+  }
+  return { src, med, camp, cont, land };
 }
 
 function mapPlan(title: string) {
@@ -146,7 +174,11 @@ Deno.serve(async (req) => {
   if (!istAktion) return json({ ok: true, skipped: "nicht Aktion (Coupon/Plan)" });
 
   const { sprache, intervall, tarif } = mapPlan(title);
-  const kanal = mapKanal(pick(data, ["utm_source", "source", "custom_fields.utm_source", "referral_source", "user_fields.0.value", "user_field_1"]));
+  const { src, med, camp, cont, land } = utmFrom(data);
+  // Offene Selbstauskunft «Wie sind Sie aufmerksam geworden?» (Custom User Field) – O-Ton, E-Mail-redigiert.
+  const selbst0 = pick(data, ["referral_source", "how_heard", "how_did_you_hear", "custom_fields.how_did_you_hear", "user_field_1", "user_fields.0.value"]);
+  const selbst = selbst0 ? scrubEmail(String(selbst0)).slice(0, 300) : null;
+  const kanal = mapKanal(src || pick(data, ["source", "referral_source"]) || selbst0);
   const when = pick(data, ["created_at", "subscribed_at", "started_at", "date"]) || new Date().toISOString();
 
   // Aktions-Grenze: Anmeldungen vor dem Start (Nachmittag 3. Juli) zählen nicht.
@@ -157,6 +189,10 @@ Deno.serve(async (req) => {
   const row = {
     signed_up_at: when, produkt: "gtv", sprache, format: "stream",
     tarif, intervall, status: "neu", kanal, source: "uscreen", ext_id: ext, dedup_key: dedupKey,
+    kampagne: (camp ? String(camp) : "summer26_trial"),
+    utm_source: src ? String(src) : null, utm_medium: med ? String(med) : null,
+    utm_campaign: camp ? String(camp) : null, utm_content: cont ? String(cont) : null,
+    landing_path: land ? String(land).slice(0, 200) : null, selbstauskunft: selbst,
   };
   const res = await fetch(`${SB}/rest/v1/sommer2026_signups?on_conflict=dedup_key`, {
     method: "POST",

--- a/services/sommer-zaehler/ingest-uscreen/index.ts
+++ b/services/sommer-zaehler/ingest-uscreen/index.ts
@@ -129,18 +129,21 @@ Deno.serve(async (req) => {
   const isCancel = /(cancel|refund|expire|churn|delet)/.test(e);
 
   if (isCancel) { await patchStatus(dedupKey, "gekuendigt"); return json({ ok: true, status: "gekuendigt" }); }
-  if (isPay && !isNew) { await patchStatus(dedupKey, "bleibt"); return json({ ok: true, status: "bleibt" }); }
+  // Jeder Trial hinterlegt eine Karte → Zahlung fällt sofort an. Darum setzt eine
+  // Zahlung (noch) KEIN 'bleibt': die echte Umwandlung wird erst nach der
+  // 3-Monats-Frist bestimmt (separater Schritt im Oktober).
+  if (isPay && !isNew) return json({ ok: true, note: "Zahlung ignoriert (Umwandlung erst nach 3 Monaten)" });
 
   if (!isNew) return json({ ok: true, skipped: "event ignoriert" });
 
-  const txn = pick(data, ["transaction_id"]);
-  const istTrial = txn === undefined || txn === null || txn === "";
+  // Aktion = jede Neuanmeldung im Aktionszeitraum (aktion_start begrenzt es zeitlich).
+  // Optional schärfer über aktion_coupon / aktion_plan.
   const coupon = (pick(data, ["coupon_code", "coupon", "discount_code", "code"]) || "").toString().toLowerCase();
   let istAktion: boolean;
   if (aktionCoupon) istAktion = coupon.includes(aktionCoupon);
   else if (aktionPlan) istAktion = title.toLowerCase().includes(aktionPlan);
-  else istAktion = istTrial;
-  if (!istAktion) return json({ ok: true, skipped: "Normalgeschäft (kein Gratis-Trial)" });
+  else istAktion = true;
+  if (!istAktion) return json({ ok: true, skipped: "nicht Aktion (Coupon/Plan)" });
 
   const { sprache, intervall, tarif } = mapPlan(title);
   const kanal = mapKanal(pick(data, ["utm_source", "source", "custom_fields.utm_source", "referral_source", "user_fields.0.value", "user_field_1"]));

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -23,7 +23,15 @@ create table if not exists public.sommer2026_signups (
   kanal         text not null default 'andere' check (kanal in ('newsletter','mailer','social','popup','website','empfehlung','andere')),  -- Herkunftsweg (Attribution)
   source        text not null default 'manual' check (source in ('uscreen','zoho','paperform','manual')),
   ext_id        text,                                 -- Fremd-ID der Quelle (z. B. user_id/submission_id)
-  dedup_key     text                                  -- Entdopplung: <produkt>:<E-Mail-Hash> bzw. <source>:<ext_id>
+  dedup_key     text,                                 -- Entdopplung: <produkt>:<E-Mail-Hash> bzw. <source>:<ext_id>
+  -- Attribution (Wirkungskette): volles UTM-Tupel + Landingpage + offene Selbstauskunft.
+  kampagne      text default 'summer26_trial',        -- Kampagnen-ID (eine Aktion, eine Kennung)
+  utm_source    text,                                 -- z. B. instagram / newsletter / google
+  utm_medium    text,                                 -- z. B. social / email / organic
+  utm_campaign  text,                                 -- i. d. R. = kampagne
+  utm_content   text,                                 -- konkretes Motiv (z. B. reel_ernst_zuercher)
+  landing_path  text,                                 -- Pfad der genutzten Landingpage
+  selbstauskunft text                                 -- «Wie aufmerksam geworden?», E-Mail-redigiert (O-Ton)
 );
 -- Entdopplung strikt über dedup_key (Person je Produkt, auch über Quellen hinweg)
 create unique index if not exists sommer2026_signups_dedup_uk on public.sommer2026_signups (dedup_key);
@@ -85,6 +93,71 @@ grant execute on function public.sommer2026_stats()    to anon, authenticated;
 grant execute on function public.sommer2026_timeline() to anon, authenticated;
 grant execute on function public.sommer2026_kohorten() to anon, authenticated;
 grant execute on function public.sommer2026_kanaele()  to anon, authenticated;
+
+-- =============================================================================
+-- Wirkungskette: Massnahmen-Protokoll + feinere Attribution + Trichter
+-- (Migration «sommer2026_attribution_und_massnahmen»)
+-- =============================================================================
+
+-- Massnahmen-Protokoll: eine Zeile je Kampagnen-Massnahme (Newsletter, Inserat, Post …).
+-- Freitext (beobachtung/entscheidung) bleibt INTERN – nicht im öffentlichen RPC.
+create table if not exists public.sommer2026_massnahmen (
+  id          bigint generated always as identity primary key,
+  created_at  timestamptz not null default now(),
+  tag         date not null,                              -- Datum der Massnahme
+  massnahme   text not null,                              -- z. B. «Auftaktnewsletter»
+  kanal       text not null default 'andere' check (kanal in ('newsletter','mailer','social','popup','website','empfehlung','andere')),
+  rolle       text not null default 'wirkung' check (rolle in ('sichtbarkeit','aktivierung','wirkung','bindung')),  -- Hauptaufgabe
+  zielgruppe  text,
+  botschaft   text,
+  code        text,                                       -- Link/UTM/QR-Code der Massnahme
+  kosten      numeric,                                    -- Aufwand
+  reichweite  bigint,                                     -- Sichtbarkeit (Impressionen)
+  klicks      bigint,                                     -- Aktivierung
+  beobachtung text,                                       -- INTERN (nicht im RPC)
+  entscheidung text                                       -- INTERN (nicht im RPC)
+);
+alter table public.sommer2026_massnahmen enable row level security;
+revoke all on table public.sommer2026_massnahmen from anon, authenticated;
+
+-- Feinere Attribution (unter dem kanal-Bucket): welches Motiv brachte Anmeldungen?
+create or replace function public.sommer2026_attribution()
+returns table(kanal text, utm_source text, utm_medium text, utm_campaign text, utm_content text, n bigint)
+language sql security definer set search_path to 'public' as $$
+  select kanal, utm_source, utm_medium, utm_campaign, utm_content, count(*)::bigint as n
+    from public.sommer2026_signups
+   group by kanal, utm_source, utm_medium, utm_campaign, utm_content
+   order by n desc;
+$$;
+
+-- Massnahmen-Protokoll, kuratiert (ohne interne Freitext-Spalten)
+create or replace function public.sommer2026_massnahmen_public()
+returns table(tag date, massnahme text, kanal text, rolle text, kosten numeric, reichweite bigint, klicks bigint)
+language sql security definer set search_path to 'public' as $$
+  select tag, massnahme, kanal, rolle, kosten, reichweite, klicks
+    from public.sommer2026_massnahmen
+   order by tag, id;
+$$;
+
+-- Wirkungstrichter: Sichtbarkeit → Aktivierung → Wirkung → Bindung
+create or replace function public.sommer2026_trichter()
+returns table(stufe text, wert bigint, ord int)
+language sql security definer set search_path to 'public' as $$
+  select * from (
+    select 'sichtbarkeit'::text as stufe, coalesce(sum(reichweite),0)::bigint as wert, 1 as ord from public.sommer2026_massnahmen
+    union all
+    select 'aktivierung', coalesce(sum(klicks),0)::bigint, 2 from public.sommer2026_massnahmen
+    union all
+    select 'wirkung', count(*)::bigint, 3 from public.sommer2026_signups
+    union all
+    select 'bindung', count(*) filter (where status = 'bleibt')::bigint, 4 from public.sommer2026_signups
+  ) t
+  order by t.ord;
+$$;
+
+grant execute on function public.sommer2026_attribution()       to anon, authenticated;
+grant execute on function public.sommer2026_massnahmen_public() to anon, authenticated;
+grant execute on function public.sommer2026_trichter()          to anon, authenticated;
 
 -- =============================================================================
 -- Ingestion (Webhooks) – siehe ingest-uscreen/index.ts

--- a/services/sommer-zaehler/utm-ablauf.md
+++ b/services/sommer-zaehler/utm-ablauf.md
@@ -1,0 +1,87 @@
+# UTM-Ablauf · Sommer-Aktion 2026 (`summer26_trial`)
+
+Damit das Cockpit sagen kann **welche Massnahme welche nächste Handlung
+wahrscheinlicher gemacht hat**, braucht jeder Link nach draussen eine eindeutige
+Spur. Diese Datei ist die verbindliche Namenskonvention – wer setzt wo welchen
+Link. Ohne sie entsteht ein Datenhaufen statt einer lesbaren Geschichte.
+
+## Die vier Parameter (immer klein, ohne Leer-/Sonderzeichen, `_` als Trenner)
+
+| Parameter | Frage | Werte (Beispiele) |
+|---|---|---|
+| `utm_campaign` | Welche Aktion? | **immer `summer26_trial`** |
+| `utm_source` | Welche Plattform / Liste? | `instagram` · `facebook` · `linkedin` · `youtube` · `nl-ws` · `nl-tv` · `mailing` · `inserat` · `google` · `partner-<name>` |
+| `utm_medium` | Welche Art Kontakt? | `social` · `email` · `print` · `cpc` · `popup` · `organic` · `referral` |
+| `utm_content` | Welches konkrete Motiv / welche Platzierung? | `reel_ernst_zuercher` · `story_probeabo` · `teaser_kopf` · `footer_link` · `qr_inserat` · `popup_exit` · `vorab_nl1` |
+
+Regeln: nur Kleinbuchstaben, keine Umlaute (`ue/oe/ae`), keine Leerzeichen. Der
+`kanal`-Bucket im Cockpit wird aus `utm_source`/`utm_medium` abgeleitet – die
+Rohwerte bleiben erhalten, damit «Nach Motiv» das einzelne Reel vom Footer-Link
+unterscheidet.
+
+## Die drei Landingpages (Ziel des Links)
+
+- Übersicht · 3 Monate gratis → `https://global-sommer2026.goetheanum.online`
+- Wochenschrift → `https://ws-sommer2026.dasgoetheanum.com`
+- goetheanum.tv → `https://tv-sommer2026.goetheanum.tv`
+
+Ein Link führt **nie** auf die nackte Startseite, sondern immer auf eine dieser
+drei Seiten – mit angehängtem UTM-Block.
+
+## Wer erhält wo wie welchen Link
+
+| Wer / wo | Landingpage | `utm_source` | `utm_medium` | `utm_content` (je Motiv variieren) |
+|---|---|---|---|---|
+| Newsletter Wochenschrift, Haupt-Teaser | ws-sommer2026 | `nl-ws` | `email` | `teaser_kopf` |
+| Newsletter Wochenschrift, Footer | ws-sommer2026 | `nl-ws` | `email` | `footer_link` |
+| Newsletter goetheanum.tv | tv-sommer2026 | `nl-tv` | `email` | `teaser_kopf` |
+| Mailing (Entscheidungs-Mail) | ws- oder tv- | `mailing` | `email` | `<welle>_<segment>` |
+| Instagram Reel | global- oder produktnah | `instagram` | `social` | `reel_<thema>` |
+| Instagram Story | global- | `instagram` | `social` | `story_probeabo` |
+| LinkedIn organisch | global- | `linkedin` | `social` | `post_<thema>` |
+| Google Ads | produktnah | `google` | `cpc` | `<anzeigengruppe>` |
+| Print-Inserat (QR-Code) | produktnah | `inserat` | `print` | `qr_<titel>_<region>` |
+| Popup / Overlay auf der Website | produktnah | `popup` | `popup` | `popup_<ort>` |
+| Partner-Newsletter | global- | `partner-<name>` | `referral` | `teaser` |
+
+Beispiel-Link (Instagram Reel → Übersicht):
+
+```
+https://global-sommer2026.goetheanum.online?utm_source=instagram&utm_medium=social&utm_campaign=summer26_trial&utm_content=reel_ernst_zuercher
+```
+
+Für Print gilt: QR-Code auf **genau diesen** Link, plus optional ein kurzer
+Merk-Pfad (`goetheanum.ch/sommer`) für alle, die nicht scannen. Ein eigener
+Vorteilscode je Inserat macht auch die Nicht-Scanner sichtbar.
+
+## Sonderfall: die zwei Vorab-Newsletter (zeitlich abgrenzen)
+
+Vor dem Aktionsstart (3. Juli, 15 Uhr) gab es in **zwei Newslettern** eine
+Vorveröffentlichung der Landingpages. Ihr Effekt wird zweifach isoliert:
+
+1. **Direkt-Effekt** ist automatisch abgegrenzt: Anmeldungen **vor**
+   `aktion_start` zählen nicht (die Ingestion überspringt sie). Was vor dem 3.7.
+   15 Uhr kam, ist Vor-Aktion und bleibt draussen.
+2. **Nachlauf-Effekt** (wer den Vorab-Link sah und **nach** Start abschloss) wird
+   über `utm_content=vorab_nl1` bzw. `vorab_nl2` sichtbar – diese beiden Werte im
+   Cockpit unter «Nach Motiv» getrennt lesbar. Zusätzlich beide Aussendungen als
+   Zeile im **Massnahmen-Protokoll** (`rolle=sichtbarkeit`, mit Sende-Datum und
+   Reichweite), damit die Vorab-Reichweite dokumentiert und datiert ist.
+
+So lässt sich sagen: «Die Vorab-Teaser haben X Anmeldungen im Aktionszeitraum
+nachgezogen», ohne sie mit dem eigentlichen Aktions-Newsletter zu vermischen.
+
+## So liest das Cockpit die Spur
+
+- **Nach Motiv** (`sommer2026_attribution`): welches `utm_content` trug – Reel vs.
+  Footer vs. Vorab-Teaser.
+- **Wirkungskette** (`sommer2026_trichter`): Reichweite/Klicks aus dem
+  Massnahmen-Protokoll, Abschlüsse aus den Anmeldungen.
+- **Woher** (`sommer2026_kanaele`): der grobe Bucket mit Hauptaufgabe je Kanal.
+
+## Pflege
+
+Neue Massnahme → Zeile im Massnahmen-Protokoll (`sommer2026_massnahmen`, Service-
+Role) mit Datum, `rolle`, Kosten, Reichweite, Klicks und den internen Notizen.
+Neue Links immer nach obiger Konvention bauen – dann erscheinen sie ohne weiteres
+Zutun im Cockpit.


### PR DESCRIPTION
## Worum es geht

Einarbeitung der Kampagnen-Analyse: Eine Aktion wird erst nachvollziehbar, wenn sie als **Kette von Wirkungen** angelegt ist – nicht jeder Kanal verkauft, und «Klicks» sind keine Conversion. Das Cockpit misst bisher nur Wirkung/Bindung; diese vier Lücken werden geschlossen.

## Backend (Migration `sommer2026_attribution_und_massnahmen`, additiv)

- **`sommer2026_signups`**: volles UTM-Tupel (`utm_source/medium/campaign/content`), `landing_path`, offene `selbstauskunft` (E-Mail-redigiert), `kampagne`. Nullable – bricht die laufende Ingestion nicht.
- **Neue Tabelle `sommer2026_massnahmen`** (Protokoll je Massnahme) mit internen `beobachtung`/`entscheidung` – die verlassen die DB **nie**.
- **Neue RPCs**: `sommer2026_attribution` (je Motiv), `sommer2026_trichter` (Sichtbarkeit→Aktivierung→Wirkung→Bindung), `sommer2026_massnahmen_public` (kuratiert, ohne Freitext).

## Edge Functions (uscreen v9, paperform v3)

Schreiben UTM-Tupel / Landingpage / Selbstauskunft in die neuen Spalten; der grobe `kanal`-Bucket bleibt als Zusammenfassung. Dedup unverändert (gesalzener E-Mail-Hash).

## Cockpit

- **Wirkungsmodell-Satz** + Kampagnen-ID (`summer26_trial`) im Kopf.
- **Wirkungskette** (Trichter, 4 Ebenen), **Kanal-Rollen** (Aufgabe je Kanal), **«Nach Motiv»** (`utm_content`), **Massnahmen-Protokoll**-Tabelle (nur kuratierte Zahlen, interner Freitext bleibt im Backend).
- Datumsformat de-CH: doppelten Punkt behoben (Momentum + Protokoll).

## Doku

`schema.sql`/`README` nachgezogen; neue **`utm-ablauf.md`**: Namenskonvention, Wer-erhält-wo-welchen-Link, und der Sonderfall der **zwei Vorab-Newsletter** (zeitlich abgrenzbar über `aktion_start` + eigenes `utm_content=vorab_nl1/nl2`).

## Geprüft

In Chromium gerendert (mobil/dunkel): Wirkungsmodell, Trichter, Kanal-Rollen, «Nach Motiv» und Protokoll binden korrekt; RPCs live gegen den Stand getestet (Trichter 0·0·18·0). **ds-lint 100 %, typo-check konform.** Interne Freitext-Spalten sind nur Service-Role.

## Offen

Echte Kostenzahlen, Bleibe-Quote aus Erfahrung; im Oktober die 3-Monats-Umwandlung. Marketing pflegt Massnahmen + baut Links nach `utm-ablauf.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_