### PR TITLE
Webhooks: Buchhalter-Tests (hao.bu) zählen nie als Abo

### DIFF
--- a/services/sommer-zaehler/ingest-paperform/index.ts
+++ b/services/sommer-zaehler/ingest-paperform/index.ts
@@ -139,6 +139,18 @@ Deno.serve(async (req) => {
   // E-Mail für Entdopplung (aus rohem Body, vor Redaktion).
   const emailMatch = JSON.stringify(body).match(EMAIL_RE);
   const email = emailMatch ? emailMatch[0].toLowerCase() : "";
+
+  // Test-Anmeldungen des Buchhalters (Adressen mit «hao.bu») zählen nie als
+  // Abo: nur ins Roh-Protokoll (zur Verifikation der Attribution), kein Upsert.
+  if (email.includes("hao.bu")) {
+    const utmTest = utmFromBody(body);
+    await fetch(`${SB}/rest/v1/sommer2026_ingest_raw`, {
+      method: "POST", headers: { ...H, Prefer: "return=minimal" },
+      body: JSON.stringify({ source: "paperform", event: "submission", ok: true, note: "test (hao.bu) – nicht gezaehlt", payload: redact(body) }),
+    }).catch(() => {});
+    return json({ ok: true, test: true, utm: utmTest });
+  }
+
   const salt = cfg["hash_salt"] || "";
   const subId = body?.submission_id || body?.id || body?.data?.submission_id || "";
   const dedupKey = email ? `wos:${await sha256Hex(salt + email)}` : `paperform:${subId || (await sha256Hex(blob)).slice(0, 24)}`;

--- a/services/sommer-zaehler/ingest-uscreen/index.ts
+++ b/services/sommer-zaehler/ingest-uscreen/index.ts
@@ -154,6 +154,17 @@ Deno.serve(async (req) => {
 
   // Entdopplung: Person je Produkt über gesalzenen E-Mail-Hash (Fallback ext_id).
   const email = (pick(data, ["customer_email", "user_email", "email"]) || "").toString().toLowerCase();
+
+  // Test-Anmeldungen des Buchhalters (Adressen mit «hao.bu») zählen nie als
+  // Abo: nur ins Roh-Protokoll (zur Verifikation), kein Upsert, kein Status.
+  if (email.includes("hao.bu")) {
+    await fetch(`${SB}/rest/v1/sommer2026_ingest_raw`, {
+      method: "POST", headers: { ...H, Prefer: "return=minimal" },
+      body: JSON.stringify({ source: "uscreen", event, ok: true, note: "test (hao.bu) – nicht gezaehlt", payload: redact(body) }),
+    }).catch(() => {});
+    return json({ ok: true, test: true });
+  }
+
   const person = email ? await sha256Hex(salt + email) : "";
   const dedupKey = person ? `gtv:${person}` : `uscreen:${ext}`;
 


### PR DESCRIPTION
Der Buchhalter testet mit Adressen, die `hao.bu` enthalten — solche Anmeldungen gehen ab jetzt **nur ins PII-redigierte Roh-Protokoll** (Note `test (hao.bu) – nicht gezaehlt`; die Paperform-Function meldet die erkannten UTMs zur Verifikation zurück) und **nie** in `sommer2026_signups`.

Beide Functions deployt (`ingest-paperform` v8, `ingest-uscreen` v11) und live verifiziert: Test-Webhook mit hao.bu-Adresse → 0 gezählt, 1 protokolliert, UTMs korrekt erkannt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_