### PR TITLE
Paperform: UTMs auch aus versteckten Formularfeldern lesen

### DIFF
--- a/services/sommer-zaehler/ingest-paperform/index.ts
+++ b/services/sommer-zaehler/ingest-paperform/index.ts
@@ -36,11 +36,24 @@ async function sha256Hex(s: string): Promise<string> {
 // Landingpage (auch bei eingebetteten Formularen). Fallback: UTMs aus einer im
 // Body eingebetteten URL.
 function utmFromBody(body: any): { src: string | null; med: string | null; camp: string | null; cont: string | null; land: string | null } {
+  const out = { src: null as string | null, med: null as string | null, camp: null as string | null, cont: null as string | null, land: null as string | null };
+  // 1) Versteckte Formularfelder mit Key utm_source/… (Prefill aus der URL).
+  const data = Array.isArray(body?.data) ? body.data : [];
+  for (const f of data) {
+    const k = String(f?.custom_key || f?.key || f?.title || "").toLowerCase();
+    const v = (f?.value ?? "").toString();
+    if (!v) continue;
+    if (k === "utm_source") out.src = out.src || v;
+    else if (k === "utm_medium") out.med = out.med || v;
+    else if (k === "utm_campaign") out.camp = out.camp || v;
+    else if (k === "utm_content") out.cont = out.cont || v;
+  }
+  // 2) Paperform-eigenes Tracking (device.utm_*), das die URL automatisch aufnimmt.
   const d = (body && typeof body.device === "object") ? body.device : {};
-  const out = {
-    src: d.utm_source || null, med: d.utm_medium || null,
-    camp: d.utm_campaign || null, cont: d.utm_content || null, land: null as string | null,
-  };
+  out.src = out.src || d.utm_source || null;
+  out.med = out.med || d.utm_medium || null;
+  out.camp = out.camp || d.utm_campaign || null;
+  out.cont = out.cont || d.utm_content || null;
   try {
     if (d.url) { const url = new URL(String(d.url)); out.land = url.searchParams.get("_d") || (url.host + (url.pathname === "/" ? "" : url.pathname)); }
   } catch { /* keine URL */ }

--- a/services/sommer-zaehler/utm-ablauf.md
+++ b/services/sommer-zaehler/utm-ablauf.md
@@ -94,6 +94,36 @@ nachgezogen», ohne sie mit dem eigentlichen Aktions-Newsletter zu vermischen.
   Massnahmen-Protokoll, Abschlüsse aus den Anmeldungen.
 - **Woher** (`sommer2026_kanaele`): der grobe Bucket mit Hauptaufgabe je Kanal.
 
+## Paperform: damit die UTMs im Webhook ankommen
+
+Die Kette ist **UTM-Link → Landingpage → Paperform-Formular → Webhook**; die UTMs
+müssen sie ganz überleben. Zwei Stellen:
+
+**1. Landingpage → Formular (Web-Seite):** Die Landingpage (`*-sommer2026…`) muss
+die eingehenden `?utm_*` an das Formular weiterreichen – am «3 Monate gratis»-
+Button (UTMs an die Formular-URL hängen) oder, bei eingebettetem Formular, die
+Query-Parameter an den Embed durchreichen. Ohne diesen Schritt sieht Paperform
+keine UTMs, egal wie sauber der Link war.
+
+**2. In Paperform, je Formular (der eigentliche To-do):** vier **versteckte
+Prefill-Felder** anlegen, deren **Key** exakt so heisst:
+
+| Feld-Key | füllt |
+|---|---|
+| `utm_source` | Quelle (instagram, nl-ws …) |
+| `utm_medium` | Art (social, email, print …) |
+| `utm_campaign` | `summer26_trial` |
+| `utm_content` | Motiv (reel_…, qr_inserat …) |
+
+Feld hinzufügen → als *Hidden* setzen → unter *Advanced/Prefilling* den **Key** auf
+`utm_source` usw. Paperform befüllt sie aus der Formular-URL. Die Function liest
+diese Felder direkt (`data[]`) **und** zusätzlich Paperforms eigenes
+`device.utm_*` – kommt die Spur über einen der Wege an, greift die Attribution.
+
+Test: einen generierten Link mit `utm_*` öffnen, Formular abschicken → in
+`sommer2026_signups` steht die Zeile mit gefüllten `utm_*`, im Cockpit unter
+«Nach Motiv».
+
 ## Pflege
 
 Neue Massnahme → Zeile im Massnahmen-Protokoll (`sommer2026_massnahmen`, Service-


### PR DESCRIPTION
## Worum es geht

Damit die vom Generator gebauten UTM-Links wirklich bis in die Auswertung tragen, muss die Function die UTMs zuverlässig aus der Paperform-Einreichung lesen – egal wie der Kollege es einrichtet.

## Änderung

- **`ingest-paperform` (v5):** `utmFromBody` liest UTMs in drei Stufen: (1) **versteckte Formularfelder** mit Key `utm_source/…` (Prefill aus der URL), (2) Paperforms eigenes **`device.utm_*`**, (3) Fallback aus eingebetteten URLs.
- **`utm-ablauf.md`:** konkrete Kollegen-Anleitung – die Landingpage muss die `?utm_*` ans Formular weiterreichen, und je Formular vier versteckte Prefill-Felder mit Key `utm_source/medium/campaign/content` anlegen.

## Geprüft

v5 deployt. Logik: data[]-Felder → device.utm_* → URL-Fallback. (Die vier Testdaten von heute waren ohne UTM; die Felder greifen, sobald ein UTM-Link genutzt wird.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_