### PR TITLE
Perspektiven: die vier Startseiten vollständig nachgebaut – echte Inhalte, Erlebnis statt Ausschnitt

### DIFF
--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -16,6 +16,24 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ---
 
+## [1.4.0] – 2026-07-06
+
+### Perspektiven als Vollnachbauten + schwebende Leiste
+- **Was:** Neue Rolle `fab` in `base.css` — schwebende Leiste unten rechts
+  (zurück ins System · Original in neuem Fenster, Fingerziele ≥44px).
+  Die vier Perspektivseiten sind jetzt **vollständige Nachbauten der echten
+  Startseiten** (Inhalte von goetheanum.ch, dasgoetheanum.com, goetheanum.tv,
+  anthroposophie.org, Stand 6. Juli 2026): ganze Webseite mit Kopfzeile,
+  Aufmacher, Rubriken/Kalender/Katalog und Fusszeile — ausschliesslich aus
+  Fundament-Rollen gesetzt.
+- **Warum:** Auftraggeber-Entscheid — keine Beispiele, keine Reduktionen,
+  keine erfundenen Inhalte: ein Erlebnis-Eindruck, wie die Seite mit dem
+  System durchgearbeitet aussähe; das Original ist einen Klick daneben.
+- **Wirkung:** `perspektiven/*.html` sind Erlebnis-Seiten ohne Hub-Rahmen
+  (Nachbau-Kopfzeile je Seite mit `# ds-ok` ratifiziert). Die
+  Gegenüberstellungs-Rollen `mockpair`/`mock` (1.3.0) bleiben im Fundament
+  verfügbar. `contract.json` → Version 1.4.0, Rolle `fab` ergänzt.
+
 ## [1.3.0] – 2026-07-06
 
 ### Gegenüberstellung «heute ↔ mit dem System» (aus den Perspektivseiten aufgenommen)

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -402,6 +402,14 @@ img,svg,canvas,video{max-width:100%}
   color:var(--ink);margin-bottom:var(--s2)}
 .ds-footer .fcols a{display:block;padding:3px 0}
 
+/* --- Schwebende Perspektiven-Leiste ------------------------------------------
+   Für Vollnachbauten fremder Startseiten: führt zurück ins System und öffnet
+   das Original in einem neuen Fenster — der einzige Rahmen, den so eine
+   Erlebnis-Seite trägt. Fingerziele ≥44px (B04). */
+.fab{position:fixed;right:var(--s4);bottom:var(--s4);z-index:70;
+  display:flex;flex-direction:column;gap:var(--s2);align-items:flex-end}
+.fab .btn{box-shadow:var(--shadow-card);min-height:var(--tap)}
+
 /* --- Gegenüberstellung (Perspektiven: heute ↔ mit dem System) ----------------
    Zwei Fenster auf dieselbe Startseite. Das Ist-Fenster (.mock.ist) zeigt den
    heutigen Zustand als Artefakt — fremde Schriften/Farben dort sind Abbild,

--- a/design-system/contract.json
+++ b/design-system/contract.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://goetheanum/design-system/contract.schema.json",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "titel": "Goetheanum Design-System – Struktur-Vertrag",
   "zweck": "Maschinenlesbare Grundlage der GESTALT-Konformität (symmetrisch zum sprachlichen Kanon in assets/typografie/). ds-lint.py prüft jede Seite hiergegen, ds-fix.py korrigiert deterministisch, das Schaufenster bildet es ab. Eine Quelle der Wahrheit für Struktur; Werte/Farben/Schnitte bleiben in tokens.css/tokens.json.",
   "geltungsbereich": {
@@ -100,7 +100,8 @@
       "related",
       "fcols",
       "mockpair",
-      "mock"
+      "mock",
+      "fab"
     ],
     "hinweis": "Treffer = Seite definiert .note/.hint/.lede/… selbst. ds-fix kann die lokale Regel entfernen, sobald base.css die Rolle trägt."
   },

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -342,13 +342,12 @@
       <p>Von und miteinander lernen.</p>
     </div>
     <p class="note" style="max-width:64ch">
-      Vier Testseiten zeigen, wie die grossen Goetheanum-Webseiten aussähen,
-      wenn sie mit dem Design-System durchgearbeitet würden — je Startseite als
-      direkte Gegenüberstellung <q>heute ↔ mit dem System</q>, dazu die
-      Kernstücke (Kalender, Artikel, Katalog, Rubrik) aus den Fundament-Rollen
-      und der Einbau-Weg der jeweiligen Plattform. Was die Seiten dem Fundament
-      gaben (Teaser, Veranstaltung, Bühne, Person, Newsletter, Artikel-Anatomie),
-      steht seit v1.2 im System; die gerechneten Zahlen dahinter stehen in
+      Vier Erlebnis-Seiten: die Startseiten der grossen Goetheanum-Webseiten,
+      <b style="font-weight:var(--w-deutlich)">vollständig nachgebaut</b> mit
+      diesem Design-System — echte Inhalte (Stand 6. Juli 2026), ganze Webseite,
+      kein Ausschnitt. Ein schwebender Knopf führt zurück hierher und öffnet das
+      Original in einem neuen Fenster, für den direkten Vergleich. Die
+      gerechneten Zahlen dahinter stehen in
       <a href="https://github.com/phtok/goeloggen/blob/main/docs/webfamilie-befund.md">docs/webfamilie-befund.md</a>;
       der <b style="font-weight:var(--w-deutlich)">maschinelle Schnellbefund</b>
       (<code>tools/ds-extern.py</code>, zwölf belegbare Prüfungen je URL, Score) liegt in
@@ -360,19 +359,19 @@
       <a class="teaser stack" href="../perspektiven/goetheanum-ch.html">
         <span class="thumb" aria-hidden="true" style="background:var(--blue-solid)"></span>
         <span><span class="kick">Hauptseite</span><h3>goetheanum.ch</h3>
-        <p class="ex">Die Startseite heute ↔ im Hausbild — dazu Kalender, Teaser und Fusszeile.</p></span></a>
+        <p class="ex">Die Startseite im Hausbild — Kalender, Teaser und der Sieben-Block-Footer, komplett.</p></span></a>
       <a class="teaser stack" href="../perspektiven/dasgoetheanum.html">
         <span class="thumb" aria-hidden="true" style="background:var(--gold-deep)"></span>
         <span><span class="kick">Wochenschrift</span><h3>dasgoetheanum.com</h3>
-        <p class="ex">Die Startseite heute ↔ im Hausbild — dazu die ganze Artikel-Anatomie.</p></span></a>
+        <p class="ex">Die Startseite im Hausbild — Aufmacher, Rubriken und Abo-Leiste, komplett.</p></span></a>
       <a class="teaser stack" href="../perspektiven/goetheanum-tv.html">
         <span class="thumb" aria-hidden="true" style="background:var(--stage-bg2)"></span>
         <span><span class="kick">Streaming</span><h3>goetheanum.tv</h3>
-        <p class="ex">Die Startseite heute ↔ im Hausbild — der Katalog auf der dunklen Bühne.</p></span></a>
+        <p class="ex">Die Startseite im Hausbild — die ganze dunkle Bühne mit echten Reihen.</p></span></a>
       <a class="teaser stack" href="../perspektiven/anthroposophie-org.html">
         <span class="thumb" aria-hidden="true" style="background:var(--sek-aas)"></span>
         <span><span class="kick">Weltweit</span><h3>anthroposophie.org</h3>
-        <p class="ex">Die Startseite heute ↔ im Hausbild — Rubrik, vier Sprachen, Newsletter.</p></span></a>
+        <p class="ex">Die Startseite im Hausbild — Rubrik, Heft-Archiv und Newsletter, komplett.</p></span></a>
     </div>
   </section>
 

--- a/perspektiven/anthroposophie-org.html
+++ b/perspektiven/anthroposophie-org.html
@@ -4,166 +4,144 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Perspektive: anthroposophie.org im Hausbild</title>
-<meta name="description" content="Testseite der Webfamilie: die Startseite von ‹Anthroposophie Weltweit› heute und im Hausbild – Teaser-Liste, vier Sprachen und Newsletter, gesetzt mit dem Goetheanum-Design-System." />
+<meta name="description" content="Die Startseite von ‹Anthroposophie Weltweit›, vollständig nachgebaut mit dem Goetheanum-Design-System – echte Beiträge vom 6. Juli 2026, als ganze Webseite erlebbar." />
 <meta name="robots" content="noindex" />
 <link rel="icon" type="image/svg+xml" href="../assets/logos/goetheanum-mark-blue.svg" />
 <link rel="stylesheet" href="../design-system/tokens.css" />
 <link rel="stylesheet" href="../design-system/base.css" />
-<link rel="stylesheet" href="../design-system/nav.css" />
 <style>
-  /* ---- Ist-Fenster: Abbild der heutigen Startseite (Artefakt). Yrsa nähern
-     wir mit der System-Serife an; Grade, Grau und das helle Gold sind die
-     gemessenen Original-Werte. Alle Literale ratifiziert. */
-  .mock.ist .screen{background:#fff;color:#333;font-family:Georgia,serif;line-height:1.43}  /* # ds-ok Abbild anthroposophie.org */
-  .iao-top{display:flex;justify-content:space-between;align-items:baseline;gap:12px;border-bottom:1px solid #ddd;padding-bottom:8px;font-family:Helvetica,Arial,sans-serif}  /* # ds-ok */
-  .iao-top .wm{font-weight:700;font-size:14px;color:#333}  /* # ds-ok */
-  .iao-top nav{display:flex;gap:8px;font-size:12px;color:#337ab7;flex-wrap:wrap}  /* # ds-ok Bootstrap-Blau wie im Original */
-  .iao-banner{margin-top:12px;background:#B19F7C;color:#fff;padding:12px 14px;border-radius:2px}  /* # ds-ok Weiss auf Gold 1.6:1 – der gemessene Banner */
-  .iao-banner b{display:block;font-family:Helvetica,Arial,sans-serif;font-size:18px;line-height:1.2}  /* # ds-ok */
-  .iao-banner span{font-size:12px}  /* # ds-ok */
-  .iao-item{display:flex;gap:10px;border-top:1px solid #eee;padding:10px 0}  /* # ds-ok */
-  .iao-item .im{flex:0 0 64px;height:44px;background:#d8d8d8;display:grid;place-items:center;font-family:Helvetica,Arial,sans-serif;font-size:10px;color:#888}  /* # ds-ok alt=„Image" wie im Original */
-  .iao-item b{display:block;font-family:Helvetica,Arial,sans-serif;font-size:14px;color:#333}  /* # ds-ok */
-  .iao-item p{font-size:12px;color:#b0b0b0;margin:2px 0 0}  /* # ds-ok 12px · Grau 2.1:1 wie gemessen */
-  .iao-langs{margin-top:10px;font-family:Helvetica,Arial,sans-serif;font-size:11px;color:#337ab7;display:flex;gap:8px}  /* # ds-ok 11px wie gemessen */
+  /* Nachbau-Kopfzeile der Zielseite – ganz aus Tokens/Rollen gesetzt. */
+  .site-head{border-bottom:1px solid var(--line);background:var(--paper)}
+  .site-head .util{display:flex;justify-content:flex-end;align-items:center;gap:var(--s4);flex-wrap:wrap;
+    padding:var(--s2) 0;font-family:var(--font-text);font-size:var(--t-small)}
+  .site-head .util a{color:var(--muted)}
+  .site-head .util a:hover{color:var(--gold-ink)}
+  .site-head .util .langs{display:flex;gap:var(--s2)}
+  .site-head .util .langs b{color:var(--ink);font-weight:600}
+  .site-head .bar{display:flex;align-items:baseline;justify-content:space-between;gap:var(--s6);
+    padding:var(--s3) 0 var(--s4);flex-wrap:wrap}
+  .site-head .brand{color:var(--ink);text-decoration:none;
+    font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:26px;line-height:1}
+  .site-head .mainnav{display:flex;gap:var(--s4);flex-wrap:wrap;font-family:var(--font-display);
+    font-weight:var(--w-deutlich);font-size:16px}
+  .site-head .mainnav a{color:var(--ink);padding:6px 0}
+  .site-head .mainnav a:hover{color:var(--gold-ink)}
 
-  .rubrik{display:grid;gap:var(--s3);max-width:760px}
-  .sprachen{display:flex;align-items:center;gap:var(--s3);flex-wrap:wrap}
-  .mehr{display:flex;justify-content:center;margin-top:var(--s6)}
-  .vergleich{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:var(--s4)}
-  .vergleich .card p{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);line-height:1.6;margin:0 0 .5em}
-  .vergleich .card p b{color:var(--ink);font-weight:600}
+  .hero{padding-block:clamp(36px,6vw,64px) var(--s4)}
+  .rubrik{display:grid;gap:var(--s3);max-width:820px}
+  .heft{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:var(--s4);margin-top:var(--s3)}
 </style>
 </head>
 <body>
-<script src="../design-system/nav.js" data-root="../"
-        data-onpage="Startseite:#startseite|Rubrik:#rubrik|Sprachen &amp; Newsletter:#sprachen|In Zahlen:#zahlen|Der Weg:#weg"></script>
 
-<main class="wrap">
+<header class="site-head"><!-- # ds-ok Nachbau: die Kopfzeile der Zielseite ist hier der Inhalt -->
+  <div class="wrap">
+    <div class="util">
+      <a href="#fussnote">Login</a>
+      <span class="langs" aria-label="Sprache"><b>DE</b><a href="#fussnote" lang="en">EN</a><a href="#fussnote" lang="fr">FR</a><a href="#fussnote" lang="es">ES</a></span>
+    </div>
+    <div class="bar">
+      <a class="brand" href="#top">Anthroposophie Weltweit</a>
+      <nav class="mainnav" aria-label="Hauptnavigation">
+        <a href="#gesellschaft">Gesellschaft</a>
+        <a href="#fussnote">Hochschule</a>
+        <a href="#fussnote">Forum</a>
+        <a href="#fussnote">Goetheanum</a>
+        <a href="#fussnote">In der Welt</a>
+        <a href="#fussnote">Denkanstoss</a>
+      </nav>
+    </div>
+  </div>
+</header>
+
+<main class="wrap" id="top">
+
   <section class="hero">
-    <span class="kicker">Perspektive · Webfamilie</span>
-    <h1>anthroposophie.org im Hausbild</h1>
-    <p class="lede">Das Nachrichtenblatt <q>Anthroposophie Weltweit</q> pflegt als
-      Einziges vier vollständige Sprachausgaben. Diese Seite zeigt, wie seine
-      Startseite aussähe, mit dem Design-System durchgearbeitet — die Stärke
-      (vier Sprachen) bleibt, die Gestalt kommt aus einer Quelle.</p>
+    <span class="kicker">Nachrichtenblatt der Allgemeinen Anthroposophischen Gesellschaft</span>
+    <h1>Anthroposophie weltweit</h1>
+    <p class="lede">Was Mitglieder und Freunde der anthroposophischen Bewegung
+      auf allen Kontinenten arbeiten — in vier Sprachen, monatlich als Heft
+      und fortlaufend hier.</p>
   </section>
 
-  <section id="startseite">
-    <div class="shead"><h2>Die Startseite: heute ↔ mit dem System</h2>
-      <p>Zwei Fenster auf denselben Inhalt. Links das Abbild des heutigen
-         Zustands (Grade, Grau und das helle Gold wie gemessen), rechts dieselbe
-         Startseite aus den Fundament-Rollen.</p></div>
-    <div class="mockpair">
-      <figure class="mock ist">
-        <figcaption><b>Heute</b><span>anthroposophie.org · Juli 2026</span></figcaption>
-        <div class="screen">
-          <div class="iao-top"><span class="wm">Anthroposophie Weltweit</span>
-            <nav><span>Gesellschaft</span><span>Hochschule</span><span>Heft</span></nav></div>
-          <div class="iao-banner"><b>Die Weltkonferenz lädt ein</b><span>Im Herbst treffen sich die Landesgesellschaften in Dornach.</span></div>
-          <div style="margin-top:10px">
-            <div class="iao-item"><span class="im">Image</span><span><b>Neue Arbeitsgruppen in drei Ländern</b><p>Von Lima bis Helsinki: wie Initiativen entstehen.</p></span></div>
-            <div class="iao-item"><span class="im">Image</span><span><b>Aus dem Heft: Ausgabe 7–8/2026</b><p>Die neue Ausgabe ist erschienen.</p></span></div>
-          </div>
-          <div class="iao-langs"><span>DE</span><span>EN</span><span>FR</span><span>ES</span></div>
-        </div>
-      </figure>
-      <figure class="mock soll">
-        <figcaption><b>Mit dem Design-System</b><span>dieselbe Startseite</span></figcaption>
-        <div class="screen">
-          <div style="display:flex;justify-content:space-between;align-items:baseline;gap:var(--s3);border-bottom:1px solid var(--line-soft);padding-bottom:var(--s2);flex-wrap:wrap">
-            <span style="font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:17px">Anthroposophie Weltweit</span>
-            <nav style="display:flex;gap:var(--s3);font-family:var(--font-display);font-size:var(--t-small)"><a href="#startseite">Gesellschaft</a><a href="#startseite">Hochschule</a><a href="#startseite">Heft</a></nav>
-          </div>
-          <div style="display:grid;gap:var(--s3);padding-top:var(--s4)">
-            <a class="teaser" href="#startseite"><span class="thumb" aria-hidden="true" style="background:var(--sek-aas)"></span>
-              <span><span class="kick">Gesellschaft</span><h3 style="font-size:18px">Die Weltkonferenz lädt ein</h3>
-              <p class="ex">Im Herbst treffen sich die Landesgesellschaften in Dornach.</p></span></a>
-            <a class="teaser" href="#startseite"><span class="thumb" aria-hidden="true" style="background:var(--sek-ssw)"></span>
-              <span><span class="kick">Gesellschaft</span><h3 style="font-size:18px">Neue Arbeitsgruppen in drei Ländern</h3>
-              <p class="ex">Von Lima bis Helsinki: wie Initiativen entstehen.</p></span></a>
-          </div>
-          <div class="sprachen" style="margin-top:var(--s4)">
-            <div class="seg" role="group" aria-label="Sprache wählen">
-              <button type="button" aria-pressed="true" lang="de">Deutsch</button>
-              <button type="button" aria-pressed="false" lang="en">English</button>
-              <button type="button" aria-pressed="false" lang="fr">Français</button>
-              <button type="button" aria-pressed="false" lang="es">Español</button>
-            </div>
-          </div>
-        </div>
-      </figure>
-    </div>
-    <p class="note" style="margin-top:var(--s4)">Der Aufmacher trägt Weiss auf gerechnetem Grund statt 1.6:1, die Bilder bekommen Beschreibungen, die Sprachwahl wird ein bedienbares Element — mehr dazu <a href="#zahlen">in Zahlen</a>.</p>
-  </section>
-
-  <section id="rubrik">
-    <div class="shead"><h2>Rubrik <q>Gesellschaft</q></h2>
-      <p>Teaser-Liste mit klarer Hierarchie — und <b style="font-weight:var(--w-deutlich)">Mehr laden</b> statt einer Endlosliste.</p></div>
+  <section id="gesellschaft">
+    <div class="shead"><h2>Gesellschaft</h2><p>Aus der Allgemeinen Anthroposophischen Gesellschaft · 29. Juni 2026</p></div>
     <div class="rubrik">
-      <a class="teaser" href="#rubrik"><span class="thumb" aria-hidden="true" style="background:var(--sek-aas)"></span>
-        <span><span class="kick">Gesellschaft</span><h3>Die Weltkonferenz lädt ein</h3>
-        <p class="ex">Im Herbst treffen sich die Landesgesellschaften in Dornach — Programm und Anmeldung.</p>
-        <span class="byline"><b>Beispiel-Autor</b> <span>2. Juli 2026</span></span></span></a>
-      <a class="teaser" href="#rubrik"><span class="thumb" aria-hidden="true" style="background:var(--sek-ssw)"></span>
-        <span><span class="kick">Gesellschaft</span><h3>Neue Arbeitsgruppen in drei Ländern</h3>
-        <p class="ex">Von Lima bis Helsinki: wie Initiativen entstehen und was sie tragen.</p>
-        <span class="byline"><b>Beispiel-Autorin</b> <span>28. Juni 2026</span></span></span></a>
-      <a class="teaser" href="#rubrik"><span class="thumb" aria-hidden="true" style="background:var(--gold)"></span>
-        <span><span class="kick">Gesellschaft</span><h3>Aus dem Heft: Ausgabe 7–8/2026</h3>
-        <p class="ex">Die neue Ausgabe ist erschienen — Überblick und Bezugswege.</p>
-        <span class="byline"><b>Redaktion</b> <span>21. Juni 2026</span></span></span></a>
+      <a class="teaser" href="#gesellschaft">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-aas)"></span>
+        <span><span class="kick">Toleranz</span><h3><q>Es muss von Herzen gehn</q></h3>
+        <p class="ex">Die <q>Wege des Vertrauens</q> — Thema der Generalversammlung 2026 — stehen auf der Grundlage einer Haltung der Toleranz.</p>
+        <span class="byline"><b>Stefan Hasler</b> <span>29. Juni 2026</span></span></span></a>
+      <a class="teaser" href="#gesellschaft">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-szw)"></span>
+        <span><span class="kick">Konvent</span><h3>Wie das Richtige finden? Auf dem Weg zur neuen Konstitution</h3>
+        <p class="ex">Mit der Vorstellung des Entwurfs zur Neu-Konstitution der Allgemeinen Anthroposophischen Gesellschaft auf der Generalversammlung 2026 hat die Vernehmlassungsphase begonnen. Seither haben den Konvent Dutzende von Rückmeldungen erreicht.</p>
+        <span class="byline"><b>Gerhard Schuster und Moritz Christoph</b> <span>29. Juni 2026</span></span></span></a>
+      <a class="teaser" href="#gesellschaft">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-ssw)"></span>
+        <span><span class="kick">Mitgliedergruppe <q>Transparente Kommunikation</q></span><h3>Neu-Konstitution: Überraschung!</h3>
+        <p class="ex">Wir hatten am 1. Juni 2026 eine Sitzung unserer Arbeitsgruppe <q>Transparente Kommunikation</q>.</p>
+        <span class="byline"><b>Andreas Heertsch</b> <span>29. Juni 2026</span></span></span></a>
+      <a class="teaser" href="#gesellschaft">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-js)"></span>
+        <span><span class="kick">Internationales Mitgliederforum</span><h3>Auf den Spuren der Weihnachtstagung 1923/24 — eine Zusammenarbeit online von und für Mitglieder</h3>
+        <p class="ex">Am 17. Mai 2026 fand das fünfte Internationale Mitgliederforum statt.</p>
+        <span class="byline"><b>Moritz Christoph, Tatiana García-Cuerva, Philip Jacobsen u. a.</b> <span>29. Juni 2026</span></span></span></a>
+      <a class="teaser" href="#gesellschaft">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-goetheanum)"></span>
+        <span><span class="kick">Mitgliederentwicklung</span><h3>Mitgliedersekretariat am Goetheanum</h3>
+        <p class="ex">Aus der laufenden Arbeit des Mitgliedersekretariats am Goetheanum.</p>
+        <span class="byline"><span>29. Juni 2026</span></span></span></a>
     </div>
-    <div class="mehr"><button class="btn" type="button">Mehr laden</button></div>
+    <div style="margin-top:var(--s6)"><a class="btn" href="#gesellschaft">Mehr laden</a></div>
   </section>
 
-  <section id="sprachen">
-    <div class="shead"><h2>Vier Sprachen &amp; Newsletter</h2>
-      <p>Die Stärke der Seite bleibt: das saubere /de·/en·/fr·/es-Schema — hier als Rolle, dazu der Newsletter-Einstieg.</p></div>
-    <div class="sprachen" style="margin-bottom:var(--s6)">
-      <span class="meta" style="font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)">Sprache:</span>
-      <div class="seg" role="group" aria-label="Sprache wählen">
-        <button type="button" aria-pressed="true" lang="de">Deutsch</button>
-        <button type="button" aria-pressed="false" lang="en">English</button>
-        <button type="button" aria-pressed="false" lang="fr">Français</button>
-        <button type="button" aria-pressed="false" lang="es">Español</button>
-      </div>
+  <section id="heft">
+    <div class="shead"><h2>Das Heft</h2><p>PDF-Archiv der aktuellen Ausgaben.</p></div>
+    <div class="heft">
+      <a class="teaser stack" href="#heft"><span class="thumb" aria-hidden="true" style="background:var(--gold)"></span>
+        <span><span class="kick">Aktuelle Ausgabe</span><h3>Nr. 7–8/2026</h3>
+        <p class="ex">Als PDF lesen oder das Heft bestellen.</p></span></a>
+      <a class="teaser stack" href="#heft"><span class="thumb" aria-hidden="true" style="background:var(--soft)"></span>
+        <span><span class="kick">Archiv</span><h3>Nr. 6/2026</h3></span></a>
+      <a class="teaser stack" href="#heft"><span class="thumb" aria-hidden="true" style="background:var(--soft)"></span>
+        <span><span class="kick">Archiv</span><h3>Nr. 5/2026</h3></span></a>
     </div>
-    <form class="subscribe" onsubmit="return false">
+    <form class="subscribe" onsubmit="return false" style="margin-top:var(--s6)">
       <label class="sr-only" for="nl">E-Mail-Adresse</label>
       <input id="nl" type="email" placeholder="E-Mail-Adresse" autocomplete="email" />
       <button class="btn primary" type="submit">Newsletter erhalten</button>
     </form>
   </section>
 
-  <section id="zahlen">
-    <div class="shead"><h2>Der Vergleich in Zahlen</h2>
-      <p>Was zwischen links und rechts liegt — gerechnet am Original (Juli 2026), Regel-IDs in Klammern.</p></div>
-    <div class="vergleich">
-      <div class="card"><p><b>6 deklarierte Schriftfamilien, 2 laden nie → eine Hausschrift + eine Leseschrift</b>, selbst gehostet statt Google Fonts.</p></div>
-      <div class="card"><p><b>Weiss auf Gold 1.6:1, Meta-Grau 2.1:1 → Tokens mit gerechneten Kontrasten</b> (B01/B02).</p></div>
-      <div class="card"><p><b>574 × alt="Image", outline:none → beschriebene Bilder, sichtbarer Fokus</b> (WCAG 1.1.1/2.4.7).</p></div>
-      <div class="card"><p><b>670-KB-Rubrikseite ohne Pagination → Mehr-laden-Muster</b>; 11–12px-Kleintext → ≥14px (B03).</p></div>
-      <div class="card"><p><b>Bootstrap-Palette → Hauspalette</b> (DS02); das verwandte Gold #B19F7C dockt an unser Gold-Token an.</p></div>
-      <div class="card"><p><b>noindex auf der Startseite → die Maschine prüft</b>: genau solche stillen Fehler findet die Konformitäts-Engine.</p></div>
-    </div>
-  </section>
-
-  <section id="weg">
-    <div class="shead"><h2>Der Weg dorthin</h2>
-      <p>Auch hier Craft CMS — dasselbe Partial wie für goetheanum.ch, verteilt über static.goetheanum.ch.</p></div>
-    <pre class="code"><code>{# _layouts/base.twig – Fundament einbinden (tokens VOR base) #}
-&lt;link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/tokens.css"&gt;
-&lt;link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/base.css"&gt;</code></pre>
-    <p class="note">Vollständiger Befund: <a href="https://github.com/phtok/goeloggen/blob/main/docs/webfamilie-befund.md">docs/webfamilie-befund.md</a></p>
-  </section>
 </main>
 
-<footer class="ds-footer">
-  <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Perspektiven der Webfamilie</span>
-    <span><a href="../design-system/">Design-System</a> · <a href="../">alle Werkzeuge</a></span>
+<footer class="ds-footer" id="fussnote">
+  <div class="wrap">
+    <div class="fcols">
+      <div><p class="ft">Anthroposophie Weltweit</p>
+        <a href="#fussnote">Originalbeiträge</a>
+        <a href="#fussnote">PDF-Archiv</a>
+        <a href="#fussnote">Kontakt</a></div>
+      <div><p class="ft">Heft</p>
+        <a href="#fussnote">Bestellen</a>
+        <a href="#fussnote">Unterstützen</a></div>
+      <div><p class="ft">Haus</p>
+        <a href="#fussnote">Das Goetheanum</a>
+        <a href="#fussnote">Impressum</a>
+        <a href="#fussnote">Datenschutz</a></div>
+    </div>
+    <div class="frow">
+      <span><strong>Anthroposophie Weltweit</strong> · Nachbau der Startseite im Design-System · Inhalte: anthroposophie.org, 6. Juli 2026</span>
+      <span><a href="../design-system/">Design-System</a></span>
+    </div>
   </div>
 </footer>
+
+<div class="fab" role="navigation" aria-label="Perspektive">
+  <a class="btn primary" href="../design-system/#perspektiven">‹ Zurück zum Design-System</a>
+  <a class="btn" href="https://anthroposophie.org/de" target="_blank" rel="noopener">Original öffnen&nbsp;↗</a>
+</div>
+
 </body>
 </html>

--- a/perspektiven/dasgoetheanum.html
+++ b/perspektiven/dasgoetheanum.html
@@ -4,192 +4,169 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Perspektive: dasgoetheanum.com im Hausbild</title>
-<meta name="description" content="Testseite der Webfamilie: die Startseite der Wochenschrift heute und im Hausbild – dazu die Artikel-Anatomie, gesetzt mit dem Goetheanum-Design-System." />
+<meta name="description" content="Die Startseite der Wochenschrift ‹Das Goetheanum›, vollständig nachgebaut mit dem Goetheanum-Design-System – echte Inhalte vom 6. Juli 2026, als ganze Webseite erlebbar." />
 <meta name="robots" content="noindex" />
 <link rel="icon" type="image/svg+xml" href="../assets/logos/goetheanum-mark-blue.svg" />
 <link rel="stylesheet" href="../design-system/tokens.css" />
 <link rel="stylesheet" href="../design-system/base.css" />
-<link rel="stylesheet" href="../design-system/nav.css" />
 <style>
-  /* ---- Ist-Fenster: Abbild der heutigen Startseite (Artefakt). Fazeta Sans
-     nähern wir mit der System-Grotesk an; Grade, Zeilenhöhe und die
-     Versal-Byline sind die gemessenen Original-Werte. Alle Literale ratifiziert. */
-  .mock.ist .screen{background:#fff;color:#222;font-family:Helvetica,Arial,sans-serif;line-height:1.4}  /* # ds-ok Abbild dasgoetheanum.com */
-  .iwg-mast{display:flex;justify-content:space-between;align-items:baseline;gap:12px;border-bottom:2px solid #222;padding-bottom:8px}  /* # ds-ok */
-  .iwg-mast .wm{font-weight:700;font-size:18px;color:#222}  /* # ds-ok */
-  .iwg-mast nav{display:flex;gap:10px;font-size:12px;color:#666;flex-wrap:wrap}  /* # ds-ok 12px wie gemessen */
-  .iwg-art{padding:14px 0 0}  /* # ds-ok Abbild */
-  .iwg-art .rub{font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:#ac9f84}  /* # ds-ok Versal-Rubrik 11px wie im Original */
-  .iwg-art h4{font-family:Helvetica,Arial,sans-serif;font-weight:700;font-size:22px;line-height:1.15;color:#222;margin:4px 0 6px}  /* # ds-ok Faux-Bold: die Seite lädt nur 2 Schnitte */
-  .iwg-art .by{font-size:12px;letter-spacing:.1em;text-transform:uppercase;color:#999}  /* # ds-ok 12px-Versal-Byline · Grau 2.8:1 wie gemessen */
-  .iwg-art p{font-size:15px;line-height:1.4;color:#444;max-width:78ch;margin:8px 0 0}  /* # ds-ok lh 1.4 · Mass ~78ch wie gemessen */
-  .iwg-more{border-top:1px solid #e5e5e5;margin-top:12px;padding-top:8px;display:grid;gap:6px}  /* # ds-ok */
-  .iwg-more b{font-size:14px;font-weight:700;color:#222}  /* # ds-ok */
-  .iwg-more span{font-size:11px;text-transform:uppercase;letter-spacing:.1em;color:#999}  /* # ds-ok */
+  /* Nachbau-Kopfzeile der Wochenschrift – ganz aus Tokens/Rollen gesetzt. */
+  .site-head{border-bottom:2px solid var(--ink);background:var(--paper)}
+  .site-head .util{display:flex;justify-content:flex-end;align-items:center;gap:var(--s4);flex-wrap:wrap;
+    padding:var(--s2) 0;font-family:var(--font-text);font-size:var(--t-small)}
+  .site-head .util a{color:var(--muted)}
+  .site-head .util a:hover{color:var(--gold-ink)}
+  .site-head .bar{display:flex;align-items:baseline;justify-content:space-between;gap:var(--s6);
+    padding:var(--s3) 0 var(--s4);flex-wrap:wrap}
+  .site-head .brand{color:var(--ink);text-decoration:none}
+  .site-head .brand .wm{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:30px;line-height:1}
+  .site-head .brand .datum{display:block;margin-top:4px;font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)}
+  .site-head .mainnav{display:flex;gap:var(--s4);flex-wrap:wrap;font-family:var(--font-display);
+    font-weight:var(--w-deutlich);font-size:16px}
+  .site-head .mainnav a{color:var(--ink);padding:6px 0}
+  .site-head .mainnav a:hover{color:var(--gold-ink)}
 
-  .artkopf{padding-block:var(--s8) var(--s6);max-width:min(72ch,100%)}
-  .artkopf h1{max-width:24ch}
-  .artkopf .byline{margin-top:var(--s4)}
-  .vergleich{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:var(--s4)}
-  .vergleich .card p{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);line-height:1.6;margin:0 0 .5em}
-  .vergleich .card p b{color:var(--ink);font-weight:600}
+  .lead{padding-block:var(--s8) var(--s6);border-bottom:1px solid var(--line);max-width:min(72ch,100%)}
+  .lead h1{max-width:22ch}
+  .lead .byline{margin-top:var(--s3)}
+  .lead .ex{font-family:var(--font-text);color:var(--muted);font-size:var(--t-lede);line-height:1.6;margin-top:var(--s3);max-width:62ch}
+
+  .agrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:var(--s4)}
+  .rubrik-liste{display:grid;gap:0;max-width:760px}
+  .rubrik-liste a{display:block;padding:var(--s3) 0;border-top:1px solid var(--line-soft);color:var(--ink);text-decoration:none}
+  .rubrik-liste a:hover h3{color:var(--gold-ink)}
+  .rubrik-liste h3{font-size:var(--t-h3);margin:0}
 </style>
 </head>
 <body>
-<script src="../design-system/nav.js" data-root="../"
-        data-onpage="Startseite:#startseite|Artikel:#nachbau|In Zahlen:#zahlen|Der Weg:#weg"></script>
 
-<main class="wrap">
-  <section class="hero">
-    <span class="kicker">Perspektive · Webfamilie</span>
-    <h1>dasgoetheanum.com im Hausbild</h1>
-    <p class="lede">Die Wochenschrift hat die reifste Artikelseite der Familie.
-      Diese Seite zeigt, wie ihre Startseite und ihr Artikel aussähen, mit dem
-      Design-System durchgearbeitet — Hausschrift, Lesemass, echte Schnitte.</p>
-  </section>
-
-  <section id="startseite">
-    <div class="shead"><h2>Die Startseite: heute ↔ mit dem System</h2>
-      <p>Zwei Fenster auf denselben Aufmacher. Links das Abbild des heutigen
-         Zustands (Grade, Zeilenhöhe und Versal-Byline wie gemessen), rechts
-         derselbe Inhalt als Teaser-Rolle aus dem Fundament.</p></div>
-    <div class="mockpair">
-      <figure class="mock ist">
-        <figcaption><b>Heute</b><span>dasgoetheanum.com · Juli 2026</span></figcaption>
-        <div class="screen">
-          <div class="iwg-mast"><span class="wm">das Goetheanum</span>
-            <nav><span>Ausgaben</span><span>Rubriken</span><span>Abo</span></nav></div>
-          <div class="iwg-art">
-            <span class="rub">Essay</span>
-            <h4>Die Stimme des Hauses</h4>
-            <span class="by">Beispiel-Autorin · 6. Juli 2026</span>
-            <p>Warum eine Schrift mehr ist als eine Wahl der Ästhetik — und was geschieht, wenn ein Haus beginnt, mit einer Stimme zu sprechen. Die Zeile läuft hier auf rund achtundsiebzig Zeichen, das Auge verliert den Anfang.</p>
-          </div>
-          <div class="iwg-more">
-            <div><b>Der Sommer der Formen</b> <span>Bühne</span></div>
-            <div><b>Beobachten als Methode</b> <span>Wissenschaft</span></div>
-          </div>
-        </div>
-      </figure>
-      <figure class="mock soll">
-        <figcaption><b>Mit dem Design-System</b><span>dieselbe Startseite</span></figcaption>
-        <div class="screen">
-          <div style="display:flex;justify-content:space-between;align-items:baseline;gap:var(--s3);border-bottom:1px solid var(--line-soft);padding-bottom:var(--s2);flex-wrap:wrap">
-            <span style="font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:19px">das Goetheanum</span>
-            <nav style="display:flex;gap:var(--s3);font-family:var(--font-display);font-size:var(--t-small)"><a href="#startseite">Ausgaben</a><a href="#startseite">Rubriken</a><a href="#startseite">Abo</a></nav>
-          </div>
-          <div style="padding:var(--s6) 0 var(--s2)">
-            <span class="kicker">Essay · Ausgabe 27–28/2026</span>
-            <h3 style="max-width:20ch">Die Stimme des Hauses</h3>
-            <p class="byline" style="margin:var(--s2) 0"><b>Beispiel-Autorin</b> <span>6. Juli 2026</span> <span>4 Min. Lesezeit</span></p>
-            <p class="note">Warum eine Schrift mehr ist als eine Wahl der Ästhetik — und was geschieht, wenn ein Haus beginnt, mit einer Stimme zu sprechen.</p>
-          </div>
-          <div style="display:grid;gap:var(--s2);border-top:1px solid var(--line-soft);padding-top:var(--s3)">
-            <a class="teaser" href="#startseite" style="border:0;padding:var(--s2) 0">
-              <span><span class="kick">Bühne</span><h3 style="font-size:17px">Der Sommer der Formen</h3></span></a>
-            <a class="teaser" href="#startseite" style="border:0;padding:var(--s2) 0">
-              <span><span class="kick">Wissenschaft</span><h3 style="font-size:17px">Beobachten als Methode</h3></span></a>
-          </div>
-        </div>
-      </figure>
+<header class="site-head"><!-- # ds-ok Nachbau: die Kopfzeile der Zielseite ist hier der Inhalt -->
+  <div class="wrap">
+    <div class="util">
+      <a href="#fussnote">Inserieren</a><a href="#fussnote">Beitragen</a><a href="#fussnote">Newsletter</a>
+      <a href="#fussnote">Schenken</a><a class="btn primary" href="#fussnote" style="padding:6px 16px">Abonnieren</a>
+      <a href="#fussnote" lang="en">English</a><a href="#fussnote">Login</a>
     </div>
-    <p class="note" style="margin-top:var(--s4)">Die Byline steht normal statt versal (G05/G23), die Rubrik ist ein Kicker, betont wird mit Gewicht — was sich sonst ändert, steht <a href="#zahlen">in Zahlen</a>.</p>
-  </section>
-
-  <section id="nachbau">
-    <div class="shead"><h2>Der Artikel</h2>
-      <p>Die komplette Artikel-Kette (Brotkrumen → Titel → Byline → Lede → Langtext
-         → Literatur → Bio → Verwandtes) — Vorlage: <a href="../design-system/starter-artikel.html">starter-artikel.html</a>.</p></div>
-
-    <header class="artkopf" style="padding-top:0">
-      <nav class="crumbs" aria-label="Pfad">
-        <a href="#nachbau">Startseite</a> <span aria-hidden="true">›</span>
-        <a href="#nachbau">Essay</a> <span aria-hidden="true">›</span>
-        <span aria-current="page">Die Stimme des Hauses</span>
+    <div class="bar">
+      <a class="brand" href="#top"><span class="wm">Das Goetheanum</span>
+        <span class="datum">Wochenschrift für Anthroposophie · 6. Juli 2026</span></a>
+      <nav class="mainnav" aria-label="Hauptnavigation">
+        <a href="#top">Home</a>
+        <a href="#aufsaetze">Aufsätze</a>
+        <a href="#zeitsymptome">Zeitsymptome</a>
+        <a href="#forum">Forum</a>
+        <a href="#worte">Worte</a>
+        <a href="#fussnote">Ausgaben</a>
       </nav>
-      <span class="kicker" style="margin-top:var(--s4);display:inline-block">Essay · Ausgabe 27–28/2026</span>
-      <h1>Die Stimme des Hauses</h1>
-      <p class="lede">Warum eine Schrift mehr ist als eine Wahl der Ästhetik —
-        und was geschieht, wenn ein Haus beginnt, mit einer Stimme zu sprechen.</p>
-      <p class="byline"><b>Beispiel-Autorin</b> <span>6. Juli 2026</span> <span>4 Min. Lesezeit</span></p>
-    </header>
-
-    <article class="prose">
-      <p>Wer die vier grossen Webseiten des Goetheanum nebeneinanderlegt, hört
-        vier Stimmen. Drei davon tasten nach derselben Schrift — nach Titillium,
-        der Basis der Hausschrift. Die Suche ist also längst im Gang; nur das
-        Finden steht noch aus. <strong>Eine Stimme ist kein Stilmittel, sondern
-        eine Haltung:</strong> Sie sagt, dass hinter allen Fenstern dasselbe Haus wohnt.</p>
-      <h3>Was langes Lesen wirklich trägt</h3>
-      <p>Nicht der Schriftwechsel macht einen Text lesbar, sondern zwei stille
-        Faktoren: eine Zeilenhöhe von mindestens 1.6 und ein Lesemass um die
-        62 Zeichen. Beides kostet nichts als eine Entscheidung. Dazu kommt der
-        echte Fettdruck: Wer nur zwei Schnitte lädt, betont mit
-        <em>synthetischem</em> Fett, das die Formen verschmiert. Ein Variable
-        Font trägt alle Grade in einer Datei.</p>
-      <p>Die Byline dieses Nachbaus steht normal, nicht versal — Betonung kommt
-        aus Gewicht und Farbe, nie aus Grossbuchstaben. Und die Bildunterschrift
-        hat hier eine Untergrenze: nichts Lesbares unter 14.</p>
-    </article>
-
-    <aside class="lit" aria-label="Literatur">
-      <p><b style="color:var(--ink)">Literatur</b></p>
-      <p>Webfamilie-Befund, <q>Was das Design-System von den vier grossen Seiten lernt</q>, Dornach 2026.</p>
-      <p>Sofie Beier, Reading Letters. Designing for legibility, Amsterdam 2012.</p>
-    </aside>
-
-    <div class="bio">
-      <span class="person"><span class="pv" aria-hidden="true">BA</span></span>
-      <p class="btext"><b>Beispiel-Autorin</b> schreibt hier stellvertretend —
-        dieser Text ist eigens für die Testseite verfasst, kein Original der
-        Wochenschrift.</p>
     </div>
+  </div>
+</header>
 
-    <div style="margin-top:var(--s8)">
-      <div class="shead"><h2>Verwandt</h2><p>Drei Wege weiter.</p></div>
-      <div class="related">
-        <a class="teaser stack" href="goetheanum-ch.html"><span class="thumb" aria-hidden="true"></span>
-          <span><span class="kick">Perspektive</span><h3>goetheanum.ch im Hausbild</h3>
-          <p class="ex">Kalender, Teaser und der Sieben-Block-Footer.</p></span></a>
-        <a class="teaser stack" href="goetheanum-tv.html"><span class="thumb" aria-hidden="true"></span>
-          <span><span class="kick">Perspektive</span><h3>goetheanum.tv im Hausbild</h3>
-          <p class="ex">Die dunkle Bühne mit Medienkacheln.</p></span></a>
-        <a class="teaser stack" href="anthroposophie-org.html"><span class="thumb" aria-hidden="true"></span>
-          <span><span class="kick">Perspektive</span><h3>anthroposophie.org im Hausbild</h3>
-          <p class="ex">Rubrik, vier Sprachen, Newsletter.</p></span></a>
-      </div>
+<main class="wrap" id="top">
+
+  <article class="lead">
+    <span class="kicker">Essay · Schwerpunkt</span>
+    <h1>Die Jugend trägt das Vermächtnis der Zukunft</h1>
+    <p class="byline"><b>Nathaniel Williams</b> <span>2. Juli 2026</span> <span>18 Min. Lesezeit</span></p>
+    <p class="ex">Wenn wir gross werden, erleben wir die Welt erhaben und doch
+      wie eine Nussschale. Wir wollen echt sein und Brücken schlagen, wenn
+      Maschinen die Führung übernehmen, wenn Nationalismus und Krieg ihr Fest
+      feiern. Die Jugend…</p>
+  </article>
+
+  <section id="aufsaetze">
+    <div class="shead"><h2>Aufsätze</h2><p>Schwerpunktbeiträge</p></div>
+    <div class="agrid">
+      <a class="teaser stack" href="#aufsaetze">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-srmk)"></span>
+        <span><span class="kick">Faust · 14 Min.</span><h3><q>Wir werden Mensch nicht ohne den Teufel</q></h3>
+        <p class="ex">Gespräch vor den <q>Faust</q>-Sommerfestspielen mit Andrea Pfaehler (Inszenierung) und Rafael Tavares (Eurythmieregie) zur Inszenierung 2026.</p>
+        <span class="byline"><b>Andrea Pfaehler, Rafael Tavares und Louis Defèche</b> <span>17. Juni 2026</span></span></span></a>
+      <a class="teaser stack" href="#aufsaetze">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-ssw)"></span>
+        <span><span class="kick">Essay · 12 Min.</span><h3>Goethe von innen</h3>
+        <p class="ex">Harzreise, Italienreise, Ilmenau und Frankreichfeldzug — eine seminaristische Annäherung an den verborgenen Goethe für das Faust-Ensemble in vier Bildern.</p>
+        <span class="byline"><b>Marcus Schneider</b> <span>17. Juni 2026</span></span></span></a>
+      <a class="teaser stack" href="#aufsaetze">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-szw)"></span>
+        <span><span class="kick">Gespräch · 11 Min.</span><h3>Ein Gefühl für die Menschheit entwickeln</h3>
+        <p class="ex">Wirtschaftliche Gesundheit ist ein Spiegel gesellschaftlicher Gesundheit. Die World Goetheanum Association sieht im Assoziativen einen Schlüssel.</p>
+        <span class="byline"><b>Karin Michael und Friederike Mainz</b> <span>10. Juni 2026</span></span></span></a>
     </div>
   </section>
 
-  <section id="zahlen">
-    <div class="shead"><h2>Der Vergleich in Zahlen</h2>
-      <p>Was zwischen links und rechts liegt — gerechnet am Original (Juli 2026), Regel-IDs in Klammern.</p></div>
-    <div class="vergleich">
-      <div class="card"><p><b>Zeilenhöhe 1.4 → 1.66</b> im Mengentext (B04); Lesemass ~78 → ~62 Zeichen (G10).</p></div>
-      <div class="card"><p><b>Byline 12px versal → 15px normal</b> (B03, G05/G23); Bildunterschrift 13 → ≥14px (B03).</p></div>
-      <div class="card"><p><b>Faux-Fett → echte Schnitte</b>: zwei statische Dateien → Variable Font 190–725; Betonung = Laut (G05).</p></div>
-      <div class="card"><p><b>`outline:0!important` → sichtbarer Fokus</b> (WCAG 2.4.7); mobiler Fliesstext 15 → ≥16px (B03).</p></div>
+  <section id="zeitsymptome">
+    <div class="shead"><h2>Zeitsymptome</h2><p>Gegenwart sehen</p></div>
+    <div class="agrid">
+      <a class="teaser stack" href="#zeitsymptome">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-js)"></span>
+        <span><span class="kick">Gespräch · 3 Min.</span><h3>Lied vom Wasser</h3>
+        <p class="ex">Musik, Bewegung und die Kraft des Wassers versetzten tausend junge Menschen aus aller Welt während der diesjährigen Internationalen Studentenkonferenz in Staunen.</p>
+        <span class="byline"><b>Gareth Dicker und Ashton Arnoldy</b> <span>2. Juli 2026</span></span></span></a>
+      <a class="teaser stack" href="#zeitsymptome">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-mas)"></span>
+        <span><span class="kick">Essay · 4 Min.</span><h3>KI und die Frage nach dem Menschlichen</h3>
+        <p class="ex">Zur Enzyklika von Papst Leo XIV. <q>Magnifica Humanitas — über die Bewahrung des Menschen im Zeitalter künstlicher Intelligenz</q>.</p>
+        <span class="byline"><b>Johannes Kronenberg</b> <span>17. Juni 2026</span></span></span></a>
+      <a class="teaser stack" href="#zeitsymptome">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-aas)"></span>
+        <span><span class="kick">Ethik · 4 Min.</span><h3>Edgar Morin — Denker der Komplexität, Freund des Menschlichen</h3>
+        <p class="ex">Er hat sehr lange gelebt — 104 Jahre. Und er hat sehr viel beigetragen — zur Menschlichkeit. Als Edgar Nahoum wurde er 1921 geboren.</p>
+        <span class="byline"><b>Bodo von Plato</b> <span>10. Juni 2026</span></span></span></a>
     </div>
   </section>
 
-  <section id="weg">
-    <div class="shead"><h2>Der Weg dorthin</h2>
-      <p>WordPress mit Child-Theme (zeen-child existiert) — das Fundament ist ein Enqueue.</p></div>
-    <pre class="code"><code>// functions.php des Child-Themes – Fundament einbinden (tokens VOR base)
-add_action('wp_enqueue_scripts', function () {
-  wp_enqueue_style('goe-tokens', 'https://werkzeuge.goetheanum.ch/design-system/tokens.css');
-  wp_enqueue_style('goe-base',   'https://werkzeuge.goetheanum.ch/design-system/base.css', ['goe-tokens']);
-});</code></pre>
-    <p class="note">Vollständiger Befund: <a href="https://github.com/phtok/goeloggen/blob/main/docs/webfamilie-befund.md">docs/webfamilie-befund.md</a> ·
-      Vorlage: <a href="../design-system/starter-artikel.html">starter-artikel.html</a></p>
+  <section id="forum">
+    <div class="shead"><h2>Forum</h2><p>Dialoge · Rückblicke · Hinweise</p></div>
+    <div class="rubrik-liste">
+      <a href="#forum"><h3>Die Spiritualität der Freiheit</h3></a>
+      <a href="#forum"><h3>Deine Entscheidung verändert die Wirtschaft</h3></a>
+      <a href="#forum"><h3>Im Uhrwerk der Welt</h3></a>
+      <a href="#forum"><h3>Lernen, in der Fantasie zu leben</h3></a>
+    </div>
   </section>
+
+  <section id="worte">
+    <div class="shead"><h2>Worte</h2><p>Sprüche · Kolumne</p></div>
+    <div class="rubrik-liste">
+      <a href="#worte"><h3>Dein Ort in der Welt</h3></a>
+      <a href="#worte"><h3>Jung bleiben</h3></a>
+      <a href="#worte"><h3>Unvollkommene Welt</h3></a>
+      <a href="#worte"><h3>Ein Meisterroman</h3></a>
+      <a href="#worte"><h3>Auge, Ohr und Herz der Gemeinschaft</h3></a>
+    </div>
+    <div style="margin-top:var(--s6)"><a class="btn" href="#worte">Mehr laden</a></div>
+  </section>
+
 </main>
 
-<footer class="ds-footer">
-  <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Perspektiven der Webfamilie</span>
-    <span><a href="../design-system/">Design-System</a> · <a href="../">alle Werkzeuge</a></span>
+<footer class="ds-footer" id="fussnote">
+  <div class="wrap">
+    <div class="fcols">
+      <div><p class="ft">Das Goetheanum</p>
+        <a href="#fussnote">Kontakt</a>
+        <a href="#fussnote">Team</a>
+        <a href="#fussnote">Autorenschaft</a></div>
+      <div><p class="ft">Abo</p>
+        <a href="#fussnote">Abonnieren</a>
+        <a href="#fussnote">Schenken</a>
+        <a href="#fussnote">Bankverbindungen</a></div>
+      <div><p class="ft">Rechtliches</p>
+        <a href="#fussnote">AGB</a>
+        <a href="#fussnote">Impressum</a>
+        <a href="#fussnote">Datenschutz</a></div>
+    </div>
+    <div class="frow">
+      <span><strong>Das Goetheanum</strong> · Nachbau der Startseite im Design-System · Inhalte: dasgoetheanum.com, 6. Juli 2026</span>
+      <span><a href="../design-system/">Design-System</a></span>
+    </div>
   </div>
 </footer>
+
+<div class="fab" role="navigation" aria-label="Perspektive">
+  <a class="btn primary" href="../design-system/#perspektiven">‹ Zurück zum Design-System</a>
+  <a class="btn" href="https://dasgoetheanum.com" target="_blank" rel="noopener">Original öffnen&nbsp;↗</a>
+</div>
+
 </body>
 </html>

--- a/perspektiven/goetheanum-ch.html
+++ b/perspektiven/goetheanum-ch.html
@@ -4,200 +4,213 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Perspektive: goetheanum.ch im Hausbild</title>
-<meta name="description" content="Testseite der Webfamilie: die Startseite von goetheanum.ch heute und im Hausbild – dazu Kalender, Teaser und Fusszeile, gesetzt mit dem Goetheanum-Design-System." />
+<meta name="description" content="Die Startseite von goetheanum.ch, vollständig nachgebaut mit dem Goetheanum-Design-System – echte Inhalte vom 6. Juli 2026, als ganze Webseite erlebbar." />
 <meta name="robots" content="noindex" />
 <link rel="icon" type="image/svg+xml" href="../assets/logos/goetheanum-mark-blue.svg" />
 <link rel="stylesheet" href="../design-system/tokens.css" />
 <link rel="stylesheet" href="../design-system/base.css" />
-<link rel="stylesheet" href="../design-system/nav.css" />
 <style>
-  /* ---- Ist-Fenster: Abbild der heutigen Startseite (Artefakt, keine Theme-
-     Flächen). Schrift: Titillium – die Seite nutzt sie wirklich; Grössen und
-     Farben sind die gemessenen Original-Werte. Alle Literale ratifiziert. */
-  @font-face{font-family:"Titillium Abbild";src:url("../assets/fonts/goetheanum/Fallback/TitilliumRUS-Regular.woff2") format("woff2");font-display:swap}
-  .mock.ist .screen{background:#fff;color:#3c3c3b;font-family:"Titillium Abbild",Arial,sans-serif;line-height:1.4}  /* # ds-ok Abbild goetheanum.ch */
-  .ich-top{display:flex;justify-content:space-between;align-items:baseline;gap:12px;border-bottom:1px solid #e3e3e3;padding-bottom:10px}  /* # ds-ok */
-  .ich-top .wm{font-weight:700;letter-spacing:.14em;font-size:14px;color:#37404c}  /* # ds-ok Wortmarke versal wie im Original */
-  .ich-top nav{display:flex;gap:10px;font-size:13px;color:#37404c;flex-wrap:wrap}  /* # ds-ok 13px wie gemessen */
-  .ich-hero{padding:18px 0 6px}
-  .ich-hero h4{font-family:"Titillium Abbild",Arial,sans-serif;font-weight:700;font-size:24px;line-height:1.15;color:#37404c;margin:0 0 6px}  /* # ds-ok */
-  .ich-hero p{font-size:13px;line-height:1.4;color:#6f6f6f;max-width:78ch;margin:0 0 12px}  /* # ds-ok 13px · lh 1.4 · Grau 3.1:1 wie gemessen */
-  .ich-btn{display:inline-block;background:#ebb565;color:#fff;font-size:13px;padding:7px 14px;border-radius:3px}  /* # ds-ok Gold+Weiss 1.85:1 – der gemessene Original-Knopf */
-  .ich-ev{border-top:1px solid #e3e3e3;padding:8px 0}  /* # ds-ok */
-  .ich-ev b{display:block;font-size:14px;font-weight:700;color:#37404c}  /* # ds-ok */
-  .ich-ev span{font-size:12.5px;color:#8a8a8a}  /* # ds-ok 12.5px Kalender-UI wie gemessen */
-  .ich-foot{margin-top:14px;background:#37404c;color:#fff;font-size:11px;padding:8px 10px;border-radius:3px;display:flex;gap:12px;flex-wrap:wrap}  /* # ds-ok */
+  /* Nachbau-Kopfzeile der Zielseite – ganz aus Tokens/Rollen gesetzt. */
+  .site-head{border-bottom:1px solid var(--line);background:var(--paper)}
+  .site-head .util{display:flex;justify-content:flex-end;align-items:center;gap:var(--s4);flex-wrap:wrap;
+    padding:var(--s2) 0;font-family:var(--font-text);font-size:var(--t-small)}
+  .site-head .util a{color:var(--muted)}
+  .site-head .util a:hover{color:var(--gold-ink)}
+  .site-head .util .langs{display:flex;gap:var(--s2)}
+  .site-head .util .langs b{color:var(--ink);font-weight:600}
+  .site-head .bar{display:flex;align-items:center;justify-content:space-between;gap:var(--s6);
+    padding:var(--s3) 0;flex-wrap:wrap}
+  .site-head .brand{display:flex;align-items:center;gap:var(--s3);color:var(--ink);text-decoration:none}
+  .site-head .brand img{height:34px}
+  .site-head .brand .wm{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:24px;line-height:1}
+  .site-head .mainnav{display:flex;gap:var(--s4);flex-wrap:wrap;font-family:var(--font-display);
+    font-weight:var(--w-deutlich);font-size:16px}
+  .site-head .mainnav a{color:var(--ink);padding:6px 0}
+  .site-head .mainnav a:hover{color:var(--gold-ink)}
 
-  /* ---- Soll-Fenster: nur Fundament-Rollen, keine Eigenwerte. */
-  .soll-brand{display:flex;justify-content:space-between;align-items:baseline;gap:var(--s3);border-bottom:1px solid var(--line-soft);padding-bottom:var(--s2);flex-wrap:wrap}
-  .soll-brand .wm{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:19px}
-  .soll-brand nav{display:flex;gap:var(--s3);font-family:var(--font-display);font-size:var(--t-small);flex-wrap:wrap}
-  .soll-foot{margin-top:var(--s4);border-top:1px solid var(--line);padding-top:var(--s3)}
-
-  .events{display:grid;gap:var(--s3);max-width:760px}
-  .trow{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:var(--s4)}
-  .vergleich{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:var(--s4)}
-  .vergleich .card p{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);line-height:1.6;margin:0 0 .5em}
-  .vergleich .card p b{color:var(--ink);font-weight:600}
-  .fdemo{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);background:var(--soft)}
-  .fdemo .fcols{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:var(--s6)}
-  .fdemo .ft{font-weight:var(--w-deutlich);margin-bottom:var(--s2)}
-  .fdemo a{display:block;padding:3px 0;font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)}
-  .fdemo a:hover{color:var(--gold-ink)}
+  .hero{padding-block:clamp(40px,7vw,80px) var(--s6)}
+  .events{display:grid;gap:var(--s3);max-width:820px}
+  .event .reihe{margin-left:var(--s2)}
+  .mehr{margin-top:var(--s6)}
+  .trow{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:var(--s4)}
+  .news{display:grid;gap:var(--s3);max-width:820px}
 </style>
 </head>
 <body>
-<script src="../design-system/nav.js" data-root="../"
-        data-onpage="Startseite:#startseite|Kalender:#kalender|Teaser:#teaser|Fusszeile:#fuss|In Zahlen:#zahlen|Der Weg:#weg"></script>
 
-<main class="wrap">
-  <section class="hero">
-    <span class="kicker">Perspektive · Webfamilie</span>
-    <h1>goetheanum.ch im Hausbild</h1>
-    <p class="lede">Die Hauptseite hat den reifsten Betrieb der Familie — vier
-      Sprachen, ein grosser Kalender, ein Bild-CDN. Diese Seite zeigt, wie ihre
-      Startseite aussähe, mit dem Design-System durchgearbeitet: links heute,
-      rechts derselbe Inhalt aus einer Quelle gesetzt.</p>
+<header class="site-head"><!-- # ds-ok Nachbau: die Kopfzeile der Zielseite ist hier der Inhalt -->
+  <div class="wrap">
+    <div class="util">
+      <a href="#gesellschaft">Mitglied werden</a><a href="#fussnote">Offene Stellen</a><a href="#fussnote">Spenden</a><a href="#fussnote">Login</a>
+      <span class="langs" aria-label="Sprache"><b>DE</b><a href="#fussnote" lang="en">EN</a><a href="#fussnote" lang="fr">FR</a><a href="#fussnote" lang="es">ES</a></span>
+    </div>
+    <div class="bar">
+      <a class="brand" href="#top" aria-label="Goetheanum – Startseite">
+        <img src="../assets/logos/goetheanum-mark-blue.svg" alt="" />
+        <span class="wm">Goetheanum</span>
+      </a>
+      <nav class="mainnav" aria-label="Hauptnavigation">
+        <a href="#demnaechst">Veranstaltungen</a>
+        <a href="#studieren">Hochschule</a>
+        <a href="#fussnote">Sektionen</a>
+        <a href="#gesellschaft">Gesellschaft</a>
+        <a href="#besuchen">Campus</a>
+        <a href="#nachrichten">Medien</a>
+      </nav>
+    </div>
+  </div>
+</header>
+
+<main class="wrap" id="top">
+
+  <section class="hero" id="gesellschaft">
+    <h1>Willkommen am Goetheanum!</h1>
+    <p class="lede">Freie Hochschule für Geisteswissenschaft und Sitz der
+      Allgemeinen Anthroposophischen Gesellschaft</p>
   </section>
 
-  <section id="startseite">
-    <div class="shead"><h2>Die Startseite: heute ↔ mit dem System</h2>
-      <p>Zwei Fenster auf denselben Inhalt. Links das Abbild des heutigen
-         Zustands (Schrift, Grade und Farben wie gemessen), rechts dieselbe
-         Startseite aus den Fundament-Rollen — Hausschrift, gerechnete
-         Kontraste, nichts Lesbares unter 14 Pixeln.</p></div>
-    <div class="mockpair">
-      <figure class="mock ist">
-        <figcaption><b>Heute</b><span>goetheanum.ch · Juli 2026</span></figcaption>
-        <div class="screen">
-          <div class="ich-top"><span class="wm">GOETHEANUM</span>
-            <nav><span>Veranstaltungen</span><span>Bühne</span><span>Sektionen</span><span>Besuch</span></nav></div>
-          <div class="ich-hero">
-            <h4>Willkommen am Goetheanum</h4>
-            <p>Das Goetheanum in Dornach ist Sitz der Allgemeinen Anthroposophischen Gesellschaft und der Freien Hochschule für Geisteswissenschaft — mit Bühne, Tagungen und Führungen über das ganze Jahr.</p>
-            <span class="ich-btn">Programm ansehen</span>
-          </div>
-          <div class="ich-ev"><b>Sommer der Formen — Eurythmie-Aufführung</b><span>11. Juli · 19.30&nbsp;Uhr · Grosser Saal</span></div>
-          <div class="ich-ev"><b>Die Pflanze im Licht — Vortrag</b><span>14. Juli · 17.00&nbsp;Uhr · Terrassensaal</span></div>
-          <div class="ich-foot"><span>Kontakt</span><span>Öffnungszeiten</span><span>Newsletter</span><span>Spenden</span></div>
-        </div>
-      </figure>
-      <figure class="mock soll">
-        <figcaption><b>Mit dem Design-System</b><span>dieselbe Startseite</span></figcaption>
-        <div class="screen">
-          <div class="soll-brand"><span class="wm">Goetheanum</span>
-            <nav><a href="#startseite">Veranstaltungen</a><a href="#startseite">Bühne</a><a href="#startseite">Sektionen</a><a href="#startseite">Besuch</a></nav></div>
-          <div style="padding:var(--s6) 0 var(--s2)">
-            <span class="kicker">Dornach · das Haus</span>
-            <h3 style="max-width:18ch">Willkommen am Goetheanum</h3>
-            <p class="note" style="margin-top:var(--s2)">Sitz der Allgemeinen Anthroposophischen Gesellschaft und der Freien Hochschule für Geisteswissenschaft — mit Bühne, Tagungen und Führungen über das ganze Jahr.</p>
-            <a class="btn primary" href="#startseite" style="margin-top:var(--s3)">Programm ansehen</a>
-          </div>
-          <div class="events" style="margin-top:var(--s4)">
-            <article class="event">
-              <div class="edate"><b>11</b><span>Juli</span></div>
-              <div><span class="kick">Bühne · Eurythmie</span>
-                <h3>Sommer der Formen</h3>
-                <p class="emeta">19.30&nbsp;Uhr · Grosser Saal</p></div>
-            </article>
-          </div>
-          <div class="soll-foot"><nav class="crumbs" aria-label="Fusszeile (Auszug)"><a href="#startseite">Kontakt</a> · <a href="#startseite">Öffnungszeiten</a> · <a href="#startseite">Newsletter</a> · <a href="#startseite">Spenden</a></nav></div>
-        </div>
-      </figure>
-    </div>
-    <p class="note" style="margin-top:var(--s4)">Was sich im Vergleich ändert, steht unten <a href="#zahlen">in Zahlen</a> — hier zählt der Eindruck: dieselben Inhalte, eine Stimme, lesbare Grade.</p>
-  </section>
-
-  <section id="kalender">
-    <div class="shead"><h2>Veranstaltungen</h2>
-      <p>Das Herzstück der Seite: Filterleiste + Veranstaltungs-Karte. Ziffern
-         tabellarisch im Datumsblock (G25), alles ≥14px (B03).</p></div>
-    <div class="filterbar">
-      <label class="field"><span class="lab">Suchen</span><input type="search" placeholder="Titel, Thema, Ort" /></label>
-      <label class="field"><span class="lab">Zeitraum</span><input type="text" placeholder="Juli 2026" /></label>
-      <label class="field"><span class="lab">Art</span><input type="text" placeholder="Alle Veranstaltungen" /></label>
-      <button class="btn" type="button">Filtern</button>
-    </div>
+  <section id="demnaechst">
+    <div class="shead"><h2>Demnächst</h2><p>Veranstaltungen der kommenden Tage am Goetheanum.</p></div>
     <div class="events">
       <article class="event">
+        <div class="edate"><b>9</b><span>Juli</span></div>
+        <div><span class="kick">Vortrag · Allgemeine Anthroposophische Sektion</span>
+          <h3>Rudolf Steiner liest Plato</h3>
+          <p class="emeta">Vortrag Salvatore Lavecchia · 19.00&nbsp;Uhr</p></div>
+      </article>
+      <article class="event">
+        <div class="edate"><b>9</b><span>Juli</span></div>
+        <div><span class="kick">Vortrag · Mathematisch-Astronomische Sektion</span>
+          <h3>Das Sommerdreieck</h3>
+          <p class="emeta">Anleitung zur Beobachtung von aktuellen Himmelserscheinungen · 22.00&nbsp;Uhr</p></div>
+      </article>
+      <article class="event">
+        <div class="edate"><b>10</b><span>Juli</span></div>
+        <div><span class="kick">Vortrag · Goetheanum-Bühne</span>
+          <h3>Der Pakt mit dem Bösen — bei Faust? Bei uns?</h3>
+          <p class="emeta">Einleitung von Philipp Reubke und Gespräch · 14.00&nbsp;Uhr</p></div>
+      </article>
+      <article class="event">
+        <div class="edate"><b>10</b><span>Juli</span></div>
+        <div><span class="kick">Vortrag · Goetheanum-Bühne</span>
+          <h3><q>Auf freiem Grund mit freiem Volke stehen</q></h3>
+          <p class="emeta">Vortrag von Gerald Häfner · 15.00&nbsp;Uhr</p></div>
+      </article>
+      <article class="event">
+        <div class="edate"><b>10</b><span>Juli</span></div>
+        <div><span class="kick">Aufführung · Goetheanum-Bühne</span>
+          <h3>Faust 1</h3>
+          <p class="emeta">16.30&nbsp;Uhr · ganze Reihe</p></div>
+      </article>
+      <article class="event">
         <div class="edate"><b>11</b><span>Juli</span></div>
-        <div><span class="kick">Bühne · Eurythmie</span>
-          <h3>Sommer der Formen — Eurythmie-Aufführung</h3>
-          <p class="emeta">19.30&nbsp;Uhr · Grosser Saal · Eintritt frei</p></div>
-      </article>
-      <article class="event">
-        <div class="edate"><b>14</b><span>Juli</span></div>
-        <div><span class="kick">Hochschule · Vortrag</span>
-          <h3>Die Pflanze im Licht — Beobachten als Methode</h3>
-          <p class="emeta">17.00&nbsp;Uhr · Terrassensaal · mit Übersetzung</p></div>
-      </article>
-      <article class="event">
-        <div class="edate"><b>21</b><span>Juli</span></div>
-        <div><span class="kick">Jugendsektion · Werkstatt</span>
-          <h3>Zukunft tragen — offene Werkstatt für Studierende</h3>
-          <p class="emeta">10.00–16.00&nbsp;Uhr · Nordatelier · Anmeldung nötig</p></div>
+        <div><span class="kick">Vortrag · Goetheanum-Bühne</span>
+          <h3>Führt Technik notwendig zu Zerstörung? Ist lebensfördernde Technik möglich?</h3>
+          <p class="emeta">Einleitung von Nathaniel Williams und Gespräch · 9.30&nbsp;Uhr</p></div>
       </article>
     </div>
-    <p class="note" style="margin-top:var(--s4)">Dazu gehörten: ICS-Export je Eintrag und die Gruppierung <q>Heute · Morgen · Datum</q> — beides bleibt Datenarbeit des CMS, die Gestalt kommt von hier.</p>
+    <div class="mehr"><a class="btn primary" href="#demnaechst">Mehr Veranstaltungen</a></div>
   </section>
 
-  <section id="teaser">
-    <div class="shead"><h2>Teaser</h2>
-      <p>Bild · Kicker · Titel · Vorspann — die Hierarchie der Startseite als Rolle statt als Einzelfall.</p></div>
+  <section id="besuchen">
+    <div class="shead"><h2>Das Goetheanum erleben</h2><p>Besuch, Studium und Führungen.</p></div>
     <div class="trow">
-      <a class="teaser stack" href="#teaser"><span class="thumb" aria-hidden="true" style="background:var(--sek-nws)"></span>
-        <span><span class="kick">Sektionen</span><h3>Naturwissenschaft am Berg</h3>
-        <p class="ex">Die Sektion öffnet ihr Labor — ein Rundgang.</p></span></a>
-      <a class="teaser stack" href="#teaser"><span class="thumb" aria-hidden="true" style="background:var(--sek-srmk)"></span>
-        <span><span class="kick">Bühne</span><h3>Der Sommer-Spielplan ist da</h3>
-        <p class="ex">Eurythmie, Sprache, Musik — alle Termine bis September.</p></span></a>
-      <a class="teaser stack" href="#teaser"><span class="thumb" aria-hidden="true" style="background:var(--gold)"></span>
-        <span><span class="kick">Haus</span><h3>Das Goetheanum besuchen</h3>
-        <p class="ex">Führungen, Öffnungszeiten und der Weg nach Dornach.</p></span></a>
+      <a class="teaser stack" href="#besuchen">
+        <span class="thumb" aria-hidden="true" style="background:var(--gold)"></span>
+        <span><span class="kick">Campus</span><h3>Besuchen Sie uns!</h3>
+        <p class="ex">Gelegen in der Juralandschaft, 10 Kilometer südlich von Basel, erhebt sich das Goetheanum in seiner expressiven Architektur auf dem Dornacher Hügel — mit malerischem Gartenpark, Café und Buchhandlung.</p>
+        <span class="byline"><b>Öffnungszeiten</b></span></span></a>
+      <a class="teaser stack" href="#studieren" id="studieren">
+        <span class="thumb" aria-hidden="true" style="background:var(--blue-solid)"></span>
+        <span><span class="kick">Hochschule</span><h3>Am Goetheanum studieren</h3>
+        <p class="ex">Die Abteilung für Weiterbildung bietet Vollzeit- und Teilzeitstudiengänge vor Ort und online für alle an, die sich für die Anthroposophie und ihre Relevanz in unterschiedlichen Praxisfeldern interessieren.</p>
+        <span class="byline"><b>Programme entdecken</b></span></span></a>
+      <a class="teaser stack" href="#besuchen">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-sbk)"></span>
+        <span><span class="kick">Campus</span><h3>Führungen</h3>
+        <p class="ex">Wir zeigen Ihnen die Geschichte des Goetheanum, erzählen von Rudolf Steiner und erklären die Anthroposophie — mit Architektur, Grossem Saal und Ausstellungsraum. Auch als Themen-, Kinder- und Schulführung.</p>
+        <span class="byline"><b>Alle Führungen</b></span></span></a>
     </div>
   </section>
 
-  <section id="fuss">
-    <div class="shead"><h2>Fusszeile</h2>
-      <p>Der Sieben-Block-Footer der Hauptseite — als Rolle .fcols, hier mit vier Blöcken gezeigt.</p></div>
-    <div class="fdemo">
-      <div class="fcols">
-        <div><p class="ft">Goetheanum</p><a href="#fuss">Rüttiweg 45, Dornach</a><a href="#fuss">Kontakt</a></div>
-        <div><p class="ft">Besuch</p><a href="#fuss">Öffnungszeiten</a><a href="#fuss">Führungen</a></div>
-        <div><p class="ft">Karten</p><a href="#fuss">Vorverkauf</a><a href="#fuss">Abendkasse</a></div>
-        <div><p class="ft">Direkt</p><a href="#fuss">Newsletter</a><a href="#fuss">Spenden</a></div>
-      </div>
+  <section id="nachrichten">
+    <div class="shead"><h2>Nachrichten</h2><p>Aus dem Haus und der Wochenschrift.</p></div>
+    <div class="news">
+      <a class="teaser" href="#nachrichten">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-aas)"></span>
+        <span><span class="kick">29. Juni 2026</span><h3>Studien- und Lernort Goetheanum</h3>
+        <p class="ex">Das Goetheanum entwickelt sich mehr als ein Jahrhundert nach seiner Gründung durch das Studium und Erforschen der Anthroposophie weiter.</p></span></a>
+      <a class="teaser" href="#nachrichten">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-srmk)"></span>
+        <span><span class="kick">26. Juni 2026</span><h3><q>Faust</q> — 99., 100. und 101. Aufführung: Feier mit Picknickdecke im Gartenpark</h3>
+        <p class="ex">Drei Sommerfestivals mit Johann Wolfgang Goethes <q>Faust 1 und 2</q> im Juli am Goetheanum: Nach Marie Steiners Uraufführung 1938 gibt es jetzt die 100. Aufführung.</p>
+        <span class="byline"><b>Wolfgang Held</b></span></span></a>
+      <a class="teaser" href="#nachrichten">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-ps)"></span>
+        <span><span class="kick">26. Juni 2026</span><h3>Das Unerwartete erwarten, das Gewohnte neu befragen</h3>
+        <p class="ex">Ob Eltern, Büromensch oder Lehrkraft: Wer das Staunen übt, kann aus Verhaltensmustern ausbrechen und sich dem öffnen, was man noch nicht kennt.</p>
+        <span class="byline"><b>Sebastian Jüngel</b></span></span></a>
+      <a class="teaser" href="#nachrichten">
+        <span class="thumb" aria-hidden="true" style="background:var(--sek-js)"></span>
+        <span><span class="kick">22. Juni 2026</span><h3>Faust: Japanischer Auftakt</h3>
+        <p class="ex">Zum Beginn der Probenzeit für die <q>Faust</q>-Aufführung hat Yuma Ito, Eurythmist im Ensemble, seinen Vater Tomokazu mit dessen Frau empfangen.</p></span></a>
     </div>
   </section>
 
-  <section id="zahlen">
-    <div class="shead"><h2>Der Vergleich in Zahlen</h2>
-      <p>Was zwischen links und rechts liegt — gerechnet am Original (Juli 2026), Regel-IDs in Klammern.</p></div>
-    <div class="vergleich">
-      <div class="card"><p><b>Gold #ebb565 + Weiss 1.85:1 → Gold-Pille 4.55:1</b> (B01/B02: Auswahl = dunkles Gold + Weiss).</p></div>
-      <div class="card"><p><b>Kalender-UI 12.5–13px → ≥14/15px</b> (B03); Grautöne 2.15–3.1:1 → --muted 4.9:1 (B02).</p></div>
-      <div class="card"><p><b>15× outline:none → sichtbarer Fokus</b>, Skip-Link aus nav.js (WCAG 2.4.1/2.4.7).</p></div>
-      <div class="card"><p><b>74 Hex-Literale + CMS-Inline-Gradients → Tokens</b> (DS02); damit wird Hell/Dunkel überhaupt erst möglich (B05).</p></div>
-      <div class="card"><p><b>11 Schnitt-Dateien → ein Variable Font</b>; Titillium-Titel → Hausschrift, die zu Ende gebaute Titillium.</p></div>
-      <div class="card"><p><b>Zeilenhöhe 1.4 → 1.66</b> im Lesetext (B04).</p></div>
-    </div>
-  </section>
-
-  <section id="weg">
-    <div class="shead"><h2>Der Weg dorthin</h2>
-      <p>Craft CMS — ein Twig-Partial im Layout, verteilt über das schon gemeinsame static.goetheanum.ch.</p></div>
-    <pre class="code"><code>{# _layouts/base.twig – Fundament einbinden (tokens VOR base) #}
-&lt;link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/tokens.css"&gt;
-&lt;link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/base.css"&gt;</code></pre>
-    <p class="note">Vollständiger Befund: <a href="https://github.com/phtok/goeloggen/blob/main/docs/webfamilie-befund.md">docs/webfamilie-befund.md</a></p>
-  </section>
 </main>
 
-<footer class="ds-footer">
-  <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Perspektiven der Webfamilie</span>
-    <span><a href="../design-system/">Design-System</a> · <a href="../">alle Werkzeuge</a></span>
+<footer class="ds-footer" id="fussnote">
+  <div class="wrap">
+    <div class="fcols">
+      <div><p class="ft">Goetheanum</p>
+        <a href="#fussnote">Rüttiweg 45, 4143 Dornach, Schweiz</a>
+        <a href="#fussnote">+41 61 706 42 42</a>
+        <a href="#fussnote">info@goetheanum.ch</a>
+        <a href="#fussnote">Kontakte &amp; Telefonzeiten</a>
+        <a href="#fussnote">Plan &amp; Zufahrt</a></div>
+      <div><p class="ft">Öffnungszeiten</p>
+        <a href="#fussnote">Täglich 9–20&nbsp;Uhr</a>
+        <a href="#fussnote">Bei Veranstaltungen erweitert</a>
+        <a href="#fussnote">Eine Führung buchen</a>
+        <a href="#fussnote">Unterkünfte</a></div>
+      <div><p class="ft">Ticketverkauf</p>
+        <a href="#fussnote">Am Empfang: Di.–So. 9–18&nbsp;Uhr</a>
+        <a href="#fussnote">Telefon: Di.–Sa. 14–18&nbsp;Uhr</a>
+        <a href="#fussnote">+41 61 706 44 44</a>
+        <a href="#fussnote">tickets@goetheanum.ch</a></div>
+      <div><p class="ft">Administration</p>
+        <a href="#fussnote">Mitgliedersekretariat</a>
+        <a href="#fussnote">Hochschulsekretariat</a>
+        <a href="#fussnote">Bühne</a>
+        <a href="#fussnote">Offene Stellen</a>
+        <a href="#fussnote">Freiwilligenarbeit</a></div>
+      <div><p class="ft">Informationen</p>
+        <a href="#fussnote">Impressum</a>
+        <a href="#fussnote">Datenschutz</a>
+        <a href="#fussnote">Nachhaltigkeit</a>
+        <a href="#fussnote">Hausordnung</a></div>
+      <div><p class="ft">Schnellzugriff</p>
+        <a href="#fussnote">Spenden</a>
+        <a href="#fussnote">Mitglied werden</a>
+        <a href="#fussnote">Medienstelle</a>
+        <a href="#fussnote">Newsletter</a></div>
+      <div><p class="ft">Soziale Medien</p>
+        <a href="#fussnote">Facebook</a>
+        <a href="#fussnote">Instagram</a>
+        <a href="#fussnote">Youtube</a>
+        <a href="#fussnote">Telegram</a></div>
+    </div>
+    <div class="frow">
+      <span><strong>Goetheanum</strong> · Nachbau der Startseite im Design-System · Inhalte: goetheanum.ch, 6. Juli 2026</span>
+      <span><a href="../design-system/">Design-System</a></span>
+    </div>
   </div>
 </footer>
+
+<div class="fab" role="navigation" aria-label="Perspektive">
+  <a class="btn primary" href="../design-system/#perspektiven">‹ Zurück zum Design-System</a>
+  <a class="btn" href="https://goetheanum.ch/de" target="_blank" rel="noopener">Original öffnen&nbsp;↗</a>
+</div>
+
 </body>
 </html>

--- a/perspektiven/goetheanum-tv.html
+++ b/perspektiven/goetheanum-tv.html
@@ -4,164 +4,122 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Perspektive: goetheanum.tv im Hausbild</title>
-<meta name="description" content="Testseite der Webfamilie: die Startseite des Streaming-Katalogs heute und im Hausbild – die dunkle Bühne des Design-Systems mit Medienkacheln, Reihen und Live." />
+<meta name="description" content="Die Startseite von Goetheanum TV, vollständig nachgebaut mit dem Goetheanum-Design-System – echte Reihen und Videos vom 6. Juli 2026, als ganze dunkle Bühne erlebbar." />
 <meta name="robots" content="noindex" />
 <link rel="icon" type="image/svg+xml" href="../assets/logos/goetheanum-mark-blue.svg" />
 <link rel="stylesheet" href="../design-system/tokens.css" />
 <link rel="stylesheet" href="../design-system/base.css" />
-<link rel="stylesheet" href="../design-system/nav.css" />
 <style>
-  /* ---- Ist-Fenster: Abbild der heutigen Startseite (Artefakt, dunkle
-     Plattform-Fläche). Grade, Grau und der Versal-Knopf wie gemessen;
-     das Fenster bleibt in Hell wie Dunkel gleich. Alle Literale ratifiziert. */
-  .mock.ist .screen{background:#121212;color:#e5e5e5;font-family:Inter,Helvetica,Arial,sans-serif;line-height:1.45}  /* # ds-ok Abbild goetheanum.tv */
-  .itv-top{display:flex;justify-content:space-between;align-items:baseline;gap:12px;border-bottom:1px solid #2a2a2a;padding-bottom:10px}  /* # ds-ok */
-  .itv-top .wm{font-weight:700;font-size:15px;color:#e5e5e5}  /* # ds-ok */
-  .itv-top nav{display:flex;gap:10px;font-size:13px;color:#6e6e6e;flex-wrap:wrap}  /* # ds-ok Grau 3.67:1 wie gemessen */
-  .itv-hero{padding:16px 0 4px}
-  .itv-hero h4{font-weight:700;font-size:22px;line-height:1.15;color:#e5e5e5;margin:0 0 6px}  /* # ds-ok */
-  .itv-hero p{font-size:13px;color:#6e6e6e;max-width:60ch;margin:0 0 12px}  /* # ds-ok 13px · Grau 3.67:1 */
-  .itv-btn{display:inline-block;background:#23323F;color:#fff;font-size:12px;letter-spacing:.12em;text-transform:uppercase;padding:8px 16px;border-radius:3px}  /* # ds-ok Versal-Knopf 12px wie im Original */
-  .itv-row{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-top:14px}
-  .itv-row .po{aspect-ratio:16/9;background:#1f1f1f;border-radius:4px}  /* # ds-ok */
-  .itv-row b{display:block;font-size:13px;font-weight:700;color:#e5e5e5;margin-top:6px}  /* # ds-ok */
-  .itv-row span{font-size:11px;color:#6e6e6e}  /* # ds-ok 11px · Grau 3.67:1 wie gemessen */
+  /* Ganze Seite = Bühne (theme-fest dunkel, wie der Katalog selbst). */
+  body{background:var(--stage-bg);color:var(--stage-ink);color-scheme:dark}
 
-  .stage .reihe{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:var(--t-h3);margin:var(--s6) 0 var(--s2)}
-  .stage .reihe:first-of-type{margin-top:var(--s2)}
-  .poster .pmark{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:15px;opacity:.92}
-  .vergleich{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:var(--s4)}
-  .vergleich .card p{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);line-height:1.6;margin:0 0 .5em}
-  .vergleich .card p b{color:var(--ink);font-weight:600}
+  /* Nachbau-Kopfzeile der Zielseite – ganz aus Tokens/Rollen gesetzt. */
+  .site-head{border-bottom:1px solid var(--stage-veil);position:sticky;top:0;background:var(--stage-bg);z-index:50}
+  .site-head .bar{display:flex;align-items:center;justify-content:space-between;gap:var(--s6);
+    padding:var(--s3) 0;flex-wrap:wrap}
+  .site-head .brand{color:var(--stage-ink);text-decoration:none;
+    font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:22px;line-height:1}
+  .site-head .mainnav{display:flex;gap:var(--s4);flex-wrap:wrap;align-items:center;
+    font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:16px}
+  .site-head .mainnav a{color:var(--stage-ink);padding:6px 0}
+  .site-head .mainnav a:hover{color:var(--gold)}
+  .site-head .cta{display:flex;gap:var(--s2);align-items:center}
+  .site-head .cta .ghostl{color:var(--stage-muted);font-family:var(--font-text);font-size:var(--t-small);padding:10px 8px}
+
+  .hero{padding-block:clamp(40px,7vw,72px) var(--s6)}
+  .hero h1{color:var(--stage-ink)}
+  .hero .lede{color:var(--stage-muted)}
+  .reihe{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:var(--t-h3);margin:var(--s8) 0 var(--s2)}
+  .poster .pmark{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:15px;opacity:.92;padding:0 10px;text-align:center}
+  .smeta{margin-top:var(--s6)}
+
+  .site-foot{border-top:1px solid var(--stage-veil);margin-top:var(--s8);padding:var(--s6) 0}
+  .site-foot .frow{display:flex;justify-content:space-between;gap:var(--s4);flex-wrap:wrap;
+    font-family:var(--font-text);font-size:var(--t-small);color:var(--stage-muted)}
+  .site-foot a{color:var(--stage-muted)}
+  .site-foot a:hover{color:var(--gold)}
 </style>
 </head>
 <body>
-<script src="../design-system/nav.js" data-root="../"
-        data-onpage="Startseite:#startseite|Katalog:#katalog|In Zahlen:#zahlen|Der Weg:#weg"></script>
 
-<main class="wrap">
+<header class="site-head"><!-- # ds-ok Nachbau: die Kopfzeile der Zielseite ist hier der Inhalt -->
+  <div class="wrap bar">
+    <a class="brand" href="#top">Goetheanum&nbsp;TV</a>
+    <nav class="mainnav" aria-label="Hauptnavigation">
+      <a href="#videothek">Videothek</a>
+      <a href="#fussnote">Community</a>
+      <a href="#fussnote">Shop</a>
+      <a href="#fussnote">Über uns</a>
+    </nav>
+    <span class="cta">
+      <a class="ghostl" href="#fussnote">Einloggen</a>
+      <a class="btn primary" href="#fussnote">Gratis testen</a>
+    </span>
+  </div>
+</header>
+
+<main class="wrap" id="top">
+
   <section class="hero">
-    <span class="kicker">Perspektive · Webfamilie</span>
-    <h1>goetheanum.tv im Hausbild</h1>
-    <p class="lede">Der Streaming-Katalog ist komplett — was fehlt, sind Marke
-      und Mass. Diese Seite zeigt, wie seine Startseite aussähe, mit dem
-      Design-System durchgearbeitet: dieselbe dunkle Fläche, aber mit Hausschrift,
-      Sektionsfarben und gerechneten Kontrasten.</p>
-  </section>
-
-  <section id="startseite">
-    <div class="shead"><h2>Die Startseite: heute ↔ mit dem System</h2>
-      <p>Zwei Fenster auf denselben Katalog. Links das Abbild des heutigen
-         Zustands (Grade, Grau und Versal-Knopf wie gemessen), rechts dieselbe
-         Startseite auf der <q>Bühne</q> des Fundaments.</p></div>
-    <div class="mockpair">
-      <figure class="mock ist">
-        <figcaption><b>Heute</b><span>goetheanum.tv · Juli 2026</span></figcaption>
-        <div class="screen">
-          <div class="itv-top"><span class="wm">goetheanum.tv</span>
-            <nav><span>Programm</span><span>Reihen</span><span>Live</span></nav></div>
-          <div class="itv-hero">
-            <h4>Alma Humana — die Konferenz</h4>
-            <p>Alle Beiträge der Konferenz als Aufzeichnung — Vorträge, Bühne und Gespräche.</p>
-            <span class="itv-btn">JETZT ANSEHEN</span>
-          </div>
-          <div class="itv-row">
-            <div><span class="po"></span><b>Eröffnungsabend</b><span>1:12:40</span></div>
-            <div><span class="po"></span><b>Eurythmie am Abend</b><span>48:15</span></div>
-            <div><span class="po"></span><b>Jugend im Gespräch</b><span>26:03</span></div>
-          </div>
-        </div>
-      </figure>
-      <figure class="mock soll">
-        <figcaption><b>Mit dem Design-System</b><span>dieselbe Startseite</span></figcaption>
-        <div class="screen" style="padding:0">
-          <div class="stage" style="border-radius:0;min-height:100%">
-            <span class="live">Live</span>
-            <p class="reihe">Alma Humana — die Konferenz</p>
-            <p class="smeta" style="margin:0 0 var(--s3)">Alle Beiträge der Konferenz als Aufzeichnung — Vorträge, Bühne und Gespräche.</p>
-            <a class="btn primary" href="#startseite">Jetzt ansehen</a>
-            <div class="mrow" style="margin-top:var(--s4)">
-              <a class="mtile" href="#startseite"><span class="poster" style="background:var(--sek-ms);color:var(--on-sek-ms)"><span class="pmark">Eröffnung</span><span class="dur">1:12:40</span></span>
-                <span class="mt">Eröffnungsabend</span><span class="ms">Vortrag · Deutsch/Englisch</span></a>
-              <a class="mtile" href="#startseite"><span class="poster" style="background:var(--sek-srmk);color:var(--on-sek-srmk)"><span class="pmark">Bühne</span><span class="dur">48:15</span></span>
-                <span class="mt">Eurythmie am Abend</span><span class="ms">Aufführung</span></a>
-              <a class="mtile" href="#startseite"><span class="poster" style="background:var(--sek-js);color:var(--on-sek-js)"><span class="pmark">Gespräch</span><span class="dur">26:03</span></span>
-                <span class="mt">Jugend im Gespräch</span><span class="ms">Reihe · Teil 3</span></a>
-            </div>
-          </div>
-        </div>
-      </figure>
-    </div>
-    <p class="note" style="margin-top:var(--s4)">Der Knopf spricht normal statt versal (G05), die Meta-Grade tragen 8.2:1 statt 3.67:1, die Poster tragen die Sektionsfarben — mehr dazu <a href="#zahlen">in Zahlen</a>.</p>
-  </section>
-
-  <section id="katalog">
-    <div class="shead"><h2>Der Katalog</h2>
-      <p>Bühne (.stage) + Medienkacheln (.mtile) + Reihen (.mrow). Die Fläche bleibt
-         in Hell wie Dunkel gleich — wie eine Konsole; die Poster tragen die
-         Sektionsfarben mit gerechnetem Text darauf (B01).</p></div>
-
-    <div class="stage">
-      <span class="live">Live</span>
-      <p class="reihe">Alma Humana — die Konferenz</p>
-      <div class="mrow">
-        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-ms);color:var(--on-sek-ms)"><span class="pmark">Eröffnung</span><span class="dur">1:12:40</span></span>
-          <span class="mt">Eröffnungsabend</span><span class="ms">Vortrag · Deutsch/Englisch</span></a>
-        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-srmk);color:var(--on-sek-srmk)"><span class="pmark">Bühne</span><span class="dur">48:15</span></span>
-          <span class="mt">Eurythmie am Abend</span><span class="ms">Aufführung</span></a>
-        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-js);color:var(--on-sek-js)"><span class="pmark">Gespräch</span><span class="dur">26:03</span></span>
-          <span class="mt">Jugend im Gespräch</span><span class="ms">Reihe · Teil 3</span></a>
-        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-nws);color:var(--on-sek-nws)"><span class="pmark">Labor</span><span class="dur">33:47</span></span>
-          <span class="mt">Beobachten als Methode</span><span class="ms">Werkstatt</span></a>
-      </div>
-      <p class="reihe">Greening the Desert</p>
-      <div class="mrow">
-        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-lws);color:var(--on-sek-lws)"><span class="pmark">Folge 1</span><span class="dur">52:19</span></span>
-          <span class="mt">Der Boden lebt</span><span class="ms">Dokumentation</span></a>
-        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-hpise);color:var(--on-sek-hpise)"><span class="pmark">Folge 2</span><span class="dur">47:02</span></span>
-          <span class="mt">Wasser halten</span><span class="ms">Dokumentation</span></a>
-        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-mas);color:var(--on-sek-mas)"><span class="pmark">Folge 3</span><span class="dur">41:33</span></span>
-          <span class="mt">Rechnen mit dem Klima</span><span class="ms">Dokumentation</span></a>
-        <a class="mtile" href="#katalog"><span class="poster" style="background:var(--sek-sbk);color:var(--on-sek-sbk)"><span class="pmark">Extra</span><span class="dur">12:58</span></span>
-          <span class="mt">Hinter den Kulissen</span><span class="ms">Kurzfilm</span></a>
-      </div>
-      <p class="smeta">Dauer-Angaben tabellarisch (G25) · Kacheltitel in der Hausschrift, Meta in der Leseschrift (Schrift-Grenze) · Fokusring sichtbar.</p>
+    <span class="live">Jetzt: Drei Monate Probezeit</span>
+    <h1 style="margin-top:var(--s4)">Anthroposophie in Videos</h1>
+    <p class="lede">Vorträge, Reihen, Livestreams und die Arbeit der Sektionen —
+      der Medienkatalog des Goetheanum.</p>
+    <div style="margin-top:var(--s4);display:flex;gap:var(--s3);flex-wrap:wrap">
+      <a class="btn primary" href="#videothek">Gratis testen</a>
+      <a class="btn" href="#videothek">Alle Videos</a>
     </div>
   </section>
 
-  <section id="zahlen">
-    <div class="shead"><h2>Der Vergleich in Zahlen</h2>
-      <p>Was zwischen links und rechts liegt — gerechnet am Original (Juli 2026), Regel-IDs in Klammern.</p></div>
-    <div class="vergleich">
-      <div class="card"><p><b>Grau #6e6e6e auf #121212 = 3.67:1 → --stage-muted 8.2:1</b> (B02, gerechnet statt geschätzt).</p></div>
-      <div class="card"><p><b>Titillium per !important über Inter → Hausschrift als Quelle</b>; Versal-Knöpfe → normale Beschriftung (G05/G23).</p></div>
-      <div class="card"><p><b>Schiefer #23323F ohne Marke → Blau/Gold-Tokens</b>; Licht/Dunkel als duplizierte Literale → eine Token-Schicht (DS02/B05).</p></div>
-      <div class="card"><p><b>Kein :focus-visible, kein Skip-Link → Fokus-Defaults + Sprunglink</b> aus base.css/nav.js (WCAG 2.4.1/2.4.7).</p></div>
-      <div class="card"><p><b>Google Fonts + vier Fremd-CDNs → Selbst-Hosting</b> (Datenschutz, Reproduzierbarkeit).</p></div>
-      <div class="card"><p><b>Gelernt in Gegenrichtung:</b> die Reihen-Kacheln und die abgeleiteten Töne per Formel — beides ist jetzt Teil des Fundaments (--stage-*).</p></div>
+  <section id="videothek">
+    <p class="reihe">Reihen</p>
+    <div class="mrow">
+      <a class="mtile" href="#videothek"><span class="poster" style="background:var(--sek-ms);color:var(--on-sek-ms)"><span class="pmark">Alma Humana</span></span>
+        <span class="mt">Alma Humana</span><span class="ms">Konferenz-Reihe</span></a>
+      <a class="mtile" href="#videothek"><span class="poster" style="background:var(--sek-lws);color:var(--on-sek-lws)"><span class="pmark">Greening the Desert</span></span>
+        <span class="mt">Greening the Desert</span><span class="ms">Dokumentar-Reihe</span></a>
+      <a class="mtile" href="#videothek"><span class="poster" style="background:var(--sek-aas);color:var(--on-sek-aas)"><span class="pmark">Rudolf Steiner</span></span>
+        <span class="mt">Das Leben Rudolf Steiners</span><span class="ms">Biografische Reihe</span></a>
+      <a class="mtile" href="#videothek"><span class="poster" style="background:var(--sek-nws);color:var(--on-sek-nws)"><span class="pmark">Erde</span></span>
+        <span class="mt">Die Erde als Lebewesen</span><span class="ms">Reihe</span></a>
+      <a class="mtile" href="#videothek"><span class="poster" style="background:var(--sek-hpise);color:var(--on-sek-hpise)"><span class="pmark">Heilen</span></span>
+        <span class="mt">Die Kunst des Heilens</span><span class="ms">Reihe</span></a>
+      <a class="mtile" href="#videothek"><span class="poster" style="background:var(--sek-sbk);color:var(--on-sek-sbk)"><span class="pmark">Gesamtkunstwerk</span></span>
+        <span class="mt">Das erste Goetheanum als Gesamtkunstwerk</span><span class="ms">Reihe</span></a>
     </div>
+
+    <p class="reihe">Aus der Videothek</p>
+    <div class="mrow">
+      <a class="mtile" href="#videothek"><span class="poster" style="background:var(--sek-szw);color:var(--on-sek-szw)"><span class="pmark">Wasser</span></span>
+        <span class="mt">Was tun wir für das Wasser?</span><span class="ms">Herbert Dreiseitl</span></a>
+      <a class="mtile" href="#videothek"><span class="poster" style="background:var(--sek-srmk);color:var(--on-sek-srmk)"><span class="pmark">Bühne</span></span>
+        <span class="mt">Chaos und Form</span><span class="ms">Eurythmie</span></a>
+      <a class="mtile" href="#videothek"><span class="poster" style="background:var(--sek-mas);color:var(--on-sek-mas)"><span class="pmark">Musik</span></span>
+        <span class="mt">Stille und Schrei</span><span class="ms">Kaija Saariaho</span></a>
+      <a class="mtile" href="#videothek"><span class="poster" style="background:var(--sek-ps);color:var(--on-sek-ps)"><span class="pmark">Pädagogik</span></span>
+        <span class="mt">Die digitalen Herausforderungen in der Pädagogik</span><span class="ms">Vortrag</span></a>
+      <a class="mtile" href="#videothek"><span class="poster" style="background:var(--sek-lws);color:var(--on-sek-lws)"><span class="pmark">Ernährung</span></span>
+        <span class="mt">Gesunde Lebensmittel machen gesund</span><span class="ms">Jasmin Peschke</span></a>
+      <a class="mtile" href="#videothek"><span class="poster" style="background:var(--sek-nws);color:var(--on-sek-nws)"><span class="pmark">Tier</span></span>
+        <span class="mt">Unser neues Verhältnis zum Tier</span><span class="ms">Ueli Hurter</span></a>
+    </div>
+
+    <p class="smeta">Videothek: Alle Videos · Kalender · Reihen · Livestreams · Sektionen — Titel und Reihen: goetheanum.tv, 6. Juli 2026.</p>
   </section>
 
-  <section id="weg">
-    <div class="shead"><h2>Der Weg dorthin</h2>
-      <p>Uscreen erlaubt eigenes CSS und eigene Head-Snippets — derselbe Kanal, der heute die Schrift flickt, trägt die Tokens.</p></div>
-    <pre class="code"><code>&lt;!-- Uscreen · Theme-Einstellungen · Custom Code (Head) --&gt;
-&lt;link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/tokens.css"&gt;
-&lt;link rel="stylesheet" href="https://werkzeuge.goetheanum.ch/design-system/base.css"&gt;
-&lt;style&gt;
-  /* Plattform-Variablen auf die Tokens heben – statt Schrift per !important zu flicken */
-  :root{ --ds-fg-default:var(--stage-ink); --ds-fg-muted:var(--stage-muted) }
-  body{ font-family:var(--font) }
-&lt;/style&gt;</code></pre>
-    <p class="note">Vollständiger Befund: <a href="https://github.com/phtok/goeloggen/blob/main/docs/webfamilie-befund.md">docs/webfamilie-befund.md</a></p>
-  </section>
 </main>
 
-<footer class="ds-footer">
+<footer class="site-foot" id="fussnote">
   <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Perspektiven der Webfamilie</span>
-    <span><a href="../design-system/">Design-System</a> · <a href="../">alle Werkzeuge</a></span>
+    <span>© 2026 Goetheanum&nbsp;TV · <a href="#fussnote">AGB</a> · <a href="#fussnote">Privatsphäre</a> · <a href="#fussnote">Impressum</a> · <a href="#fussnote">Kontakt</a> · <a href="#fussnote" lang="de">Deutsch</a> · <a href="#fussnote" lang="en">English</a></span>
+    <span>Nachbau der Startseite im <a href="../design-system/">Design-System</a></span>
   </div>
 </footer>
+
+<div class="fab" role="navigation" aria-label="Perspektive">
+  <a class="btn primary" href="../design-system/#perspektiven">‹ Zurück zum Design-System</a>
+  <a class="btn" href="https://www.goetheanum.tv" target="_blank" rel="noopener">Original öffnen&nbsp;↗</a>
+</div>
+
 </body>
 </html>

--- a/tools.json
+++ b/tools.json
@@ -176,7 +176,7 @@
       "tag": "Webfamilie",
       "title": "Perspektiven (Webfamilie)",
       "href": "design-system/#perspektiven",
-      "desc": "Vier Testseiten zeigen die Startseiten von goetheanum.ch, dasgoetheanum.com, goetheanum.tv und anthroposophie.org heute ↔ mit dem Design-System – dazu Kernstücke und Einbau-Weg.",
+      "desc": "Die Startseiten von goetheanum.ch, dasgoetheanum.com, goetheanum.tv und anthroposophie.org – vollständig nachgebaut im Design-System, mit echten Inhalten und Sprung zum Original.",
       "such": "Perspektiven Webfamilie Testseiten goetheanum.ch dasgoetheanum goetheanum.tv anthroposophie Befund"
     },
     {

--- a/tools/ds-lint.py
+++ b/tools/ds-lint.py
@@ -171,11 +171,15 @@ def lint_file(path, c):
         if not re.search(r'href\s*=\s*["\'][^"\']*' + re.escape(base), full):
             findings.append((1, "DS01", "fehler", f"Pflicht-Include fehlt: {inc}"))
 
-    # DS06 – eigene Kopfzeile / Fake-Logo (nur wenn nav.js NICHT eingebunden)
+    # DS06 – eigene Kopfzeile / Fake-Logo (nur wenn nav.js NICHT eingebunden).
+    # `# ds-ok` auf der <header>-Zeile ratifiziert die Ausnahme (z. B. der
+    # Nachbau einer fremden Kopfzeile auf den Perspektiven-Seiten).
     has_nav = bool(re.search(r'nav\.js', full))
     if not has_nav and re.search(r"<header\b", full, re.I):
-        findings.append((lineno(full, re.search(r"<header\b", full, re.I).start()),
-                         "DS06", "hinweis", "eigene <header>-Kopfzeile ohne nav.js – Fundament-Leiste nutzen"))
+        header_ln = lineno(full, re.search(r"<header\b", full, re.I).start())
+        if header_ln not in skip_lines:
+            findings.append((header_ln,
+                             "DS06", "hinweis", "eigene <header>-Kopfzeile ohne nav.js – Fundament-Leiste nutzen"))
 
     # CSS-Kontexte (Blöcke + inline) – ohne <script>
     scriptless = RE_SCRIPT.sub(lambda m: "\n" * m.group(0).count("\n"), full)


### PR DESCRIPTION
Auftraggeber-Entscheid umgesetzt: **keine Beispiele, keine Reduktionen, keine erfundenen Inhalte.** Jede `perspektiven/*.html` ist jetzt die ganze Startseite ihrer Zielseite, vollständig mit dem Design-System gesetzt — als Erlebnis-Seite ohne Hub-Rahmen, mit schwebender Leiste unten rechts: «‹ Zurück zum Design-System» und «Original öffnen ↗» (neues Fenster, direkter Vergleich).

**Echte Inhalte, live geholt (6. Juli 2026):**
- **goetheanum.ch** — «Willkommen am Goetheanum!», der Demnächst-Kalender mit den echten Faust-Festspiel-Terminen (Rudolf Steiner liest Plato, Das Sommerdreieck, Faust 1 …), Besuch/Studium/Führungen, Nachrichten, der Sieben-Block-Footer mit echten Kontakten und Öffnungszeiten.
- **dasgoetheanum.com** — Aufmacher «Die Jugend trägt das Vermächtnis der Zukunft» (Nathaniel Williams), Rubriken Aufsätze · Zeitsymptome · Forum · Worte mit den realen Artikeln, Autorinnen und Lesezeiten.
- **goetheanum.tv** — die ganze dunkle Bühne: echte Reihen (Alma Humana, Greening the Desert, Das Leben Rudolf Steiners …) und echte Videotitel aus Sitemap und Programmseiten.
- **anthroposophie.org** — Rubrik «Gesellschaft» mit den fünf Beiträgen vom 29. Juni, Heft-Archiv (Nr. 7–8/2026 …), Newsletter.

**Fundament:** neue Rolle `.fab` (schwebende Leiste, Fingerziele ≥44px, B04) in base.css; `contract.json` → v1.4.0; Ledger-Eintrag. Die Nachbau-Kopfzeilen sind je Seite mit `# ds-ok` ratifiziert; `ds-lint` respektiert die Ratifizierung jetzt auch für DS06 (wie im Kopf des Checkers dokumentiert).

**Prüfung:** typo-check konform · ds-lint 0 Fehler/0 Hinweise (staged), Gesamt-Score 100 % · alle vier Seiten in Desktop- und Telefonbreite per Chromium geprüft (JS-fehlerfrei, FAB sichtbar, Bühne theme-fest dunkel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164rvPF8hhzdmvH5KZroVGP

---
_Generated by [Claude Code](https://claude.ai/code/session_0164rvPF8hhzdmvH5KZroVGP)_