### PR TITLE
Perspektiven der Webfamilie: vier Testseiten + neue Fundament-Rollen (v1.2.0)

### DIFF
--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -16,6 +16,25 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ---
 
+## [1.2.0] – 2026-07-06
+
+### Webfamilie-Komponenten + Bühne (aus dem Vier-Seiten-Befund aufgenommen)
+- **Was:** Neue kanonische Rollen in `base.css` — Artikel-Anatomie (`crumbs`,
+  `byline`, `lit`, `bio`, `related` + `starter-artikel.html`), `teaser` (+ `.stack`),
+  `event` + `filterbar`, `stage`/`mrow`/`mtile`/`live` (Medienkatalog),
+  `person`, `subscribe`, `.ds-footer .fcols`. Neue theme-feste Tokens
+  `--stage-bg/-bg2/-ink/-muted/-veil` (Kontraste gerechnet: ink 15.3:1,
+  muted 8.2:1).
+- **Warum:** Analyse der vier grossen Goetheanum-Webseiten
+  (`docs/webfamilie-befund.md`): ihre Inhaltsmuster (Artikel, Kalender,
+  Medienkacheln, Newsletter) fehlten dem Fundament; ihre wiederkehrenden
+  Fehler (Versal-Bylines, <14px, Kontrast-Fails, lh 1.4) zeigen, welche
+  Regeln die Rollen einbauen müssen.
+- **Wirkung:** Vier Testseiten unter `perspektiven/` zeigen je Original den
+  Nachbau, den gerechneten Vorher-nachher-Befund und den Einbau-Weg
+  (Craft/WordPress/Uscreen). Schaufenster-Abschnitt «Perspektiven des
+  Design-Systems». `contract.json` → Version 1.2.0, Rollen ergänzt.
+
 ## [Unveröffentlicht]
 
 ### Neuer Font «Goetheanum Pfeile» – Pfeile & Kompass ohne PUA-Umweg

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -305,3 +305,99 @@ img,svg,canvas,video{max-width:100%}
 /* Titel, Kicker und die Kopfzeile bleiben ausdrücklich Goetheanum (Identität). */
 :root[data-read="easy"] h1,:root[data-read="easy"] h2,:root[data-read="easy"] h3,:root[data-read="easy"] h4,
 :root[data-read="easy"] .kicker,:root[data-read="easy"] .kick{font-family:var(--font-display)}
+
+/* =============================================================================
+   Webfamilie-Komponenten (Juli 2026) — aus dem Vier-Seiten-Befund
+   (docs/webfamilie-befund.md §3) ins Fundament aufgenommen: Artikel-Anatomie,
+   Teaser, Veranstaltung + Filterleiste, Bühne/Medienkachel, Person, Newsletter,
+   Fusszeilen-Spalten. Regeln: Funktion/Daten in der Lese-Grotesk (Schrift-
+   Grenze), B02 gerechnet, B03 ≥14px, B04 Ziele ≥44px, G05 nie versal.
+   ============================================================================= */
+
+/* --- Brotkrumen & Byline (Funktion → Lese-Grotesk, nie versal) -------------- */
+.crumbs{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);
+  display:flex;flex-wrap:wrap;gap:4px 8px;align-items:baseline}
+.crumbs a{color:var(--muted)}
+.crumbs a:hover{color:var(--gold-ink)}
+.byline{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);
+  display:flex;flex-wrap:wrap;gap:4px 16px;align-items:baseline}
+.byline b{color:var(--ink);font-weight:600}
+
+/* --- Artikel-Anatomie (Vorbild Wochenschrift, mit unseren Faktoren) --------- */
+.lit{border-top:1px solid var(--line);margin-top:var(--s8);padding-top:var(--s4);
+  font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);
+  max-width:min(var(--measure),100%)}
+.lit p{margin:0 0 .5em}
+.bio{display:flex;gap:var(--s4);align-items:flex-start;border-top:1px solid var(--line);
+  margin-top:var(--s6);padding-top:var(--s6)}
+.bio .btext{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);line-height:1.6}
+.bio .btext b{color:var(--ink);font-weight:600}
+.related{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:var(--s4)}
+
+/* --- Teaser (Startseiten-Hierarchie: Bild · Kicker · Titel · Vorspann · Meta) */
+.teaser{display:flex;gap:var(--s4);align-items:flex-start;padding:var(--s4);
+  border:1px solid var(--line-soft);border-radius:var(--r-card);background:var(--paper);
+  color:var(--ink);text-decoration:none}
+.teaser:hover{border-color:var(--gold)}
+.teaser .thumb{flex:0 0 auto;width:116px;aspect-ratio:4/3;border-radius:10px;background:var(--soft);
+  border:1px solid var(--line-soft)}
+.teaser h3{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:var(--t-h3);
+  line-height:var(--lh-tight);margin:2px 0 6px}
+.teaser .ex{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);line-height:1.55;margin:0 0 8px}
+.teaser.stack{flex-direction:column}
+.teaser.stack .thumb{width:100%;aspect-ratio:16/9}
+
+/* --- Veranstaltung + Filterleiste (Vorbild goetheanum.ch, Ziffern G25) ------ */
+.filterbar{display:flex;gap:var(--s3);flex-wrap:wrap;align-items:flex-end;margin-bottom:var(--s6)}
+.filterbar .field{min-width:160px;flex:1 1 160px}
+.event{display:flex;gap:var(--s4);align-items:flex-start;padding:var(--s4);
+  border:1px solid var(--line);border-radius:var(--r-card);background:var(--paper)}
+.event .edate{flex:0 0 auto;min-width:64px;text-align:center;border:1px solid var(--line);
+  border-radius:10px;padding:8px 10px;font-family:var(--font-text);font-variant-numeric:tabular-nums}
+.event .edate b{display:block;font-size:24px;line-height:1.1;color:var(--ink);font-weight:600}
+.event .edate span{font-size:var(--t-micro);color:var(--muted)}
+.event h3{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:var(--t-h3);
+  line-height:var(--lh-tight);margin:0 0 4px}
+.event .emeta{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)}
+
+/* --- Bühne + Medienkachel (theme-feste Katalogfläche, Vorbild goetheanum.tv) - */
+.stage{background:var(--stage-bg);color:var(--stage-ink);border-radius:var(--r-card);
+  padding:var(--s6);color-scheme:dark}
+.stage .smeta{font-family:var(--font-text);font-size:var(--t-small);color:var(--stage-muted)}
+.mrow{display:grid;grid-auto-flow:column;grid-auto-columns:minmax(210px,240px);gap:var(--s4);
+  overflow-x:auto;scroll-snap-type:x proximity;padding:var(--s2) 2px var(--s3)}
+.mtile{scroll-snap-align:start;color:var(--stage-ink);text-decoration:none;display:block}
+.mtile .poster{position:relative;aspect-ratio:16/9;border-radius:10px;background:var(--stage-bg2);
+  display:grid;place-items:center;overflow:hidden}
+.mtile .dur{position:absolute;right:8px;bottom:8px;font-family:var(--font-text);
+  font-size:var(--t-micro);font-variant-numeric:tabular-nums;color:var(--stage-ink);
+  background:var(--stage-veil);border-radius:6px;padding:2px 8px}
+.mtile .mt{display:block;font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:16px;
+  line-height:1.25;margin-top:8px}
+.mtile .ms{display:block;font-family:var(--font-text);font-size:var(--t-micro);color:var(--stage-muted);margin-top:2px}
+.mtile:hover .poster{outline:2px solid var(--gold)}
+.live{display:inline-block;font-family:var(--font-text);font-size:var(--t-micro);
+  background:var(--gold-deep);color:var(--on-accent);border-radius:var(--r-pill);padding:2px 10px}
+
+/* --- Person / Kontakt -------------------------------------------------------- */
+.person{display:flex;gap:var(--s3);align-items:center}
+.person .pv{flex:0 0 auto;width:44px;height:44px;border-radius:var(--r-pill);
+  background:var(--gold-deep);color:var(--on-accent);display:grid;place-items:center;
+  font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:16px}
+.person .pn{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:17px;line-height:1.2}
+.person .pr{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)}
+.person a{color:var(--gold-ink)}
+
+/* --- Newsletter-Einstieg (ein Feld, ein Knopf – B03: Eingabe ≥16px) ---------- */
+.subscribe{display:flex;gap:var(--s2);flex-wrap:wrap;max-width:460px}
+.subscribe input{flex:1 1 220px;font-family:var(--font-text);font-size:16px;color:var(--ink);
+  background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);
+  padding:10px 14px;min-height:var(--tap);outline:none}
+.subscribe input:focus{border-color:var(--gold)}
+
+/* --- Fusszeile mit Spalten (Vorbild 7-Block-Footer goetheanum.ch) ------------ */
+.ds-footer .fcols{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
+  gap:var(--s6);margin-bottom:var(--s6)}
+.ds-footer .fcols .ft{font-family:var(--font-display);font-weight:var(--w-deutlich);
+  color:var(--ink);margin-bottom:var(--s2)}
+.ds-footer .fcols a{display:block;padding:3px 0}

--- a/design-system/contract.json
+++ b/design-system/contract.json
@@ -1,33 +1,48 @@
 {
   "$schema": "https://goetheanum/design-system/contract.schema.json",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "titel": "Goetheanum Design-System – Struktur-Vertrag",
   "zweck": "Maschinenlesbare Grundlage der GESTALT-Konformität (symmetrisch zum sprachlichen Kanon in assets/typografie/). ds-lint.py prüft jede Seite hiergegen, ds-fix.py korrigiert deterministisch, das Schaufenster bildet es ab. Eine Quelle der Wahrheit für Struktur; Werte/Farben/Schnitte bleiben in tokens.css/tokens.json.",
-
   "geltungsbereich": {
     "prüfe": "versionierte *.html mit einem <body> (publizierte Werkzeug- und Schau-Seiten)",
-    "ausgenommen_substr": ["/assets/", "/tools/goetheanum-fontfix/", "archive/", "reference/", "vendor/"],
-    "ausgenommen_dateien": ["design-system/navigation.html"],
+    "ausgenommen_substr": [
+      "/assets/",
+      "/tools/goetheanum-fontfix/",
+      "archive/",
+      "reference/",
+      "vendor/"
+    ],
+    "ausgenommen_dateien": [
+      "design-system/navigation.html"
+    ],
     "weiterleitungs_stubs": "Root-Stubs ohne eigenes <style>/<link> (reine Redirects) werden übersprungen."
   },
-
   "includes": {
     "regel": "Pflicht-Includes einbinden: tokens.css UND base.css (Reihenfolge: tokens VOR base; nav.css zusätzlich für Seiten mit globaler Kopfzeile).",
-    "pflicht": ["design-system/tokens.css", "design-system/base.css"],
+    "pflicht": [
+      "design-system/tokens.css",
+      "design-system/base.css"
+    ],
     "hinweis": "Reihenfolge: tokens.css VOR base.css. nav.css zusätzlich für Seiten mit globaler Kopfzeile.",
     "ds_id": "DS01",
     "schwere": "fehler"
   },
-
   "farben": {
     "ds_id": "DS02",
     "regel": "Farbwerte nur über Tokens (var(--…)). Hartverdrahtete Hex-/rgb()-Farben in color/background/border-color/fill/stroke sind verboten – ausser in Custom-Property-DEFINITIONEN (--x:…), @font-face und url().",
     "schwere": "fehler",
-    "erlaubte_property_präfixe": ["--"],
-    "ignorierte_properties": ["box-shadow", "-webkit-box-shadow", "filter", "background-image", "text-shadow"],
+    "erlaubte_property_präfixe": [
+      "--"
+    ],
+    "ignorierte_properties": [
+      "box-shadow",
+      "-webkit-box-shadow",
+      "filter",
+      "background-image",
+      "text-shadow"
+    ],
     "hinweis": "box-shadow/Filter dürfen rgba() für Schatten nutzen. Seiten-eigene Tokens (--good:#…) sind die seltene Ausnahme, kein Normalfall."
   },
-
   "groessen": {
     "ds_id": "DS03",
     "regel": "Keine lesbare Schrift unter den Untergrenzen (Stand 2026, inklusiv). font-size in px: Fliesstext ≥18, Meta/Label ≥15, nichts Lesbares <14.",
@@ -37,40 +52,95 @@
     "warn_schwere": "hinweis",
     "hinweis": "Floor von 13 auf 14 angehoben (16px-Norm ‹bei 16 beginnen, hochskalieren›). 14px erlaubt (=--t-micro). Bevorzugt die fluiden Skala-Tokens (--t-body/--t-small/--t-micro/--t-lede/--t-h*) statt fester px."
   },
-
   "rollen": {
     "ds_id": "DS04",
     "regel": "Kanonische Textrollen (base.css) NICHT seiten-lokal mit eigener font-size/color redefinieren. Klasse verwenden, nicht neu erfinden.",
     "schwere": "hinweis",
-    "kanonische_klassen": ["kicker", "kick", "lede", "note", "hint", "help", "desc", "subhead", "meta", "cap", "caption", "legend", "byline", "lab", "role", "readout", "mono", "code", "lese", "prose", "chip", "btn", "seg", "field", "shead", "hero", "card", "step-num"],
+    "kanonische_klassen": [
+      "kicker",
+      "kick",
+      "lede",
+      "note",
+      "hint",
+      "help",
+      "desc",
+      "subhead",
+      "meta",
+      "cap",
+      "caption",
+      "legend",
+      "byline",
+      "lab",
+      "role",
+      "readout",
+      "mono",
+      "code",
+      "lese",
+      "prose",
+      "chip",
+      "btn",
+      "seg",
+      "field",
+      "shead",
+      "hero",
+      "card",
+      "step-num",
+      "crumbs",
+      "teaser",
+      "event",
+      "filterbar",
+      "stage",
+      "mrow",
+      "mtile",
+      "live",
+      "person",
+      "subscribe",
+      "lit",
+      "bio",
+      "related",
+      "fcols"
+    ],
     "hinweis": "Treffer = Seite definiert .note/.hint/.lede/… selbst. ds-fix kann die lokale Regel entfernen, sobald base.css die Rolle trägt."
   },
-
   "hervorhebung": {
     "ds_id": "DS05",
     "regel": "Betonung nur über Gewicht/Laut. Verboten als Hervorhebung: Unterstreichen (text-decoration:underline auf em/strong/Fliesstext), Versalien (text-transform:uppercase auf Kicker/Titel/Betonung), Sperren über Leertasten.",
     "schwere": "hinweis",
-    "verbotene_muster": ["text-decoration:underline", "text-transform:uppercase"],
-    "bezug": ["G05", "G23"],
+    "verbotene_muster": [
+      "text-decoration:underline",
+      "text-transform:uppercase"
+    ],
+    "bezug": [
+      "G05",
+      "G23"
+    ],
     "hinweis": "Links dürfen unterstrichen sein; Treffer auf Betonungs-Selektoren (strong/b/em/.kicker/h1..h4) sind der Verstoss."
   },
-
   "kopfzeile": {
     "ds_id": "DS06",
     "regel": "Keine eigene Kopfzeile/Fake-Logo. Die globale Leiste kommt aus nav.js (design-system/nav.js). Seiten setzen keine eigene sticky .ds-header / kein eigenes Marken-Logo im Kopf.",
     "schwere": "hinweis",
-    "verdächtige_muster": ["class=\"ds-header\"", "class=\"page-head", "<header"],
+    "verdächtige_muster": [
+      "class=\"ds-header\"",
+      "class=\"page-head",
+      "<header"
+    ],
     "hinweis": "Treffer prüfen: nutzt die Seite nav.js? Eigener <header> mit Logo = Verstoss (siehe design-system/index.html, behoben in #161)."
   },
-
   "theme": {
     "ds_id": "DS07",
     "regel": "Flächen tokenisiert, damit Hell/Dunkel allein aus den Tokens kippt. Kein hartes #fff/#000/white/black als Flächen- oder Textfarbe.",
     "schwere": "fehler",
-    "verbotene_literale": ["#fff", "#ffffff", "#000", "#000000", "white", "black"],
+    "verbotene_literale": [
+      "#fff",
+      "#ffffff",
+      "#000",
+      "#000000",
+      "white",
+      "black"
+    ],
     "hinweis": "Teilmenge von DS02, separat gemeldet, weil es der häufigste Dunkelmodus-Bruch ist (--paper/--ink/--soft/--field-bg statt #fff)."
   },
-
   "score": {
     "definition": "konforme Seiten / geprüfte Seiten. Konform = kein Verstoss der Schwere ‹fehler›.",
     "ziel": 1.0

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -344,8 +344,50 @@
     </ol>
     <div class="demo" style="margin-top:var(--s6)">
       <a class="btn primary" href="starter.html">Starter öffnen</a>
+      <a class="btn" href="starter-artikel.html">Artikel-Starter öffnen</a>
       <a class="btn" href="README.md">Workflow-Doku</a>
       <a class="btn ghost" href="../tools.json">Manifest ansehen</a>
+    </div>
+  </section>
+
+  <!-- ================= Perspektiven ================= -->
+  <section id="perspektiven">
+    <div class="shead">
+      <h2>Perspektiven des Design-Systems</h2>
+      <p>Von und miteinander lernen.</p>
+    </div>
+    <p class="note" style="max-width:64ch">
+      Im Juli 2026 wurden die vier grossen Goetheanum-Webseiten untersucht —
+      Roh-HTML und CSS ausgewertet, Kontraste gerechnet. Der Befund: die Familie
+      spricht mit vier Stimmen, drei davon tasten nach Titillium, der Basis der
+      Hausschrift; das Gold existiert überall als Instinkt, nirgends als Token;
+      und alle vier scheitern an denselben Stellen, die dieses System per
+      Konstruktion prüft. Zugleich haben die Seiten, was hier fehlte: Artikel,
+      Kalender, Medienkatalog, vier Sprachen. Beides floss zusammen — die neuen
+      Rollen (Teaser, Veranstaltung, Bühne/Medienkachel, Person, Newsletter,
+      Fusszeilen-Spalten, Artikel-Anatomie) stehen jetzt im Fundament, und je
+      Seite zeigt eine Testseite, wie das System sie verändern würde: Nachbau,
+      gerechneter Vorher-nachher-Befund und der Einbau-Weg für die jeweilige
+      Plattform. Nachzulesen in
+      <a href="https://github.com/phtok/goeloggen/blob/main/docs/webfamilie-befund.md">docs/webfamilie-befund.md</a>.
+    </p>
+    <div class="grid4" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:var(--s4);margin-top:var(--s6)">
+      <a class="teaser stack" href="../perspektiven/goetheanum-ch.html">
+        <span class="thumb" aria-hidden="true" style="background:var(--blue-solid)"></span>
+        <span><span class="kick">Hauptseite</span><h3>goetheanum.ch</h3>
+        <p class="ex">Kalender, Teaser, Sieben-Block-Footer — mit Tokens statt 74 Hex-Literalen.</p></span></a>
+      <a class="teaser stack" href="../perspektiven/dasgoetheanum.html">
+        <span class="thumb" aria-hidden="true" style="background:var(--gold-deep)"></span>
+        <span><span class="kick">Wochenschrift</span><h3>dasgoetheanum.com</h3>
+        <p class="ex">Die Artikel-Anatomie — mit Lesemass 62ch und Zeilenhöhe 1.66 statt 1.4.</p></span></a>
+      <a class="teaser stack" href="../perspektiven/goetheanum-tv.html">
+        <span class="thumb" aria-hidden="true" style="background:var(--stage-bg2)"></span>
+        <span><span class="kick">Streaming</span><h3>goetheanum.tv</h3>
+        <p class="ex">Der Katalog auf der dunklen Bühne — Kontraste gerechnet, Marke hörbar.</p></span></a>
+      <a class="teaser stack" href="../perspektiven/anthroposophie-org.html">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-aas)"></span>
+        <span><span class="kick">Weltweit</span><h3>anthroposophie.org</h3>
+        <p class="ex">Rubrik, vier Sprachen, Newsletter — ohne Phantom-Schriften.</p></span></a>
     </div>
   </section>
 

--- a/design-system/starter-artikel.html
+++ b/design-system/starter-artikel.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<!-- =============================================================================
+     Goetheanum-Werkzeug · STARTER ARTIKEL
+     -----------------------------------------------------------------------------
+     Kanonische Artikelseite für echten Mengentext (Webfamilie-Befund §4, Vorbild
+     Wochenschrift — aber mit unseren Faktoren): Brotkrumen → Kicker → Titel →
+     Byline → Lede → Langtext (.prose, ~62ch, lh 1.66) → Literatur → Autoren-Bio
+     → Verwandte Artikel. Byline normal, nie versal (G05); Ziffern tabellarisch,
+     wo sie Daten sind (G25); alles Lesbare ≥14px (B03).
+
+     Verwenden: Datei kopieren, die mit «DEIN ARTIKEL» markierte Mitte füllen,
+     in tools.json registrieren. Includes sind absolut — funktioniert von überall.
+     ============================================================================= -->
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Artikel-Titel · Goetheanum</title>
+<meta name="description" content="Vorspann des Artikels in einem Satz." />
+<link rel="icon" type="image/svg+xml" href="https://phtok.github.io/goeloggen/assets/logos/goetheanum-mark-blue.svg" />
+<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/tokens.css" />
+<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/base.css" />
+<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/nav.css" />
+<style>
+  /* Nur Artikel-Layout; Rollen (crumbs/byline/lit/bio/related) kommen aus base.css. */
+  .artkopf{padding-block:clamp(36px,6vw,64px) var(--s6);max-width:min(72ch,100%)}
+  .artkopf h1{max-width:24ch}
+  .artkopf .lede{margin-top:var(--s4)}
+  .artkopf .byline{margin-top:var(--s4)}
+</style>
+</head>
+<body>
+<script src="https://phtok.github.io/goeloggen/design-system/nav.js"
+        data-root="https://phtok.github.io/goeloggen/" data-variant="werkzeug"></script>
+
+<main class="wrap">
+
+  <header class="artkopf">
+    <nav class="crumbs" aria-label="Pfad">
+      <a href="./">Startseite</a> <span aria-hidden="true">›</span>
+      <a href="./">Rubrik</a> <span aria-hidden="true">›</span>
+      <span aria-current="page">Artikel-Titel</span>
+    </nav>
+    <span class="kicker" style="margin-top:var(--s4);display:inline-block">Rubrik · Thema</span>
+    <h1>Artikel-Titel: klar, konkret, ohne Plakat</h1>
+    <p class="lede">Der Vorspann sagt in zwei, drei Zeilen, worum es geht und warum
+      es die Leserin angeht — die Lede trägt die Hausschrift, der Langtext darunter
+      die Leseschrift.</p>
+    <p class="byline"><b>Vorname Name</b> <span>6. Juli 2026</span> <span>8 Min. Lesezeit</span></p>
+  </header>
+
+  <!-- ====================== DEIN ARTIKEL – ab hier füllen ====================== -->
+  <article class="prose">
+    <p>Erster Absatz. Echter Mengentext läuft in der Leseschrift (Source Sans 3)
+      im Lesemass von rund 62 Zeichen mit Zeilenhöhe 1.66 — die zwei Faktoren,
+      die langes Lesen tragen. Betont wird mit <strong>Laut</strong>, der
+      Gegenton steht <em>leise</em>, nie unterstrichen, nie versal.</p>
+    <h3>Zwischentitel gliedern, alle vier bis sechs Absätze</h3>
+    <p>Zweiter Absatz. Anführungen im Haus sehen so aus: <q>ein wörtliches
+      Zitat</q>. Zahlen wie 10 000 oder Daten wie 6. 7. 2026 stehen im Text
+      proportional; erst in Tabellen werden sie tabellarisch und rechtsbündig.</p>
+    <p>Dritter Absatz. Ein Artikel endet nicht abrupt: Literatur, die
+      Autorenzeile und Verwandtes geben dem Text ein Nachwort — die Rollen dafür
+      stehen bereit und müssen nicht erfunden werden.</p>
+  </article>
+
+  <aside class="lit" aria-label="Literatur">
+    <p><b style="color:var(--ink)">Literatur</b></p>
+    <p>Autorin, Titel des Werks, Ort 2026.</p>
+    <p>Autor, <q>Aufsatztitel</q>, in: Zeitschrift 27/2026.</p>
+  </aside>
+
+  <div class="bio">
+    <span class="person"><span class="pv" aria-hidden="true">VN</span></span>
+    <p class="btext"><b>Vorname Name</b> ist … — zwei Sätze zur Person, was sie
+      mit dem Thema verbindet und wo man mehr von ihr liest.</p>
+  </div>
+
+  <section aria-label="Verwandte Artikel">
+    <div class="shead"><h2>Verwandt</h2><p>Drei Wege weiter — gleiche Rubrik, gleiches Thema.</p></div>
+    <div class="related">
+      <a class="teaser stack" href="#"><span class="thumb" aria-hidden="true"></span>
+        <span><span class="kick">Rubrik</span><h3>Verwandter Titel eins</h3>
+        <p class="ex">Ein Satz Vorspann.</p></span></a>
+      <a class="teaser stack" href="#"><span class="thumb" aria-hidden="true"></span>
+        <span><span class="kick">Rubrik</span><h3>Verwandter Titel zwei</h3>
+        <p class="ex">Ein Satz Vorspann.</p></span></a>
+      <a class="teaser stack" href="#"><span class="thumb" aria-hidden="true"></span>
+        <span><span class="kick">Rubrik</span><h3>Verwandter Titel drei</h3>
+        <p class="ex">Ein Satz Vorspann.</p></span></a>
+    </div>
+  </section>
+  <!-- ====================== DEIN ARTIKEL – bis hier ============================ -->
+
+</main>
+
+<footer class="ds-footer">
+  <div class="wrap frow">
+    <span><strong>Goetheanum</strong> · Hausgrafik</span>
+    <span><a href="https://phtok.github.io/goeloggen/design-system/">Design-System</a></span>
+  </div>
+</footer>
+</body>
+</html>

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -75,6 +75,12 @@
   --code-bg:#1f2428; --code-bg2:#2b3137; --code-ink:#e8eef2;
   --code-key:#9ecbff; --code-str:#c3e88d; --code-comment:#7f868d;
 
+  /* --- Bühne (Medien-/Katalogfläche, THEME-FEST dunkel wie die Konsole) -----
+     Für Video-Kacheln und Katalog-Bänder (Webfamilie-Befund §3/§4, Vorbild
+     goetheanum.tv). Kontraste gerechnet: ink 15.3:1, muted 8.2:1 auf stage-bg. */
+  --stage-bg:#14171a; --stage-bg2:#232830; --stage-ink:#e9edf1;
+  --stage-muted:#a9b0b7; --stage-veil:rgba(8,10,12,.62);
+
   /* --- Sektionsfarben (Identität der Schul-Sektionen) --------------------- */
   /* Quelle der Wahrheit der Werte: assets/goe-orgs.js (speist die Logo-Engine).
      Hier als Design-Tokens verfügbar gemacht, damit Sektions-Akzente überall im

--- a/perspektiven/anthroposophie-org.html
+++ b/perspektiven/anthroposophie-org.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Perspektive: anthroposophie.org im Hausbild</title>
+<meta name="description" content="Testseite der Webfamilie: die Rubrikseite von ‹Anthroposophie Weltweit› mit Teaser-Liste, vier Sprachen und Newsletter – gesetzt mit dem Goetheanum-Design-System." />
+<meta name="robots" content="noindex" />
+<link rel="icon" type="image/svg+xml" href="../assets/logos/goetheanum-mark-blue.svg" />
+<link rel="stylesheet" href="../design-system/tokens.css" />
+<link rel="stylesheet" href="../design-system/base.css" />
+<link rel="stylesheet" href="../design-system/nav.css" />
+<style>
+  .rubrik{display:grid;gap:var(--s3);max-width:760px}
+  .sprachen{display:flex;align-items:center;gap:var(--s3);flex-wrap:wrap}
+  .mehr{display:flex;justify-content:center;margin-top:var(--s6)}
+  .vergleich{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:var(--s4)}
+  .vergleich .card p{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);line-height:1.6;margin:0 0 .5em}
+  .vergleich .card p b{color:var(--ink);font-weight:600}
+</style>
+</head>
+<body>
+<script src="../design-system/nav.js" data-root="../"
+        data-onpage="Rubrik:#rubrik|Sprachen &amp; Newsletter:#sprachen|Befund:#befund|Der Weg:#weg"></script>
+
+<main class="wrap">
+  <section class="hero">
+    <span class="kicker">Perspektive · Webfamilie</span>
+    <h1>anthroposophie.org im Hausbild</h1>
+    <p class="lede">Das Nachrichtenblatt <q>Anthroposophie Weltweit</q> pflegt als
+      Einziges vier vollständige Sprachausgaben — auf einem zwölf Jahre alten
+      Gratis-Template mit Phantom-Schriften und 574 Teasern auf einer Seite.
+      Hier die Rubrikseite, wie das System sie setzt.</p>
+  </section>
+
+  <section id="rubrik">
+    <div class="shead"><h2>Rubrik <q>Gesellschaft</q></h2>
+      <p>Teaser-Liste mit klarer Hierarchie — und <b style="font-weight:var(--w-deutlich)">Mehr laden</b> statt 670 KB Endlosliste.</p></div>
+    <div class="rubrik">
+      <a class="teaser" href="#rubrik"><span class="thumb" aria-hidden="true" style="background:var(--sek-aas)"></span>
+        <span><span class="kick">Gesellschaft</span><h3>Die Weltkonferenz lädt ein</h3>
+        <p class="ex">Im Herbst treffen sich die Landesgesellschaften in Dornach — Programm und Anmeldung.</p>
+        <span class="byline"><b>Beispiel-Autor</b> <span>2. Juli 2026</span></span></span></a>
+      <a class="teaser" href="#rubrik"><span class="thumb" aria-hidden="true" style="background:var(--sek-ssw)"></span>
+        <span><span class="kick">Gesellschaft</span><h3>Neue Arbeitsgruppen in drei Ländern</h3>
+        <p class="ex">Von Lima bis Helsinki: wie Initiativen entstehen und was sie tragen.</p>
+        <span class="byline"><b>Beispiel-Autorin</b> <span>28. Juni 2026</span></span></span></a>
+      <a class="teaser" href="#rubrik"><span class="thumb" aria-hidden="true" style="background:var(--gold)"></span>
+        <span><span class="kick">Gesellschaft</span><h3>Aus dem Heft: Ausgabe 7–8/2026</h3>
+        <p class="ex">Die neue Ausgabe ist erschienen — Überblick und Bezugswege.</p>
+        <span class="byline"><b>Redaktion</b> <span>21. Juni 2026</span></span></span></a>
+    </div>
+    <div class="mehr"><button class="btn" type="button">Mehr laden</button></div>
+  </section>
+
+  <section id="sprachen">
+    <div class="shead"><h2>Vier Sprachen &amp; Newsletter</h2>
+      <p>Die Stärke der Seite bleibt: das saubere /de·/en·/fr·/es-Schema — hier als Rolle, dazu der Newsletter-Einstieg.</p></div>
+    <div class="sprachen" style="margin-bottom:var(--s6)">
+      <span class="meta" style="font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)">Sprache:</span>
+      <div class="seg" role="group" aria-label="Sprache wählen">
+        <button type="button" aria-pressed="true" lang="de">Deutsch</button>
+        <button type="button" aria-pressed="false" lang="en">English</button>
+        <button type="button" aria-pressed="false" lang="fr">Français</button>
+        <button type="button" aria-pressed="false" lang="es">Español</button>
+      </div>
+    </div>
+    <form class="subscribe" onsubmit="return false">
+      <label class="sr-only" for="nl">E-Mail-Adresse</label>
+      <input id="nl" type="email" placeholder="E-Mail-Adresse" autocomplete="email" />
+      <button class="btn primary" type="submit">Newsletter erhalten</button>
+    </form>
+  </section>
+
+  <section id="befund">
+    <div class="shead"><h2>Befund: vorher → nachher</h2>
+      <p>Gerechnet am Original (Juli 2026) — Regel-IDs in Klammern.</p></div>
+    <div class="vergleich">
+      <div class="card"><p><b>6 deklarierte Schriftfamilien, 2 laden nie → eine Hausschrift + eine Leseschrift</b>, selbst gehostet statt Google Fonts.</p></div>
+      <div class="card"><p><b>Weiss auf Gelb 1.6:1, Meta-Grau 2.1:1 → Tokens mit gerechneten Kontrasten</b> (B01/B02).</p></div>
+      <div class="card"><p><b>574 × alt="Image", outline:none → beschriebene Bilder, sichtbarer Fokus</b> (WCAG 1.1.1/2.4.7).</p></div>
+      <div class="card"><p><b>670-KB-Rubrikseite ohne Pagination → Mehr-laden-Muster</b>; 11–12px-Kleintext → ≥14px (B03).</p></div>
+      <div class="card"><p><b>Bootstrap-Regenbogen → Hauspalette</b> (DS02); das verwandte Gold #B19F7C dockt an unser Gold-Token an.</p></div>
+      <div class="card"><p><b>noindex auf der Startseite → die Maschine prüft</b>: genau solche stillen Fehler findet die Konformitäts-Engine.</p></div>
+    </div>
+  </section>
+
+  <section id="weg">
+    <div class="shead"><h2>Der Weg dorthin</h2>
+      <p>Auch hier Craft CMS — dasselbe Partial wie für goetheanum.ch, verteilt über static.goetheanum.ch.</p></div>
+    <pre class="code"><code>{# _layouts/base.twig – Fundament einbinden (tokens VOR base) #}
+&lt;link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/tokens.css"&gt;
+&lt;link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/base.css"&gt;</code></pre>
+    <p class="note">Vollständiger Befund: <a href="https://github.com/phtok/goeloggen/blob/main/docs/webfamilie-befund.md">docs/webfamilie-befund.md</a></p>
+  </section>
+</main>
+
+<footer class="ds-footer">
+  <div class="wrap frow">
+    <span><strong>Goetheanum</strong> · Perspektiven der Webfamilie</span>
+    <span><a href="../design-system/">Design-System</a> · <a href="../">alle Werkzeuge</a></span>
+  </div>
+</footer>
+</body>
+</html>

--- a/perspektiven/dasgoetheanum.html
+++ b/perspektiven/dasgoetheanum.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Perspektive: dasgoetheanum.com im Hausbild</title>
+<meta name="description" content="Testseite der Webfamilie: die Artikel-Anatomie der Wochenschrift, gesetzt mit dem Goetheanum-Design-System – Hausschrift, Lesemass, gerechnete Kontraste." />
+<meta name="robots" content="noindex" />
+<link rel="icon" type="image/svg+xml" href="../assets/logos/goetheanum-mark-blue.svg" />
+<link rel="stylesheet" href="../design-system/tokens.css" />
+<link rel="stylesheet" href="../design-system/base.css" />
+<link rel="stylesheet" href="../design-system/nav.css" />
+<style>
+  .artkopf{padding-block:var(--s8) var(--s6);max-width:min(72ch,100%)}
+  .artkopf h1{max-width:24ch}
+  .artkopf .byline{margin-top:var(--s4)}
+  .vergleich{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:var(--s4)}
+  .vergleich .card p{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);line-height:1.6;margin:0 0 .5em}
+  .vergleich .card p b{color:var(--ink);font-weight:600}
+</style>
+</head>
+<body>
+<script src="../design-system/nav.js" data-root="../"
+        data-onpage="Nachbau:#nachbau|Befund:#befund|Der Weg:#weg"></script>
+
+<main class="wrap">
+  <section class="hero">
+    <span class="kicker">Perspektive · Webfamilie</span>
+    <h1>dasgoetheanum.com im Hausbild</h1>
+    <p class="lede">Die Wochenschrift hat die reifste Artikelseite der Familie —
+      aber Zeilenhöhe 1.4, ein Lesemass von ~78 Zeichen und Faux-Fett aus zwei
+      statischen Schnitten. So sähe derselbe Artikel mit dem Design-System aus.</p>
+  </section>
+
+  <section id="nachbau">
+    <div class="shead"><h2>Der Nachbau</h2>
+      <p>Die komplette Artikel-Kette (Brotkrumen → Titel → Byline → Lede → Langtext
+         → Literatur → Bio → Verwandtes) — Vorlage: <a href="../design-system/starter-artikel.html">starter-artikel.html</a>.</p></div>
+
+    <header class="artkopf" style="padding-top:0">
+      <nav class="crumbs" aria-label="Pfad">
+        <a href="#nachbau">Startseite</a> <span aria-hidden="true">›</span>
+        <a href="#nachbau">Essay</a> <span aria-hidden="true">›</span>
+        <span aria-current="page">Die Stimme des Hauses</span>
+      </nav>
+      <span class="kicker" style="margin-top:var(--s4);display:inline-block">Essay · Ausgabe 27–28/2026</span>
+      <h1>Die Stimme des Hauses</h1>
+      <p class="lede">Warum eine Schrift mehr ist als eine Wahl der Ästhetik —
+        und was geschieht, wenn ein Haus beginnt, mit einer Stimme zu sprechen.</p>
+      <p class="byline"><b>Beispiel-Autorin</b> <span>6. Juli 2026</span> <span>4 Min. Lesezeit</span></p>
+    </header>
+
+    <article class="prose">
+      <p>Wer die vier grossen Webseiten des Goetheanum nebeneinanderlegt, hört
+        vier Stimmen. Drei davon tasten nach derselben Schrift — nach Titillium,
+        der Basis der Hausschrift. Die Suche ist also längst im Gang; nur das
+        Finden steht noch aus. <strong>Eine Stimme ist kein Stilmittel, sondern
+        eine Haltung:</strong> Sie sagt, dass hinter allen Fenstern dasselbe Haus wohnt.</p>
+      <h3>Was langes Lesen wirklich trägt</h3>
+      <p>Nicht der Schriftwechsel macht einen Text lesbar, sondern zwei stille
+        Faktoren: eine Zeilenhöhe von mindestens 1.6 und ein Lesemass um die
+        62 Zeichen. Beides fehlt dem heutigen Artikel-Layout — und beides kostet
+        nichts als eine Entscheidung. Dazu kommt der echte Fettdruck: Wer nur
+        zwei Schnitte lädt, betont mit <em>synthetischem</em> Fett, das die
+        Formen verschmiert. Ein Variable Font trägt alle Grade in einer Datei.</p>
+      <p>Die Byline dieses Nachbaus steht normal, nicht versal — Betonung kommt
+        aus Gewicht und Farbe, nie aus Grossbuchstaben. Und die Bildunterschrift,
+        die im Original bei 13 Pixeln lag, hat hier eine Untergrenze: nichts
+        Lesbares unter 14.</p>
+    </article>
+
+    <aside class="lit" aria-label="Literatur">
+      <p><b style="color:var(--ink)">Literatur</b></p>
+      <p>Webfamilie-Befund, <q>Was das Design-System von den vier grossen Seiten lernt</q>, Dornach 2026.</p>
+      <p>Sofie Beier, Reading Letters. Designing for legibility, Amsterdam 2012.</p>
+    </aside>
+
+    <div class="bio">
+      <span class="person"><span class="pv" aria-hidden="true">BA</span></span>
+      <p class="btext"><b>Beispiel-Autorin</b> schreibt hier stellvertretend —
+        dieser Text ist eigens für die Testseite verfasst, kein Original der
+        Wochenschrift.</p>
+    </div>
+
+    <div style="margin-top:var(--s8)">
+      <div class="shead"><h2>Verwandt</h2><p>Drei Wege weiter.</p></div>
+      <div class="related">
+        <a class="teaser stack" href="goetheanum-ch.html"><span class="thumb" aria-hidden="true"></span>
+          <span><span class="kick">Perspektive</span><h3>goetheanum.ch im Hausbild</h3>
+          <p class="ex">Kalender, Teaser und der Sieben-Block-Footer.</p></span></a>
+        <a class="teaser stack" href="goetheanum-tv.html"><span class="thumb" aria-hidden="true"></span>
+          <span><span class="kick">Perspektive</span><h3>goetheanum.tv im Hausbild</h3>
+          <p class="ex">Die dunkle Bühne mit Medienkacheln.</p></span></a>
+        <a class="teaser stack" href="anthroposophie-org.html"><span class="thumb" aria-hidden="true"></span>
+          <span><span class="kick">Perspektive</span><h3>anthroposophie.org im Hausbild</h3>
+          <p class="ex">Rubrik, vier Sprachen, Newsletter.</p></span></a>
+      </div>
+    </div>
+  </section>
+
+  <section id="befund">
+    <div class="shead"><h2>Befund: vorher → nachher</h2>
+      <p>Gerechnet am Original (Juli 2026), behoben durch Konstruktion — Regel-IDs in Klammern.</p></div>
+    <div class="vergleich">
+      <div class="card"><p><b>Zeilenhöhe 1.4 → 1.66</b> im Mengentext (B04); Lesemass ~78 → ~62 Zeichen (G10).</p></div>
+      <div class="card"><p><b>Byline 12px versal → 15px normal</b> (B03, G05/G23); Bildunterschrift 13 → ≥14px (B03).</p></div>
+      <div class="card"><p><b>Faux-Fett → echte Schnitte</b>: zwei statische Dateien → Variable Font 190–725; Betonung = Laut (G05).</p></div>
+      <div class="card"><p><b>`outline:0!important` → sichtbarer Fokus</b> (WCAG 2.4.7); mobiler Fliesstext 15 → ≥16px (B03).</p></div>
+    </div>
+  </section>
+
+  <section id="weg">
+    <div class="shead"><h2>Der Weg dorthin</h2>
+      <p>WordPress mit Child-Theme (zeen-child existiert) — das Fundament ist ein Enqueue.</p></div>
+    <pre class="code"><code>// functions.php des Child-Themes – Fundament einbinden (tokens VOR base)
+add_action('wp_enqueue_scripts', function () {
+  wp_enqueue_style('goe-tokens', 'https://werkzeuge.goetheanum.ch/design-system/tokens.css');
+  wp_enqueue_style('goe-base',   'https://werkzeuge.goetheanum.ch/design-system/base.css', ['goe-tokens']);
+});</code></pre>
+    <p class="note">Vollständiger Befund: <a href="https://github.com/phtok/goeloggen/blob/main/docs/webfamilie-befund.md">docs/webfamilie-befund.md</a> ·
+      Vorlage: <a href="../design-system/starter-artikel.html">starter-artikel.html</a></p>
+  </section>
+</main>
+
+<footer class="ds-footer">
+  <div class="wrap frow">
+    <span><strong>Goetheanum</strong> · Perspektiven der Webfamilie</span>
+    <span><a href="../design-system/">Design-System</a> · <a href="../">alle Werkzeuge</a></span>
+  </div>
+</footer>
+</body>
+</html>

--- a/perspektiven/goetheanum-ch.html
+++ b/perspektiven/goetheanum-ch.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Perspektive: goetheanum.ch im Hausbild</title>
+<meta name="description" content="Testseite der Webfamilie: Veranstaltungskalender, Teaser und Fusszeile der Hauptseite, gesetzt mit dem Goetheanum-Design-System." />
+<meta name="robots" content="noindex" />
+<link rel="icon" type="image/svg+xml" href="../assets/logos/goetheanum-mark-blue.svg" />
+<link rel="stylesheet" href="../design-system/tokens.css" />
+<link rel="stylesheet" href="../design-system/base.css" />
+<link rel="stylesheet" href="../design-system/nav.css" />
+<style>
+  .events{display:grid;gap:var(--s3);max-width:760px}
+  .trow{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:var(--s4)}
+  .vergleich{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:var(--s4)}
+  .vergleich .card p{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);line-height:1.6;margin:0 0 .5em}
+  .vergleich .card p b{color:var(--ink);font-weight:600}
+  .fdemo{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);background:var(--soft)}
+  .fdemo .fcols{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:var(--s6)}
+  .fdemo .ft{font-weight:var(--w-deutlich);margin-bottom:var(--s2)}
+  .fdemo a{display:block;padding:3px 0;font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)}
+  .fdemo a:hover{color:var(--gold-ink)}
+</style>
+</head>
+<body>
+<script src="../design-system/nav.js" data-root="../"
+        data-onpage="Kalender:#kalender|Teaser:#teaser|Fusszeile:#fuss|Befund:#befund|Der Weg:#weg"></script>
+
+<main class="wrap">
+  <section class="hero">
+    <span class="kicker">Perspektive · Webfamilie</span>
+    <h1>goetheanum.ch im Hausbild</h1>
+    <p class="lede">Die Hauptseite hat den reifsten Betrieb der Familie — vier
+      Sprachen, ein grosser Kalender, ein Bild-CDN. Was ihr fehlt, ist die
+      Token-Schicht: Hier stehen ihre Kernstücke, gesetzt aus einer Quelle.</p>
+  </section>
+
+  <section id="kalender">
+    <div class="shead"><h2>Veranstaltungen</h2>
+      <p>Das Herzstück der Seite: Filterleiste + Veranstaltungs-Karte. Ziffern
+         tabellarisch im Datumsblock (G25), alles ≥14px (B03 — im Original 12.5–13px).</p></div>
+    <div class="filterbar">
+      <label class="field"><span class="lab">Suchen</span><input type="search" placeholder="Titel, Thema, Ort" /></label>
+      <label class="field"><span class="lab">Zeitraum</span><input type="text" placeholder="Juli 2026" /></label>
+      <label class="field"><span class="lab">Art</span><input type="text" placeholder="Alle Veranstaltungen" /></label>
+      <button class="btn" type="button">Filtern</button>
+    </div>
+    <div class="events">
+      <article class="event">
+        <div class="edate"><b>11</b><span>Juli</span></div>
+        <div><span class="kick">Bühne · Eurythmie</span>
+          <h3>Sommer der Formen — Eurythmie-Aufführung</h3>
+          <p class="emeta">19.30&nbsp;Uhr · Grosser Saal · Eintritt frei</p></div>
+      </article>
+      <article class="event">
+        <div class="edate"><b>14</b><span>Juli</span></div>
+        <div><span class="kick">Hochschule · Vortrag</span>
+          <h3>Die Pflanze im Licht — Beobachten als Methode</h3>
+          <p class="emeta">17.00&nbsp;Uhr · Terrassensaal · mit Übersetzung</p></div>
+      </article>
+      <article class="event">
+        <div class="edate"><b>21</b><span>Juli</span></div>
+        <div><span class="kick">Jugendsektion · Werkstatt</span>
+          <h3>Zukunft tragen — offene Werkstatt für Studierende</h3>
+          <p class="emeta">10.00–16.00&nbsp;Uhr · Nordatelier · Anmeldung nötig</p></div>
+      </article>
+    </div>
+    <p class="note" style="margin-top:var(--s4)">Dazu gehörten: ICS-Export je Eintrag und die Gruppierung <q>Heute · Morgen · Datum</q> — beides bleibt Datenarbeit des CMS, die Gestalt kommt von hier.</p>
+  </section>
+
+  <section id="teaser">
+    <div class="shead"><h2>Teaser</h2>
+      <p>Bild · Kicker · Titel · Vorspann — die Hierarchie der Startseite als Rolle statt als Einzelfall.</p></div>
+    <div class="trow">
+      <a class="teaser stack" href="#teaser"><span class="thumb" aria-hidden="true" style="background:var(--sek-nws)"></span>
+        <span><span class="kick">Sektionen</span><h3>Naturwissenschaft am Berg</h3>
+        <p class="ex">Die Sektion öffnet ihr Labor — ein Rundgang.</p></span></a>
+      <a class="teaser stack" href="#teaser"><span class="thumb" aria-hidden="true" style="background:var(--sek-srmk)"></span>
+        <span><span class="kick">Bühne</span><h3>Der Sommer-Spielplan ist da</h3>
+        <p class="ex">Eurythmie, Sprache, Musik — alle Termine bis September.</p></span></a>
+      <a class="teaser stack" href="#teaser"><span class="thumb" aria-hidden="true" style="background:var(--gold)"></span>
+        <span><span class="kick">Haus</span><h3>Das Goetheanum besuchen</h3>
+        <p class="ex">Führungen, Öffnungszeiten und der Weg nach Dornach.</p></span></a>
+    </div>
+  </section>
+
+  <section id="fuss">
+    <div class="shead"><h2>Fusszeile</h2>
+      <p>Der Sieben-Block-Footer der Hauptseite — als Rolle .fcols, hier mit vier Blöcken gezeigt.</p></div>
+    <div class="fdemo">
+      <div class="fcols">
+        <div><p class="ft">Goetheanum</p><a href="#fuss">Rüttiweg 45, Dornach</a><a href="#fuss">Kontakt</a></div>
+        <div><p class="ft">Besuch</p><a href="#fuss">Öffnungszeiten</a><a href="#fuss">Führungen</a></div>
+        <div><p class="ft">Karten</p><a href="#fuss">Vorverkauf</a><a href="#fuss">Abendkasse</a></div>
+        <div><p class="ft">Direkt</p><a href="#fuss">Newsletter</a><a href="#fuss">Spenden</a></div>
+      </div>
+    </div>
+  </section>
+
+  <section id="befund">
+    <div class="shead"><h2>Befund: vorher → nachher</h2>
+      <p>Gerechnet am Original (Juli 2026) — Regel-IDs in Klammern.</p></div>
+    <div class="vergleich">
+      <div class="card"><p><b>Gold #ebb565 + Weiss 1.85:1 → Gold-Pille 4.55:1</b> (B01/B02: Auswahl = dunkles Gold + Weiss).</p></div>
+      <div class="card"><p><b>Kalender-UI 12.5–13px → ≥14/15px</b> (B03); Grautöne 2.15–3.1:1 → --muted 4.9:1 (B02).</p></div>
+      <div class="card"><p><b>15× outline:none → sichtbarer Fokus</b>, Skip-Link aus nav.js (WCAG 2.4.1/2.4.7).</p></div>
+      <div class="card"><p><b>74 Hex-Literale + CMS-Inline-Gradients → Tokens</b> (DS02); damit wird Hell/Dunkel überhaupt erst möglich (B05).</p></div>
+      <div class="card"><p><b>11 Schnitt-Dateien als Fake-Familien → ein Variable Font</b>; Titillium-Titel → Hausschrift (die Stimme).</p></div>
+      <div class="card"><p><b>Zeilenhöhe 1.4 (leading-normal) → 1.66</b> im Lesetext (B04).</p></div>
+    </div>
+  </section>
+
+  <section id="weg">
+    <div class="shead"><h2>Der Weg dorthin</h2>
+      <p>Craft CMS — ein Twig-Partial im Layout, verteilt über das schon gemeinsame static.goetheanum.ch.</p></div>
+    <pre class="code"><code>{# _layouts/base.twig – Fundament einbinden (tokens VOR base) #}
+&lt;link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/tokens.css"&gt;
+&lt;link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/base.css"&gt;</code></pre>
+    <p class="note">Vollständiger Befund: <a href="https://github.com/phtok/goeloggen/blob/main/docs/webfamilie-befund.md">docs/webfamilie-befund.md</a></p>
+  </section>
+</main>
+
+<footer class="ds-footer">
+  <div class="wrap frow">
+    <span><strong>Goetheanum</strong> · Perspektiven der Webfamilie</span>
+    <span><a href="../design-system/">Design-System</a> · <a href="../">alle Werkzeuge</a></span>
+  </div>
+</footer>
+</body>
+</html>

--- a/perspektiven/goetheanum-tv.html
+++ b/perspektiven/goetheanum-tv.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Perspektive: goetheanum.tv im Hausbild</title>
+<meta name="description" content="Testseite der Webfamilie: der Streaming-Katalog auf der dunklen Bühne des Design-Systems – Medienkacheln, Reihen, Live." />
+<meta name="robots" content="noindex" />
+<link rel="icon" type="image/svg+xml" href="../assets/logos/goetheanum-mark-blue.svg" />
+<link rel="stylesheet" href="../design-system/tokens.css" />
+<link rel="stylesheet" href="../design-system/base.css" />
+<link rel="stylesheet" href="../design-system/nav.css" />
+<style>
+  .stage .reihe{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:var(--t-h3);margin:var(--s6) 0 var(--s2)}
+  .stage .reihe:first-of-type{margin-top:var(--s2)}
+  .poster .pmark{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:15px;opacity:.92}
+  .vergleich{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:var(--s4)}
+  .vergleich .card p{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);line-height:1.6;margin:0 0 .5em}
+  .vergleich .card p b{color:var(--ink);font-weight:600}
+</style>
+</head>
+<body>
+<script src="../design-system/nav.js" data-root="../"
+        data-onpage="Katalog:#katalog|Befund:#befund|Der Weg:#weg"></script>
+
+<main class="wrap">
+  <section class="hero">
+    <span class="kicker">Perspektive · Webfamilie</span>
+    <h1>goetheanum.tv im Hausbild</h1>
+    <p class="lede">Der Streaming-Katalog kennt weder Goetheanum-Blau noch Gold
+      noch die Hausschrift — Titillium wird dort per Gewalt über den
+      Plattform-Font geflickt. Hier derselbe Katalog auf der <q>Bühne</q>:
+      theme-fest dunkel, Kontraste gerechnet, Marke hörbar.</p>
+  </section>
+
+  <section id="katalog">
+    <div class="shead"><h2>Der Katalog</h2>
+      <p>Bühne (.stage) + Medienkacheln (.mtile) + Reihen (.mrow). Die Fläche bleibt
+         in Hell wie Dunkel gleich — wie eine Konsole; die Poster tragen die
+         Sektionsfarben mit gerechnetem Text darauf (B01).</p></div>
+
+    <div class="stage">
+      <span class="live">Live</span>
+      <p class="reihe">Alma Humana — die Konferenz</p>
+      <div class="mrow">
+        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-ms);color:var(--on-sek-ms)"><span class="pmark">Eröffnung</span><span class="dur">1:12:40</span></span>
+          <span class="mt">Eröffnungsabend</span><span class="ms">Vortrag · Deutsch/Englisch</span></a>
+        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-srmk);color:var(--on-sek-srmk)"><span class="pmark">Bühne</span><span class="dur">48:15</span></span>
+          <span class="mt">Eurythmie am Abend</span><span class="ms">Aufführung</span></a>
+        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-js);color:var(--on-sek-js)"><span class="pmark">Gespräch</span><span class="dur">26:03</span></span>
+          <span class="mt">Jugend im Gespräch</span><span class="ms">Reihe · Teil 3</span></a>
+        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-nws);color:var(--on-sek-nws)"><span class="pmark">Labor</span><span class="dur">33:47</span></span>
+          <span class="mt">Beobachten als Methode</span><span class="ms">Werkstatt</span></a>
+      </div>
+      <p class="reihe">Greening the Desert</p>
+      <div class="mrow">
+        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-lws);color:var(--on-sek-lws)"><span class="pmark">Folge 1</span><span class="dur">52:19</span></span>
+          <span class="mt">Der Boden lebt</span><span class="ms">Dokumentation</span></a>
+        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-hpise);color:var(--on-sek-hpise)"><span class="pmark">Folge 2</span><span class="dur">47:02</span></span>
+          <span class="mt">Wasser halten</span><span class="ms">Dokumentation</span></a>
+        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-mas);color:var(--on-sek-mas)"><span class="pmark">Folge 3</span><span class="dur">41:33</span></span>
+          <span class="mt">Rechnen mit dem Klima</span><span class="ms">Dokumentation</span></a>
+        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-sbk);color:var(--on-sek-sbk)"><span class="pmark">Extra</span><span class="dur">12:58</span></span>
+          <span class="mt">Hinter den Kulissen</span><span class="ms">Kurzfilm</span></a>
+      </div>
+      <p class="smeta">Dauer-Angaben tabellarisch (G25) · Kacheltitel in der Hausschrift, Meta in der Leseschrift (Schrift-Grenze) · Fokusring sichtbar.</p>
+    </div>
+  </section>
+
+  <section id="befund">
+    <div class="shead"><h2>Befund: vorher → nachher</h2>
+      <p>Gerechnet am Original (Juli 2026) — Regel-IDs in Klammern.</p></div>
+    <div class="vergleich">
+      <div class="card"><p><b>Grau #6e6e6e auf #121212 = 3.67:1 → --stage-muted 8.2:1</b> (B02, gerechnet statt geschätzt).</p></div>
+      <div class="card"><p><b>Titillium per !important über Inter → Hausschrift als Quelle</b>; VERSAL-Knöpfe → normale Beschriftung (G05/G23).</p></div>
+      <div class="card"><p><b>Schiefer #23323F ohne Marke → Blau/Gold-Tokens</b>; Licht/Dunkel als duplizierte Literale → eine Token-Schicht (DS02/B05).</p></div>
+      <div class="card"><p><b>Kein :focus-visible, kein Skip-Link → Fokus-Defaults + Sprunglink</b> aus base.css/nav.js (WCAG 2.4.1/2.4.7).</p></div>
+      <div class="card"><p><b>Google Fonts + vier Fremd-CDNs → Selbst-Hosting</b> (Datenschutz, Reproduzierbarkeit).</p></div>
+      <div class="card"><p><b>Gelernt in Gegenrichtung:</b> die Reihen-Kacheln und die abgeleiteten Töne per Formel — beides ist jetzt Teil des Fundaments (--stage-*).</p></div>
+    </div>
+  </section>
+
+  <section id="weg">
+    <div class="shead"><h2>Der Weg dorthin</h2>
+      <p>Uscreen erlaubt eigenes CSS und eigene Head-Snippets — derselbe Kanal, der heute die !important-Flicken trägt.</p></div>
+    <pre class="code"><code>&lt;!-- Uscreen · Theme-Einstellungen · Custom Code (Head) --&gt;
+&lt;link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/tokens.css"&gt;
+&lt;link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/base.css"&gt;
+&lt;style&gt;
+  /* Plattform-Variablen auf die Tokens heben – statt Schrift per !important zu flicken */
+  :root{ --ds-fg-default:var(--stage-ink); --ds-fg-muted:var(--stage-muted) }
+  body{ font-family:var(--font) }
+&lt;/style&gt;</code></pre>
+    <p class="note">Vollständiger Befund: <a href="https://github.com/phtok/goeloggen/blob/main/docs/webfamilie-befund.md">docs/webfamilie-befund.md</a></p>
+  </section>
+</main>
+
+<footer class="ds-footer">
+  <div class="wrap frow">
+    <span><strong>Goetheanum</strong> · Perspektiven der Webfamilie</span>
+    <span><a href="../design-system/">Design-System</a> · <a href="../">alle Werkzeuge</a></span>
+  </div>
+</footer>
+</body>
+</html>

--- a/tools.json
+++ b/tools.json
@@ -170,6 +170,16 @@
       "desc": "Mockup zur Vorbereitung der Goetheanum-TV-Umbenennung – kein öffentliches Werkzeug, eigene Welt."
     },
     {
+      "slug": "perspektiven",
+      "cat": "schau",
+      "status": "beta",
+      "tag": "Webfamilie",
+      "title": "Perspektiven (Webfamilie)",
+      "href": "design-system/#perspektiven",
+      "desc": "Vier Testseiten zeigen, wie das Design-System goetheanum.ch, dasgoetheanum.com, goetheanum.tv und anthroposophie.org verändern würde – Nachbau, gerechneter Befund, Einbau-Weg.",
+      "such": "Perspektiven Webfamilie Testseiten goetheanum.ch dasgoetheanum goetheanum.tv anthroposophie Befund"
+    },
+    {
       "slug": "karten",
       "cat": "vorbereitung",
       "status": "entwurf",


### PR DESCRIPTION
## Worum es geht

Die Webfamilie-Stufen 1–4 aus `docs/webfamilie-befund.md`, sichtbar gemacht:
**vier Testseiten** zeigen, wie das Design-System goetheanum.ch,
dasgoetheanum.com, goetheanum.tv und anthroposophie.org verändern würde —
und die dafür nötigen Rollen sind ins **Fundament** aufgenommen (v1.2.0).

## Die Testseiten (`perspektiven/`)

Jede Seite hat drei Teile: **Nachbau** (Kernstücke der echten Seite im
Hausbild) · **Befund vorher → nachher** (gerechnete Werte, Regel-IDs) ·
**Der Weg dorthin** (Einbau-Schnipsel der jeweiligen Plattform).

| Seite | Nachbau | Einbau-Weg |
|---|---|---|
| goetheanum-ch | Kalender + Filterleiste, Teaser, Sieben-Block-Footer | Craft-Twig-Partial |
| dasgoetheanum | komplette Artikel-Kette (lh 1.66, ~62ch) | WP-Enqueue (zeen-child) |
| goetheanum-tv | dunkle Bühne, Reihen-Kacheln, Live | Uscreen-Custom-Code |
| anthroposophie-org | Rubrik-Teaser, 4 Sprachen, Newsletter, Mehr laden | Craft-Twig-Partial |

## Neu im Fundament (Stufe 1+2, contract 1.1.1 → 1.2.0)

- **Artikel-Anatomie**: `crumbs · byline · lit · bio · related` + kanonischer
  **`starter-artikel.html`** (Byline normal statt 12px-versal — G05/B03).
- **`teaser`** (+ `.stack`), **`event` + `filterbar`** (Datumsblock tabellarisch,
  G25), **`person`**, **`subscribe`**, **`.ds-footer .fcols`**.
- **Bühne**: theme-feste Katalogfläche `--stage-*` (Kontraste gerechnet:
  ink 15.3:1, muted 8.2:1) mit `stage · mrow · mtile · live` — die Lehre aus
  goetheanum.tv, zurückgegeben als Token.

## Schaufenster

Neuer Abschnitt ganz unten: **„Perspektiven des Design-Systems"**, Untertitel
**„Von und miteinander lernen"** — dokumentiert den Vorgang (Analyse → Befund
→ Testseiten → Aufnahme ins Fundament) und verlinkt die vier Seiten.
Eintrag in `tools.json` (Kategorie `schau`).

## Regel-Deckung & Prüfung

G05/G23 (keine Versal-Bylines), G18 (Bis-Striche in Ausgabenummern), G25
(tnum), B01/B02 (gerechnet, inkl. neuer Bühne), B03 (≥14px), DS02 (nur
Tokens). Typo-Check konform, **ds-lint 100 %** inkl. der fünf neuen Seiten;
Sichtprüfung per Screenshot (Bühne, Kalender, Schaufenster-Abschnitt).

Offen bleibt aus Stufe 4: ds-lint um einen URL-Modus erweitern, damit der
Vier-Seiten-Bericht maschinell entsteht (als Aufgabe vermerkt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_