### PR TITLE
Arbeitsregeln: Claude-PRs werden automatisch gemerged

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,3 +135,12 @@ Bei Änderungen an der Schnittzahl **alle** Beschreibungen mitziehen
 Änderungen an Schriftdateien über die Skripte in `tools/goetheanum-fontfix/`
 (idempotent, aus sauberem Stand) — nicht freihändig Binärdateien patchen.
 Nach Font-Änderungen Webfonts (woff/woff2) und das Komplett-ZIP neu packen.
+
+## Pull Requests: direkt mergen, nicht liegen lassen
+Von Claude erstellte PRs werden **automatisch gemerged** (Beschluss vom
+6. Juli 2026, «ab jetzt immer automatisch»): nicht als Draft parken, nicht
+auf Freigabe warten — wenn die Prüfmaschinen grün sind (typo-check, ds-lint,
+ggf. CI), als **Squash** mergen (Titel + PR-Nummer, wie im Verlauf üblich)
+und den Arbeits-Branch für Folgearbeit frisch von `main` starten.
+Ausnahme: der PR berührt Secrets-/Zahlungs-Konfiguration oder löscht
+Daten — dann vor dem Merge fragen.


### PR DESCRIPTION
Verankert den Beschluss vom 6. Juli 2026 («ab jetzt immer automatisch») in `CLAUDE.md`: Von Claude erstellte PRs werden bei grünen Prüfmaschinen (typo-check, ds-lint, ggf. CI) direkt als Squash gemerged statt als Draft geparkt; der Arbeits-Branch startet danach frisch von `main`. Ausnahme: Secrets-/Zahlungs-Konfiguration oder Datenlöschung — dort wird weiterhin vorher gefragt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164rvPF8hhzdmvH5KZroVGP

---
_Generated by [Claude Code](https://claude.ai/code/session_0164rvPF8hhzdmvH5KZroVGP)_