### PR TITLE
Webhooks: Platzhalter-UTMs (none/leer) nicht als Attribution werten

### DIFF
--- a/services/sommer-zaehler/ingest-paperform/index.ts
+++ b/services/sommer-zaehler/ingest-paperform/index.ts
@@ -31,6 +31,13 @@ async function sha256Hex(s: string): Promise<string> {
   return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
+// Platzhalter-Werte (Feld-Default «none», leer, «n/a» …) NICHT als UTM werten.
+function cleanUtm(v: any): string | null {
+  if (v == null) return null;
+  const s = String(v).trim();
+  return (s === "" || /^(none|n\/?a|null|undefined|-)$/i.test(s)) ? null : s;
+}
+
 // UTM-Tupel + Landingpage. Paperform legt die Herkunft in `device` ab
 // (device.utm_source/…); ausserdem trägt device.url bzw. der ?_d=-Parameter die
 // Landingpage (auch bei eingebetteten Formularen). Fallback: UTMs aus einer im
@@ -67,6 +74,8 @@ function utmFromBody(body: any): { src: string | null; med: string | null; camp:
       } catch { /* keine URL */ }
     }
   }
+  out.src = cleanUtm(out.src); out.med = cleanUtm(out.med);
+  out.camp = cleanUtm(out.camp); out.cont = cleanUtm(out.cont);
   return out;
 }
 

--- a/services/sommer-zaehler/ingest-uscreen/index.ts
+++ b/services/sommer-zaehler/ingest-uscreen/index.ts
@@ -54,6 +54,13 @@ function scrubEmail(s: string): string {
   return s.replace(/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi, "***");
 }
 
+// Platzhalter-Werte (Feld-Default «none», leer, «n/a» …) NICHT als UTM werten.
+function cleanUtm(v: any): string | null {
+  if (v == null) return null;
+  const s = String(v).trim();
+  return (s === "" || /^(none|n\/?a|null|undefined|-)$/i.test(s)) ? null : s;
+}
+
 // Volles UTM-Tupel + Landingpage: direkte Felder, sonst aus einer eingebetteten URL nachziehen.
 function utmFrom(data: any): { src: any; med: any; camp: any; cont: any; land: any } {
   const g = (k: string) => pick(data, [k, "custom_fields." + k, "utm." + k.replace("utm_", ""), "query." + k]);
@@ -174,7 +181,8 @@ Deno.serve(async (req) => {
   if (!istAktion) return json({ ok: true, skipped: "nicht Aktion (Coupon/Plan)" });
 
   const { sprache, intervall, tarif } = mapPlan(title);
-  const { src, med, camp, cont, land } = utmFrom(data);
+  const utmRaw = utmFrom(data);
+  const src = cleanUtm(utmRaw.src), med = cleanUtm(utmRaw.med), camp = cleanUtm(utmRaw.camp), cont = cleanUtm(utmRaw.cont), land = utmRaw.land;
   // Offene Selbstauskunft «Wie sind Sie aufmerksam geworden?» (Custom User Field) – O-Ton, E-Mail-redigiert.
   const selbst0 = pick(data, ["referral_source", "how_heard", "how_did_you_hear", "custom_fields.how_did_you_hear", "user_field_1", "user_fields.0.value"]);
   const selbst = selbst0 ? scrubEmail(String(selbst0)).slice(0, 300) : null;


### PR DESCRIPTION
## Worum es geht

Bei den Live-Tests kamen die versteckten Paperform-Felder mit ihrem Default-Wert **`none`** an (weil die Landingpage die echten `?utm_*` noch nicht ins Popup durchreicht). Ein solcher Platzhalter darf die Attribution nicht verschmutzen.

## Änderung

- Neue Helferin `cleanUtm()`: wertet `none` / leer / `n/a` / `null` / `-` als **kein UTM** (→ `null`).
- Angewandt in **beiden** Functions: `ingest-paperform` (v6) und `ingest-uscreen` (v10).
- `kampagne` fällt entsprechend auf `summer26_trial` zurück statt „none".

## Geprüft

Beide Functions deployt. Verhalten unverändert bei echten UTM-Werten (im vorigen Test bestätigt: `deviceauto`/`hiddenfield` wurden gelesen); nur Platzhalter werden jetzt verworfen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_