### PR TITLE
Link-Register: Team-Schlüssel wieder entfernt

### DIFF
--- a/apps/utm-generator/index.html
+++ b/apps/utm-generator/index.html
@@ -373,34 +373,18 @@
 
   el('slugNew').addEventListener('click', function(){ el('slug').value = neuerKurzname(); });
 
-  // Schreiben ins Register verlangt den Team-Schlüssel (einmal eingeben, der
-  // Browser merkt ihn sich). Lesen bleibt frei – es fliessen keine Personendaten.
-  function teamSchluessel(){
-    var s = '';
-    try { s = localStorage.getItem('sommer26_schluessel') || ''; } catch(e){}
-    if(!s){
-      s = window.prompt('Team-Schlüssel (einmalig – für Anlegen und Löschen im Register):') || '';
-      s = s.trim();
-      if(s){ try { localStorage.setItem('sommer26_schluessel', s); } catch(e){} }
-    }
-    return s;
-  }
-  function schluesselVerwerfen(){
-    try { localStorage.removeItem('sommer26_schluessel'); } catch(e){}
-  }
-
+  // Schreiben läuft über die RPCs (p_schluessel bleibt aus Kompatibilität in
+  // der Signatur, wird serverseitig ignoriert – Beschluss vom 6.7.2026).
   el('regBtn').addEventListener('click', function(){
     if(!current){ say('Erst Quelle und Medium wählen.', true); return; }
     var code = slugCode(el('slug').value) || neuerKurzname();
     el('slug').value = code;
     if(usedCodes[code]){ say('Kurzname „' + code + '“ ist schon vergeben – bitte ein anderes Tier.', true); return; }
-    var s = teamSchluessel();
-    if(!s){ say('Ohne Team-Schlüssel kein Eintrag.', true); return; }
     fetch(SB + '/rest/v1/rpc/sommer2026_link_anlegen', {
       method:'POST',
       headers:{ 'Content-Type':'application/json', 'apikey':KEY, 'Authorization':'Bearer ' + KEY },
       body: JSON.stringify({
-        p_schluessel: s, p_source: current.src, p_medium: current.med,
+        p_schluessel: '', p_source: current.src, p_medium: current.med,
         p_content: current.con || null, p_landing: current.angebot, p_sprache: current.sprache,
         p_url: current.url, p_code: code, p_rolle: el('rolle').value,
         p_ersteller: slug(el('ersteller').value) || null
@@ -409,7 +393,6 @@
       .then(function(ergebnis){
         if(ergebnis === 'ok'){ say('Im Register gespeichert.'); zeigeKurzlink(code); loadRegister(); }
         else if(ergebnis === 'vergeben'){ say('Kurzname oder Link schon vergeben – bitte ein anderes Tier.', true); }
-        else if(ergebnis === 'schluessel'){ schluesselVerwerfen(); say('Team-Schlüssel stimmt nicht – beim nächsten Versuch neu eingeben.', true); }
         else { say('Eintrag unvollständig – Quelle, Medium und Link prüfen.', true); }
       })
       .catch(function(){ say('Register nicht erreichbar.', true); });
@@ -417,15 +400,12 @@
 
   function loescheLink(url){
     if(!window.confirm('Diesen Link wirklich aus dem Register löschen?')) return;
-    var s = teamSchluessel();
-    if(!s){ say('Ohne Team-Schlüssel kein Löschen.', true); return; }
     fetch(SB + '/rest/v1/rpc/sommer2026_link_loeschen', {
       method:'POST', headers:{ 'Content-Type':'application/json', 'apikey':KEY, 'Authorization':'Bearer ' + KEY },
-      body: JSON.stringify({ p_url: url, p_schluessel: s })
+      body: JSON.stringify({ p_url: url, p_schluessel: '' })
     }).then(function(r){ if(!r.ok) throw new Error(r.status); return r.json(); })
       .then(function(ergebnis){
         if(ergebnis === 'ok'){ say('Link gelöscht.'); loadRegister(); }
-        else if(ergebnis === 'schluessel'){ schluesselVerwerfen(); say('Team-Schlüssel stimmt nicht – beim nächsten Versuch neu eingeben.', true); }
         else { say('Löschen nicht möglich.', true); }
       })
       .catch(function(){ say('Löschen nicht erreichbar.', true); });

--- a/docs/uebergabe-utm-landingpages.md
+++ b/docs/uebergabe-utm-landingpages.md
@@ -107,9 +107,8 @@ Popup-Öffnen per `history.replaceState` zurück auf die URL schreiben und
 ## Randbedingungen
 
 - **Keine Personendaten** ins Repo oder in Screenshots; E-Mails liegen nur
-  gehasht in der Datenbank. Secrets (Webhook-Secret, Team-Schlüssel des
-  Link-Registers) stehen **nicht** in diesem Brief — beim Auftraggeber
-  erfragen.
+  gehasht in der Datenbank. Secrets (Webhook-Secret) stehen **nicht** in diesem
+  Brief — beim Auftraggeber erfragen.
 - Lovable-Projekte gehören dem Auftraggeber (Zugang via lovable.dev).
   Königsweg für präzise Arbeit: **GitHub-Sync** des Lovable-Projekts
   aktivieren, dann kann eine Claude-Code-Session den Landing-Code direkt

--- a/services/sommer-zaehler/kurzlink-site/README.md
+++ b/services/sommer-zaehler/kurzlink-site/README.md
@@ -22,8 +22,7 @@ keine Link-Liste; neue Kurzlinks entstehen im Generator und wirken sofort.
 Nicht hier im Repo, sondern im **UTM-Generator** (nur intern gelistet):
 `werkzeuge.goetheanum.ch/apps/utm-generator/` → Ziel-URL + UTM-Merkmale
 eintragen, Kurznamen wählen, ins Register schreiben. Der Kurzname wird zum
-Pfad `/s/<kurzname>`. Anlegen und Löschen im Register verlangen den
-**Team-Schlüssel** (einmal im Generator eingeben, der Browser merkt ihn).
+Pfad `/s/<kurzname>`.
 
 **Slug-Stil:** kurz, klein, ein zweisilbiger Tiername mit Bild (`otter`,
 `biber`, `reiher` …). Menschlich abtippbar aus Bio, Caption oder Papier.

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -183,8 +183,7 @@ create unique index if not exists sommer2026_links_url_uk  on public.sommer2026_
 create unique index if not exists sommer2026_links_code_uk on public.sommer2026_links (code);
 alter table public.sommer2026_links enable row level security;
 revoke all on table public.sommer2026_links from anon, authenticated;
--- Schreiben NUR über die Schlüssel-RPCs unten (Migration
--- «sommer2026_links_schreibschutz») – kein offenes anon-INSERT mehr.
+-- Schreiben über die RPCs unten (kein direktes anon-INSERT auf die Tabelle).
 
 -- Soll/Ist: je registriertem Link die Zahl der Anmeldungen über genau dieses UTM-Tupel
 create or replace function public.sommer2026_links_public()
@@ -207,31 +206,16 @@ grant execute on function public.sommer2026_links_public() to anon, authenticate
 -- Kurzlink-Weiterleitung: Edge Function `go` liest sommer2026_links.code (Service-Role)
 -- und leitet per 302 auf die volle UTM-URL. Siehe go/index.ts.
 
--- Schreibschutz (Migration «sommer2026_links_schreibschutz»): Anlegen und
--- Löschen verlangen den Team-Schlüssel. Sein SHA-256-Hash liegt in
--- sommer2026_config unter «links_schluessel_hash» (Präfix 'goe-links:');
--- Schlüsselwechsel = diese eine Config-Zeile neu setzen.
-create or replace function public.sommer2026_links_schluessel_ok(p_schluessel text)
-returns boolean language sql security definer set search_path to 'public' as $$
-  select exists (
-    select 1 from public.sommer2026_config
-     where key = 'links_schluessel_hash'
-       and value = encode(extensions.digest('goe-links:' || coalesce(p_schluessel, ''), 'sha256'), 'hex')
-  );
-$$;
-revoke execute on function public.sommer2026_links_schluessel_ok(text) from public, anon, authenticated;
-
--- Anlegen nur per RPC: prüft Schlüssel, meldet 'ok' | 'schluessel' |
--- 'vergeben' (unique) | 'unvollstaendig' als Text an den Generator.
+-- Anlegen per RPC: meldet 'ok' | 'vergeben' (unique) | 'unvollstaendig'
+-- als Text an den Generator. Der einst eingeführte Team-Schlüssel wurde am
+-- 6.7.2026 wieder entfernt (Migration «sommer2026_links_schluessel_entfernen»);
+-- p_schluessel bleibt aus Kompatibilität in der Signatur und wird ignoriert.
 create or replace function public.sommer2026_link_anlegen(
   p_schluessel text, p_source text, p_medium text, p_content text,
   p_landing text, p_sprache text, p_url text, p_code text,
   p_rolle text, p_ersteller text)
 returns text language plpgsql security definer set search_path to 'public' as $$
 begin
-  if not public.sommer2026_links_schluessel_ok(p_schluessel) then
-    return 'schluessel';
-  end if;
   if coalesce(p_source, '') = '' or coalesce(p_medium, '') = '' or coalesce(p_url, '') = '' then
     return 'unvollstaendig';
   end if;
@@ -251,13 +235,10 @@ end;
 $$;
 grant execute on function public.sommer2026_link_anlegen(text, text, text, text, text, text, text, text, text, text) to anon, authenticated;
 
--- Kontrolliertes Löschen (per URL), ebenfalls nur mit Schlüssel.
+-- Kontrolliertes Löschen (per URL, nur RPC – p_schluessel wird ignoriert).
 create or replace function public.sommer2026_link_loeschen(p_url text, p_schluessel text)
 returns text language plpgsql security definer set search_path to 'public' as $$
 begin
-  if not public.sommer2026_links_schluessel_ok(p_schluessel) then
-    return 'schluessel';
-  end if;
   delete from public.sommer2026_links where url = p_url and kampagne = 'summer26_trial';
   return 'ok';
 end;
@@ -291,8 +272,6 @@ revoke all on table public.sommer2026_config from anon, authenticated;
 -- Schlüssel in sommer2026_config:
 --   webhook_secret : Secret für ?key= der Ingestion-Functions
 --   hash_salt      : Salt für den E-Mail-Hash (Entdopplung)
---   links_schluessel_hash : SHA-256 des Team-Schlüssels (Präfix 'goe-links:')
---                    fürs Link-Register (Anlegen/Löschen)
 --   aktion_aktiv   : 'true' = zählen, sonst nur loggen
 --   aktion_start   : Zeitgrenze (Anmeldungen davor zählen nicht), z. B.
 --                    '2026-07-03T12:00:00+02:00'


### PR DESCRIPTION
Beschluss des Auftraggebers: zu kompliziert im Arbeitsfluss; das Vandalismus-Risiko ist durch die bereinigte Kurzlink-Domain (Wurzel ohne Werkzeug-Links, Werkzeuge nur intern gelistet) klein genug.

- Migration `sommer2026_links_schluessel_entfernen` **angewandt und live verifiziert**: Anlegen/Löschen funktionieren ohne Schlüssel; RPC-Signaturen unverändert (kein Bruch für die ausgelieferte Version), Prüf-Funktion und Hash entfernt.
- Generator: Abfrage-Dialog raus, RPC-Aufrufe senden leeres `p_schluessel`.
- `schema.sql`, `kurzlink-site/README.md` und Übergabe-Brief nachgezogen.

ds-lint 100 %, typo-check konform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_