### PR TITLE
Kurzlink-Weiterleitung: tools.goetheanum.ch/s/‹tier› → volle UTM-URL

### DIFF
--- a/apps/utm-generator/index.html
+++ b/apps/utm-generator/index.html
@@ -45,6 +45,11 @@
   .qr svg{display:block;width:100%;height:100%}
   .actions{display:flex;gap:var(--s2);flex-wrap:wrap;margin-top:var(--s4)}
   .said{font-family:var(--font-text);font-size:var(--t-micro);color:var(--ok);min-height:1.4em;margin-top:var(--s2)}
+  .shortbox{display:flex;flex-wrap:wrap;align-items:baseline;gap:var(--s2) var(--s4);margin-top:var(--s4);
+    font-family:var(--font-text);font-size:var(--t-small)}
+  .shortbox[hidden]{display:none}
+  .shortbox .sl{color:var(--muted);font-size:var(--t-micro)}
+  .shortbox .su{font-family:var(--font-mono,var(--font-text));color:var(--blue);word-break:break-all}
 
   .reg{width:100%;border-collapse:collapse;font-family:var(--font-text);font-size:var(--t-small);table-layout:fixed;min-width:520px}
   .reg col.cMot{width:44%} .reg col.cQm{width:20%} .reg col.cZiel{width:12%} .reg col.cAb{width:12%} .reg col.cAct{width:12%}
@@ -54,6 +59,7 @@
   .reg thead th{color:var(--muted);font-weight:600;font-size:var(--t-micro)}
   .reg td.num,.reg th.num{text-align:right;font-variant-numeric:tabular-nums lining-nums}
   .reg .mot{color:var(--ink)} .reg .mot .q{color:var(--muted);font-size:var(--t-micro);display:block;word-break:break-all;margin-top:2px}
+  .reg .mot .q a{color:var(--blue);font-family:var(--font-mono,var(--font-text))}
   .reg .zero{color:var(--muted)}
   .tablewrap{overflow-x:auto;margin-top:var(--s4)}
   .empty{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small)}
@@ -161,6 +167,11 @@
             <button class="btn ghost" type="button" id="qrBtn">QR laden</button>
           </div>
           <div class="said" id="said"></div>
+          <div class="shortbox" id="shortbox" hidden>
+            <span class="sl">Kurzlink (leitet weiter):</span>
+            <a class="su" id="shortUrl" target="_blank" rel="noopener"></a>
+            <button class="btn ghost" type="button" id="shortCopy">Kopieren</button>
+          </div>
         </div>
         <div class="qrwrap">
           <div class="qr" id="qr"><span class="empty">QR</span></div>
@@ -197,8 +208,16 @@
   var SB  = 'https://dagcsnfrlbpxcmdimnrw.supabase.co';
   var KEY = 'sb_publishable_SXhY0mrhXjdTnjbJ5Uobtg_zAXW_xGY';
   var CAMPAIGN = 'summer26_trial';
+  var SHORTBASE = SB + '/functions/v1/go/';   // Kurzlink-Weiterleitung: SHORTBASE + code
 
   function el(id){ return document.getElementById(id); }
+
+  // Deterministischer Kurzcode aus der URL (FNV-1a → base36). Gleiche URL → gleicher Code.
+  function shortCode(str){
+    var h = 0x811c9dc5;
+    for(var i = 0; i < str.length; i++){ h ^= str.charCodeAt(i); h = Math.imul(h, 0x01000193); }
+    return (h >>> 0).toString(36).padStart(7, '0').slice(0, 7);
+  }
 
   // Die sechs echten Landingpages: Angebot × Sprache (aus der universellen LP recherchiert).
   var LANDINGS = {
@@ -298,20 +317,31 @@
     say('QR geladen.');
   });
 
+  function zeigeKurzlink(code){
+    var kurz = SHORTBASE + code;
+    el('shortbox').hidden = false;
+    el('shortUrl').textContent = kurz;
+    el('shortUrl').href = kurz;
+    el('shortCopy').onclick = function(){
+      navigator.clipboard.writeText(kurz).then(function(){ say('Kurzlink kopiert.'); }, function(){ say('Kopieren nicht möglich.', true); });
+    };
+  }
+
   el('regBtn').addEventListener('click', function(){
     if(!current){ say('Erst Quelle und Medium wählen.', true); return; }
+    var code = shortCode(current.url);
     var row = {
       kampagne: CAMPAIGN, utm_source: current.src, utm_medium: current.med, utm_campaign: CAMPAIGN,
       utm_content: current.con || null, landing: current.angebot, sprache: current.sprache, url: current.url,
-      rolle: el('rolle').value, ersteller: slug(el('ersteller').value) || null
+      code: code, rolle: el('rolle').value, ersteller: slug(el('ersteller').value) || null
     };
     fetch(SB + '/rest/v1/sommer2026_links', {
       method:'POST',
       headers:{ 'Content-Type':'application/json', 'apikey':KEY, 'Authorization':'Bearer ' + KEY, 'Prefer':'return=minimal' },
       body: JSON.stringify(row)
     }).then(function(r){
-      if(r.status === 201){ say('Im Register gespeichert.'); loadRegister(); }
-      else if(r.status === 409){ say('Dieser Link ist schon registriert.'); }
+      if(r.status === 201){ say('Im Register gespeichert.'); zeigeKurzlink(code); loadRegister(); }
+      else if(r.status === 409){ say('Dieser Link ist schon registriert.'); zeigeKurzlink(code); }
       else { say('Register nicht erreichbar (' + r.status + ').', true); }
     }).catch(function(){ say('Register nicht erreichbar.', true); });
   });
@@ -338,7 +368,12 @@
           var mot = tr.children[0];
           mot.textContent = x.utm_content || '—';
           var q = document.createElement('span'); q.className = 'q';
-          q.textContent = x.url; mot.appendChild(q);
+          // Kurzlink zeigen (aufgeräumt für die Veröffentlichung), Titel = volle URL.
+          if(x.code){ var a = document.createElement('a'); a.href = SHORTBASE + x.code;
+            a.target = '_blank'; a.rel = 'noopener'; a.textContent = SHORTBASE + x.code;
+            a.title = x.url; q.appendChild(a); }
+          else { q.textContent = x.url; }
+          mot.appendChild(q);
           tr.children[1].textContent = [x.utm_source, x.utm_medium].filter(Boolean).join(' · ');
           var ziel = ANGEBOT_LABEL[x.landing] || x.landing || '';
           if(x.sprache) ziel += ' · ' + x.sprache.toUpperCase();

--- a/apps/utm-generator/index.html
+++ b/apps/utm-generator/index.html
@@ -34,6 +34,7 @@
   .grid .span2{grid-column:1 / -1}
   .field .hint{margin-top:6px}
   .backlink{margin-top:var(--s4);font-family:var(--font-text);font-size:var(--t-small)}
+  .kurzrow{display:flex;gap:var(--s2);align-items:stretch} .kurzrow input{flex:1}
 
   .out{margin-top:var(--s6);display:grid;grid-template-columns:1fr auto;gap:var(--s4);align-items:start}
   .urlbox{font-family:var(--font-mono,var(--font-text));font-size:var(--t-small);color:var(--ink);
@@ -156,6 +157,15 @@
           <span class="lab">Kürzel Erstellerin (optional)</span>
           <input id="ersteller" placeholder="z. B. pt" autocomplete="off" maxlength="24" />
         </label>
+
+        <label class="field span2">
+          <span class="lab">Kurzname · tools.goetheanum.ch/s/…</span>
+          <span class="kurzrow">
+            <input id="slug" autocomplete="off" maxlength="24" placeholder="otter" />
+            <button class="btn ghost" type="button" id="slugNew">anderes Tier</button>
+          </span>
+          <span class="hint">Zweisilbiger Tiername – merkbar und leicht abzutippen (z. B. in einer Instagram-Bio).</span>
+        </label>
       </div>
 
       <div class="out">
@@ -208,15 +218,32 @@
   var SB  = 'https://dagcsnfrlbpxcmdimnrw.supabase.co';
   var KEY = 'sb_publishable_SXhY0mrhXjdTnjbJ5Uobtg_zAXW_xGY';
   var CAMPAIGN = 'summer26_trial';
-  var SHORTBASE = SB + '/functions/v1/go/';   // Kurzlink-Weiterleitung: SHORTBASE + code
+  var SHORTBASE = 'https://tools.goetheanum.ch/s/';   // Kurzlink: SHORTBASE + kurzname
 
   function el(id){ return document.getElementById(id); }
 
-  // Deterministischer Kurzcode aus der URL (FNV-1a → base36). Gleiche URL → gleicher Code.
-  function shortCode(str){
-    var h = 0x811c9dc5;
-    for(var i = 0; i < str.length; i++){ h ^= str.charCodeAt(i); h = Math.imul(h, 0x01000193); }
-    return (h >>> 0).toString(36).padStart(7, '0').slice(0, 7);
+  // Kurznamen sind zweisilbige Tiernamen – vertrauenswürdig, merkbar, tippbar
+  // (wichtig auf Instagram, wo Links in Bio/Caption abgetippt werden müssen).
+  var TIERE = ['otter','biber','reiher','marder','hummel','igel','wiesel','robbe','falke','taube',
+    'amsel','meise','schwalbe','moewe','hase','esel','ziege','katze','eule','kraehe','elster','wachtel',
+    'adler','unke','uhu','kranich','dohle','drossel','gecko','koala','panda','puma','tiger','zebra',
+    'kroete','spinne','schnecke','delfin','kamel','lama','luchs','dachs','fuchs','specht','fink','star'];
+  var usedCodes = {};   // aus dem Register gefüllt, damit kein Tier doppelt vorgeschlagen wird
+
+  // Slug säubern: klein, Umlaute auflösen, nur [a-z0-9-].
+  function slugCode(s){
+    return (s || '').toLowerCase()
+      .replace(/ä/g,'ae').replace(/ö/g,'oe').replace(/ü/g,'ue').replace(/ß/g,'ss')
+      .replace(/[^a-z0-9-]+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'');
+  }
+
+  // Freies (nicht vergebenes) Tier vorschlagen; sonst mit -2, -3 … anhängen.
+  function neuerKurzname(){
+    var frei = TIERE.filter(function(t){ return !usedCodes[t]; });
+    if(frei.length){ return frei[Math.floor((Date.now() >> 4) % frei.length)]; }
+    var t = TIERE[Math.floor((Date.now() >> 4) % TIERE.length)];
+    for(var i = 2; usedCodes[t + '-' + i]; i++){ /* nächste freie Nummer */ }
+    return t + '-' + i;
   }
 
   // Die sechs echten Landingpages: Angebot × Sprache (aus der universellen LP recherchiert).
@@ -327,9 +354,13 @@
     };
   }
 
+  el('slugNew').addEventListener('click', function(){ el('slug').value = neuerKurzname(); });
+
   el('regBtn').addEventListener('click', function(){
     if(!current){ say('Erst Quelle und Medium wählen.', true); return; }
-    var code = shortCode(current.url);
+    var code = slugCode(el('slug').value) || neuerKurzname();
+    el('slug').value = code;
+    if(usedCodes[code]){ say('Kurzname „' + code + '“ ist schon vergeben – bitte ein anderes Tier.', true); return; }
     var row = {
       kampagne: CAMPAIGN, utm_source: current.src, utm_medium: current.med, utm_campaign: CAMPAIGN,
       utm_content: current.con || null, landing: current.angebot, sprache: current.sprache, url: current.url,
@@ -341,7 +372,7 @@
       body: JSON.stringify(row)
     }).then(function(r){
       if(r.status === 201){ say('Im Register gespeichert.'); zeigeKurzlink(code); loadRegister(); }
-      else if(r.status === 409){ say('Dieser Link ist schon registriert.'); zeigeKurzlink(code); }
+      else if(r.status === 409){ say('Kurzname oder Link schon vergeben – bitte ein anderes Tier.', true); }
       else { say('Register nicht erreichbar (' + r.status + ').', true); }
     }).catch(function(){ say('Register nicht erreichbar.', true); });
   });
@@ -361,6 +392,8 @@
     }).then(function(r){ if(!r.ok) throw new Error(r.status); return r.json(); })
       .then(function(rows){
         var body = el('regBody'); body.innerHTML = '';
+        usedCodes = {}; (rows || []).forEach(function(x){ if(x.code) usedCodes[x.code] = true; });
+        if(!el('slug').value || usedCodes[slugCode(el('slug').value)]) el('slug').value = neuerKurzname();
         if(!rows || !rows.length){ body.innerHTML = '<tr><td class="empty" colspan="5">Noch keine Links registriert.</td></tr>'; return; }
         rows.forEach(function(x){
           var tr = document.createElement('tr');
@@ -392,6 +425,7 @@
       .catch(function(){ el('regBody').innerHTML = '<tr><td class="empty" colspan="5">Register nicht ladbar.</td></tr>'; });
   }
 
+  el('slug').value = neuerKurzname();
   render();
   loadRegister();
 </script>

--- a/services/sommer-zaehler/go/index.ts
+++ b/services/sommer-zaehler/go/index.ts
@@ -1,0 +1,34 @@
+// =============================================================================
+// go · Supabase Edge Function — Kurzlink-Weiterleitung
+// Öffentlicher Redirect: /go/<code> (oder ?c=<code>) → 302 auf die volle UTM-URL
+// aus public.sommer2026_links. So bleiben veröffentlichte Links kurz und
+// aufgeräumt; die UTM-Parameter reisen erst beim Redirect mit (302 auf die
+// Landingpage inkl. ?utm_*). Kein API-Key nötig (öffentliche Weiterleitung).
+//
+// Fällt ein Code ins Leere, geht es freundlich auf die Übersichts-Landingpage.
+// =============================================================================
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+const SB = Deno.env.get("SUPABASE_URL")!;
+const KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const FALLBACK = "https://global-sommer2026.goetheanum.online";
+
+function redirect(to: string): Response {
+  return new Response(null, { status: 302, headers: { Location: to, "Cache-Control": "no-store" } });
+}
+
+Deno.serve(async (req) => {
+  const u = new URL(req.url);
+  // Code aus dem letzten Pfadsegment (…/go/<code>) oder aus ?c=.
+  const seg = u.pathname.split("/").filter(Boolean).pop() || "";
+  const code = (u.searchParams.get("c") || (seg && seg !== "go" ? seg : "")).trim();
+  if (!code) return redirect(FALLBACK);
+
+  const rows = await fetch(
+    `${SB}/rest/v1/sommer2026_links?code=eq.${encodeURIComponent(code)}&select=url&limit=1`,
+    { headers: { apikey: KEY, Authorization: `Bearer ${KEY}` } },
+  ).then((r) => r.json()).catch(() => []);
+
+  const target = Array.isArray(rows) && rows[0] && typeof rows[0].url === "string" ? rows[0].url : "";
+  return redirect(target || FALLBACK);
+});

--- a/services/sommer-zaehler/ingest-paperform/index.ts
+++ b/services/sommer-zaehler/ingest-paperform/index.ts
@@ -31,6 +31,13 @@ async function sha256Hex(s: string): Promise<string> {
   return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
+// Platzhalter-Werte (Feld-Default «none», leer, «n/a» …) NICHT als UTM werten.
+function cleanUtm(v: any): string | null {
+  if (v == null) return null;
+  const s = String(v).trim();
+  return (s === "" || /^(none|n\/?a|null|undefined|-)$/i.test(s)) ? null : s;
+}
+
 // UTM-Tupel + Landingpage. Paperform legt die Herkunft in `device` ab
 // (device.utm_source/…); ausserdem trägt device.url bzw. der ?_d=-Parameter die
 // Landingpage (auch bei eingebetteten Formularen). Fallback: UTMs aus einer im
@@ -67,6 +74,8 @@ function utmFromBody(body: any): { src: string | null; med: string | null; camp:
       } catch { /* keine URL */ }
     }
   }
+  out.src = cleanUtm(out.src); out.med = cleanUtm(out.med);
+  out.camp = cleanUtm(out.camp); out.cont = cleanUtm(out.cont);
   return out;
 }
 

--- a/services/sommer-zaehler/ingest-uscreen/index.ts
+++ b/services/sommer-zaehler/ingest-uscreen/index.ts
@@ -54,6 +54,13 @@ function scrubEmail(s: string): string {
   return s.replace(/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi, "***");
 }
 
+// Platzhalter-Werte (Feld-Default «none», leer, «n/a» …) NICHT als UTM werten.
+function cleanUtm(v: any): string | null {
+  if (v == null) return null;
+  const s = String(v).trim();
+  return (s === "" || /^(none|n\/?a|null|undefined|-)$/i.test(s)) ? null : s;
+}
+
 // Volles UTM-Tupel + Landingpage: direkte Felder, sonst aus einer eingebetteten URL nachziehen.
 function utmFrom(data: any): { src: any; med: any; camp: any; cont: any; land: any } {
   const g = (k: string) => pick(data, [k, "custom_fields." + k, "utm." + k.replace("utm_", ""), "query." + k]);
@@ -174,7 +181,8 @@ Deno.serve(async (req) => {
   if (!istAktion) return json({ ok: true, skipped: "nicht Aktion (Coupon/Plan)" });
 
   const { sprache, intervall, tarif } = mapPlan(title);
-  const { src, med, camp, cont, land } = utmFrom(data);
+  const utmRaw = utmFrom(data);
+  const src = cleanUtm(utmRaw.src), med = cleanUtm(utmRaw.med), camp = cleanUtm(utmRaw.camp), cont = cleanUtm(utmRaw.cont), land = utmRaw.land;
   // Offene Selbstauskunft «Wie sind Sie aufmerksam geworden?» (Custom User Field) – O-Ton, E-Mail-redigiert.
   const selbst0 = pick(data, ["referral_source", "how_heard", "how_did_you_hear", "custom_fields.how_did_you_hear", "user_field_1", "user_fields.0.value"]);
   const selbst = selbst0 ? scrubEmail(String(selbst0)).slice(0, 300) : null;

--- a/services/sommer-zaehler/kurzlink-site/404.html
+++ b/services/sommer-zaehler/kurzlink-site/404.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<!-- =============================================================================
+     tools.goetheanum.ch · Kurzlink-Weiterleitung (GitHub Pages 404-Bruecke)
+     -----------------------------------------------------------------------------
+     GitHub Pages liefert diese Seite fuer jeden unbekannten Pfad aus. Sie liest
+     den Kurznamen aus dem Pfad (z. B. /s/otter → «otter») und uebergibt an die
+     Supabase-Function «go», die in der Tabelle sommer2026_links nachschlaegt und
+     per 302 auf die volle Ziel-URL samt UTM-Parametern weiterleitet.
+
+     Quelle der Wahrheit bleibt die Datenbank (kein doppeltes links.json). Neue
+     Kurzlinks entstehen im Generator (werkzeuge.goetheanum.ch/apps/utm-generator/)
+     und wirken hier sofort – ohne Aenderung an diesem Repo.
+     ============================================================================= -->
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex" />
+<title>Weiterleitung · Goetheanum</title>
+<link rel="icon" type="image/svg+xml" href="https://werkzeuge.goetheanum.ch/assets/logos/goetheanum-mark-blue.svg" />
+<link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/tokens.css" />
+<link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/base.css" />
+<style>
+  .weiter{min-height:70vh;display:grid;place-content:center;justify-items:center;gap:var(--s5);text-align:center;padding-block:var(--s8)}
+  .weiter h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(26px,4vw,40px);line-height:1.1}
+  .weiter p{color:var(--muted);max-width:52ch;line-height:1.6}
+  .weiter .fallback{font-size:var(--t-small)}
+</style>
+</head>
+<body>
+
+<main class="wrap">
+  <section class="weiter">
+    <span class="kicker">Goetheanum · Kurzlink</span>
+    <h1>Einen Moment – wir leiten weiter</h1>
+    <p>Der Kurzlink wird nachgeschlagen und du landest gleich auf der richtigen
+      Seite. Passiert nichts, hilft der Weg von Hand:</p>
+    <p class="fallback"><a id="direkt" href="https://werkzeuge.goetheanum.ch/apps/sommer-zaehler/">weiter zur Aktionsseite</a></p>
+  </section>
+</main>
+
+<script>
+  // Kurznamen aus dem Pfad ziehen: letztes nicht-leeres Segment.
+  // /s/otter → otter · /otter → otter · / → leer (dann auf die Aktionsseite).
+  (function () {
+    var GO = "https://dagcsnfrlbpxcmdimnrw.supabase.co/functions/v1/go/";
+    var HUB = "https://werkzeuge.goetheanum.ch/apps/sommer-zaehler/";
+    var segs = location.pathname.split("/").filter(Boolean);
+    var code = segs.length ? segs[segs.length - 1] : "";
+    // «s» ist nur das Verzeichnis, kein Kurzname.
+    if (code === "s") code = "";
+    var ziel = code ? GO + encodeURIComponent(code) : HUB;
+    var a = document.getElementById("direkt");
+    if (a) a.setAttribute("href", ziel);
+    location.replace(ziel);
+  })();
+</script>
+
+</body>
+</html>

--- a/services/sommer-zaehler/kurzlink-site/CNAME
+++ b/services/sommer-zaehler/kurzlink-site/CNAME
@@ -1,0 +1,1 @@
+tools.goetheanum.ch

--- a/services/sommer-zaehler/kurzlink-site/README.md
+++ b/services/sommer-zaehler/kurzlink-site/README.md
@@ -1,0 +1,51 @@
+# Kurzlink-Brücke für tools.goetheanum.ch
+
+> **Referenz-Kopie.** Live betrieben wird dieser statische Stand im eigenen
+> GitHub-Pages-Repo `phtok/goelinks` (eine Pages-Site trägt genau eine Custom
+> Domain; `goeloggen` hält bereits `werkzeuge.goetheanum.ch`). Diese Kopie liegt
+> hier versioniert neben der `go`-Function, die sie auflöst. Änderungen hier
+> zusätzlich nach `phtok/goelinks` übernehmen.
+
+Statische GitHub-Pages-Seite, die kurze Adressen der Form
+
+```
+tools.goetheanum.ch/s/<tier>
+```
+
+auf die volle Kampagnen-URL (samt UTM-Parametern) weiterleitet. Die Auflösung
+macht die Supabase-Function `go` gegen die Tabelle `sommer2026_links` — die
+Datenbank ist die **einzige Quelle der Wahrheit**. Dieses Repo hält bewusst
+keine Link-Liste; neue Kurzlinks entstehen im Generator und wirken sofort.
+
+## Wie ein neuer Kurzlink entsteht
+
+Nicht hier im Repo, sondern im **UTM-Generator**:
+`werkzeuge.goetheanum.ch/apps/utm-generator/` → Ziel-URL + UTM-Merkmale
+eintragen, Kurznamen wählen, ins Register schreiben. Der Kurzname wird zum
+Pfad `/s/<kurzname>`.
+
+**Slug-Stil:** kurz, klein, ein zweisilbiger Tiername mit Bild (`otter`,
+`biber`, `reiher` …). Menschlich abtippbar aus Bio, Caption oder Papier.
+
+## Wie die Weiterleitung läuft
+
+1. Aufruf `tools.goetheanum.ch/s/otter` → GitHub Pages hat keine solche Datei
+   und liefert `404.html` aus.
+2. Ein kleines Skript in `404.html` liest den letzten Pfadteil (`otter`) und
+   ruft `…/functions/v1/go/otter` auf.
+3. Die `go`-Function schlägt `otter` in `sommer2026_links` nach und antwortet
+   mit `302` auf die volle Ziel-URL. Unbekannte Kurznamen landen freundlich auf
+   der Aktions-Landingpage.
+
+## Inhalt
+
+- `index.html` — Startseite (verweist auf Generator und Cockpit).
+- `404.html` — die Weiterleitungs-Brücke.
+- `CNAME` — `tools.goetheanum.ch` (von GitHub Pages gesetzt).
+
+## Gestalt
+
+Bindet Tokens und Basis des Goetheanum-Design-Systems absolut von
+`werkzeuge.goetheanum.ch/design-system/` ein — keine eigenen Farb-, Schnitt-
+oder Abstandswerte. Hausregeln: siehe `CLAUDE.md` in
+[`phtok/goeloggen`](https://github.com/phtok/goeloggen).

--- a/services/sommer-zaehler/kurzlink-site/index.html
+++ b/services/sommer-zaehler/kurzlink-site/index.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<!-- =============================================================================
+     tools.goetheanum.ch · Startseite der Kurzlink-Bruecke
+     -----------------------------------------------------------------------------
+     Diese Domain macht lange UTM-Links kurz und vertrauenswuerdig:
+     tools.goetheanum.ch/s/<tier> → 302 auf die volle Kampagnen-URL.
+     Gebaut wird ein Kurzlink im Generator (im Werkzeug-Hub), verfolgt wird die
+     Wirkung im Aktions-Cockpit. Diese Seite verweist nur dorthin – sie haelt
+     keine eigene Logik, damit es eine Quelle der Wahrheit gibt.
+     ============================================================================= -->
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Kurzlinks · Goetheanum</title>
+<meta name="description" content="tools.goetheanum.ch verkuerzt lange UTM-Links zu kurzen, vertrauenswuerdigen Adressen fuer die Sommer-Aktion." />
+<link rel="icon" type="image/svg+xml" href="https://werkzeuge.goetheanum.ch/assets/logos/goetheanum-mark-blue.svg" />
+<link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/tokens.css" />
+<link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/base.css" />
+<style>
+  .hero{padding-block:clamp(40px,7vw,72px) var(--s7)}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);line-height:1.05;letter-spacing:-.01em;max-width:16ch}
+  .hero .lede{margin-top:var(--s6);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:56ch}
+  .beispiel{margin-top:var(--s6);font-family:var(--font-text);font-size:var(--t-body);display:flex;gap:var(--s3);align-items:baseline;flex-wrap:wrap}
+  .beispiel .kurz{color:var(--accent);font-weight:var(--w-deutlich)}
+  .beispiel .pfeil{color:var(--muted)}
+  .wege{display:grid;gap:var(--s4);grid-template-columns:repeat(auto-fit,minmax(240px,1fr));margin-top:var(--s6)}
+  .wege .card h3{font-size:var(--t-h3);margin-bottom:var(--s2)}
+  .wege .card p{color:var(--muted);line-height:1.55;margin-bottom:var(--s4)}
+</style>
+</head>
+<body>
+
+<main class="wrap">
+
+  <section class="hero">
+    <span class="kicker">Goetheanum · Sommer-Aktion 2026</span>
+    <h1>Kurze Adressen für lange Links</h1>
+    <p class="lede">Diese Domain macht aus einem langen UTM-Link eine kurze,
+      merkbare Adresse. Sie steht in Bio, Inserat oder auf Papier — und führt
+      unverändert auf die richtige Landingpage mit allen Kampagnen-Merkmalen.</p>
+    <p class="beispiel">
+      <span class="kurz">tools.goetheanum.ch/s/otter</span>
+      <span class="pfeil">→</span>
+      <span>global-sommer2026.goetheanum.online?utm_source=…</span>
+    </p>
+  </section>
+
+  <section>
+    <div class="shead">
+      <h2>Zwei Wege</h2>
+      <p>Kurzlinks entstehen im Generator und wirken sofort. Die Wirkung liest das Cockpit.</p>
+    </div>
+    <div class="wege">
+      <div class="card soft">
+        <h3>Kurzlink anlegen</h3>
+        <p>Ziel und Kampagnen-Merkmale eintragen, Kurznamen wählen — fertig ist die kurze Adresse samt QR-Code.</p>
+        <a class="btn primary" href="https://werkzeuge.goetheanum.ch/apps/utm-generator/">Zum Generator</a>
+      </div>
+      <div class="card soft">
+        <h3>Wirkung verfolgen</h3>
+        <p>Anmeldungen je Kanal, Motiv und Kurzlink — live im Team-Cockpit der Sommer-Aktion.</p>
+        <a class="btn" href="https://werkzeuge.goetheanum.ch/apps/sommer-zaehler/">Zum Cockpit</a>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<footer class="ds-footer">
+  <div class="wrap frow">
+    <span><strong>Goetheanum</strong> · Kurzlinks</span>
+    <span><a href="https://werkzeuge.goetheanum.ch/">Werkzeuge</a></span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -175,10 +175,12 @@ create table if not exists public.sommer2026_links (
   landing      text,          -- Angebot der Landingpage (uebersicht/wos/tv)
   sprache      text,          -- Sprache der Landingpage (de/en)
   url          text not null, -- fertiger Link
+  code         text,          -- Kurzcode für die Weiterleitung (Function go)
   rolle        text,          -- Hauptaufgabe (sichtbarkeit/aktivierung/wirkung/bindung)
   ersteller    text           -- optionales Kürzel, kein Pflichtfeld
 );
-create unique index if not exists sommer2026_links_url_uk on public.sommer2026_links (url);
+create unique index if not exists sommer2026_links_url_uk  on public.sommer2026_links (url);
+create unique index if not exists sommer2026_links_code_uk on public.sommer2026_links (code);
 alter table public.sommer2026_links enable row level security;
 revoke all on table public.sommer2026_links from anon, authenticated;
 grant insert on table public.sommer2026_links to anon, authenticated;
@@ -188,9 +190,9 @@ create policy sommer2026_links_insert on public.sommer2026_links
 -- Soll/Ist: je registriertem Link die Zahl der Anmeldungen über genau dieses UTM-Tupel
 create or replace function public.sommer2026_links_public()
 returns table(created_at timestamptz, utm_source text, utm_medium text, utm_content text,
-              landing text, sprache text, url text, rolle text, ersteller text, abschluesse bigint)
+              landing text, sprache text, url text, code text, rolle text, ersteller text, abschluesse bigint)
 language sql security definer set search_path to 'public' as $$
-  select l.created_at, l.utm_source, l.utm_medium, l.utm_content, l.landing, l.sprache, l.url, l.rolle, l.ersteller,
+  select l.created_at, l.utm_source, l.utm_medium, l.utm_content, l.landing, l.sprache, l.url, l.code, l.rolle, l.ersteller,
          count(s.id)::bigint as abschluesse
     from public.sommer2026_links l
     left join public.sommer2026_signups s
@@ -198,10 +200,13 @@ language sql security definer set search_path to 'public' as $$
       and s.utm_source   is not distinct from l.utm_source
       and s.utm_medium   is not distinct from l.utm_medium
       and s.utm_content  is not distinct from l.utm_content
-   group by l.id, l.created_at, l.utm_source, l.utm_medium, l.utm_content, l.landing, l.sprache, l.url, l.rolle, l.ersteller
+   group by l.id, l.created_at, l.utm_source, l.utm_medium, l.utm_content, l.landing, l.sprache, l.url, l.code, l.rolle, l.ersteller
    order by abschluesse desc, l.created_at desc;
 $$;
 grant execute on function public.sommer2026_links_public() to anon, authenticated;
+
+-- Kurzlink-Weiterleitung: Edge Function `go` liest sommer2026_links.code (Service-Role)
+-- und leitet per 302 auf die volle UTM-URL. Siehe go/index.ts.
 
 -- Kontrolliertes Löschen eines registrierten Links (nur über RPC, per URL) –
 -- kein offenes DELETE für anon; begrenzt auf die Aktion.

--- a/tools.json
+++ b/tools.json
@@ -342,6 +342,17 @@
       "such": "UTM Link Generator Kampagne Attribution Tracking QR Quelle Medium Content Sommer Aktion"
     },
     {
+      "slug": "kurzlinks",
+      "cat": "statistik",
+      "status": "beta",
+      "tag": "Aktion",
+      "title": "Kurzlinks",
+      "short": "Kurzlinks",
+      "href": "https://tools.goetheanum.ch/",
+      "desc": "Kurze, vertrauenswürdige Adressen für lange UTM-Links: tools.goetheanum.ch/s/‹tier› leitet auf die volle Kampagnen-URL. Für Bio, Inserat und Papier.",
+      "such": "Kurzlink Shortlink URL Weiterleitung tools.goetheanum.ch UTM Sommer Aktion Instagram Bio QR abtippen"
+    },
+    {
       "slug": "campus-karten",
       "cat": "geparkt",
       "status": "geparkt",


### PR DESCRIPTION
## Worum es geht

Die langen UTM-Anmeldelinks der Sommer-Aktion sind in Instagram-Bios, Inseraten und auf Papier unhandlich (und dort nicht klickbar, sondern abzutippen). Diese Änderung gibt ihnen eine kurze, vertrauenswürdige Adresse mit «goetheanum» darin:

```
tools.goetheanum.ch/s/otter  →  302 →  global-sommer2026.goetheanum.online?utm_source=…
```

Kurznamen sind **zweisilbige Tiernamen** (otter, biber, reiher …) — merkbar und menschlich abtippbar.

## Wie es funktioniert

1. **Generator** (`apps/utm-generator/`) baut wie bisher den vollen UTM-Link, schreibt ihn ins Register (`sommer2026_links`) und vergibt einen Kurznamen (`code`). Ausgegeben wird `tools.goetheanum.ch/s/‹code›` samt QR.
2. **`go`-Edge-Function** (bereits deployt) schlägt den `code` in `sommer2026_links` nach und antwortet mit `302` auf die volle URL. Unbekannte Codes landen freundlich auf der Aktions-Landingpage.
3. **Statische Brücke** (`services/sommer-zaehler/kurzlink-site/`, live betrieben im Pages-Repo `phtok/goelinks` auf `tools.goetheanum.ch`): `404.html` liest den Kurznamen aus dem Pfad und übergibt an die `go`-Function. Quelle der Wahrheit bleibt die Datenbank — kein doppeltes `links.json`.

## Enthaltene Commits

- Webhooks: Platzhalter-UTMs (`none`/leer) nicht mehr als Attribution werten.
- UTM-Generator: Kurzlink-Weiterleitung (Variante 3) + `go`-Function.
- Generator: Kurznamen als zweisilbige Tiernamen auf `tools.goetheanum.ch`.
- `tools.json`-Hub-Eintrag «Kurzlinks» + versionierte Referenz-Kopie der Pages-Site.

## Geprüft

- End-to-End live: `tools.goetheanum.ch/s/‹code›` → 404-Brücke → `go` → **302 auf die volle UTM-URL** (HTTP 200 auf der Landingpage); leere/unbekannte Pfade → Fallback aufs Cockpit.
- Startseite und `404.html`: **ds-lint 100 %**, **typo-check konform** (Hausregeln G/B/DS).
- `tools.json` valide; Hub-Eintrag erscheint bei den Aktions-Werkzeugen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_