### PR TITLE
Kurzlinks: tools.goetheanum.ch-Weiterleitung, Tiernamen-Slugs, Team-Schlüssel fürs Register

### DIFF
--- a/apps/utm-generator/index.html
+++ b/apps/utm-generator/index.html
@@ -356,33 +356,61 @@
 
   el('slugNew').addEventListener('click', function(){ el('slug').value = neuerKurzname(); });
 
+  // Schreiben ins Register verlangt den Team-Schlüssel (einmal eingeben, der
+  // Browser merkt ihn sich). Lesen bleibt frei – es fliessen keine Personendaten.
+  function teamSchluessel(){
+    var s = '';
+    try { s = localStorage.getItem('sommer26_schluessel') || ''; } catch(e){}
+    if(!s){
+      s = window.prompt('Team-Schlüssel (einmalig – für Anlegen und Löschen im Register):') || '';
+      s = s.trim();
+      if(s){ try { localStorage.setItem('sommer26_schluessel', s); } catch(e){} }
+    }
+    return s;
+  }
+  function schluesselVerwerfen(){
+    try { localStorage.removeItem('sommer26_schluessel'); } catch(e){}
+  }
+
   el('regBtn').addEventListener('click', function(){
     if(!current){ say('Erst Quelle und Medium wählen.', true); return; }
     var code = slugCode(el('slug').value) || neuerKurzname();
     el('slug').value = code;
     if(usedCodes[code]){ say('Kurzname „' + code + '“ ist schon vergeben – bitte ein anderes Tier.', true); return; }
-    var row = {
-      kampagne: CAMPAIGN, utm_source: current.src, utm_medium: current.med, utm_campaign: CAMPAIGN,
-      utm_content: current.con || null, landing: current.angebot, sprache: current.sprache, url: current.url,
-      code: code, rolle: el('rolle').value, ersteller: slug(el('ersteller').value) || null
-    };
-    fetch(SB + '/rest/v1/sommer2026_links', {
+    var s = teamSchluessel();
+    if(!s){ say('Ohne Team-Schlüssel kein Eintrag.', true); return; }
+    fetch(SB + '/rest/v1/rpc/sommer2026_link_anlegen', {
       method:'POST',
-      headers:{ 'Content-Type':'application/json', 'apikey':KEY, 'Authorization':'Bearer ' + KEY, 'Prefer':'return=minimal' },
-      body: JSON.stringify(row)
-    }).then(function(r){
-      if(r.status === 201){ say('Im Register gespeichert.'); zeigeKurzlink(code); loadRegister(); }
-      else if(r.status === 409){ say('Kurzname oder Link schon vergeben – bitte ein anderes Tier.', true); }
-      else { say('Register nicht erreichbar (' + r.status + ').', true); }
-    }).catch(function(){ say('Register nicht erreichbar.', true); });
+      headers:{ 'Content-Type':'application/json', 'apikey':KEY, 'Authorization':'Bearer ' + KEY },
+      body: JSON.stringify({
+        p_schluessel: s, p_source: current.src, p_medium: current.med,
+        p_content: current.con || null, p_landing: current.angebot, p_sprache: current.sprache,
+        p_url: current.url, p_code: code, p_rolle: el('rolle').value,
+        p_ersteller: slug(el('ersteller').value) || null
+      })
+    }).then(function(r){ if(!r.ok) throw new Error(r.status); return r.json(); })
+      .then(function(ergebnis){
+        if(ergebnis === 'ok'){ say('Im Register gespeichert.'); zeigeKurzlink(code); loadRegister(); }
+        else if(ergebnis === 'vergeben'){ say('Kurzname oder Link schon vergeben – bitte ein anderes Tier.', true); }
+        else if(ergebnis === 'schluessel'){ schluesselVerwerfen(); say('Team-Schlüssel stimmt nicht – beim nächsten Versuch neu eingeben.', true); }
+        else { say('Eintrag unvollständig – Quelle, Medium und Link prüfen.', true); }
+      })
+      .catch(function(){ say('Register nicht erreichbar.', true); });
   });
 
   function loescheLink(url){
     if(!window.confirm('Diesen Link wirklich aus dem Register löschen?')) return;
+    var s = teamSchluessel();
+    if(!s){ say('Ohne Team-Schlüssel kein Löschen.', true); return; }
     fetch(SB + '/rest/v1/rpc/sommer2026_link_loeschen', {
       method:'POST', headers:{ 'Content-Type':'application/json', 'apikey':KEY, 'Authorization':'Bearer ' + KEY },
-      body: JSON.stringify({ p_url: url })
-    }).then(function(r){ if(r.ok){ say('Link gelöscht.'); loadRegister(); } else { say('Löschen nicht möglich (' + r.status + ').', true); } })
+      body: JSON.stringify({ p_url: url, p_schluessel: s })
+    }).then(function(r){ if(!r.ok) throw new Error(r.status); return r.json(); })
+      .then(function(ergebnis){
+        if(ergebnis === 'ok'){ say('Link gelöscht.'); loadRegister(); }
+        else if(ergebnis === 'schluessel'){ schluesselVerwerfen(); say('Team-Schlüssel stimmt nicht – beim nächsten Versuch neu eingeben.', true); }
+        else { say('Löschen nicht möglich.', true); }
+      })
       .catch(function(){ say('Löschen nicht erreichbar.', true); });
   }
 

--- a/services/sommer-zaehler/kurzlink-site/404.html
+++ b/services/sommer-zaehler/kurzlink-site/404.html
@@ -9,7 +9,9 @@
 
      Quelle der Wahrheit bleibt die Datenbank (kein doppeltes links.json). Neue
      Kurzlinks entstehen im Generator (werkzeuge.goetheanum.ch/apps/utm-generator/)
-     und wirken hier sofort – ohne Aenderung an diesem Repo.
+     und wirken hier sofort – ohne Aenderung an diesem Repo. Leere und
+     unbekannte Pfade landen auf der Aktions-Landingpage – nie auf den
+     internen Werkzeugen.
      ============================================================================= -->
 <html lang="de-CH">
 <head>
@@ -35,7 +37,7 @@
     <h1>Einen Moment – wir leiten weiter</h1>
     <p>Der Kurzlink wird nachgeschlagen und du landest gleich auf der richtigen
       Seite. Passiert nichts, hilft der Weg von Hand:</p>
-    <p class="fallback"><a id="direkt" href="https://werkzeuge.goetheanum.ch/apps/sommer-zaehler/">weiter zur Aktionsseite</a></p>
+    <p class="fallback"><a id="direkt" href="https://global-sommer2026.goetheanum.online">weiter zur Aktionsseite</a></p>
   </section>
 </main>
 
@@ -44,12 +46,12 @@
   // /s/otter → otter · /otter → otter · / → leer (dann auf die Aktionsseite).
   (function () {
     var GO = "https://dagcsnfrlbpxcmdimnrw.supabase.co/functions/v1/go/";
-    var HUB = "https://werkzeuge.goetheanum.ch/apps/sommer-zaehler/";
+    var LANDING = "https://global-sommer2026.goetheanum.online";
     var segs = location.pathname.split("/").filter(Boolean);
     var code = segs.length ? segs[segs.length - 1] : "";
     // «s» ist nur das Verzeichnis, kein Kurzname.
     if (code === "s") code = "";
-    var ziel = code ? GO + encodeURIComponent(code) : HUB;
+    var ziel = code ? GO + encodeURIComponent(code) : LANDING;
     var a = document.getElementById("direkt");
     if (a) a.setAttribute("href", ziel);
     location.replace(ziel);

--- a/services/sommer-zaehler/kurzlink-site/README.md
+++ b/services/sommer-zaehler/kurzlink-site/README.md
@@ -19,10 +19,11 @@ keine Link-Liste; neue Kurzlinks entstehen im Generator und wirken sofort.
 
 ## Wie ein neuer Kurzlink entsteht
 
-Nicht hier im Repo, sondern im **UTM-Generator**:
+Nicht hier im Repo, sondern im **UTM-Generator** (nur intern gelistet):
 `werkzeuge.goetheanum.ch/apps/utm-generator/` → Ziel-URL + UTM-Merkmale
 eintragen, Kurznamen wählen, ins Register schreiben. Der Kurzname wird zum
-Pfad `/s/<kurzname>`.
+Pfad `/s/<kurzname>`. Anlegen und Löschen im Register verlangen den
+**Team-Schlüssel** (einmal im Generator eingeben, der Browser merkt ihn).
 
 **Slug-Stil:** kurz, klein, ein zweisilbiger Tiername mit Bild (`otter`,
 `biber`, `reiher` …). Menschlich abtippbar aus Bio, Caption oder Papier.
@@ -39,13 +40,17 @@ Pfad `/s/<kurzname>`.
 
 ## Inhalt
 
-- `index.html` — Startseite (verweist auf Generator und Cockpit).
-- `404.html` — die Weiterleitungs-Brücke.
+- `index.html` — die Wurzel leitet auf die Aktions-Landingpage weiter.
+  **Kein Schaufenster:** die internen Werkzeuge (Generator, Cockpit) werden
+  hier bewusst nicht verlinkt — die Wurzel eines Kürzers zeigt nie das
+  Werkzeug. Nach dem 8. August 2026 das Ziel auf `goetheanum.ch` umstellen.
+- `404.html` — die Weiterleitungs-Brücke; leere und unbekannte Pfade landen
+  ebenfalls auf der Aktions-Landingpage.
 - `CNAME` — `tools.goetheanum.ch` (von GitHub Pages gesetzt).
 
 ## Gestalt
 
-Bindet Tokens und Basis des Goetheanum-Design-Systems absolut von
+`404.html` bindet Tokens und Basis des Goetheanum-Design-Systems absolut von
 `werkzeuge.goetheanum.ch/design-system/` ein — keine eigenen Farb-, Schnitt-
 oder Abstandswerte. Hausregeln: siehe `CLAUDE.md` in
 [`phtok/goeloggen`](https://github.com/phtok/goeloggen).

--- a/services/sommer-zaehler/kurzlink-site/index.html
+++ b/services/sommer-zaehler/kurzlink-site/index.html
@@ -1,78 +1,24 @@
 <!doctype html>
 <!-- =============================================================================
-     tools.goetheanum.ch · Startseite der Kurzlink-Bruecke
+     tools.goetheanum.ch · Wurzel = Weiterleitung, kein Schaufenster
      -----------------------------------------------------------------------------
-     Diese Domain macht lange UTM-Links kurz und vertrauenswuerdig:
-     tools.goetheanum.ch/s/<tier> → 302 auf die volle Kampagnen-URL.
-     Gebaut wird ein Kurzlink im Generator (im Werkzeug-Hub), verfolgt wird die
-     Wirkung im Aktions-Cockpit. Diese Seite verweist nur dorthin – sie haelt
-     keine eigene Logik, damit es eine Quelle der Wahrheit gibt.
+     Wer die Domain ohne Kurznamen eintippt, hat einen Shortlink der Aktion in
+     der Hand – er landet auf der Aktions-Landingpage (ohne UTM, zaehlt als
+     direkt). Die internen Werkzeuge (Generator, Cockpit) werden hier bewusst
+     NICHT verlinkt: Die Wurzel eines Kuerzers zeigt nie das Werkzeug.
+     Nach dem 8. August 2026 das Ziel auf https://goetheanum.ch umstellen.
      ============================================================================= -->
 <html lang="de-CH">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Kurzlinks · Goetheanum</title>
-<meta name="description" content="tools.goetheanum.ch verkuerzt lange UTM-Links zu kurzen, vertrauenswuerdigen Adressen fuer die Sommer-Aktion." />
+<meta name="robots" content="noindex" />
+<meta http-equiv="refresh" content="0;url=https://global-sommer2026.goetheanum.online" />
+<title>Goetheanum</title>
 <link rel="icon" type="image/svg+xml" href="https://werkzeuge.goetheanum.ch/assets/logos/goetheanum-mark-blue.svg" />
-<link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/tokens.css" />
-<link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/base.css" />
-<style>
-  .hero{padding-block:clamp(40px,7vw,72px) var(--s7)}
-  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);line-height:1.05;letter-spacing:-.01em;max-width:16ch}
-  .hero .lede{margin-top:var(--s6);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:56ch}
-  .beispiel{margin-top:var(--s6);font-family:var(--font-text);font-size:var(--t-body);display:flex;gap:var(--s3);align-items:baseline;flex-wrap:wrap}
-  .beispiel .kurz{color:var(--accent);font-weight:var(--w-deutlich)}
-  .beispiel .pfeil{color:var(--muted)}
-  .wege{display:grid;gap:var(--s4);grid-template-columns:repeat(auto-fit,minmax(240px,1fr));margin-top:var(--s6)}
-  .wege .card h3{font-size:var(--t-h3);margin-bottom:var(--s2)}
-  .wege .card p{color:var(--muted);line-height:1.55;margin-bottom:var(--s4)}
-</style>
 </head>
 <body>
-
-<main class="wrap">
-
-  <section class="hero">
-    <span class="kicker">Goetheanum · Sommer-Aktion 2026</span>
-    <h1>Kurze Adressen für lange Links</h1>
-    <p class="lede">Diese Domain macht aus einem langen UTM-Link eine kurze,
-      merkbare Adresse. Sie steht in Bio, Inserat oder auf Papier — und führt
-      unverändert auf die richtige Landingpage mit allen Kampagnen-Merkmalen.</p>
-    <p class="beispiel">
-      <span class="kurz">tools.goetheanum.ch/s/otter</span>
-      <span class="pfeil">→</span>
-      <span>global-sommer2026.goetheanum.online?utm_source=…</span>
-    </p>
-  </section>
-
-  <section>
-    <div class="shead">
-      <h2>Zwei Wege</h2>
-      <p>Kurzlinks entstehen im Generator und wirken sofort. Die Wirkung liest das Cockpit.</p>
-    </div>
-    <div class="wege">
-      <div class="card soft">
-        <h3>Kurzlink anlegen</h3>
-        <p>Ziel und Kampagnen-Merkmale eintragen, Kurznamen wählen — fertig ist die kurze Adresse samt QR-Code.</p>
-        <a class="btn primary" href="https://werkzeuge.goetheanum.ch/apps/utm-generator/">Zum Generator</a>
-      </div>
-      <div class="card soft">
-        <h3>Wirkung verfolgen</h3>
-        <p>Anmeldungen je Kanal, Motiv und Kurzlink — live im Team-Cockpit der Sommer-Aktion.</p>
-        <a class="btn" href="https://werkzeuge.goetheanum.ch/apps/sommer-zaehler/">Zum Cockpit</a>
-      </div>
-    </div>
-  </section>
-
-</main>
-
-<footer class="ds-footer">
-  <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Kurzlinks</span>
-    <span><a href="https://werkzeuge.goetheanum.ch/">Werkzeuge</a></span>
-  </div>
-</footer>
-
+<p><a href="https://global-sommer2026.goetheanum.online">weiter zu goetheanum.online</a></p>
+<script>location.replace("https://global-sommer2026.goetheanum.online");</script>
 </body>
 </html>

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -183,9 +183,8 @@ create unique index if not exists sommer2026_links_url_uk  on public.sommer2026_
 create unique index if not exists sommer2026_links_code_uk on public.sommer2026_links (code);
 alter table public.sommer2026_links enable row level security;
 revoke all on table public.sommer2026_links from anon, authenticated;
-grant insert on table public.sommer2026_links to anon, authenticated;
-create policy sommer2026_links_insert on public.sommer2026_links
-  for insert to anon, authenticated with check (kampagne = 'summer26_trial');
+-- Schreiben NUR über die Schlüssel-RPCs unten (Migration
+-- «sommer2026_links_schreibschutz») – kein offenes anon-INSERT mehr.
 
 -- Soll/Ist: je registriertem Link die Zahl der Anmeldungen über genau dieses UTM-Tupel
 create or replace function public.sommer2026_links_public()
@@ -208,13 +207,62 @@ grant execute on function public.sommer2026_links_public() to anon, authenticate
 -- Kurzlink-Weiterleitung: Edge Function `go` liest sommer2026_links.code (Service-Role)
 -- und leitet per 302 auf die volle UTM-URL. Siehe go/index.ts.
 
--- Kontrolliertes Löschen eines registrierten Links (nur über RPC, per URL) –
--- kein offenes DELETE für anon; begrenzt auf die Aktion.
-create or replace function public.sommer2026_link_loeschen(p_url text)
-returns void language sql security definer set search_path to 'public' as $$
-  delete from public.sommer2026_links where url = p_url and kampagne = 'summer26_trial';
+-- Schreibschutz (Migration «sommer2026_links_schreibschutz»): Anlegen und
+-- Löschen verlangen den Team-Schlüssel. Sein SHA-256-Hash liegt in
+-- sommer2026_config unter «links_schluessel_hash» (Präfix 'goe-links:');
+-- Schlüsselwechsel = diese eine Config-Zeile neu setzen.
+create or replace function public.sommer2026_links_schluessel_ok(p_schluessel text)
+returns boolean language sql security definer set search_path to 'public' as $$
+  select exists (
+    select 1 from public.sommer2026_config
+     where key = 'links_schluessel_hash'
+       and value = encode(extensions.digest('goe-links:' || coalesce(p_schluessel, ''), 'sha256'), 'hex')
+  );
 $$;
-grant execute on function public.sommer2026_link_loeschen(text) to anon, authenticated;
+revoke execute on function public.sommer2026_links_schluessel_ok(text) from public, anon, authenticated;
+
+-- Anlegen nur per RPC: prüft Schlüssel, meldet 'ok' | 'schluessel' |
+-- 'vergeben' (unique) | 'unvollstaendig' als Text an den Generator.
+create or replace function public.sommer2026_link_anlegen(
+  p_schluessel text, p_source text, p_medium text, p_content text,
+  p_landing text, p_sprache text, p_url text, p_code text,
+  p_rolle text, p_ersteller text)
+returns text language plpgsql security definer set search_path to 'public' as $$
+begin
+  if not public.sommer2026_links_schluessel_ok(p_schluessel) then
+    return 'schluessel';
+  end if;
+  if coalesce(p_source, '') = '' or coalesce(p_medium, '') = '' or coalesce(p_url, '') = '' then
+    return 'unvollstaendig';
+  end if;
+  begin
+    insert into public.sommer2026_links
+      (kampagne, utm_source, utm_medium, utm_campaign, utm_content,
+       landing, sprache, url, code, rolle, ersteller)
+    values
+      ('summer26_trial', p_source, p_medium, 'summer26_trial', nullif(p_content, ''),
+       nullif(p_landing, ''), nullif(p_sprache, ''), p_url, nullif(p_code, ''),
+       nullif(p_rolle, ''), nullif(p_ersteller, ''));
+  exception when unique_violation then
+    return 'vergeben';
+  end;
+  return 'ok';
+end;
+$$;
+grant execute on function public.sommer2026_link_anlegen(text, text, text, text, text, text, text, text, text, text) to anon, authenticated;
+
+-- Kontrolliertes Löschen (per URL), ebenfalls nur mit Schlüssel.
+create or replace function public.sommer2026_link_loeschen(p_url text, p_schluessel text)
+returns text language plpgsql security definer set search_path to 'public' as $$
+begin
+  if not public.sommer2026_links_schluessel_ok(p_schluessel) then
+    return 'schluessel';
+  end if;
+  delete from public.sommer2026_links where url = p_url and kampagne = 'summer26_trial';
+  return 'ok';
+end;
+$$;
+grant execute on function public.sommer2026_link_loeschen(text, text) to anon, authenticated;
 
 -- =============================================================================
 -- Ingestion (Webhooks) – siehe ingest-uscreen/index.ts
@@ -243,6 +291,8 @@ revoke all on table public.sommer2026_config from anon, authenticated;
 -- Schlüssel in sommer2026_config:
 --   webhook_secret : Secret für ?key= der Ingestion-Functions
 --   hash_salt      : Salt für den E-Mail-Hash (Entdopplung)
+--   links_schluessel_hash : SHA-256 des Team-Schlüssels (Präfix 'goe-links:')
+--                    fürs Link-Register (Anlegen/Löschen)
 --   aktion_aktiv   : 'true' = zählen, sonst nur loggen
 --   aktion_start   : Zeitgrenze (Anmeldungen davor zählen nicht), z. B.
 --                    '2026-07-03T12:00:00+02:00'

--- a/tools.json
+++ b/tools.json
@@ -4,7 +4,8 @@
     "live": "Im Einsatz, gepflegt",
     "beta": "Nutzbar, in Überarbeitung",
     "entwurf": "Grober Entwurf",
-    "geparkt": "Konzept, später"
+    "geparkt": "Konzept, später",
+    "intern": "Nur im Backstage-Modus gelistet – Direktlink funktioniert"
   },
   "categories": [
     {
@@ -332,7 +333,7 @@
     {
       "slug": "sommer-zaehler",
       "cat": "statistik",
-      "status": "beta",
+      "status": "intern",
       "tag": "Aktion",
       "title": "Sommer-Zähler 2026",
       "short": "Sommer-Zähler",
@@ -343,24 +344,13 @@
     {
       "slug": "utm-generator",
       "cat": "statistik",
-      "status": "beta",
+      "status": "intern",
       "tag": "Aktion",
       "title": "UTM-Link-Generator",
       "short": "UTM-Generator",
       "href": "apps/utm-generator/",
       "desc": "Saubere, konventionskonforme Anmelde-Links der Sommer-Aktion bauen – mit QR und Link-Register, damit das Cockpit auch Links mit null Abschlüssen zeigt.",
       "such": "UTM Link Generator Kampagne Attribution Tracking QR Quelle Medium Content Sommer Aktion"
-    },
-    {
-      "slug": "kurzlinks",
-      "cat": "statistik",
-      "status": "beta",
-      "tag": "Aktion",
-      "title": "Kurzlinks",
-      "short": "Kurzlinks",
-      "href": "https://tools.goetheanum.ch/",
-      "desc": "Kurze, vertrauenswürdige Adressen für lange UTM-Links: tools.goetheanum.ch/s/‹tier› leitet auf die volle Kampagnen-URL. Für Bio, Inserat und Papier.",
-      "such": "Kurzlink Shortlink URL Weiterleitung tools.goetheanum.ch UTM Sommer Aktion Instagram Bio QR abtippen"
     },
     {
       "slug": "campus-karten",


### PR DESCRIPTION
## Was dieser PR bündelt

**Variante 3 (Link-Kürzer) komplett + Härtung nach Rückfrage des Auftraggebers.**

### Kurzlink-Kette (live verifiziert)
- `apps/utm-generator/`: Kurznamen als **zweisilbige Tiernamen** (`/s/otter`), Register zeigt `tools.goetheanum.ch/s/<tier>`-Kurzlinks; `SHORTBASE` auf die neue Domain.
- `services/sommer-zaehler/go/`: Edge Function (deployed) — 302 vom Kurzcode auf die volle UTM-URL aus `sommer2026_links`; unbekannte Codes → Aktions-Landingpage.
- `services/sommer-zaehler/kurzlink-site/`: Referenz-Kopie der GitHub-Pages-Brücke (live in `phtok/goelinks`, Domain `tools.goetheanum.ch`).

### Härtung (Wurzel kein Schaufenster, Schreiben nur mit Schlüssel)
- **Wurzel `tools.goetheanum.ch`** leitet auf die Aktions-Landingpage weiter — die internen Werkzeuge werden dort nicht mehr verlinkt.
- **`tools.json`**: Cockpit + UTM-Generator auf Status `intern` (nur Backstage-Modus `intern`, Direktlinks unverändert); neuer Status in der Legende dokumentiert.
- **Link-Register**: Anlegen/Löschen nur noch per RPC mit Team-Schlüssel (SHA-256-Hash in `sommer2026_config`); offenes anon-INSERT entfernt. Migration `sommer2026_links_schreibschutz` angewandt; live geprüft: falscher Schlüssel → `schluessel`, direktes INSERT → 401.
- **Webhooks**: Platzhalter-UTMs (`none`/leer) werden nicht mehr als Attribution gewertet (deployed, verifiziert).

### Regel-Checks
ds-lint 100 % (0 Fehler), typo-check konform auf allen berührten HTML-Seiten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_