### PR TITLE
Generator: Backlink zum Kampagnen-Cockpit

### DIFF
--- a/apps/utm-generator/index.html
+++ b/apps/utm-generator/index.html
@@ -33,6 +33,7 @@
   .grid{display:grid;grid-template-columns:1fr 1fr;gap:var(--s4)}
   .grid .span2{grid-column:1 / -1}
   .field .hint{margin-top:6px}
+  .backlink{margin-top:var(--s4);font-family:var(--font-text);font-size:var(--t-small)}
 
   .out{margin-top:var(--s6);display:grid;grid-template-columns:1fr auto;gap:var(--s4);align-items:start}
   .urlbox{font-family:var(--font-mono,var(--font-text));font-size:var(--t-small);color:var(--ink);
@@ -72,6 +73,7 @@
     <span class="kicker">Kampagne · summer26_trial</span>
     <h1>UTM-Link-Generator</h1>
     <p class="lede">Baue in Sekunden einen sauberen Anmelde-Link – Quelle, Motiv und Ziel eindeutig beschriftet. So weiss das Cockpit später, welche Massnahme getragen hat.</p>
+    <p class="backlink"><a href="../sommer-zaehler/">← Zum Kampagnen-Cockpit (Sommer-Zähler)</a></p>
   </section>
 
   <section>


### PR DESCRIPTION
## Worum es geht

Der Generator hatte keinen sichtbaren Weg zurück zum Kampagnen-Monitor (nur klein im Footer).

## Änderung

- Sichtbarer Link im Kopf des Generators: **«← Zum Kampagnen-Cockpit (Sommer-Zähler)»**, symmetrisch zum «UTM-Links bauen →» im Cockpit. Der Footer-Link bleibt zusätzlich.

## Geprüft

ds-lint 100 %, typo-check konform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_