### PR TITLE
Kartentool: fortlaufende Nummern fix, nur Infotisch beweglich, einklappbare Kategorien, Ausschnitt-Steuerung unter der Karte

### DIFF
--- a/apps/karten-generator/app.js
+++ b/apps/karten-generator/app.js
@@ -74,7 +74,6 @@ const state = {
   format: "a4",
   beschnitt: true,
   marken: false,
-  nummerierung: "fortlaufend",   // oder "vorlage" (feste Nummern der Beispiele)
   zoom: 1.15,
   an: {},              // Ort-id -> true = auf der Karte (Start: leeres Blatt)
   teileAus: {},        // Ort-id -> { Teil-Index: true } (abgewählte Teil-Orte)
@@ -247,10 +246,9 @@ function naechsteEigeneNummer() {
 
 // Fortlaufende Nummerierung: aktive Orte zählen in Legendenreihenfolge ab 1;
 // Buchstabenmarken (Treppen, P) behalten ihre Buchstaben.
-let nummern = null;
+let nummern = {};
 
 function nummernBerechnen() {
-  if (state.nummerierung !== "fortlaufend") { nummern = null; return; }
   nummern = {};
   let n = 1;
   alleOrte().filter(ortAktiv).forEach((ort) => {
@@ -261,8 +259,13 @@ function nummernBerechnen() {
 }
 
 function ortMarker(ort) {
-  if (nummern && nummern[ort.id]) return nummern[ort.id];
-  return ort.marker;
+  return nummern[ort.id] || ort.marker;
+}
+
+// Beweglich sind nur der Infotisch und die eigenen Marken — alles andere
+// ist aus den Vorlagen fixiert; für Einmaliges gibt es die eigene Marke.
+function ortBeweglich(ort) {
+  return ort.id === "o4" || ort.art === "eigene";
 }
 
 /* ---------- SVG-Bausteine der Szene ---------- */
@@ -391,17 +394,15 @@ function legendeZeilen() {
   let vorher = null;
   alleOrte().filter(ortAktiv).forEach((ort) => {
     if (vorher) {
-      const a = parseInt(vorher.marker, 10), b = parseInt(ort.marker, 10);
-      const dekade = state.nummerierung === "vorlage"
-        && !Number.isNaN(a) && !Number.isNaN(b) && Math.floor(a / 10) !== Math.floor(b / 10);
       const treppen = vorher.art === "treppe" && ort.art === "treppe";
-      if (vorher.art !== ort.art || dekade || treppen) zeilen.push({ typ: "abstand", hoehe: LEGENDE_LAYOUT.gruppe });
+      if (vorher.art !== ort.art || treppen) zeilen.push({ typ: "abstand", hoehe: LEGENDE_LAYOUT.gruppe });
     }
     const zeilenTexte = ortLabel(ort).split("\n");
     zeilen.push({
       typ: "ort", ort, zeilenTexte,
       hoehe: LEGENDE_LAYOUT.zeile + (zeilenTexte.length - 1) * LEGENDE_LAYOUT.extraZeile
     });
+    // (Abstände nur bei Art-Wechseln — feste Dekaden gibt es nicht mehr.)
     if (ort.art === "treppe") {
       aktiveNotizen(ort).forEach(({ notiz }) => {
         zeilen.push({ typ: "notiz", notiz, ort, hoehe: LEGENDE_LAYOUT.notiz });
@@ -623,7 +624,7 @@ function ortZeile(ort, loeschbar) {
 
   const markerSpan = document.createElement("span");
   markerSpan.className = "object-marker";
-  markerSpan.textContent = ortAktiv(ort) ? ortMarker(ort) : (state.nummerierung === "vorlage" ? ort.marker : "–");
+  markerSpan.textContent = ortAktiv(ort) ? ortMarker(ort) : "–";
   zeile.appendChild(markerSpan);
 
   const stift = document.createElement("button");
@@ -638,21 +639,23 @@ function ortZeile(ort, loeschbar) {
   });
   zeile.appendChild(stift);
 
-  const verschieben = document.createElement("button");
-  verschieben.type = "button";
-  verschieben.className = "row-btn";
-  verschieben.title = "Marke auf der Karte verschieben";
-  verschieben.textContent = "✥";
-  verschieben.addEventListener("click", (e) => {
-    e.stopPropagation();
-    state.an[ort.id] = true;
-    state.platzierenOrt = ort.id;
-    state.platzieren = null;
-    renderVorschau();
-    eigeneHint.textContent = `‹${ortLabel(ort).split("\n")[0]}› — neue Stelle in der Vorschau anklicken. ‹Esc› bricht ab.`;
-    printSvg.scrollIntoView({ behavior: "smooth", block: "nearest" });
-  });
-  zeile.appendChild(verschieben);
+  if (ortBeweglich(ort)) {
+    const verschieben = document.createElement("button");
+    verschieben.type = "button";
+    verschieben.className = "row-btn";
+    verschieben.title = "Marke auf der Karte verschieben";
+    verschieben.textContent = "✥";
+    verschieben.addEventListener("click", (e) => {
+      e.stopPropagation();
+      state.an[ort.id] = true;
+      state.platzierenOrt = ort.id;
+      state.platzieren = null;
+      renderVorschau();
+      eigeneHint.textContent = `‹${ortLabel(ort).split("\n")[0]}› — neue Stelle in der Vorschau anklicken. ‹Esc› bricht ab.`;
+      printSvg.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    });
+    zeile.appendChild(verschieben);
+  }
 
   if (loeschbar) {
     const weg = document.createElement("button");
@@ -716,21 +719,40 @@ function ortMitUnterzeilen(ort, loeschbar) {
   return halter;
 }
 
+// Hauptkategorien einklappbar — Übersicht in den Editing-Werkzeugen;
+// zugeklappt zeigt der Kopf, wie viele Orte aktiv sind.
+const aufgeklappt = { Orientierung: false, Veranstaltungsorte: false, Treppenhaus: false };
+
 function renderOrte() {
-  document.querySelectorAll("#nummerierung-row [data-nummerierung]").forEach((knopf) => {
-    knopf.setAttribute("aria-pressed", knopf.dataset.nummerierung === state.nummerierung ? "true" : "false");
-  });
   document.querySelectorAll("#sprache-row [data-sprache]").forEach((knopf) => {
     knopf.setAttribute("aria-pressed", knopf.dataset.sprache === state.sprache ? "true" : "false");
   });
   orteGruppen.innerHTML = "";
   GRUPPEN.forEach(([titel, filter]) => {
     const gruppe = document.createElement("div");
-    gruppe.innerHTML = `<div class="object-group-title">${titel}</div>`;
-    const liste = document.createElement("div");
-    liste.className = "object-list";
-    ORTE.filter(filter).forEach((ort) => liste.appendChild(ortMitUnterzeilen(ort, false)));
-    gruppe.appendChild(liste);
+    const eintraege = ORTE.filter(filter);
+    const aktiv = eintraege.filter(ortAktiv).length;
+    const offen = aufgeklappt[titel];
+
+    const kopf = document.createElement("button");
+    kopf.type = "button";
+    kopf.className = "object-group-title";
+    kopf.setAttribute("aria-expanded", offen ? "true" : "false");
+    kopf.innerHTML = `<span class="chevron">${offen ? "▾" : "▸"}</span>`
+      + `<span>${titel}</span>`
+      + `<span class="zaehler">${aktiv ? `${aktiv} aktiv` : ""}</span>`;
+    kopf.addEventListener("click", () => {
+      aufgeklappt[titel] = !offen;
+      renderOrte();
+    });
+    gruppe.appendChild(kopf);
+
+    if (offen) {
+      const liste = document.createElement("div");
+      liste.className = "object-list";
+      eintraege.forEach((ort) => liste.appendChild(ortMitUnterzeilen(ort, false)));
+      gruppe.appendChild(liste);
+    }
     orteGruppen.appendChild(gruppe);
   });
 
@@ -831,7 +853,6 @@ function speichern() {
     localStorage.setItem(SPEICHER_SCHLUESSEL, JSON.stringify({
       titel: state.titel, sprache: state.sprache, format: state.format,
       beschnitt: state.beschnitt, marken: state.marken,
-      nummerierung: state.nummerierung,
       an: Object.keys(state.an), labels: state.labels,
       teileAus: state.teileAus, notizenAus: state.notizenAus,
       markerFarben: state.markerFarben, positionen: state.positionen,
@@ -853,7 +874,6 @@ function laden() {
     if (s.format === "a3") state.format = "a3";
     state.beschnitt = s.beschnitt !== false;
     state.marken = Boolean(s.marken);
-    if (s.nummerierung === "vorlage") state.nummerierung = "vorlage";
     if (s.sprache === "en") state.sprache = "en";
     (s.an || []).forEach((id) => { state.an[id] = true; });
     state.labels = s.labels || {};
@@ -878,7 +898,7 @@ function laden() {
   }
 }
 
-/* ---------- Interaktion Vorschau: Platzieren und Ausschnitt ziehen ---------- */
+/* ---------- Interaktion Vorschau: Platzieren; Ausschnitt über Pfeile ---------- */
 
 function svgPunkt(clientX, clientY) {
   const punkt = new DOMPoint(clientX, clientY);
@@ -888,45 +908,19 @@ function svgPunkt(clientX, clientY) {
   return { x: p.x, y: p.y };
 }
 
-let ziehen = null;
+// Karte in Blatt-Millimetern verschieben (Pfeilknöpfe und Pfeiltasten).
+const AUSSCHNITT_SCHRITT = 5;
 
-printSvg.addEventListener("pointerdown", (ereignis) => {
-  if (state.platzieren || state.platzierenOrt || ereignis.button !== 0) return;
-  ziehen = {
-    startX: ereignis.clientX, startY: ereignis.clientY,
-    dx: state.ausschnitt.dx, dy: state.ausschnitt.dy,
-    bewegt: false
-  };
-  printSvg.setPointerCapture(ereignis.pointerId);
-});
-
-printSvg.addEventListener("pointermove", (ereignis) => {
-  if (!ziehen) return;
-  const matrix = printSvg.getScreenCTM();
-  if (!matrix) return;
-  const proMm = matrix.a; // Pixel je Blatt-mm
-  const dxMm = (ereignis.clientX - ziehen.startX) / proMm;
-  const dyMm = (ereignis.clientY - ziehen.startY) / proMm;
-  if (!ziehen.bewegt && Math.hypot(dxMm, dyMm) < 0.5) return;
-  ziehen.bewegt = true;
-  state.ausschnitt.dx = ziehen.dx + dxMm;
-  state.ausschnitt.dy = ziehen.dy + dyMm;
+function karteVerschieben(dx, dy) {
+  state.ausschnitt.dx += dx;
+  state.ausschnitt.dy += dy;
   renderVorschau();
-});
-
-printSvg.addEventListener("pointerup", () => {
-  if (ziehen && ziehen.bewegt) {
-    renderOptionen();
-    speichern();
-  }
-  ziehen = ziehen && ziehen.bewegt ? { fertig: true } : null;
-  setTimeout(() => { ziehen = null; }, 0);
-});
+  speichern();
+}
 
 const EIGENE_HINT_STANDARD = "Erst Beschriftung eingeben, dann in der Vorschau die Stelle anklicken. ‹Esc› bricht ab.";
 
 printSvg.addEventListener("click", (ereignis) => {
-  if (ziehen && ziehen.fertig) return; // Klick am Ende einer Zieh-Geste
   if (!state.platzieren && !state.platzierenOrt) return;
   const p = svgPunkt(ereignis.clientX, ereignis.clientY);
   if (!p) return;
@@ -991,13 +985,6 @@ document.querySelectorAll("#format-row [data-format]").forEach((knopf) => {
   });
 });
 
-document.querySelectorAll("#nummerierung-row [data-nummerierung]").forEach((knopf) => {
-  knopf.addEventListener("click", () => {
-    state.nummerierung = knopf.dataset.nummerierung;
-    render();
-  });
-});
-
 document.querySelectorAll("#sprache-row [data-sprache]").forEach((knopf) => {
   knopf.addEventListener("click", () => {
     state.sprache = knopf.dataset.sprache;
@@ -1035,6 +1022,26 @@ document.getElementById("ausschnitt-skala").addEventListener("change", () => {
 document.getElementById("ausschnitt-reset").addEventListener("click", () => {
   state.ausschnitt = { skala: 1, dx: 0, dy: 0 };
   render();
+});
+
+document.getElementById("karte-links").addEventListener("click", () => karteVerschieben(-AUSSCHNITT_SCHRITT, 0));
+document.getElementById("karte-rechts").addEventListener("click", () => karteVerschieben(AUSSCHNITT_SCHRITT, 0));
+document.getElementById("karte-hoch").addEventListener("click", () => karteVerschieben(0, -AUSSCHNITT_SCHRITT));
+document.getElementById("karte-runter").addEventListener("click", () => karteVerschieben(0, AUSSCHNITT_SCHRITT));
+
+// Pfeiltasten verschieben die Karte, solange kein Eingabefeld den Fokus hat.
+document.addEventListener("keydown", (ereignis) => {
+  const ziel = ereignis.target;
+  if (ziel && /^(INPUT|TEXTAREA|SELECT)$/.test(ziel.tagName)) return;
+  const richtung = {
+    ArrowLeft: [-AUSSCHNITT_SCHRITT, 0],
+    ArrowRight: [AUSSCHNITT_SCHRITT, 0],
+    ArrowUp: [0, -AUSSCHNITT_SCHRITT],
+    ArrowDown: [0, AUSSCHNITT_SCHRITT]
+  }[ereignis.key];
+  if (!richtung) return;
+  ereignis.preventDefault();
+  karteVerschieben(richtung[0], richtung[1]);
 });
 
 document.getElementById("zuruecksetzen").addEventListener("click", () => {

--- a/apps/karten-generator/index.html
+++ b/apps/karten-generator/index.html
@@ -86,9 +86,19 @@
     .button-row { display: flex; flex-wrap: wrap; gap: var(--s2); }
 
     .object-group-title {
-      font-size: var(--t-small);
+      display: flex; align-items: center; gap: var(--s2);
+      width: 100%;
+      min-height: var(--tap);                     /* B04 */
+      border: 0; background: none; color: var(--ink);
+      font: inherit; font-size: var(--t-small);
       font-weight: var(--w-strong);
-      margin: var(--s2) 0 var(--s1);
+      cursor: pointer; padding: 0;
+      border-bottom: 1px solid var(--line);
+    }
+    .object-group-title .chevron { color: var(--muted); width: 1em; }
+    .object-group-title .zaehler {
+      margin-left: auto; color: var(--muted);
+      font-weight: normal; font-variant-numeric: tabular-nums;  /* G25 */
     }
     .object-list { display: flex; flex-direction: column; }
     .object-row {
@@ -178,9 +188,17 @@
       background: #ffffff; /* # ds-ok: gedrucktes Blatt ist physisch weiss, keine Theme-Flaeche */
       box-shadow: 0 2px 14px rgba(0,0,0,.18);
     }
-    .print-svg { display: block; width: 100%; height: auto; cursor: grab; }
-    .print-svg:active { cursor: grabbing; }
+    .print-svg { display: block; width: 100%; height: auto; }
     .print-svg.platzieren { cursor: crosshair; }
+    .ausschnitt-panel {
+      display: flex; align-items: center; flex-wrap: wrap;
+      gap: var(--s3);
+    }
+    .ausschnitt-panel input[type="range"] {
+      flex: 1; min-width: 160px; min-height: var(--tap);  /* B04 */
+      accent-color: var(--blue-solid);
+    }
+    .ausschnitt-panel .button-row button { min-width: var(--tap); }
     /* Blatt-Text darf keine Seiten-Typografie erben: das globale Tracking
        (base.css letter-spacing) würde im SVG in Blatt-Millimetern wirken
        und den Satz sperren — Export und Vorschau müssen identisch sein. */
@@ -206,25 +224,7 @@
           <button type="button" data-sprache="de" aria-pressed="true">Deutsch</button>
           <button type="button" data-sprache="en" aria-pressed="false">English</button>
         </div>
-        <div class="seg" id="nummerierung-row">
-          <button type="button" data-nummerierung="fortlaufend" aria-pressed="true">Nummern fortlaufend</button>
-          <button type="button" data-nummerierung="vorlage" aria-pressed="false">wie Vorlage</button>
-        </div>
         <div id="orte-gruppen"></div>
-      </fieldset>
-
-      <fieldset>
-        <legend>Kartenausschnitt</legend>
-        <div class="hint">Karte in der Vorschau ziehen, um den Ausschnitt zu verschieben.
-          Die Marker wandern mit.</div>
-        <div class="farb-reihe">
-          <label for="ausschnitt-skala">Grösse</label>
-          <input id="ausschnitt-skala" type="range" min="70" max="180" step="5" value="100" />
-          <span id="ausschnitt-wert" class="zoom-value">100%</span>
-        </div>
-        <div class="button-row">
-          <button id="ausschnitt-reset" type="button" class="btn">Standardlage</button>
-        </div>
       </fieldset>
 
       <fieldset>
@@ -294,6 +294,20 @@
             <svg id="print-svg" class="print-svg" viewBox="0 0 297 210" xmlns="http://www.w3.org/2000/svg"></svg>
           </div>
         </div>
+      </div>
+      <div class="ausschnitt-panel">
+        <span class="hint">Kartenausschnitt</span>
+        <input id="ausschnitt-skala" type="range" min="70" max="180" step="5" value="100"
+               title="Grösse des Kartenausschnitts" />
+        <span id="ausschnitt-wert" class="zoom-value">100%</span>
+        <div class="button-row">
+          <button id="karte-links" type="button" class="btn" title="Karte nach links">←</button>
+          <button id="karte-hoch" type="button" class="btn" title="Karte nach oben">↑</button>
+          <button id="karte-runter" type="button" class="btn" title="Karte nach unten">↓</button>
+          <button id="karte-rechts" type="button" class="btn" title="Karte nach rechts">→</button>
+          <button id="ausschnitt-reset" type="button" class="btn">Standardlage</button>
+        </div>
+        <span class="hint">Auch mit den Pfeiltasten verschiebbar.</span>
       </div>
     </section>
   </main>


### PR DESCRIPTION
# Rückmeldungen aus dem fünften Praxistest

**Nummerierungs-Option entfernt.** Fortlaufend ist der Standard und einzige Modus; die festen Vorlagen-Nummern und ihre Dekaden-Abstände sind raus.

**Nur der Infotisch ist beweglich.** Der ✥-Knopf erscheint ausschließlich beim Infotisch und bei eigenen Marken — alle anderen Orte sind aus den Vorlagen fixiert; für Bewegliches und Einmaliges gibt es die eigene Marke.

**Einklappbare Hauptkategorien.** Orientierung / Veranstaltungsorte / Treppenhaus sind jetzt Aufklapp-Köpfe (Pfeil + Zähler ‹n aktiv›), standardmäßig geschlossen — deutlich mehr Übersicht in der Editor-Spalte. Die eigenen Marken folgen direkt darunter.

**Kartenausschnitt unter die Karte verlegt.** Das Panel sitzt jetzt in der Vorschau-Spalte direkt unter dem Blatt: Größenregler (70–180 %), vier Pfeilknöpfe ← ↑ ↓ →, und der ‹Standardlage›-Knopf ist sichtbar dabei (er existierte, war aber in der linken Spalte vergraben). Zusätzlich verschieben die **Tastatur-Pfeiltasten** die Karte in 5-mm-Schritten (außer ein Eingabefeld hat den Fokus). Das Maus-/Trackpad-Ziehen der Karte ist entfernt.

## Verifikation
Chromium-Durchlauf: drei zugeklappte Kategorien mit Zähler, genau eine Zeile mit ✥ (Infotisch), Pfeilknopf + Pfeiltaste verschieben je 5 mm, Panel mit Regler/Pfeilen/Standardlage unter der Karte, PDF-Export fehlerfrei. typo-check konform, ds-lint Score 100 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgMfxisgg9yjRqFZhd6wuC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgMfxisgg9yjRqFZhd6wuC)_