### PR TITLE
Generator-Löschknopf + Paperform gehärtet (PII/UTM/Format)

### DIFF
--- a/apps/utm-generator/index.html
+++ b/apps/utm-generator/index.html
@@ -47,7 +47,9 @@
   .said{font-family:var(--font-text);font-size:var(--t-micro);color:var(--ok);min-height:1.4em;margin-top:var(--s2)}
 
   .reg{width:100%;border-collapse:collapse;font-family:var(--font-text);font-size:var(--t-small);table-layout:fixed;min-width:520px}
-  .reg col.cMot{width:50%} .reg col.cQm{width:22%} .reg col.cZiel{width:12%} .reg col.cAb{width:16%}
+  .reg col.cMot{width:44%} .reg col.cQm{width:20%} .reg col.cZiel{width:12%} .reg col.cAb{width:12%} .reg col.cAct{width:12%}
+  .reg .del{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);background:none;border:0;cursor:pointer;padding:4px 6px;min-height:var(--tap)}
+  .reg .del:hover{color:var(--bad)} .reg td.act{text-align:right}
   .reg th,.reg td{padding:10px 12px;border-bottom:1px solid var(--line-soft);text-align:left;vertical-align:top}
   .reg thead th{color:var(--muted);font-weight:600;font-size:var(--t-micro)}
   .reg td.num,.reg th.num{text-align:right;font-variant-numeric:tabular-nums lining-nums}
@@ -174,9 +176,9 @@
     </div>
     <div class="tablewrap">
       <table class="reg">
-        <colgroup><col class="cMot" /><col class="cQm" /><col class="cZiel" /><col class="cAb" /></colgroup>
-        <thead><tr><th>Motiv</th><th>Quelle · Medium</th><th>Ziel</th><th class="num">Abschlüsse</th></tr></thead>
-        <tbody id="regBody"><tr><td class="empty" colspan="4">lädt …</td></tr></tbody>
+        <colgroup><col class="cMot" /><col class="cQm" /><col class="cZiel" /><col class="cAb" /><col class="cAct" /></colgroup>
+        <thead><tr><th>Motiv</th><th>Quelle · Medium</th><th>Ziel</th><th class="num">Abschlüsse</th><th></th></tr></thead>
+        <tbody id="regBody"><tr><td class="empty" colspan="5">lädt …</td></tr></tbody>
       </table>
     </div>
   </section>
@@ -314,16 +316,25 @@
     }).catch(function(){ say('Register nicht erreichbar.', true); });
   });
 
+  function loescheLink(url){
+    if(!window.confirm('Diesen Link wirklich aus dem Register löschen?')) return;
+    fetch(SB + '/rest/v1/rpc/sommer2026_link_loeschen', {
+      method:'POST', headers:{ 'Content-Type':'application/json', 'apikey':KEY, 'Authorization':'Bearer ' + KEY },
+      body: JSON.stringify({ p_url: url })
+    }).then(function(r){ if(r.ok){ say('Link gelöscht.'); loadRegister(); } else { say('Löschen nicht möglich (' + r.status + ').', true); } })
+      .catch(function(){ say('Löschen nicht erreichbar.', true); });
+  }
+
   function loadRegister(){
     fetch(SB + '/rest/v1/rpc/sommer2026_links_public', {
       method:'POST', headers:{ 'Content-Type':'application/json', 'apikey':KEY, 'Authorization':'Bearer ' + KEY }, body:'{}'
     }).then(function(r){ if(!r.ok) throw new Error(r.status); return r.json(); })
       .then(function(rows){
         var body = el('regBody'); body.innerHTML = '';
-        if(!rows || !rows.length){ body.innerHTML = '<tr><td class="empty" colspan="4">Noch keine Links registriert.</td></tr>'; return; }
+        if(!rows || !rows.length){ body.innerHTML = '<tr><td class="empty" colspan="5">Noch keine Links registriert.</td></tr>'; return; }
         rows.forEach(function(x){
           var tr = document.createElement('tr');
-          tr.innerHTML = '<td class="mot"></td><td></td><td></td><td class="num"></td>';
+          tr.innerHTML = '<td class="mot"></td><td></td><td></td><td class="num"></td><td class="act"></td>';
           var mot = tr.children[0];
           mot.textContent = x.utm_content || '—';
           var q = document.createElement('span'); q.className = 'q';
@@ -335,10 +346,15 @@
           var n = Number(x.abschluesse) || 0;
           tr.children[3].textContent = n.toLocaleString('de-CH');
           if(n === 0) tr.children[3].className = 'num zero';
+          var del = document.createElement('button');
+          del.type = 'button'; del.className = 'del'; del.textContent = 'Löschen';
+          del.setAttribute('aria-label', 'Link löschen');
+          del.addEventListener('click', function(){ loescheLink(x.url); });
+          tr.children[4].appendChild(del);
           body.appendChild(tr);
         });
       })
-      .catch(function(){ el('regBody').innerHTML = '<tr><td class="empty" colspan="4">Register nicht ladbar.</td></tr>'; });
+      .catch(function(){ el('regBody').innerHTML = '<tr><td class="empty" colspan="5">Register nicht ladbar.</td></tr>'; });
   }
 
   render();

--- a/services/sommer-zaehler/ingest-paperform/index.ts
+++ b/services/sommer-zaehler/ingest-paperform/index.ts
@@ -21,34 +21,52 @@ const SB = Deno.env.get("SUPABASE_URL")!;
 const KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 const H = { "Content-Type": "application/json", apikey: KEY, Authorization: `Bearer ${KEY}` };
 const EMAIL_RE = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i;
+// PII an der Paperform-Feldbeschriftung (data[].title/custom_key) erkennen …
+const PII_LABEL = /(name|vorname|nachname|first.?name|last.?name|e-?mail|phone|tel|mobil|strasse|street|address|adresse|\bzip\b|\bplz\b|city|\bort\b|company|unternehmen|country|\bland\b)/i;
+// … und an PII-tragenden Werten (z. B. Zoho-Checkout-URL mit ?first_name=&email=…).
+const PII_STR = /@|%40|(first_name|last_name|[?&]email=|street=|billing_|shipping_)/i;
 
 async function sha256Hex(s: string): Promise<string> {
   const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(s));
   return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-// UTM-Tupel + Landingpage aus einer im Body eingebetteten URL (Paperform trägt die
-// Herkunfts-URL mit; die Anmelde-Links tragen die UTM-Parameter der Massnahme).
+// UTM-Tupel + Landingpage. Paperform legt die Herkunft in `device` ab
+// (device.utm_source/…); ausserdem trägt device.url bzw. der ?_d=-Parameter die
+// Landingpage (auch bei eingebetteten Formularen). Fallback: UTMs aus einer im
+// Body eingebetteten URL.
 function utmFromBody(body: any): { src: string | null; med: string | null; camp: string | null; cont: string | null; land: string | null } {
-  const out = { src: null as string | null, med: null as string | null, camp: null as string | null, cont: null as string | null, land: null as string | null };
-  const urls = (JSON.stringify(body).match(/https?:\/\/[^\s"'<>\\]+/gi) || []);
-  for (const u of urls) {
-    try {
-      const url = new URL(u);
-      const q = url.searchParams;
-      out.src = out.src || q.get("utm_source"); out.med = out.med || q.get("utm_medium");
-      out.camp = out.camp || q.get("utm_campaign"); out.cont = out.cont || q.get("utm_content");
-      if ((q.get("utm_source") || q.get("utm_campaign")) && !out.land) out.land = url.pathname;
-    } catch { /* keine URL */ }
+  const d = (body && typeof body.device === "object") ? body.device : {};
+  const out = {
+    src: d.utm_source || null, med: d.utm_medium || null,
+    camp: d.utm_campaign || null, cont: d.utm_content || null, land: null as string | null,
+  };
+  try {
+    if (d.url) { const url = new URL(String(d.url)); out.land = url.searchParams.get("_d") || (url.host + (url.pathname === "/" ? "" : url.pathname)); }
+  } catch { /* keine URL */ }
+  if (!out.src && !out.camp) {
+    const urls = (JSON.stringify(body).match(/https?:\/\/[^\s"'<>\\]+/gi) || []);
+    for (const u of urls) {
+      try {
+        const q = new URL(u).searchParams;
+        out.src = out.src || q.get("utm_source"); out.med = out.med || q.get("utm_medium");
+        out.camp = out.camp || q.get("utm_campaign"); out.cont = out.cont || q.get("utm_content");
+      } catch { /* keine URL */ }
+    }
   }
   return out;
 }
 
-// PII entfernen: nach Schlüsselname UND E-Mail-artige Werte.
+// PII entfernen – Paperform-tauglich: nach Schlüsselname, nach Feldbeschriftung
+// (data[].title/custom_key) UND nach PII-tragenden Werten (E-Mail, Checkout-URL).
 function redact(o: any): any {
-  if (typeof o === "string") return EMAIL_RE.test(o) ? "***" : o;
+  if (typeof o === "string") return (EMAIL_RE.test(o) || PII_STR.test(o)) ? "***" : o;
   if (Array.isArray(o)) return o.map(redact);
   if (o && typeof o === "object") {
+    if (Object.prototype.hasOwnProperty.call(o, "value") && ("title" in o || "custom_key" in o)) {
+      const label = `${o.title ?? ""} ${o.custom_key ?? ""}`;
+      if (o.type === "email" || PII_LABEL.test(label)) return { ...o, value: "***" };
+    }
     const r: any = {};
     for (const k of Object.keys(o)) r[k] = /(email|name|phone|address|\bip\b|vorname|nachname|strasse)/i.test(k) ? "***" : redact(o[k]);
     return r;
@@ -87,9 +105,10 @@ Deno.serve(async (req) => {
   // Sprache/Format: URL-Vorgabe je Formular hat Vorrang, sonst aus Inhalt geraten.
   const sprache = (u.searchParams.get("sprache") || (/english|englisch/.test(blob) ? "en" : "de")).toLowerCase() === "en" ? "en" : "de";
   const formatQ = (u.searchParams.get("format") || "").toLowerCase();
+  // «Papier & Online» ist das Papier-Abo (inkl. Online) → papier hat Vorrang.
   const format = formatQ === "papier" || formatQ === "digital" ? formatQ
-    : /digital|online|e-?paper|\bpdf\b/.test(blob) ? "digital"
-    : /papier|print|gedruckt|\bpaper\b|frei haus/.test(blob) ? "papier" : "papier";
+    : /papier|print|gedruckt|\bpaper\b|frei haus/.test(blob) ? "papier"
+    : /digital|online|e-?paper|\bpdf\b/.test(blob) ? "digital" : "papier";
   const tarif = /erm(ä|ae)ss|reduc|student|reduziert/.test(blob) ? "ermaessigt" : "standard";
   const intervall = /(monat|month|mensuel)/.test(blob) ? "monatlich" : /(jähr|jahr|year|annual)/.test(blob) ? "jaehrlich" : "jaehrlich";
   const waehrungQ = (u.searchParams.get("waehrung") || "").toLowerCase();

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -203,6 +203,14 @@ language sql security definer set search_path to 'public' as $$
 $$;
 grant execute on function public.sommer2026_links_public() to anon, authenticated;
 
+-- Kontrolliertes Löschen eines registrierten Links (nur über RPC, per URL) –
+-- kein offenes DELETE für anon; begrenzt auf die Aktion.
+create or replace function public.sommer2026_link_loeschen(p_url text)
+returns void language sql security definer set search_path to 'public' as $$
+  delete from public.sommer2026_links where url = p_url and kampagne = 'summer26_trial';
+$$;
+grant execute on function public.sommer2026_link_loeschen(text) to anon, authenticated;
+
 -- =============================================================================
 -- Ingestion (Webhooks) – siehe ingest-uscreen/index.ts
 -- =============================================================================


### PR DESCRIPTION
## Worum es geht

Zwei Dinge: der gewünschte **Lösch-Knopf** im Link-Register, und **Härtung der Paperform-Ingestion** nach den ersten echten Einreichungen (Webhooks sind jetzt aktiv).

## Generator

- **Lösch-Knopf pro Zeile** im Register (mit Rückfrage). Löschen läuft über eine **kontrollierte RPC** `sommer2026_link_loeschen(p_url)` – kein offenes DELETE für anon.

## ingest-paperform (v4)

- **PII-Redaktion Paperform-tauglich:** maskiert `data[].value` nach Feldbeschriftung (Name/Adresse/PLZ/Ort/…) **und** PII-tragende Werte (E-Mail, Zoho-Checkout-URL mit `?first_name=&email=…`). Zuvor standen Name/Adresse im internen Roh-Log im Klartext.
- **UTMs aus `device.utm_*`** (dort legt Paperform sie ab), Landingpage aus `device.url`/`?_d`; der bisherige URL-Regex bleibt Fallback.
- **«Papier & Online» → `format=papier`** (papier hat Vorrang vor «online»).

## schema.sql

Lösch-RPC ergänzt (Doku-Gleichstand).

## Geprüft

Lösch-RPC live: insert → loeschen (204) → Register leer. Paperform v4 deployt. In Chromium gerendert: Lösch-Spalte, Rücklink, weicher QR. **ds-lint 100 %, typo-check konform.** Die vier Test-Einreichungen von heute wurden verifiziert (Dedup, Sprache/Währung korrekt) und anschliessend samt Roh-Log entfernt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_