### PR TITLE
Lead-Maschine: fünf Schleifen ins Zentrum + Seelenkalender-Werkzeug

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/SECRETS.md
+++ b/SECRETS.md
@@ -1,0 +1,71 @@
+# Secrets & Zugänge — wie Tokens hier bereitliegen
+
+Ziel: Zugänge (Vercel, Supabase, Resend, …) liegen **bereit** und werden **bei
+Bedarf freigegeben** — ohne pro Nutzung einen Token neu zu erzeugen und wieder
+zu widerrufen. Es gibt zwei Mechanismen; nimm für jeden Dienst den oberen, wenn
+möglich.
+
+## 1. MCP-Connector (OAuth) — bevorzugt, «nie einsehbar»
+Einmal auf Org-Ebene in den **claude.ai-Connector-Einstellungen** autorisieren.
+Danach liegt der Token in Anthropics verwaltetem Speicher, **kommt nie in den
+Container** (weder Session noch Assistent sehen ihn), und wird server-seitig
+eingespeist. «Freigeben bei Bedarf» = der **Pro-Chat-Schalter** je Connector.
+Kein Neu-Erzeugen, kein Widerrufen pro Nutzung.
+
+## 2. Environment-Variable — nur wo es keinen Connector gibt
+Ein **langlebiger, eng gescopter** Key als Umgebungs-Variable in der
+Environment-Konfiguration (`.env`-Format, `KEY=value`, ohne Anführungszeichen).
+Einmal setzen, dauerhaft wiederverwenden.
+
+> **Vorbehalt (Doku):** Ein dediziertes, verschlüsseltes Secrets-Lager gibt es
+> bei Claude Code on the web noch nicht. Environment-Variablen sind für **jeden
+> sichtbar, der die Umgebung bearbeiten darf**, und jeder Prozess der Session
+> kann sie lesen. Darum: minimale Scopes, Ablaufdatum, und — wenn Trennung
+> wichtig ist — sensible Keys in eine **eigene Umgebung**, die nur bei Bedarf
+> aktiviert wird.
+
+**Nie** Tokens in Chat, Commits oder ins Repo schreiben.
+
+## Dienste-Register
+
+| Dienst | Mechanismus | Secret-Name (Env) | Minimal-Scope | Stand |
+|---|---|---|---|---|
+| **Vercel** | Connector | — | — | verbunden |
+| **Supabase** | Connector | — | — | verbunden |
+| **Canva** | Connector | — | — | verbunden |
+| **Google Drive** | Connector | — | — | verbunden |
+| **ActiveCampaign** | Connector | — | — | installiert, **Auth erneuern** |
+| **GitHub** | Connector/Proxy | (`GH_TOKEN` nur für `gh`-CLI) | `repo`, `read:org` | über Proxy |
+| **Resend** | Env-Variable | `RESEND_API_KEY` | nur Senden (`sending`) | einzutragen |
+| *(Alternative: Brevo)* | Connector | — | — | im Verzeichnis, nicht installiert |
+
+## Env-Variablen setzen (Web-UI)
+Umgebung wählen → bearbeiten → **Environment variables** → `.env`-Zeilen, z. B.:
+
+```text
+RESEND_API_KEY=<eintragen, nicht hier>
+```
+
+`gh`-CLI (falls je nötig) liest automatisch `GH_TOKEN`.
+
+## `.mcp.json` (Projekt-Scope, für key-basierte MCP-Server)
+Die verwalteten Connector (Vercel/Supabase/…) werden **im claude.ai-UI**
+gepflegt, **nicht** hier — deshalb ist `mcpServers` leer. Für einen
+**key-basierten** Server (der einen Env-Token liest) eine Zeile ergänzen, z. B.:
+
+```jsonc
+{
+  "mcpServers": {
+    // Beispiel — nur eintragen, wenn ein solcher Server wirklich genutzt wird:
+    // "resend": {
+    //   "command": "npx",
+    //   "args": ["-y", "@some/resend-mcp-server"],
+    //   "env": { "RESEND_API_KEY": "${RESEND_API_KEY}" }
+    // }
+  }
+}
+```
+
+## Merksatz
+Connector, wo es einen gibt (parat + nie einsehbar + kein Recycling); Env-Key
+mit Minimal-Scope nur für den Rest; niemals im Chat oder Repo.

--- a/apps/seelenkalender/index.html
+++ b/apps/seelenkalender/index.html
@@ -1,0 +1,216 @@
+<!doctype html>
+<!-- =============================================================================
+     Seelenkalender · der Wochenspruch als Eintrittstür (Lead-Schleife 1)
+     Konzept: docs/marketing-maschine.md · Spec: docs/specs/lead-maschine.md
+     Gebaut aus design-system/starter.html – nur Tokens + base.css (DS01–DS07).
+     Regel-IDs: Kicker normal (G05) · Vers = Stimme in Hausschrift · Betonung Laut
+     (G01/G05) · Ziffern tabellarisch (G25) · B01–B05 über Tokens.
+     Verstexte: Rudolf Steiner, Anthroposophischer Seelenkalender (1912/13),
+     gemeinfrei; Quelle anthro.world, abgerufen 8.7.2026.
+     ============================================================================= -->
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Seelenkalender · Goetheanum</title>
+<meta name="description" content="Der Wochenspruch des Anthroposophischen Seelenkalenders – jede Woche neu, im Takt der Wochenschrift." />
+<link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
+
+<link rel="stylesheet" href="../../design-system/tokens.css" />
+<link rel="stylesheet" href="../../design-system/base.css" />
+<link rel="stylesheet" href="../../design-system/nav.css" />
+
+<style>
+  /* Nur seiteneigene Gestaltung – alles Gemeinsame kommt aus base.css. */
+  .hero{padding-block:clamp(36px,6vw,60px) var(--s6)}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(28px,4.6vw,44px);line-height:1.06;letter-spacing:-.01em;max-width:20ch}
+  .hero .lede{margin-top:var(--s4);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:58ch}
+
+  /* Der Spruch – die Stimme des Hauses, gross und ruhig */
+  .spruch-card{max-width:720px;margin-top:var(--s5);padding:clamp(24px,4vw,44px)}
+  .spruch-meta{display:flex;align-items:baseline;gap:var(--s3);flex-wrap:wrap}
+  .spruch-meta .readout{font-variant-numeric:tabular-nums}
+  .vers{margin:var(--s5) 0 0;font-family:var(--font);font-weight:var(--w-text);font-size:clamp(20px,2.8vw,27px);line-height:1.6;letter-spacing:.002em;white-space:pre-line}
+  .byline{margin-top:var(--s5)}
+
+  .blaettern{display:flex;gap:var(--s2);flex-wrap:wrap;margin-top:var(--s5)}
+
+  .weiter{display:grid;gap:var(--s4);grid-template-columns:repeat(auto-fit,minmax(260px,1fr));margin-top:var(--s5);max-width:720px}
+</style>
+</head>
+<body>
+
+<script src="../../design-system/nav.js" data-root="../../" data-section="anwendung" data-active="seelenkalender"></script>
+
+<main class="wrap">
+
+  <section class="hero">
+    <span class="kicker">Anthroposophischer Seelenkalender</span>
+    <h1>Der Wochenspruch</h1>
+    <p class="lede">Zweiundfünfzig Sprüche, einer je Woche, im Gang des Jahres —
+      von Ostern zu Ostern. Jede Woche erscheint hier der Spruch der laufenden
+      Woche, im selben Takt wie die Wochenschrift.</p>
+  </section>
+
+  <section>
+    <div class="card soft spruch-card">
+      <div class="spruch-meta">
+        <span class="readout" id="wo-nr">—</span>
+        <span class="meta" id="wo-datum">wird berechnet …</span>
+        <span class="badge" id="wo-stimmung" hidden></span>
+      </div>
+      <blockquote class="vers" id="vers">…</blockquote>
+      <p class="byline">Rudolf Steiner · Anthroposophischer Seelenkalender (1912/13)</p>
+      <div class="blaettern">
+        <button class="btn" type="button" id="zurueck">← vorige Woche</button>
+        <button class="btn" type="button" id="heute">aktuelle Woche</button>
+        <button class="btn" type="button" id="vor">nächste Woche →</button>
+        <button class="btn ghost" type="button" id="teilen">Spruch kopieren</button>
+      </div>
+      <p class="hint" id="teilen-echo" hidden>Kopiert — zum Weitergeben bereit.</p>
+    </div>
+  </section>
+
+  <section>
+    <div class="shead">
+      <h2>Im Takt bleiben</h2>
+      <p>Der Spruch ist der Anfang — die Vertiefung erscheint wöchentlich.</p>
+    </div>
+    <div class="weiter">
+      <div class="card soft">
+        <span class="kicker">Wochenschrift</span>
+        <p class="desc">Das anthroposophische Weltgeschehen, wöchentlich verdichtet
+          — seit 1921, im selben Rhythmus wie der Seelenkalender.</p>
+        <p><a class="btn primary" href="https://dasgoetheanum.com/?utm_source=werkzeuge&amp;utm_medium=web&amp;utm_campaign=evergreen&amp;utm_content=seelenkalender">Zur Wochenschrift</a></p>
+      </div>
+      <div class="card soft">
+        <span class="kicker">goetheanum.tv</span>
+        <p class="desc">Vorträge, Gespräche und Kunst aus dem Goetheanum — die
+          Vertiefung zum Spruch in Bewegtbild.</p>
+        <p><a class="btn primary" href="https://goetheanum.tv/?utm_source=werkzeuge&amp;utm_medium=web&amp;utm_campaign=evergreen&amp;utm_content=seelenkalender">Zu goetheanum.tv</a></p>
+      </div>
+      <div class="card soft">
+        <span class="kicker">Wöchentlich per E-Mail</span>
+        <p class="desc">Der Spruch der Woche als stiller Wochengruss ins Postfach —
+          die Versand-Strecke ist in Vorbereitung.</p>
+        <p><span class="badge">in Vorbereitung</span></p>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<footer class="ds-footer">
+  <div class="wrap frow">
+    <span><strong>Goetheanum</strong> · Hausgrafik</span>
+    <span><a href="../../design-system/">Design-System</a></span>
+  </div>
+</footer>
+
+<script>
+/* Verstexte: gemeinfrei (Steiner, 1912/13). Woche 1 beginnt mit der Osterwoche. */
+const SPRUECHE = {
+ "1": "Wenn aus den Weltenweiten\nDie Sonne spricht zum Menschensinn\nUnd Freude aus den Seelentiefen\nDem Licht sich eint im Schauen,\nDann ziehen aus der Selbstheit Hülle\nGedanken in die Raumesfernen\nUnd binden dumpf\nDes Menschen Wesen an des Geistes Sein.",
+ "2": "Ins Äußere des Sinnesalls\nVerliert Gedankenmacht ihr Eigensein;\nEs finden Geisteswelten\nDen Menschensprossen wieder,\nDer seinen Keim in ihnen,\nDoch seine Seelenfrucht\nIn sich muss finden.",
+ "3": "Es spricht zum Weltenall,\nSich selbst vergessend\nUnd seines Urstands eingedenk,\nDes Menschen wachsend Ich:\nIn dir, befreiend mich\nAus meiner Eigenheiten Fessel,\nErgründe ich mein echtes Wesen.",
+ "4": "Ich fühle Wesen meines Wesens:\nSo spricht Empfindung,\nDie in der sonnerhellten Welt\nMit Lichtesfluten sich vereint;\nSie will dem Denken\nZur Klarheit Wärme schenken\nUnd Mensch und Welt in Einheit fest verbinden.",
+ "5": "Im Lichte das aus Geistestiefen\nIm Raume fruchtbar webend\nDer Götter Schaffen offenbart:\nIn ihm erscheint der Seele Wesen\nGeweitet zu dem Weltensein\nUnd auferstanden\nAus enger Selbstheit Innenmacht.",
+ "6": "Es ist erstanden aus der Eigenheit\nMein Selbst und findet sich\nAls Weltenoffenbarung\nIn Zeit- und Raumeskräften;\nDie Welt, sie zeigt mir überall\nAls göttlich Urbild\nDes eignen Abbilds Wahrheit.",
+ "7": "Mein Selbst, es drohet zu entfliehen,\nVom Weltenlichte mächtig angezogen;\nNun trete du mein Ahnen\nIn deine Rechte kräftig ein,\nErsetze mir des Denkens Macht,\nDas in der Sinne Schein\nSich selbst verlieren will.",
+ "8": "Es wächst der Sinne Macht\nIm Bunde mit der Götter Schaffen,\nSie drückt des Denkens Kraft\nZur Traumes Dumpfheit mir herab.\nWenn göttlich Wesen\nSich meiner Seele einen will,\nMuss menschlich Denken\nIm Traumessein sich still bescheiden.",
+ "9": "Vergessend meine Willenseigenheit\nErfüllet Weltenwärme sommerkündend\nMir Geist und Seelenwesen;\nIm Licht mich zu verlieren\nGebietet mir das Geistesschauen,\nUnd kraftvoll kündet Ahnung mir:\nVerliere dich, um dich zu finden.",
+ "10": "Zu sommerlichen Höhen\nErhebt der Sonne leuchtend Wesen sich,\nEs nimmt mein menschlich Fühlen\nIn seine Raumesweiten mit,\nErahnend regt im Inneren sich\nEmpfindung, dumpf mir kündend,\nErkennen wirst du einst:\nDich fühlte jetzt ein Gotteswesen.",
+ "11": "Es ist in dieser Sonnenstunde\nAn dir, die weise Kunde zu erkennen:\nAn Weltenschönheit hingegeben,\nIn dir dich fühlend zu durchleben:\nVerlieren kann das Menschen-Ich\nUnd finden sich im Welten-Ich.",
+ "12": "Der Welten Schönheitsglanz\nEr zwinget mich aus Seelentiefen\nDes Eigenlebens Götterkräfte\nZum Weltenfluge zu entbinden;\nMich selber zu verlassen,\nVertrauend nur mich suchend\nIn Weltenlicht und Weltenwärme.",
+ "13": "Und bin ich in den Sinneshöhen,\nSo flammt in meinen Seelentiefen\nAus Geistes Feuerwelten\nDer Götter Wahrheitswort:\nIn Geistesgründen suche ahnend\nDich geistverwandt zu finden.",
+ "14": "An Sinnesoffenbarung hingegeben\nVerlor ich Eigenwesens Trieb,\nGedankentraum, er schien\nBetäubend mir das Selbst zu rauben,\nDoch weckend nahet schon\nIm Sinnenschein mir Weltendenken.",
+ "15": "Ich fühle wie verzaubert\nim Weltenschein des Geistes Weben,\nEs hat in Sinnesdumpfheit\nGehüllt mein Eigenwesen,\nZu schenken mir die Kraft,\nDie ohnmächtig sich selbst zu geben\nMein Ich in seinen Schranken ist.",
+ "16": "Zu bergen Geistgeschenk im Innern\nGebietet Strenge mir mein Ahnen,\nDass reifend Gottesgaben\nIn Seelengründen fruchtend\nDer Selbstheit Früchte bringen.",
+ "17": "Es spricht das Weltenwort,\nDas ich durch Sinnestore\nIn Seelengründe durfte führen:\nErfülle deine Geistestiefen\nMit meinen Weltenweiten\nZu finden einstens mich in dir.",
+ "18": "Kann ich die Seele weiten,\nDass sie sich selbst verbindet\nEmpfangenem Welten-Keimesworte?\nIch ahne, dass ich Kraft muss finden\nDie Seele würdig zu gestalten,\nZum Geisteskleide sich zu bilden.",
+ "19": "Geheimnisvoll das Neu-Empfang’ne\nMit der Erinn’rung zu umschließen,\nSei meines Strebens weitrer Sinn:\nEs soll erstarkend Eigenkräfte\nIn meinem Innern wecken\nUnd werdend mich mir selber geben.",
+ "20": "So fühl’ ich erst mein Sein,\nDas fern vom Welten-Dasein\nIn sich, sich selbst erlöschen\nUnd bauend nur auf eignem Grunde\nIn sich, sich selbst ertöten müsste.",
+ "21": "Ich fühle fruchtend fremde Macht\nSich stärkend mir mich selbst verleihn,\nDen Keim empfind ich reifend\nUnd Ahnung lichtvoll weben\nIm Innern an der Selbstheit Macht.",
+ "22": "Das Licht aus Weltenweiten,\nIm Innern lebt es kräftig fort,\nEs wird zum Seelenlichte\nUnd leuchtet in die Geistestiefen,\nU m Früchte zu entbinden,\nDie Menschenselbst aus Weltenselbst\nIm Zeitenlaufe reifen lassen.",
+ "23": "Es dämpfet herbstlich sich\nDer Sinne Reizesstreben,\nIn Lichtesoffenbarung mischen\nDer Nebel dumpfe Schleier sich,\nIch selber schau in Raumesweiten\nDes Herbstes Weltenschlaf,\nDer Sommer hat an mich\nSich selber hingegeben.",
+ "24": "Sich selbst erschaffend stets\nWird Seelensein sich selbst gewahr;\nDer Weltengeist, er strebet fort\nIn Selbsterkenntnis neu belebt\nUnd schafft aus Seelenfinsternis\nDes Selbstsinns Willensfrucht.",
+ "25": "Ich darf nun mir gehören\nUnd leuchtend breiten Innenlicht\nIn Raumes- und in Zeitenfinsternis.\nZum Schlafe drängt natürlich Wesen,\nDer Seele Tiefen sollen wachen\nUnd wachend tragen Sonnengluten\nIn kalte Winterfluten.",
+ "26": "Natur, dein mütterliches Sein,\nIch trage es in meinem Willenswesen;\nUnd meines Willens Feuermacht,\nSie stählet meines Geistes Triebe,\nDass sie gebären Selbstgefühl,\nZu tragen mich in mir.",
+ "27": "In meines Wesens Tiefen dringen\nErregt ein ahnungsvolles Sehnen,\nDass ich mich selbstbetrachtend finde\nAls Sommersonnengabe, die als Keim\nIn Herbstesstimmung wärmend lebt\nAls meiner Seele Kräftetrieb.",
+ "28": "Ich kann im Innern neu belebt\nErfühlen eignen Wesens Weiten\nUnd krafterfüllt Gedankenstrahlen\nAus Seelensonnenmacht\nDen Lebensrätseln lösend spenden,\nErfüllung manchem Wunsche leihen,\nDem Hoffnung schon die Schwingen lähmte.",
+ "29": "Sich selbst des Denkens Leuchten\nIm Innern kraftvoll zu entfachen,\nErlebtes sinnvoll deutend\nAus Weltengeistes Kräftequell,\nIst mir nun Sommererbe\nIst Herbstesruhe und auch Winterhoffnung.",
+ "30": "Es sprießen mir im Seelensonnenlicht\nDes Denkens reife Früchte,\nIn Selbstbewußtseins Sicherheit\nVerwandelt alles Fühlen sich,\nEmpfinden kann ich freudevoll\nDes Herbstes Geisterwachen,\nDer Winter wird in mir\nDen Seelensommer wecken.",
+ "31": "Das Licht aus Geistestiefen,\nNach außen strebt es sonnenhaft,\nEs wird zur Lebenswillenskraft\nUnd leuchtet in der Sinne Dumpfheit,\nUm Kräfte zu entbinden,\nDie Schaffensmächte aus Seelentrieben\nIm Menschenwerke reifen lassen.",
+ "32": "Ich fühle fruchtend eigne Kraft\nSich stärkend mich der Welt verleihn,\nMein Eigenwesen fühl ich kraftend\nZur Klarheit sich zu wenden\nIm Lebens-Schicksalsweben.",
+ "33": "So fühl’ ich erst die Welt,\nDie außer meiner Seele Miterleben\nAn sich nur frostig leeres Leben\nUnd ohne Macht sich offenbarend\nIn Seelen sich von neuem schaffend\nIn sich den Tod nur finden könnte.",
+ "34": "Geheimnisvoll das Alt-Bewahrte\nMit neu erstandnem Eigensein\nIm Innern sich belebend fühlen:\nEs soll erweckend Weltenkräfte\nIn meines Lebens Außenwerk ergießen\nUnd werdend mich ins Dasein prägen.",
+ "35": "Kann ich das Sein erkennen,\nDass es sich wiederfindet\nIm Seelen-Schaffens-Drange?\nIch fühle, dass mir Macht verlieh’n\nDas eigne Selbst dem Weltenselbst\nAls Glied bescheiden einzuleben.",
+ "36": "In meines Wesens Tiefen spricht\nZur Offenbarung drängend\nGeheimnisvoll das Weltenwort:\nErfülle deiner Arbeit Ziele\nMit meinem Geisteslichte\nZu opfern dich durch mich.",
+ "37": "Zu tragen Geisteslicht in Weltenwinternacht\nErstrebet selig meines Herzens Trieb,\nDass leuchtend Seelenkeime\nIn Weltengründen wurzeln\nUnd Gotteswort im Sinnesdunkel\nVerklärend alles Sein durchtönt.",
+ "38": "Ich fühle wie entzaubert\nDas Geisteskind im Seelenschoß,\nEs hat in Herzenshelligkeit\nGezeugt das heil’ge Weltenwort\nDer Hoffnung Himmelsfrucht,\nDie jubelnd wächst in Weltenfernen\nAus meines Wesens Gottesgrund.",
+ "39": "An Geistesoffenbarung hingegeben\nGewinne ich des Weltenwesens Licht,\nGedankenkraft, sie wächst\nSich klärend mir mich selbst zu geben\nUnd weckend löst sich mir\nAus Denkermacht das Selbstgefühl.",
+ "40": "Und bin ich in den Geistestiefen,\nErfüllt in meinen Seelengründen\nAus Herzens Liebewelten\nDer Eigenheiten leerer Wahn\nSich mit des Weltenwortes Feuerkraft.",
+ "41": "Der Seele Schaffensmacht\nSie strebet aus dem Herzensgrunde\nIm Menschenleben Götterkräfte\nZu rechtem Wirken zu entflammen,\nSich selber zu gestalten\nIn Menschenliebe und im Menschenwerke.",
+ "42": "Es ist in diesem Winterdunkel\nDie Offenbarung eigner Kraft\nDer Seele starker Trieb,\nIn Finsternisse sie zu lenken\nUnd ahnend vorzufühlen\nDurch Herzenswärme Sinnesoffenbarung.",
+ "43": "In winterlichen Tiefen\nErwärmt des Geistes wahres Sein,\nEs gibt dem Weltenscheine\nDurch Herzenskräfte Daseinsmächte;\nDer Weltenkälte trotzt erstarkend\nDas Seelenfeuer im Menscheninnern.",
+ "44": "Ergreifend neue Sinnesreize\nErfüllet Seelenklarheit,\nEingedenk vollzogner Geistgeburt,\nVerwirrend sprossend Weltenwerden\nMit meines Denkens Schöpferwillen.",
+ "45": "Es festigt sich Gedankenmacht\nIm Bunde mit der Geistgeburt,\nSie hellt der Sinne dumpfe Reize\nZur vollen Klarheit auf.\nWenn Seelenfülle\nSich mit dem Weltenwerden einen will,\nMuss Sinnesoffenbarung\nDes Denkens Licht empfangen.",
+ "46": "Die Welt, sie drohet zu betäuben\nDer Seele eingeborne Kraft;\nNun trete du, Erinnerung,\nAus Geistestiefen leuchtend auf\nUnd stärke mir das Schauen,\nDas nur durch Willenskräfte\nSich selbst erhalten kann.",
+ "47": "Es will erstehen aus dem Weltenschoße,\nDen Sinnenschein erquickend, Werdelust,\nSie finde meines Denkens Kraft\nGerüstet durch die Gotteskräfte\nDie kräftig mir im Innern leben.",
+ "48": "Im Lichte das aus Weltenhöhen\nDer Seele machtvoll fließen will\nErscheine, lösend Seelenrätsel,\nDes Weltendenkens Sicherheit\nVersammelnd seiner Strahlen Macht\nIm Menschenherzen Liebe weckend.",
+ "49": "Ich fühle Kraft des Weltenseins:\nSo spricht Gedankenklarheit,\nGedenkend eignen Geistes Wachsen\nIn finstern Weltennächten\nUnd neigt dem nahen Weltentage\nDes Innern Hoffnungsstrahlen.",
+ "50": "Es spricht zum Menschen-Ich,\nSich machtvoll offenbarend\nUnd seines Wesens Kräfte lösend,\nDes Weltendaseins Werdelust:\nIn dich mein Leben tragend\nAus seinem Zauberbanne\nErreiche ich mein wahres Ziel.",
+ "51": "Ins Innre des Menschenwesens\nErgießt der Sinne Reichtum sich,\nEs findet sich der Weltengeist\nIm Spiegelbild des Menschenauges,\nDas seine Kraft aus ihm\nSich neu erschaffen muss.",
+ "52": "Wenn aus den Seelentiefen\nDer Geist sich wendet zu dem Weltensein\nUnd Schönheit quillt aus Raumesweiten,\nDann zieht aus Himmelsfernen\nDes Lebens Kraft in Menschenleiber\nUnd einet, machtvoll wirkend,\nDes Geistes Wesen mit dem Menschensein."
+};
+const STIMMUNG = {1:'Oster-Stimmung',12:'Johanni-Stimmung',26:'Michaeli-Stimmung',38:'Weihnacht-Stimmung'};
+
+/* Ostersonntag (gregorianisch), Anonymous-Gauss */
+function ostern(j){
+  const a=j%19,b=Math.floor(j/100),c=j%100,d=Math.floor(b/4),e=b%4,
+        f=Math.floor((b+8)/25),g=Math.floor((b-f+1)/3),
+        h=(19*a+b-d-g+15)%30,i=Math.floor(c/4),k=c%4,
+        l=(32+2*e+2*i-h-k)%7,m=Math.floor((a+11*h+22*l)/451),
+        mo=Math.floor((h+l-7*m+114)/31),ta=((h+l-7*m+114)%31)+1;
+  return new Date(j,mo-1,ta);
+}
+function wocheHeute(){
+  const heute=new Date(); heute.setHours(12,0,0,0);
+  let o=ostern(heute.getFullYear());
+  if(heute<o) o=ostern(heute.getFullYear()-1);
+  const w=Math.floor((heute-o)/(7*24*3600*1000))+1;
+  return {nr:Math.min(Math.max(w,1),52), ostern:o};
+}
+function datumsSpanne(o,nr){
+  const von=new Date(o.getTime()+(nr-1)*7*24*3600*1000);
+  const bis=new Date(von.getTime()+6*24*3600*1000);
+  const f=d=>d.toLocaleDateString('de-CH',{day:'numeric',month:'long'});
+  return f(von)+' – '+f(bis);
+}
+
+const st={...wocheHeute()};
+let nr=st.nr;
+const $=id=>document.getElementById(id);
+function zeige(){
+  $('wo-nr').textContent=nr+'. Woche';
+  $('wo-datum').textContent=(nr===st.nr?'':'') + datumsSpanne(st.ostern,nr) + (nr===st.nr?' · diese Woche':'');
+  $('vers').textContent=SPRUECHE[nr];
+  const s=STIMMUNG[nr];
+  $('wo-stimmung').hidden=!s; if(s) $('wo-stimmung').textContent=s;
+  $('teilen-echo').hidden=true;
+}
+$('zurueck').addEventListener('click',()=>{nr=nr>1?nr-1:52;zeige();});
+$('vor').addEventListener('click',()=>{nr=nr<52?nr+1:1;zeige();});
+$('heute').addEventListener('click',()=>{nr=st.nr;zeige();});
+$('teilen').addEventListener('click',async()=>{
+  const t=SPRUECHE[nr]+'\n\n— Rudolf Steiner, Seelenkalender, '+nr+'. Woche\n'+location.href;
+  try{
+    if(navigator.share){await navigator.share({text:t});}
+    else{await navigator.clipboard.writeText(t);$('teilen-echo').hidden=false;}
+  }catch(e){}
+});
+zeige();
+</script>
+
+</body>
+</html>

--- a/docs/marketing-maschine.md
+++ b/docs/marketing-maschine.md
@@ -4,7 +4,7 @@
 2026), das Strategieblatt (`docs/strategie.md`), sowie eine mehrsträngige,
 quellengeprüfte Recherche zu Vergleichsprodukten, Abo-Ökonomie, dem empirischen
 Marketing-Kanon (Sharp/Ehrenberg-Bass, Binet & Field), Marty Neumeier und
-Null-Budget-Wachstum. Belegte Zahlen sind mit Quelle und Abrufdatum in §14
+Null-Budget-Wachstum. Belegte Zahlen sind mit Quelle und Abrufdatum in §15
 geführt; jede Aussage trägt einen Evidenzgrad: **[belegt]** (Primärquelle,
 adversarisch geprüft), **[plausibel]** (Quelle vorhanden, nicht gegengeprüft),
 **[anekdotisch]** (Einzelfall, illustrativ).*
@@ -52,7 +52,7 @@ Probezeit** **[belegt]**. **Ein aufschlussreicher Befund:** die Abo-Seite
 `dasgoetheanum.com/subscribe` leitet aktuell **direkt auf die
 Sommer-Aktions-Landingpage** um (`ws-en-sommer2026…`) — der reguläre Weg zum Abo
 führt also mitten durch die Kampagne. Das ist gut fürs Aktionsfenster, aber es
-fehlt der **immer geöffnete** Standard-Abo-Weg (Evergreen, §8) für die 49 Wochen
+fehlt der **immer geöffnete** Standard-Abo-Weg (Evergreen, §9) für die 49 Wochen
 ausserhalb des Fensters. Die Sommer-Aktion 2026 fährt sechs Landingpages auf
 eigenen Subdomains (`tv-sommer2026.goetheanum.tv`, `ws-sommer2026.dasgoetheanum.com`,
 je DE/EN). *(YouTube-/Social-Reichweiten waren zum Redaktionszeitpunkt nicht
@@ -106,7 +106,7 @@ Kaufrate der Bestehenden **[plausibel]**. Marketing allein bringt uns die ersten
 Vervielfachungen (bis in den mittleren fünfstelligen Bereich — vgl. Republik mit
 ~36 000 Abos, werbefrei, deutschsprachig, aus dem Stand in wenigen Jahren
 **[belegt]**). Der Sprung in den **oberen** fünfstelligen Bereich ist ein
-Mehrjahres-Zinseszins und hängt an der englischen Schiene (§10).
+Mehrjahres-Zinseszins und hängt an der englischen Schiene (§11).
 
 ---
 
@@ -166,8 +166,8 @@ Artikeln.
 
 **Cross-Selling-Grundlage:** WoS-Leser und GTV-Zuschauer sind weitgehend
 **dasselbe Publikum in zwei Zuständen** — lesend und schauend. Wer den einen Job
-mietet, hat oft auch den anderen. Das begründet die Bündel-Kommunikation (§7, §12),
-verlangt aber Frequenz-Disziplin (§11), damit dasselbe Publikum nicht doppelt
+mietet, hat oft auch den anderen. Das begründet die Bündel-Kommunikation (§8, §13),
+verlangt aber Frequenz-Disziplin (§12), damit dasselbe Publikum nicht doppelt
 bespielt und müde wird.
 
 ---
@@ -190,7 +190,7 @@ Binet & Field.
 **Binet & Field — 60/40.** Langfristiger Markenaufbau (~60 % des Aufwands) und
 kurzfristige Aktivierung (~40 %) müssen im Gleichgewicht stehen; reine
 Aktivierung (Rabatte, Countdown) verpufft langfristig. *Für uns:* die
-Kampagnenfenster (§6) sind die 40 %; der Evergreen-Sockel aus Archiv-SEO,
+Kampagnenfenster (§7) sind die 40 %; der Evergreen-Sockel aus Archiv-SEO,
 YouTube-Präsenz und Newsletter ist die 60 %. **[plausibel]**
 
 **Abo-Ökonomie — Churn, LTV, Payback.** Plattformweiter Benchmark:
@@ -199,7 +199,7 @@ unfreiwillig (Zahlungsausfälle) **[belegt]**. Rund ein Viertel der Abwanderung
 ist also **technisch** (Karte abgelaufen, Zahlung fehlgeschlagen) und ohne jede
 Inhaltsarbeit durch **Dunning/Zahlungs-Retry** rückholbar. Jahresabos bringen
 deutlich mehr Umsatz je Nutzer als Monatsabos **[plausibel]** — die Verschiebung
-zur Jahreszahlweise ist eine **Rahmung**, keine Produktänderung (§12).
+zur Jahreszahlweise ist eine **Rahmung**, keine Produktänderung (§13).
 
 **Newsletter-first & Konversion.** Realistische Free→Paid-Konversion liegt
 niedriger als erhofft: Platformer erreichte **~5 %** statt der angenommenen
@@ -253,11 +253,77 @@ Transparenz-Cockpit** — genau das, was der Sommer-Zähler im Ansatz schon ist.
 
 ---
 
-## 6. Der Jahreszyklus — das Jahresrad
+## 6. Die Lead-Maschine — fünf Schleifen, die von selbst laufen
 
-Kern-Artefakt. Das Jahr hat einen **Evergreen-Sockel** (läuft immer: Archiv-SEO,
-YouTube, Newsletter, Empfehlung) und **drei bis vier Kampagnenfenster**, die auf
-den anthroposophischen Jahreslauf und die Abo-Saisonalität gelegt sind.
+Das Herzstück — vor dem Kalender, denn der Kalender verstärkt nur, was hier
+dauernd läuft. Eine Schleife ist etwas anderes als eine Massnahme: sie wird
+**einmal gebaut**, läuft dann **ohne wöchentliches Zutun**, und jede Umdrehung
+erzeugt Leads, die die nächste Umdrehung billiger machen. Fünf Schleifen, alle
+aus dem eigenen Bestand, alle ohne Werbebudget:
+
+**Schleife 1 — Der Seelenkalender-Keil.** Steiners 52 Wochensprüche (1912/13,
+gemeinfrei) sind *die* anthroposophische Wochenrhythmik — **im selben Takt wie
+die Wochenschrift**. Als freier Wochenspruch (Web + E-Mail, hausgesetzt) ist er
+der perfekte Einstieg: minimale Hürde, echter Wert, und er selektiert exakt das
+eigene Publikum — Menschen aus Ring 2, die nie kalt ein Bezahl-Trial starten,
+nehmen einen freien Wochenspruch. Jeder Spruch verlinkt die Vertiefung
+(WoS-Artikel, GTV-Beitrag). *Automatik:* Woche wechselt von selbst
+(Oster-Anker), Versand per Vorlage + Zeitplan. *Messpunkt:*
+Newsletter-Netto-Wachstum, Klicks zur Vertiefung. **Status: gebaut** —
+`apps/seelenkalender/` zeigt den Spruch der laufenden Woche; die
+Versand-Strecke ist der nächste Bauschritt (Spec: `docs/specs/lead-maschine.md`).
+
+**Schleife 2 — Das Archiv als Sog.** 100 Jahrgänge + ~500 Aufnahmen sind der
+grösste ungehobene Schatz: **«Vor 100 Jahren»** (automatisch tagesgenau ein
+Archivstück), öffentliche Volltextsuche mit Volltext hinter E-Mail/Abo (jeder
+historische Artikel wird ein Sucheintrag), und **«Frag das Archiv»**
+(semantische Suche über hundert Jahre — ein Werkzeug, das nur dieses Haus haben
+kann). *Automatik:* einmal indexiert, wächst die Sichtbarkeit kumulativ ohne
+Kampagne. *Messpunkt:* Suche-Einstiege, E-Mail-Freischaltungen. **Status:
+spezifiziert** (`docs/specs/lead-maschine.md`).
+
+**Schleife 3 — Das Netzwerk als Kanal (Partner-Kit).** Die Zielmarke wird nicht
+durch eigenes Posten erreicht, sondern durch die **über 1200 Waldorfschulen,
+Weleda, Demeter, Kliniken, Zweige und die Christengemeinschaft**, die die
+Beziehungen zu Ring 2 bereits halten. Jede Institution erhält monatlich ein
+fertiges, hausgesetztes Stück (Spruch-Kachel, Archiv-Perle, Clip) mit
+getracktem Rücklink — **1200 Institutionen werden zu automatischen
+Verteilknoten.** *Automatik:* Kit wird aus der Atomisierung (Schleife 4)
+gespeist; Versandliste statt Einzelarbeit. *Messpunkt:* Rücklink-Konversionen
+je Partner (UTM-Konvention besteht). **Status: spezifiziert.**
+
+**Schleife 4 — Die Atomisierungs-Pipeline.** *Ein* Artikel oder *eine* Aufnahme
+wird automatisch zu **fünf Lead-Flächen**: Zitat-Kachel in der Hausschrift
+(über die **bestehenden Generatoren**), 60-Sekunden-Clip, Newsletter-Anriss,
+Archiv-SEO-Seite, Seelenkalender-Bezug. Redaktionsarbeit bleibt eine Einheit —
+die Maschine vervielfältigt die Oberfläche. *Messpunkt:* Lead-Flächen je
+Redaktions-Einheit, Konversion je Fläche (Attribution je Motiv besteht).
+**Status: spezifiziert.**
+
+**Schleife 5 — Würdevolles Schenken.** Kein «wirb einen Freund»-Rabatt, sondern
+**«Schenke einen Monat»**: Abonnenten verschenken einen Gratismonat, der
+Empfänger erhält eine persönliche Übergabe. Jedes Geschenk ist ein
+vorqualifizierter Lead, überbracht von einer vertrauten Person — kulturell
+stimmig (Weihnacht, Gedenken). *Automatik:* Uscreen-Coupons
+(Once/Repeating, belegt in §8) tragen die Mechanik ohne Zusatzkosten.
+*Messpunkt:* K-Faktor (Geschenke je 100 Abonnenten, Einlösung, Bleibe-Quote).
+**Status: spezifiziert.**
+
+**Die Logik dahinter:** Schleifen 1–2 stellen **mentale Verfügbarkeit** her
+(die 60 % nach Binet & Field), Schleife 3 kauft **Reichweite mit Vertrauen
+statt Geld**, Schleife 4 senkt die **Kosten je Kontakt** gegen null, Schleife 5
+macht aus **Bindung Akquise**. Der Kalender (§7) sagt nur noch, wann man diese
+Maschine lauter dreht.
+
+---
+
+## 7. Der Jahreszyklus — das Jahresrad
+
+Der Kalender ist **nicht** die Maschine — er ist ihr **Verstärker**: Der
+Evergreen-Sockel sind die fünf Schleifen aus §6, die immer laufen; die **drei
+bis vier Kampagnenfenster** sind die Momente, in denen das Haus dieselben
+Schleifen lauter dreht, gelegt auf den anthroposophischen Jahreslauf und die
+Abo-Saisonalität.
 
 | Monat | Anlass / Jahreslauf | WoS-Themenanlass | Kampagnenfenster | Kanal-Schwerpunkt |
 |---:|---|---|---|---|
@@ -285,7 +351,7 @@ Wirkung → Ist, Entscheid). Das Rad dreht sich, das Cockpit misst jede Umdrehun
 
 ---
 
-## 7. Die Maschine — Automatisierungs-Architektur
+## 8. Die Maschine — Automatisierungs-Architektur
 
 Auf dem bestehenden Fundament (`services/sommer-zaehler/`, `apps/utm-generator/`).
 Fünf Bauteile.
@@ -297,7 +363,7 @@ Herkunfts-**Motiv** (volles UTM-Tupel), Interessens-Signal (WoS/GTV, DE/EN).
 Capture-Punkte: Newsletter-Formular, Trial-Checkout, Landingpages, Print-QR,
 Live-Event-Anmeldung.
 
-**(b) Nurture-Strecken** (getaktete E-Mail-Folgen, im vorhandenen Stack, §10):
+**(b) Nurture-Strecken** (getaktete E-Mail-Folgen, im vorhandenen Stack, §11):
 - **Willkommen** (neuer Newsletter-Leser): Bestes aus dem Archiv, sanfte
   Hinführung zum ersten Trial.
 - **Trial-Begleitung Tag 1–7** (GTV): drei Impulse, die zum Schauen führen —
@@ -316,7 +382,7 @@ Kündigung, Zahlungsausfall (→ Dunning, holt bis zu ~0,86 %-Punkte Churn zurü
 Erscheinungsformen: **Artikel (WoS) → Clip/Aufnahme (GTV) → Newsletter-Anriss →
 Landingpage.** Jeder Kanal trägt jeden. Ein WoS-Leser bekommt gelegentlich den
 passenden GTV-Beitrag, ein GTV-Zuschauer den vertiefenden WoS-Artikel — **mit
-Frequenz-Deckel** (§11).
+Frequenz-Deckel** (§12).
 
 **(e) Verstetigung `sommer2026_*` → `marketing_*`** *(Folge-Bauvorhaben, hier nur
 als Prinzip).* Das Aktions-Schema (signups, Massnahmen-Protokoll, Trichter-RPCs)
@@ -330,15 +396,15 @@ Strecken sind ohne Zusatzkosten möglich: **Uscreen** hat eine **eingebaute
 Abandoned-Cart-Automation** (drei Mails nach 15 Minuten / +6 Stunden / +24 Stunden,
 Rabatt 10–15 % empfohlen) **[belegt]** und **Coupons** in zwei Formen (fester
 Betrag oder Prozent) mit drei Laufzeiten — **Once / Forever / Repeating** —, womit
-Intro-Rahmung (§12) und Win-back technisch abgedeckt sind **[belegt]**. **Zoho
-Campaigns** unterstützt **Double-Opt-in** (einwilligungsbasiert, §11b) **[belegt]**.
+Intro-Rahmung (§13) und Win-back technisch abgedeckt sind **[belegt]**. **Zoho
+Campaigns** unterstützt **Double-Opt-in** (einwilligungsbasiert, §12b) **[belegt]**.
 Was **nicht** belegt geklärt ist: ob eine mehrstufige, verhaltensgetriggerte
 Nurture-Strecke rein in Uscreen/Zoho läuft oder einen separaten ESP braucht — das
-ist die eine offene Vorab-Entscheidung vor Phase 1 (§13).
+ist die eine offene Vorab-Entscheidung vor Phase 1 (§14).
 
 ---
 
-## 8. Die Null-Budget-Phase — Organik zuerst
+## 9. Die Null-Budget-Phase — Organik zuerst
 
 Alles hier kostet **Zeit, kein Geld**. Reihenfolge nach Hebel.
 
@@ -360,11 +426,11 @@ Alles hier kostet **Zeit, kein Geld**. Reihenfolge nach Hebel.
    **Verteil-Multiplikatoren** (Empfehlung an ihre Kreise), nicht als Werbekauf.
 6. **Angebots-Rahmungen ohne Produktänderung:** Geschenk-, Gemeinschafts- und
    Klassensatz-Abos sind **Kommunikation und Bündelung** bestehender Tarife
-   (§12), kein neues Produkt.
+   (§13), kein neues Produkt.
 
 ---
 
-## 9. Die 10-Prozent-Regel — Experiment-Governance
+## 10. Die 10-Prozent-Regel — Experiment-Governance
 
 Ab dem ersten Gewinn dürfen 10 % in Services/Ads/Werkzeuge fliessen — **aber nur
 belegt auf Wirkung, nichts läuft unbeaufsichtigt.** Der Mechanismus existiert
@@ -384,7 +450,7 @@ Quartals-Prüfung. So bleibt das Reinvest ein Regelkreis, kein Fass ohne Boden.
 
 ---
 
-## 10. KPI-System & Wachstumsmodell
+## 11. KPI-System & Wachstumsmodell
 
 **North-Star je Produkt:** zahlende Abos (WoS / GTV, netto nach Churn).
 **Hilfsgrössen:** Newsletter-Netto-Wachstum · Trial-Starts · Trial→Paid ·
@@ -412,14 +478,14 @@ kippt. Ehrlich benannt, nicht versteckt.
 
 ---
 
-## 11. Spannungen & Grundsätze
+## 12. Spannungen & Grundsätze
 
 Kein Anhang — ein eigenes Kapitel, weil hier die Haltung des Hauses auf die
 Marktlogik trifft.
 
 **(a) Wachstum ohne Produktänderung.** 10–20× kommt aus **Publikums-Erweiterung**
 (Positionierung für Ring 2/3), nicht aus Produktumbau. Grenze der Aussage: ohne
-englische Schiene ist der obere fünfstellige Bereich nicht erreichbar (§10) —
+englische Schiene ist der obere fünfstellige Bereich nicht erreichbar (§11) —
 das ist Reichweitenarbeit, keine Produktarbeit, aber sie braucht Jahre.
 
 **(b) Datensparsamkeit vs. Automation.** Das Haus führt Datensparsamkeit als
@@ -445,7 +511,7 @@ Cross-Selling die Bindung.
 
 ---
 
-## 12. Fahrplan in Phasen
+## 13. Fahrplan in Phasen
 
 Jede Phase mit Eintritts-/Austrittskriterium in Zahlen.
 
@@ -466,9 +532,12 @@ gezielt 10 % des Gewinns in die wirksamsten Kanäle, jede Ausgabe im Protokoll.
 **Phase 3 — Skalierung EN/Partner.** Englische Schiene und Partnernetz
 hochfahren — der Weg in den oberen fünfstelligen Bereich. *Austritt:* Zielmarke.
 
-**Umsetzungs-Backlog (priorisiert, als Folgearbeit):**
+**Umsetzungs-Backlog (priorisiert, als Folgearbeit; Schleifen-Details in
+`docs/specs/lead-maschine.md`):**
+0. ~~Seelenkalender-Werkzeug~~ **gebaut** (`apps/seelenkalender/`); als Nächstes
+   die Versand-Strecke (Schleife 1).
 1. `marketing_*`-Schema aus `sommer2026_*` ableiten (Datenkontinuität).
-2. Nurture-Strecken in Uscreen/Zoho konfigurieren (§10-Machbarkeit zuerst klären).
+2. Nurture-Strecken in Uscreen/Zoho konfigurieren (Stack-Machbarkeit belegt, §8).
 3. Jahresrad als HTML-Werkzeug aus `design-system/starter.html` (heute nur als
    Tabelle in diesem Dokument und im Einseiter `marketing-maschine.html`).
 4. Empfehlungsprogramm-Mechanik (doppelseitig, würdig).
@@ -476,10 +545,10 @@ hochfahren — der Weg in den oberen fünfstelligen Bereich. *Austritt:* Zielmar
 
 ---
 
-## 13. Offene Entscheidungen
+## 14. Offene Entscheidungen
 
 - **E-Mail-Werkzeug (ESP):** Double-Opt-in (Zoho) und Uscreens Abandoned-Cart/
-  Coupons sind belegt vorhanden (§7); **offen bleibt**, ob eine mehrstufige,
+  Coupons sind belegt vorhanden (§8); **offen bleibt**, ob eine mehrstufige,
   verhaltensgetriggerte Nurture-Strecke rein im Bestand läuft oder einen
   separaten ESP braucht. **Vor Phase 1 zu klären.**
 - **Standard-Abo-Weg (Evergreen):** Der reguläre Abo-Link führt derzeit auf die
@@ -489,13 +558,13 @@ hochfahren — der Weg in den oberen fünfstelligen Bereich. *Austritt:* Zielmar
   Szenario.)
 - **Verhältnis zu bestehenden Redaktions-Newslettern:** ein Absender-Haus oder
   getrennte Stimmen?
-- **Zuständigkeit & Betriebsstunden:** wer pflegt die Maschine (Zeit-Budget, §11d)?
+- **Zuständigkeit & Betriebsstunden:** wer pflegt die Maschine (Zeit-Budget, §12d)?
 - **Zahlweise-Verschiebung:** Umstellung auf Jahreszahlweise aktiv bewerben
-  (Rahmung, §4/§12) — ab wann?
+  (Rahmung, §4/§13) — ab wann?
 
 ---
 
-## 14. Quellen
+## 15. Quellen
 
 Belegte externe Zahlen mit Abrufdatum **6. Juli 2026**. Interne Zahlen (4650 /
 15 000 / ~500) sind aus Mediadaten/Aufgabenstellung übernommen und **zu

--- a/docs/specs/lead-maschine.md
+++ b/docs/specs/lead-maschine.md
@@ -1,0 +1,140 @@
+# Lead-Maschine — Pflichtenheft der fünf Schleifen
+
+*Arbeitsstand. Ausführungs-Spezifikation zu `docs/marketing-maschine.md` §6.
+Eine Schleife gilt als «gebaut», wenn sie ohne wöchentliches Zutun läuft und
+ihre Messpunkte im Cockpit erscheinen. Stack-Voraussetzungen (Uscreen-Coupons
+und Abandoned-Cart, Zoho Double-Opt-in, Supabase Edge Functions + `pg_cron`)
+sind belegt — Quellen im Konzept §15.*
+
+---
+
+## Schleife 1 — Seelenkalender-Keil
+
+**Zweck:** freier Wochenspruch als Eintrittstür; wöchentlicher Takt = Takt der
+Wochenschrift; Leads aus Ring 2 (anthroposophisch Berührte).
+
+**Baustufe A — Web (gebaut):** `apps/seelenkalender/` zeigt den Spruch der
+laufenden Woche (Oster-Anker, Gauss-Osterformel, Woche 1 = Osterwoche), blättern,
+kopieren/teilen, Vertiefungs-Verweise mit UTM (`utm_campaign=evergreen`,
+`utm_content=seelenkalender`). Verstexte gemeinfrei (Steiner 1912/13), Quelle
+anthro.world, alle 52 eindeutig extrahiert; Stichproben (1, 12, 26, 40, 52)
+verifiziert.
+
+**Baustufe B — Versand-Strecke:**
+1. Anmeldung: Formular (Paperform-Muster wie Sommer-Aktion) → Webhook →
+   `marketing_leads` (gehashte E-Mail, Einwilligung Double-Opt-in, Herkunfts-Motiv).
+2. Versand: wöchentlich (So/Mo früh) per Edge Function + `pg_cron`; Inhalt =
+   Spruch der Woche + **ein** Vertiefungs-Verweis (WoS oder GTV, alternierend,
+   Frequenz-Deckel beachten). ESP-Entscheid (Zoho Campaigns vs. schlanker
+   SMTP-Dienst) = offene Entscheidung im Konzept §14.
+3. Jede Ausgabe trägt UTM je Motiv (`vers_NN`), Attribution besteht.
+
+**Baustufe C — Verbreitung:** einbettbares Widget (ein `<script>`-Einzeiler für
+Partnerseiten, Schleife 3) + Spruch-Kachel als Bild (Schleife 4, Cover-Generator-
+Muster).
+
+**Messpunkte:** Netto-Listenwachstum/Woche · Öffnungs-/Klickrate ·
+Klicks zur Vertiefung je `vers_NN` · Trials mit Herkunft `seelenkalender`.
+**Aufwand:** einmalig 2–4 Tage (B), laufend ≈ 0 (Inhalt ist fix, 52 Wochen).
+
+---
+
+## Schleife 2 — Archiv als Sog
+
+**Zweck:** 100 Jahrgänge + ~500 Aufnahmen von totem Bestand zu kumulativ
+wachsender Eintrittsfläche machen.
+
+**Baustufen:**
+1. **«Vor 100 Jahren»** — tagesgenau ein Archivstück (Titel, Auszug, Scan) als
+   Auto-Post (Web-Seite + Newsletter-Baustein + Kachel). Voraussetzung: Zugriff
+   auf digitalisierte Jahrgänge (Bestand `collections/jahrgaenge` — Umfang und
+   Rechte **zu klären**, offene Entscheidung).
+2. **Offene Volltextsuche** — Index öffentlich (jeder Treffer = Sucheintrag),
+   Volltext hinter E-Mail-Freischaltung (Lead) bzw. Abo (Konversion).
+3. **«Frag das Archiv»** — semantische Suche (Supabase `pgvector`, Embeddings je
+   Absatz; Antwort mit Fundstellen-Zitaten, **keine** freie Generierung ohne
+   Quelle — Würde-Regel). Jede Anfrage ohne Abo endet in einer
+   Freischaltungs-Einladung.
+
+**Messpunkte:** organische Einstiege/Monat (kumulativ) · Freischaltungen ·
+Suche→Trial-Konversion. **Aufwand:** der grösste der fünf — je Baustufe einzeln
+schätzen; 1 ist klein, 2–3 hängen an der Digitalisierungs-Frage.
+
+---
+
+## Schleife 3 — Netzwerk als Kanal (Partner-Kit)
+
+**Zweck:** die über 1200 Waldorfschulen, Weleda/Demeter-Kreise, Kliniken, Zweige
+und die Christengemeinschaft als vertrauenswürdige Verteilknoten gewinnen —
+Reichweite mit Vertrauen statt Geld.
+
+**Bausteine:**
+1. **Partner-Register** (`marketing_partner`): Institution, Sprache, Kanal
+   (Eltern-Newsletter, Aushang, Website), Ansprechperson (gehasht/extern gepflegt).
+2. **Monats-Kit**, automatisch aus Schleife 4 gespeist: eine Spruch-Kachel, eine
+   Archiv-Perle, ein Clip-Verweis — je Partner mit **eigenem UTM-Rücklink**
+   (UTM-Generator besteht) und einbettbarem Widget (Schleife 1C).
+3. **Gegenwert statt Bitte:** das Kit ist für den Partner selbst brauchbar
+   (fertiger Inhalt für dessen Newsletter) — deshalb wird es genommen.
+4. Quartalsweise: Partner-Rangliste im Cockpit (Konversionen je Rücklink),
+   stille Partner erhalten ein anderes Kit, nicht mehr Druck (Würde-Regel).
+
+**Messpunkte:** aktive Partner · Konversionen je Partner-Motiv · CPA = 0.
+**Aufwand:** einmalig Kit-Vorlage + Register; laufend ≈ 1 h/Monat Kuratierung.
+
+---
+
+## Schleife 4 — Atomisierungs-Pipeline
+
+**Zweck:** aus jeder Redaktions-Einheit (Artikel/Aufnahme) automatisch fünf
+Lead-Flächen — Kosten je Kontakt gegen null.
+
+**Pipeline je Einheit:**
+| Fläche | Werkzeug | Automatisierungsgrad |
+|---|---|---|
+| Zitat-Kachel (Hausschrift) | bestehender Cover-/Kachel-Generator | Vorlage + Text einsetzen |
+| 60-Sekunden-Clip | Schnitt aus GTV-Aufnahme | halbautomatisch (Markierung) |
+| Newsletter-Anriss | Redaktionstext, gekürzt | Vorlage |
+| Archiv-/SEO-Seite | statische Seite je Beitrag | automatisch |
+| Seelenkalender-Bezug | Verweis Spruch ↔ Thema | redaktionell, 1 Zeile |
+
+Jede Fläche trägt ihr UTM-Motiv; die Attribution je Motiv besteht im Cockpit.
+**Messpunkte:** Flächen je Einheit · Konversion je Fläche · beste Motive je
+Quartal (Entscheid: mehr davon). **Aufwand:** Vorlagen einmalig; laufend Minuten
+je Einheit statt Stunden.
+
+---
+
+## Schleife 5 — Würdevolles Schenken
+
+**Zweck:** aus Bindung Akquise machen — ohne Rabatt-Rhetorik.
+
+**Mechanik:** «Schenke einen Monat»: Abonnent löst Geschenk aus → Empfänger
+erhält persönliche Übergabe (Karte/Mail mit Absender-Name, hausgesetzt) + Code.
+Technisch: Uscreen-Coupon (100 %, Dauer `Once` bzw. `Repeating` für
+Mehrmonats-Geschenke) — **belegt vorhanden, keine Zusatzkosten**. Für die
+Wochenschrift analog über Zoho-Gutschein (zu verifizieren) oder manuelle Liste
+in Stufe 1.
+
+**Regeln (Würde):** kein Countdown, kein Kettenzwang, Empfänger kann still
+ablehnen; ein Geschenk je Empfänger je Jahr (Frequenz-Deckel).
+
+**Messpunkte:** Geschenke je 100 Abonnenten · Einlösequote · Bleibe-Quote der
+Beschenkten nach 3 Monaten (Kohorten-Muster des Sommer-Zählers). **Aufwand:**
+Coupon-Vorlage + Übergabe-Vorlage einmalig; laufend ≈ 0.
+
+---
+
+## Reihenfolge & Abhängigkeiten
+
+1. **Jetzt:** Schleife 1B (Versand) — kleinster Bau, grösster Taktgewinn;
+   braucht nur ESP-Entscheid (§14 im Konzept).
+2. **Dann:** Schleife 4 (Vorlagen) — speist 3 und verbilligt alles Weitere.
+3. **Dann:** Schleife 3 (Partner-Kit) — braucht 4 als Zulieferer.
+4. **Parallel klein:** Schleife 5 (Coupon + Vorlage, Weihnachtsfenster als
+   erster Test — Massnahme im Protokoll).
+5. **Gross, eigenes Vorhaben:** Schleife 2 (Digitalisierungs-/Rechtsfrage
+   zuerst klären).
+
+Jede Schleife wird als **Massnahme im Protokoll** geführt (Hypothese → Ist →
+Entscheid), Zeitaufwand wie Geld bilanziert (Konzept §12d).

--- a/marketing-maschine.html
+++ b/marketing-maschine.html
@@ -51,9 +51,9 @@
   <section class="hero">
     <span class="kicker">Strategie · Wochenschrift & goetheanum.tv</span>
     <h1>Die Marketing-Maschine</h1>
-    <p class="lede">Aus der einmaligen Sommer-Aktion wird ein Jahresrad, aus dem
-      Cockpit ein Regelkreis. Kampagnen im Jahreslauf, Leads in Strecken, jede
-      Ausgabe mit Wirkungsnachweis — ohne Produktänderung, zuerst ohne Geld.</p>
+    <p class="lede">Fünf Lead-Schleifen, die von selbst laufen — und ein Jahresrad,
+      das sie zur rechten Zeit lauter dreht. Jede Ausgabe mit Wirkungsnachweis —
+      ohne Produktänderung, zuerst ohne Geld.</p>
   </section>
 
   <section>
@@ -120,8 +120,47 @@
 
   <section>
     <div class="shead">
+      <h2>Die fünf Schleifen — das Herzstück</h2>
+      <p>Einmal gebaut, laufen sie ohne wöchentliches Zutun. Jede Umdrehung erzeugt Leads.</p>
+    </div>
+    <div class="duo">
+      <div class="card soft">
+        <span class="kicker">1 · Seelenkalender-Keil</span>
+        <p class="desc">Der freie Wochenspruch — im Takt der Wochenschrift, minimale
+          Hürde, selektiert exakt das eigene Publikum. Jeder Spruch verlinkt die
+          Vertiefung. <strong>Gebaut:</strong> <a href="apps/seelenkalender/">Werkzeug ansehen</a>.</p>
+      </div>
+      <div class="card soft">
+        <span class="kicker">2 · Archiv als Sog</span>
+        <p class="desc">100 Jahrgänge + 500 Aufnahmen: <q>Vor 100 Jahren</q>, offene
+          Volltextsuche, <q>Frag das Archiv</q>. Einmal indexiert, wächst die
+          Sichtbarkeit kumulativ — ohne Kampagne.</p>
+      </div>
+      <div class="card soft">
+        <span class="kicker">3 · Netzwerk als Kanal</span>
+        <p class="desc">1200 Waldorfschulen, Weleda, Demeter, Zweige halten die
+          Beziehungen schon. Ein monatliches Partner-Kit macht sie zu
+          Verteilknoten — Vertrauen statt Werbebudget.</p>
+      </div>
+      <div class="card soft">
+        <span class="kicker">4 · Atomisierung</span>
+        <p class="desc">Ein Artikel, eine Aufnahme — fünf Lead-Flächen:
+          Zitat-Kachel, Clip, Anriss, Archiv-Seite, Spruch-Bezug. Automatisch,
+          über die bestehenden Generatoren.</p>
+      </div>
+      <div class="card soft">
+        <span class="kicker">5 · Würdevolles Schenken</span>
+        <p class="desc"><q>Schenke einen Monat</q> — jedes Geschenk ein
+          vorqualifizierter Lead von vertrauter Hand. Uscreen-Coupons tragen die
+          Mechanik ohne Zusatzkosten.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="shead">
       <h2>Das Jahresrad</h2>
-      <p>Ein Evergreen-Sockel, der immer läuft — und vier Kampagnenfenster im Jahreslauf.</p>
+      <p>Der Kalender ist nicht die Maschine — er ist ihr Verstärker: vier Fenster, in denen die Schleifen lauter drehen.</p>
     </div>
     <div class="rad-scroll">
       <table class="rad">

--- a/marketing-maschine.html
+++ b/marketing-maschine.html
@@ -12,11 +12,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Marketing-Maschine · Goetheanum</title>
 <meta name="description" content="Jahreszyklus, Kampagnen, Leads: die weitgehend automatisierte Marketing-Maschine für die Wochenschrift und goetheanum.tv – auf einer Seite." />
-<link rel="icon" type="image/svg+xml" href="https://phtok.github.io/goeloggen/assets/logos/goetheanum-mark-blue.svg" />
+<link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
 
-<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/tokens.css" />
-<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/base.css" />
-<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/nav.css" />
+<link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/base.css" />
+<link rel="stylesheet" href="design-system/nav.css" />
 
 <style>
   /* Nur seiteneigene Feinheiten – alles Gemeinsame steht in base.css. Tokens statt Werte. */
@@ -41,9 +41,10 @@
 </head>
 <body>
 
-<script src="https://phtok.github.io/goeloggen/design-system/nav.js"
-        data-root="https://phtok.github.io/goeloggen/"
-        data-variant="werkzeug"></script>
+<script src="design-system/nav.js"
+        data-root="./"
+        data-section="statistik"
+        data-active="marketing-maschine"></script>
 
 <main class="wrap">
 

--- a/tools.json
+++ b/tools.json
@@ -397,6 +397,17 @@
       "href": "marketing-maschine.html",
       "desc": "Gesetzte Zusammenfassung des Marketing-Konzepts: Jahresrad, Kennzahlen, die zwei Stimmen und die drei Wachstums-Wege — auf einer Seite. Volltext im Konzeptdokument.",
       "such": "Marketing Maschine Kampagne Jahresrad Abo Wachstum Wochenschrift goetheanum.tv Leads Strategie Neumeier Newsletter Michaeli"
+    },
+    {
+      "slug": "seelenkalender",
+      "cat": "anwendung",
+      "status": "beta",
+      "tag": "Neu",
+      "title": "Seelenkalender",
+      "short": "Seelenkalender",
+      "href": "apps/seelenkalender/",
+      "desc": "Der Wochenspruch des Anthroposophischen Seelenkalenders — jede Woche neu, mit Blättern, Teilen und Vertiefungs-Verweisen. Erste Schleife der Lead-Maschine.",
+      "such": "Seelenkalender Wochenspruch Steiner Spruch Woche Ostern Michaeli Johanni Kalender Lead"
     }
   ],
   "docs": [
@@ -447,6 +458,12 @@
       "tag": "Strategie",
       "href": "https://github.com/phtok/goeloggen/blob/main/docs/marketing-maschine.md",
       "desc": "Jahreszyklus, Kampagnen, Leads: Konzept der weitgehend automatisierten Marketing-Maschine für die Wochenschrift und goetheanum.tv."
+    },
+    {
+      "title": "Lead-Maschine — Pflichtenheft",
+      "tag": "Spec",
+      "href": "https://github.com/phtok/goeloggen/blob/main/docs/specs/lead-maschine.md",
+      "desc": "Ausführungs-Spezifikation der fünf Lead-Schleifen: Seelenkalender, Archiv-Sog, Partner-Kit, Atomisierung, Schenken."
     }
   ]
 }


### PR DESCRIPTION
## Worum es geht

Antwort auf die Rückmeldung zum Konzept: «bestätigend, aber nicht erhellend, erweiternd oder automatisierend — besonders das Sammeln von Leads braucht frische Ideen.» Die Korrektur: **Der Kalender ist nicht die Maschine — er ist ihr Verstärker.** Ins Zentrum rücken fünf Lead-Schleifen, die einmal gebaut werden und dann von selbst laufen.

## Die fünf Schleifen (neu, Konzept §6)

1. **Seelenkalender-Keil** — der freie Wochenspruch (52 gemeinfreie Verse, Steiner 1912/13) im selben Wochentakt wie die Wochenschrift: minimale Hürde, selektiert exakt das eigene Publikum, jeder Spruch verlinkt die Vertiefung. **In diesem PR gebaut.**
2. **Archiv als Sog** — «Vor 100 Jahren», offene Volltextsuche (Volltext hinter E-Mail/Abo), «Frag das Archiv» (semantische Suche über 100 Jahrgänge).
3. **Netzwerk als Kanal** — monatliches Partner-Kit für >1200 Waldorfschulen, Weleda/Demeter-Kreise, Zweige: Reichweite mit Vertrauen statt Geld.
4. **Atomisierungs-Pipeline** — ein Artikel/eine Aufnahme → fünf Lead-Flächen (Kachel, Clip, Anriss, Archiv-Seite, Spruch-Bezug), über die bestehenden Generatoren.
5. **Würdevolles Schenken** — «Schenke einen Monat» über belegte Uscreen-Coupons; jedes Geschenk ein vorqualifizierter Lead von vertrauter Hand.

## Änderungen

- **`apps/seelenkalender/`** — neues Werkzeug: Spruch der laufenden Woche (Oster-Anker, Gauss-Osterformel — Referenzdaten 2024/2025/2026 geprüft), blättern, kopieren/teilen, Vertiefungs-Verweise mit UTM. Verstexte von anthro.world extrahiert (52/52 eindeutig, Stichproben 1·12·26·40·52 gegen bekannte Texte verifiziert), Apostrophe typografisch (G16). Relative Asset-Pfade (Lehre aus #256).
- **`docs/marketing-maschine.md`** — neue §6 «Die Lead-Maschine», Jahresrad als Verstärker-Ebene umgerahmt, Abschnitte 6–14 → 7–15 renummeriert, Querverweise nachgeführt, Backlog aktualisiert.
- **`docs/specs/lead-maschine.md`** — Pflichtenheft aller fünf Schleifen: Baustufen, Automatik, Messpunkte, Aufwand, Reihenfolge und Abhängigkeiten.
- **`marketing-maschine.html`** — Schleifen-Sektion vor dem Jahresrad, Lede neu.
- **`tools.json`** — Werkzeug (`anwendung`, beta) und Spec (`docs[]`) registriert.

## Prüfung

- `typo-check.py` grün über alle vier Dateien; `ds-lint.py` DS-Score 100 % (beide HTML-Seiten).
- Osterformel gegen Referenzdaten verifiziert (31.3.2024, 20.4.2025, 5.4.2026); heute → 14. Woche.
- Keine ß-Regel im Hauskanon — historische Verstexte bleiben unangetastet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dxfjredm1xtFBrrYcnKjc

---
_Generated by [Claude Code](https://claude.ai/code/session_019Dxfjredm1xtFBrrYcnKjc)_