### PR TITLE
Fix: Marketing-Maschine-Seite lädt Styling + Secrets-Gerüst

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/SECRETS.md
+++ b/SECRETS.md
@@ -1,0 +1,71 @@
+# Secrets & Zugänge — wie Tokens hier bereitliegen
+
+Ziel: Zugänge (Vercel, Supabase, Resend, …) liegen **bereit** und werden **bei
+Bedarf freigegeben** — ohne pro Nutzung einen Token neu zu erzeugen und wieder
+zu widerrufen. Es gibt zwei Mechanismen; nimm für jeden Dienst den oberen, wenn
+möglich.
+
+## 1. MCP-Connector (OAuth) — bevorzugt, «nie einsehbar»
+Einmal auf Org-Ebene in den **claude.ai-Connector-Einstellungen** autorisieren.
+Danach liegt der Token in Anthropics verwaltetem Speicher, **kommt nie in den
+Container** (weder Session noch Assistent sehen ihn), und wird server-seitig
+eingespeist. «Freigeben bei Bedarf» = der **Pro-Chat-Schalter** je Connector.
+Kein Neu-Erzeugen, kein Widerrufen pro Nutzung.
+
+## 2. Environment-Variable — nur wo es keinen Connector gibt
+Ein **langlebiger, eng gescopter** Key als Umgebungs-Variable in der
+Environment-Konfiguration (`.env`-Format, `KEY=value`, ohne Anführungszeichen).
+Einmal setzen, dauerhaft wiederverwenden.
+
+> **Vorbehalt (Doku):** Ein dediziertes, verschlüsseltes Secrets-Lager gibt es
+> bei Claude Code on the web noch nicht. Environment-Variablen sind für **jeden
+> sichtbar, der die Umgebung bearbeiten darf**, und jeder Prozess der Session
+> kann sie lesen. Darum: minimale Scopes, Ablaufdatum, und — wenn Trennung
+> wichtig ist — sensible Keys in eine **eigene Umgebung**, die nur bei Bedarf
+> aktiviert wird.
+
+**Nie** Tokens in Chat, Commits oder ins Repo schreiben.
+
+## Dienste-Register
+
+| Dienst | Mechanismus | Secret-Name (Env) | Minimal-Scope | Stand |
+|---|---|---|---|---|
+| **Vercel** | Connector | — | — | verbunden |
+| **Supabase** | Connector | — | — | verbunden |
+| **Canva** | Connector | — | — | verbunden |
+| **Google Drive** | Connector | — | — | verbunden |
+| **ActiveCampaign** | Connector | — | — | installiert, **Auth erneuern** |
+| **GitHub** | Connector/Proxy | (`GH_TOKEN` nur für `gh`-CLI) | `repo`, `read:org` | über Proxy |
+| **Resend** | Env-Variable | `RESEND_API_KEY` | nur Senden (`sending`) | einzutragen |
+| *(Alternative: Brevo)* | Connector | — | — | im Verzeichnis, nicht installiert |
+
+## Env-Variablen setzen (Web-UI)
+Umgebung wählen → bearbeiten → **Environment variables** → `.env`-Zeilen, z. B.:
+
+```text
+RESEND_API_KEY=<eintragen, nicht hier>
+```
+
+`gh`-CLI (falls je nötig) liest automatisch `GH_TOKEN`.
+
+## `.mcp.json` (Projekt-Scope, für key-basierte MCP-Server)
+Die verwalteten Connector (Vercel/Supabase/…) werden **im claude.ai-UI**
+gepflegt, **nicht** hier — deshalb ist `mcpServers` leer. Für einen
+**key-basierten** Server (der einen Env-Token liest) eine Zeile ergänzen, z. B.:
+
+```jsonc
+{
+  "mcpServers": {
+    // Beispiel — nur eintragen, wenn ein solcher Server wirklich genutzt wird:
+    // "resend": {
+    //   "command": "npx",
+    //   "args": ["-y", "@some/resend-mcp-server"],
+    //   "env": { "RESEND_API_KEY": "${RESEND_API_KEY}" }
+    // }
+  }
+}
+```
+
+## Merksatz
+Connector, wo es einen gibt (parat + nie einsehbar + kein Recycling); Env-Key
+mit Minimal-Scope nur für den Rest; niemals im Chat oder Repo.

--- a/marketing-maschine.html
+++ b/marketing-maschine.html
@@ -12,11 +12,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Marketing-Maschine · Goetheanum</title>
 <meta name="description" content="Jahreszyklus, Kampagnen, Leads: die weitgehend automatisierte Marketing-Maschine für die Wochenschrift und goetheanum.tv – auf einer Seite." />
-<link rel="icon" type="image/svg+xml" href="https://phtok.github.io/goeloggen/assets/logos/goetheanum-mark-blue.svg" />
+<link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
 
-<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/tokens.css" />
-<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/base.css" />
-<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/nav.css" />
+<link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/base.css" />
+<link rel="stylesheet" href="design-system/nav.css" />
 
 <style>
   /* Nur seiteneigene Feinheiten – alles Gemeinsame steht in base.css. Tokens statt Werte. */
@@ -41,9 +41,10 @@
 </head>
 <body>
 
-<script src="https://phtok.github.io/goeloggen/design-system/nav.js"
-        data-root="https://phtok.github.io/goeloggen/"
-        data-variant="werkzeug"></script>
+<script src="design-system/nav.js"
+        data-root="./"
+        data-section="statistik"
+        data-active="marketing-maschine"></script>
 
 <main class="wrap">
 


### PR DESCRIPTION
## Worum es geht

Zwei Dinge:

### 1. Bugfix — die Live-Seite rendert unstyled
`marketing-maschine.html` band `tokens.css` / `base.css` / `nav.js` mit **absoluten** `https://phtok.github.io/goeloggen/…`-URLs ein. Auf der Produktivdomain **`werkzeuge.goetheanum.ch`** (CNAME) leiten diese per **301 auf `http://`** um → auf der HTTPS-Seite blockiert der Browser das als **Mixed Content** → kein CSS, keine Kopfleiste. Umgestellt auf **relative Pfade** (`design-system/tokens.css`, `data-root="./"`, `data-section="statistik"`), genau wie alle bereits funktionierenden Seiten (`typografie.html`, `apps/*`). Die Seite erscheint damit wieder im Hausbild.

### 2. Secrets-Gerüst (Zugangs-Verwaltung)
- **`SECRETS.md`** — Strategie: MCP-Connector (OAuth, „nie einsehbar") wo verfügbar, sonst langlebige, eng gescopte Env-Variable; Dienste-Register (Vercel, Supabase, Canva, ActiveCampaign, GitHub, Resend/Brevo) mit Minimal-Scopes; ehrlicher Vorbehalt zur Env-Sichtbarkeit.
- **`.mcp.json`** — leeres, valides Projekt-Gerüst (die verwalteten Connector laufen im claude.ai-UI, nicht hier).

## Prüfung
- `typo-check.py` grün (de-CH; G20 schmales Spatium in Abkürzungen).
- `ds-lint.py` — DS-Score **100 %**.
- Fix verifiziert an der Ursache: Domain liefert `tokens.css` über HTTPS (200); bestehende Seiten binden relativ ein.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dxfjredm1xtFBrrYcnKjc

---
_Generated by [Claude Code](https://claude.ai/code/session_019Dxfjredm1xtFBrrYcnKjc)_