### PR TITLE
UTM-Generator: sechs Landingpages (Angebot × Sprache)

### DIFF
--- a/apps/utm-generator/index.html
+++ b/apps/utm-generator/index.html
@@ -82,12 +82,19 @@
 
     <div class="card soft">
       <div class="grid">
-        <label class="field span2">
-          <span class="lab">Ziel-Landingpage</span>
-          <select id="landing">
-            <option value="global|https://global-sommer2026.goetheanum.online">Übersicht · 3 Monate gratis</option>
-            <option value="ws|https://ws-sommer2026.dasgoetheanum.com">Wochenschrift</option>
-            <option value="tv|https://tv-sommer2026.goetheanum.tv">goetheanum.tv</option>
+        <label class="field">
+          <span class="lab">Angebot</span>
+          <select id="angebot">
+            <option value="uebersicht">Übersicht · 3 Monate gratis</option>
+            <option value="wos">Wochenschrift</option>
+            <option value="tv">goetheanum.tv</option>
+          </select>
+        </label>
+        <label class="field">
+          <span class="lab">Sprache der Landingpage</span>
+          <select id="sprache">
+            <option value="de">Deutsch</option>
+            <option value="en">English</option>
           </select>
         </label>
 
@@ -189,23 +196,32 @@
 
   function el(id){ return document.getElementById(id); }
 
+  // Die sechs echten Landingpages: Angebot × Sprache (aus der universellen LP recherchiert).
+  var LANDINGS = {
+    uebersicht: { de:'https://global-sommer2026.goetheanum.online',    en:'https://global-sommer2026.goetheanum.online/en' },
+    wos:        { de:'https://ws-sommer2026.dasgoetheanum.com',        en:'https://ws-en-sommer2026.dasgoetheanum.com' },
+    tv:         { de:'https://tv-sommer2026.goetheanum.tv',            en:'https://tv-en-sommer2026.goetheanum.tv' }
+  };
+  var ANGEBOT_LABEL = { uebersicht:'Übersicht', wos:'Wochenschrift', tv:'goetheanum.tv' };
+
   // Konvention erzwingen: klein, Umlaute auflösen, nur [a-z0-9_-], Rest → _
   function slug(s){
     return (s || '').toLowerCase()
       .replace(/ä/g,'ae').replace(/ö/g,'oe').replace(/ü/g,'ue').replace(/ß/g,'ss')
       .replace(/[^a-z0-9_-]+/g,'_').replace(/_+/g,'_').replace(/^_|_$/g,'');
   }
-  function landingParts(){ return el('landing').value.split('|'); }
 
   function buildUrl(){
     var src = slug(el('source').value), med = slug(el('medium').value), con = slug(el('content').value);
     if(!src || !med) return null;
-    var base = landingParts()[1];
+    var angebot = el('angebot').value, sprache = el('sprache').value;
+    var base = (LANDINGS[angebot] || {})[sprache];
+    if(!base) return null;
     var u = base + '?utm_source=' + encodeURIComponent(src) +
             '&utm_medium=' + encodeURIComponent(med) +
             '&utm_campaign=' + CAMPAIGN;
     if(con) u += '&utm_content=' + encodeURIComponent(con);
-    return { url:u, src:src, med:med, con:con };
+    return { url:u, src:src, med:med, con:con, angebot:angebot, sprache:sprache };
   }
 
   var current = null;
@@ -226,7 +242,7 @@
     } catch(e){ qr.innerHTML = '<span class="empty">QR</span>'; }
   }
 
-  ['source','medium','content','landing','rolle','ersteller'].forEach(function(id){
+  ['source','medium','content','angebot','sprache','rolle','ersteller'].forEach(function(id){
     el(id).addEventListener('input', render);
     el(id).addEventListener('change', render);
   });
@@ -257,7 +273,7 @@
     if(!current){ say('Erst Quelle und Medium wählen.', true); return; }
     var row = {
       kampagne: CAMPAIGN, utm_source: current.src, utm_medium: current.med, utm_campaign: CAMPAIGN,
-      utm_content: current.con || null, landing: landingParts()[0], url: current.url,
+      utm_content: current.con || null, landing: current.angebot, sprache: current.sprache, url: current.url,
       rolle: el('rolle').value, ersteller: slug(el('ersteller').value) || null
     };
     fetch(SB + '/rest/v1/sommer2026_links', {
@@ -286,7 +302,9 @@
           var q = document.createElement('span'); q.className = 'q';
           q.textContent = x.url; mot.appendChild(q);
           tr.children[1].textContent = [x.utm_source, x.utm_medium].filter(Boolean).join(' · ');
-          tr.children[2].textContent = x.landing || '';
+          var ziel = ANGEBOT_LABEL[x.landing] || x.landing || '';
+          if(x.sprache) ziel += ' · ' + x.sprache.toUpperCase();
+          tr.children[2].textContent = ziel;
           var n = Number(x.abschluesse) || 0;
           tr.children[3].textContent = n.toLocaleString('de-CH');
           if(n === 0) tr.children[3].className = 'num zero';

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -172,7 +172,8 @@ create table if not exists public.sommer2026_links (
   utm_medium   text not null,
   utm_campaign text not null default 'summer26_trial',
   utm_content  text,
-  landing      text,          -- welche Landingpage (global/ws/tv)
+  landing      text,          -- Angebot der Landingpage (uebersicht/wos/tv)
+  sprache      text,          -- Sprache der Landingpage (de/en)
   url          text not null, -- fertiger Link
   rolle        text,          -- Hauptaufgabe (sichtbarkeit/aktivierung/wirkung/bindung)
   ersteller    text           -- optionales Kürzel, kein Pflichtfeld
@@ -187,9 +188,9 @@ create policy sommer2026_links_insert on public.sommer2026_links
 -- Soll/Ist: je registriertem Link die Zahl der Anmeldungen über genau dieses UTM-Tupel
 create or replace function public.sommer2026_links_public()
 returns table(created_at timestamptz, utm_source text, utm_medium text, utm_content text,
-              landing text, url text, rolle text, ersteller text, abschluesse bigint)
+              landing text, sprache text, url text, rolle text, ersteller text, abschluesse bigint)
 language sql security definer set search_path to 'public' as $$
-  select l.created_at, l.utm_source, l.utm_medium, l.utm_content, l.landing, l.url, l.rolle, l.ersteller,
+  select l.created_at, l.utm_source, l.utm_medium, l.utm_content, l.landing, l.sprache, l.url, l.rolle, l.ersteller,
          count(s.id)::bigint as abschluesse
     from public.sommer2026_links l
     left join public.sommer2026_signups s
@@ -197,7 +198,7 @@ language sql security definer set search_path to 'public' as $$
       and s.utm_source   is not distinct from l.utm_source
       and s.utm_medium   is not distinct from l.utm_medium
       and s.utm_content  is not distinct from l.utm_content
-   group by l.id, l.created_at, l.utm_source, l.utm_medium, l.utm_content, l.landing, l.url, l.rolle, l.ersteller
+   group by l.id, l.created_at, l.utm_source, l.utm_medium, l.utm_content, l.landing, l.sprache, l.url, l.rolle, l.ersteller
    order by abschluesse desc, l.created_at desc;
 $$;
 grant execute on function public.sommer2026_links_public() to anon, authenticated;

--- a/services/sommer-zaehler/utm-ablauf.md
+++ b/services/sommer-zaehler/utm-ablauf.md
@@ -28,14 +28,20 @@ Regeln: nur Kleinbuchstaben, keine Umlaute (`ue/oe/ae`), keine Leerzeichen. Der
 Rohwerte bleiben erhalten, damit «Nach Motiv» das einzelne Reel vom Footer-Link
 unterscheidet.
 
-## Die drei Landingpages (Ziel des Links)
+## Die sechs Landingpages (Angebot × Sprache)
 
-- Übersicht · 3 Monate gratis → `https://global-sommer2026.goetheanum.online`
-- Wochenschrift → `https://ws-sommer2026.dasgoetheanum.com`
-- goetheanum.tv → `https://tv-sommer2026.goetheanum.tv`
+Drei Angebote, je Deutsch und English (EN = eigene Subdomain `…-en-…`, bei der
+Übersicht der Pfad `/en`):
+
+| Angebot | Deutsch | English |
+|---|---|---|
+| Übersicht · 3 Monate gratis | `https://global-sommer2026.goetheanum.online` | `https://global-sommer2026.goetheanum.online/en` |
+| Wochenschrift | `https://ws-sommer2026.dasgoetheanum.com` | `https://ws-en-sommer2026.dasgoetheanum.com` |
+| goetheanum.tv | `https://tv-sommer2026.goetheanum.tv` | `https://tv-en-sommer2026.goetheanum.tv` |
 
 Ein Link führt **nie** auf die nackte Startseite, sondern immer auf eine dieser
-drei Seiten – mit angehängtem UTM-Block.
+sechs Seiten – mit angehängtem UTM-Block. Der Generator wählt sie über
+Angebot + Sprache und führt die Sprache als Dimension ins Register.
 
 ## Wer erhält wo wie welchen Link
 


### PR DESCRIPTION
## Worum es geht

Der Generator kannte bisher nur drei Basis-Landingpages. Es gibt aber **sechs** – drei Angebote je Deutsch und English. Die echten URLs habe ich aus der universellen Landingpage recherchiert (sie verlinkt alle Varianten).

| Angebot | Deutsch | English |
|---|---|---|
| Übersicht | `global-sommer2026.goetheanum.online` | `…/en` |
| Wochenschrift | `ws-sommer2026.dasgoetheanum.com` | `ws-en-sommer2026.dasgoetheanum.com` |
| goetheanum.tv | `tv-sommer2026.goetheanum.tv` | `tv-en-sommer2026.goetheanum.tv` |

(EN = eigene `-en-`-Subdomain, bei der Übersicht der Pfad `/en`.)

## Änderungen

- **Generator** (`apps/utm-generator/`): statt einer Landing-Auswahl jetzt **Angebot × Sprache**; die sechs echten Ziele fest verdrahtet. Die Sprache wandert als Dimension ins Register und erscheint in der Soll/Ist-Tabelle (`Ziel · DE/EN`).
- **Backend** (Migration `sommer2026_links_sprache`): Spalte `sprache` in `sommer2026_links`, `sommer2026_links_public` gibt sie mit aus. Additiv.
- **`schema.sql` / `utm-ablauf.md`** nachgezogen (Sechser-Tabelle, EN-Muster).

## Geprüft

Live: Wochenschrift × English → `ws-en-sommer2026…`; Insert 201 mit `sprache`, RPC gibt `sprache` zurück (Testzeile danach entfernt). In Chromium gerendert: die zwei Selects (Angebot/Sprache) binden, URL + QR aktualisieren korrekt. **ds-lint 100 %, typo-check konform.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_