### PR TITLE
Kartentool: WC-Piktos einzeln und als Pille, Medizin-Pfeil zurück, eigene Marken in Spalte 2 und zweizeilig, Logo justierbar

### DIFF
--- a/apps/karten-generator/app.js
+++ b/apps/karten-generator/app.js
@@ -94,10 +94,12 @@ const state = {
   wiesen: { klein: false, gross: false },
   kompakt: false,       // kompakte Legende (kleinerer Grad, engere Zeilen)
   ausschnitt: { skala: 1, dx: 0, dy: 0 },  // Kartenausschnitt relativ zur Standardlage
+  logo: { x: null, y: null, skala: 1 },    // Campus-Logo: Mitte (mm) + Grösse
   preset: "gedeckt",   // Standard; Anpassung je Rolle bleibt möglich
   farben: { ...PRESETS["gedeckt"] },
   platzieren: null,    // { label, farbe } während der Platzierung (neue Marke)
   platzierenOrt: null, // Ort-id, deren Marke gerade verschoben wird
+  platzierenLogo: false, // Logo wird gerade neu platziert
   bearbeiten: null     // Ort-id, deren Beschriftung gerade editiert wird
 };
 
@@ -149,7 +151,7 @@ async function ladeIkone(name) {
 }
 
 async function ladeIkonen() {
-  const namen = ["kompass-2", "pfeil-rechts-fett", "wc-rollstuhl", "wc-gruppe"];
+  const namen = ["kompass-2", "pfeil-rechts-fett", "wc-rollstuhl", "wc-gruppe", "wc-herren", "wc-damen", "wickelraum"];
   await Promise.all(namen.map(async (name) => {
     try {
       ikonen[name] = await ladeIkone(name);
@@ -461,16 +463,40 @@ function zentrierterText(x, y, text, groesse, farbe) {
   }).join("");
 }
 
+// Symbol-Marken sind eine Spur grösser als Zahlkreise (Piktos brauchen
+// Fläche); mehrere Piktos teilen sich eine Pille.
+const SYMBOL_FAKTOR = 1.25;
+
+function markenBreite(ort, r) {
+  if (!ort.symbol || !Array.isArray(ort.symbol)) return 2 * r * (ort.symbol ? SYMBOL_FAKTOR : 1);
+  const rr = r * SYMBOL_FAKTOR;
+  return rr * 1.55 * (ort.symbol.length - 1) + 2 * rr;
+}
+
 function markenKreis(x, y, hex, text, r, symbol) {
   // Kreiszahl nach dem Sonderelement des Design-Systems (.step-num):
   // Hausschrift Laut, fester Kreis, Tintenmitte der Ziffern auf der
   // Kreismitte (ZIFFERN_SITZ). Grad = 0.5 × Durchmesser — eine Spur
   // kräftiger als die 0.72/1.6-Proportion, zweistellige Zahlen füllen
   // den Kreis, ohne ihn zu sprengen (Entscheid Auftraggeber, 8. Juli 2026).
-  // Symbol-Marken (z. B. barrierefreier Zugang) tragen ein Icon statt Ziffer.
+  // Symbol-Marken (z. B. WCs) tragen Piktos statt Ziffer — einzeln im
+  // grösseren Kreis, mehrere nebeneinander in einer Pille.
   if (symbol) {
-    return `<circle cx="${x}" cy="${y}" r="${r}" fill="${hex}" />`
-      + symbolMarkup(symbol, x, y, r * 1.35, "#ffffff");
+    const symbole = Array.isArray(symbol) ? symbol : [symbol];
+    const rr = r * SYMBOL_FAKTOR;
+    if (symbole.length === 1) {
+      return `<circle cx="${x}" cy="${y}" r="${rr}" fill="${hex}" />`
+        + symbolMarkup(symbole[0], x, y, rr * 1.5, "#ffffff");
+    }
+    const schritt = rr * 1.55;
+    const breite = schritt * (symbole.length - 1) + 2 * rr;
+    let aus = `<rect x="${(x - breite / 2).toFixed(3)}" y="${(y - rr).toFixed(3)}"`
+      + ` width="${breite.toFixed(3)}" height="${(2 * rr).toFixed(3)}" rx="${rr}" fill="${hex}" />`;
+    symbole.forEach((s, index) => {
+      const cx = x + (index - (symbole.length - 1) / 2) * schritt;
+      aus += symbolMarkup(s, cx, y, rr * 1.5, "#ffffff");
+    });
+    return aus;
   }
   const groesse = r;
   return `<circle cx="${x}" cy="${y}" r="${r}" fill="${hex}" />`
@@ -643,6 +669,11 @@ function legendeZeilen() {
     const kategorie = ort.kategorie || "eigene";
     if (mitKoepfen && (!vorher || (vorher.kategorie || "eigene") !== kategorie)) {
       if (vorher) zeilen.push({ typ: "abstand", hoehe: L.gruppe * 0.6 });
+      // Eigene (veranstaltungsspezifische) Marken beginnen in Spalte 2 —
+      // klar getrennt vom Standard-Inventar der Karte.
+      if (ort.art === "eigene" && (!vorher || vorher.art !== "eigene")) {
+        zeilen.push({ typ: "umbruch" });
+      }
       const eigener = state.eigeneTitel.trim();
       const name = ort.art === "eigene"
         ? (eigener ? { de: eigener, en: eigener } : { de: "Eigene Marken", en: "Own Markers" })
@@ -680,6 +711,11 @@ function legendeMarkup() {
   legendeZeilen().forEach((zeile) => {
     // Gruppenköpfe binden sich an ihren ersten Eintrag: reicht der Platz
     // nicht für Kopf UND eine Zeile, bricht die Spalte vor dem Kopf um.
+    if (zeile.typ === "umbruch") {
+      // manueller Spaltenwechsel (eigene Marken beginnen in Spalte 2)
+      if (spalte < L.spaltenX.length - 1) { spalte += 1; y = start; }
+      return;
+    }
     const bedarf = zeile.hoehe + (zeile.typ === "kopf" ? L.zeile : 0);
     if (zeile.typ !== "abstand" && y + bedarf > untergrenze && spalte < L.spaltenX.length - 1) {
       spalte += 1;
@@ -710,13 +746,17 @@ function legendeMarkup() {
     }
     const ort = zeile.ort;
     const hex = ortFarbeHex(ort);
+    let textX = x + L.labelAbstand;
     if (ort.art === "treppe") {
       teile += treppenBadge(x, y - 0.9, ort.marker, "treppe", hex, true);
     } else {
-      teile += markenKreis(x, y - 0.9, hex, ortMarker(ort), 2.03, ort.symbol);
+      // Breite Symbol-Pillen linksbündig zur Spalte, Text weicht aus.
+      const b = markenBreite(ort, 2.03);
+      teile += markenKreis(x - 2.03 + b / 2, y - 0.9, hex, ortMarker(ort), 2.03, ort.symbol);
+      textX = x + Math.max(L.labelAbstand, b - 2.03 + 1.6);
     }
     zeile.zeilenTexte.forEach((text, index) => {
-      teile += `<text x="${x + L.labelAbstand}" y="${y + index * L.extraZeile}"`
+      teile += `<text x="${textX}" y="${y + index * L.extraZeile}"`
         + ` font-size="${L.labelGroesse}" fill="${TINTE}" font-family="${SCHRIFT_SPRACHE}">${escapeXml(text)}</text>`;
     });
     y += zeile.hoehe;
@@ -739,10 +779,15 @@ function kompassMarkup() {
 
 function logoMarkup() {
   if (!logoInhalt) return "";
-  const breite = 22; // mm — rechtsbündig, Rand wie die Legende links (10.5)
+  // Grundbreite 24 mm (minimal grösser, Entscheid 8. Juli 2026), per
+  // Regler skalierbar; Lage per Klick setzbar (state.logo = Mitte in mm),
+  // Standard rechtsbündig oben mit Rand wie die Legende links (10.5).
+  const breite = 24 * state.logo.skala;
+  const hoehe = breite * logoInhalt.hoehe / logoInhalt.breite;
   const skala = breite / logoInhalt.breite;
-  const x = SZENE.breite - 10.5 - breite;
-  return `<g transform="translate(${x} 6.5) scale(${skala})">${logoInhalt.markup}</g>`;
+  const x = state.logo.x != null ? state.logo.x - breite / 2 : SZENE.breite - 10.5 - breite;
+  const y = state.logo.y != null ? state.logo.y - hoehe / 2 : 6.5;
+  return `<g transform="translate(${x.toFixed(2)} ${y.toFixed(2)}) scale(${skala})">${logoInhalt.markup}</g>`;
 }
 
 function szeneMarkup(anschnitt) {
@@ -815,7 +860,7 @@ function renderVorschau() {
       ? " ⚠ Legende voll — bitte Orte reduzieren."
       : " ⚠ Legende voll — kompakte Legende einschalten oder Orte reduzieren.";
   }
-  printSvg.classList.toggle("platzieren", Boolean(state.platzieren || state.platzierenOrt));
+  printSvg.classList.toggle("platzieren", Boolean(state.platzieren || state.platzierenOrt || state.platzierenLogo));
 }
 
 /* ---------- Seitenleiste ---------- */
@@ -891,6 +936,15 @@ function ortZeile(ort, loeschbar) {
   markerSpan.className = "object-marker";
   markerSpan.textContent = ortAktiv(ort) ? ortMarker(ort) : "–";
   zeile.appendChild(markerSpan);
+
+  // Eigene Marken tragen viele Knöpfe (Farbe, ✥, ▲▼, ✕) — die Zeile
+  // bricht dafür in zwei Zeilen um: oben Titel, unten die Werkzeuge.
+  if (loeschbar) {
+    zeile.classList.add("zweizeilig");
+    const umbruch = document.createElement("span");
+    umbruch.className = "zeilen-umbruch";
+    zeile.appendChild(umbruch);
+  }
 
   const farbKnopf = document.createElement("button");
   farbKnopf.type = "button";
@@ -1240,6 +1294,9 @@ function renderOptionen() {
   document.getElementById("opt-wiese-klein").checked = state.wiesen.klein;
   document.getElementById("opt-wiese-gross").checked = state.wiesen.gross;
   document.getElementById("opt-kompakt").checked = state.kompakt;
+
+  document.getElementById("logo-skala").value = String(Math.round(state.logo.skala * 100));
+  document.getElementById("logo-wert").textContent = `${Math.round(state.logo.skala * 100)}%`;
 }
 
 /* ---------- Zoom (nur Bildschirm-Vorschau) ---------- */
@@ -1264,6 +1321,7 @@ function standAlsJson() {
     teileAus: state.teileAus, notizenAus: state.notizenAus,
     markerFarben: state.markerFarben, positionen: state.positionen,
     eigene: state.eigene, wiesen: state.wiesen, kompakt: state.kompakt, ausschnitt: state.ausschnitt,
+    logo: state.logo,
     preset: state.preset, farben: state.farben
   };
 }
@@ -1307,6 +1365,11 @@ function standAnwenden(s) {
         dy: Number(s.ausschnitt.dy) || 0
       };
     }
+    state.logo = s.logo && typeof s.logo === "object"
+      ? { x: typeof s.logo.x === "number" ? s.logo.x : null,
+          y: typeof s.logo.y === "number" ? s.logo.y : null,
+          skala: Math.min(2, Math.max(0.6, Number(s.logo.skala) || 1)) }
+      : { x: null, y: null, skala: 1 };
     if (typeof s.preset === "string") state.preset = PRESET_MIGRATION[s.preset] || s.preset;
     if (!PRESETS[state.preset] && state.preset !== "eigene Mischung") state.preset = "gedeckt";
     if (s.farben) state.farben = { ...PRESETS["gedeckt"], ...s.farben };
@@ -1441,9 +1504,18 @@ function karteVerschieben(dx, dy) {
 const EIGENE_HINT_STANDARD = "Erst Beschriftung eingeben, dann in der Vorschau die Stelle anklicken. ‹Esc› bricht ab.";
 
 printSvg.addEventListener("click", (ereignis) => {
-  if (!state.platzieren && !state.platzierenOrt) return;
+  if (!state.platzieren && !state.platzierenOrt && !state.platzierenLogo) return;
   const p = svgPunkt(ereignis.clientX, ereignis.clientY);
   if (!p) return;
+  if (state.platzierenLogo) {
+    // Logo liegt fest auf dem Blatt (nicht im Ausschnitt): rohe Blatt-mm.
+    state.logo.x = Math.round(p.x * 10) / 10;
+    state.logo.y = Math.round(p.y * 10) / 10;
+    state.platzierenLogo = false;
+    eigeneHint.textContent = EIGENE_HINT_STANDARD;
+    render();
+    return;
+  }
   const [x, y] = anpZurueck(p.x, p.y);
   const gerundet = [Math.round(x * 100) / 100, Math.round(y * 100) / 100];
   if (state.platzierenOrt) {
@@ -1471,9 +1543,10 @@ printSvg.addEventListener("click", (ereignis) => {
 });
 
 document.addEventListener("keydown", (ereignis) => {
-  if (ereignis.key === "Escape" && (state.platzieren || state.platzierenOrt)) {
+  if (ereignis.key === "Escape" && (state.platzieren || state.platzierenOrt || state.platzierenLogo)) {
     state.platzieren = null;
     state.platzierenOrt = null;
+    state.platzierenLogo = false;
     eigeneHint.textContent = EIGENE_HINT_STANDARD;
     render();
   }
@@ -1530,6 +1603,28 @@ document.getElementById("opt-wiese-klein").addEventListener("change", (e) => {
 });
 document.getElementById("opt-wiese-gross").addEventListener("change", (e) => {
   state.wiesen.gross = e.target.checked;
+  render();
+});
+
+document.getElementById("logo-skala").addEventListener("input", (e) => {
+  state.logo.skala = Math.min(2, Math.max(0.6, Number(e.target.value) / 100));
+  document.getElementById("logo-wert").textContent = `${Math.round(state.logo.skala * 100)}%`;
+  renderVorschau();
+});
+document.getElementById("logo-skala").addEventListener("change", () => {
+  renderOptionen();
+  speichern();
+});
+document.getElementById("logo-platzieren").addEventListener("click", () => {
+  state.platzierenLogo = true;
+  state.platzieren = null;
+  state.platzierenOrt = null;
+  renderVorschau();
+  eigeneHint.textContent = "Logo — neue Stelle in der Vorschau anklicken (Mitte). ‹Esc› bricht ab.";
+  printSvg.scrollIntoView({ behavior: "smooth", block: "nearest" });
+});
+document.getElementById("logo-reset").addEventListener("click", () => {
+  state.logo = { x: null, y: null, skala: 1 };
   render();
 });
 

--- a/apps/karten-generator/index.html
+++ b/apps/karten-generator/index.html
@@ -129,6 +129,12 @@
       cursor: pointer;
     }
     .object-row:last-child { border-bottom: 0; }
+    /* Eigene Marken: Titelzeile oben, Werkzeuge (Farbe, Verschieben,
+       Sortieren, Entfernen) in der zweiten Zeile — die Beschriftung
+       behält volle Breite statt in Buchstabentürme zu brechen. */
+    .object-row.zweizeilig { flex-wrap: wrap; padding: var(--s1) 0; }
+    .object-row.zweizeilig .zeilen-umbruch { flex-basis: 100%; height: 0; }
+    .object-row.zweizeilig .object-title { min-width: 0; }
     .object-dot {
       width: 14px; height: 14px; border-radius: 50%;
       flex: none;
@@ -304,6 +310,21 @@
           <span>Wiese gross einfärben (mit Rudolf-Steiner-Archiv)</span>
         </label>
         <div id="farb-rollen"></div>
+      </fieldset>
+
+      <fieldset>
+        <legend>Logo</legend>
+        <div class="farb-reihe">
+          <label for="logo-skala">Grösse</label>
+          <input id="logo-skala" type="range" min="60" max="200" value="100" />
+          <span class="zoom-value" id="logo-wert">100%</span>
+        </div>
+        <div class="button-row">
+          <button id="logo-platzieren" type="button" class="btn">Logo platzieren</button>
+          <button id="logo-reset" type="button" class="btn">Standardlage</button>
+        </div>
+        <div class="hint">Klick auf ‹Logo platzieren›, dann in der Vorschau die
+          neue Mitte anklicken. Standard: rechts oben.</div>
       </fieldset>
 
       <fieldset>

--- a/apps/karten-generator/orte.js
+++ b/apps/karten-generator/orte.js
@@ -164,14 +164,14 @@ const ORTE = [
     "symbol": "wc-rollstuhl"
   },
   {
-    "id": "wc-goetheanum",
+    "id": "wc-g-herren",
     "marker": "WC",
     "art": "orientierung",
     "kategorie": "eingaenge",
     "farbe": "blau",
     "label": {
-      "de": "WC Goetheanum",
-      "en": "WC Goetheanum"
+      "de": "WC Herren (Goetheanum)",
+      "en": "WC Men (Goetheanum)"
     },
     "positionen": [
       [
@@ -179,25 +179,119 @@ const ORTE = [
         150.8
       ]
     ],
-    "symbol": "wc-gruppe"
+    "symbol": "wc-herren"
   },
   {
-    "id": "wc-schreinerei",
+    "id": "wc-g-damen",
     "marker": "WC",
     "art": "orientierung",
     "kategorie": "eingaenge",
     "farbe": "blau",
     "label": {
-      "de": "WC Schreinerei",
-      "en": "WC Schreinerei"
+      "de": "WC Damen (Goetheanum)",
+      "en": "WC Women (Goetheanum)"
     },
     "positionen": [
       [
-        224.5,
-        83.5
+        192.5,
+        145.5
       ]
     ],
-    "symbol": "wc-gruppe"
+    "symbol": "wc-damen"
+  },
+  {
+    "id": "wc-g-rollstuhl",
+    "marker": "WC",
+    "art": "orientierung",
+    "kategorie": "eingaenge",
+    "farbe": "blau",
+    "label": {
+      "de": "WC barrierefrei (Goetheanum)",
+      "en": "Accessible WC (Goetheanum)"
+    },
+    "positionen": [
+      [
+        196.0,
+        142.0
+      ]
+    ],
+    "symbol": "wc-rollstuhl"
+  },
+  {
+    "id": "wc-g-wickeltisch",
+    "marker": "WC",
+    "art": "orientierung",
+    "kategorie": "eingaenge",
+    "farbe": "blau",
+    "label": {
+      "de": "Wickeltisch (Goetheanum)",
+      "en": "Baby Changing (Goetheanum)"
+    },
+    "positionen": [
+      [
+        199.5,
+        138.5
+      ]
+    ],
+    "symbol": "wickelraum"
+  },
+  {
+    "id": "wc-g-kombi",
+    "marker": "WC",
+    "art": "orientierung",
+    "kategorie": "eingaenge",
+    "farbe": "blau",
+    "label": {
+      "de": "WC Damen · barrierefrei · Wickeltisch (Goetheanum)",
+      "en": "WC Women · Accessible · Baby Changing (Goetheanum)"
+    },
+    "positionen": [
+      [
+        192.5,
+        141.0
+      ]
+    ],
+    "symbol": [
+      "wc-damen",
+      "wc-rollstuhl",
+      "wickelraum"
+    ]
+  },
+  {
+    "id": "wc-s-herren",
+    "marker": "WC",
+    "art": "orientierung",
+    "kategorie": "eingaenge",
+    "farbe": "blau",
+    "label": {
+      "de": "WC Herren (Schreinerei)",
+      "en": "WC Men (Schreinerei)"
+    },
+    "positionen": [
+      [
+        222.0,
+        82.0
+      ]
+    ],
+    "symbol": "wc-herren"
+  },
+  {
+    "id": "wc-s-damen",
+    "marker": "WC",
+    "art": "orientierung",
+    "kategorie": "eingaenge",
+    "farbe": "blau",
+    "label": {
+      "de": "WC Damen (Schreinerei)",
+      "en": "WC Women (Schreinerei)"
+    },
+    "positionen": [
+      [
+        227.0,
+        85.5
+      ]
+    ],
+    "symbol": "wc-damen"
   },
   {
     "id": "f46",
@@ -1141,7 +1235,8 @@ const ORTE = [
         270.95,
         125.81
       ]
-    ]
+    ],
+    "pfeil": "rechts"
   },
   {
     "id": "s-landwirtschaft",

--- a/tools/karten/extract-marker-positionen.py
+++ b/tools/karten/extract-marker-positionen.py
@@ -178,14 +178,33 @@ WILLKOMMEN = [
      {"de": "Barrierefreier Zugang", "en": "Barrier-free access"},
      [[222.5, 130.6]], {"symbol": "wc-rollstuhl"}),
 
-    # WCs (Icon ‹wc-gruppe›, blau statt Eingangs-Gold): Startlagen sind
-    # Setzungen — wie Sektionen/Gärten justierbar, bis Feinlagen bestätigt.
-    ("wc-goetheanum", "WC", "eingaenge",
-     {"de": "WC Goetheanum", "en": "WC Goetheanum"},
-     [[188.5, 150.8]], {"symbol": "wc-gruppe", "farbe": "blau"}),
-    ("wc-schreinerei", "WC", "eingaenge",
-     {"de": "WC Schreinerei", "en": "WC Schreinerei"},
-     [[224.5, 83.5]], {"symbol": "wc-gruppe", "farbe": "blau"}),
+    # WCs (Original-Piktos, blau statt Eingangs-Gold): Goetheanum trennt
+    # Herren von Damen/barrierefrei/Wickeltisch — die drei versuchsweise
+    # einzeln UND kombiniert (Platzprobe des Auftraggebers); Schreinerei
+    # klassisch getrennt. Startlagen sind Setzungen — alle justierbar
+    # (✥), der Lagen-Export liefert die Feinkoordinaten zurück.
+    ("wc-g-herren", "WC", "eingaenge",
+     {"de": "WC Herren (Goetheanum)", "en": "WC Men (Goetheanum)"},
+     [[188.5, 150.8]], {"symbol": "wc-herren", "farbe": "blau"}),
+    ("wc-g-damen", "WC", "eingaenge",
+     {"de": "WC Damen (Goetheanum)", "en": "WC Women (Goetheanum)"},
+     [[192.5, 145.5]], {"symbol": "wc-damen", "farbe": "blau"}),
+    ("wc-g-rollstuhl", "WC", "eingaenge",
+     {"de": "WC barrierefrei (Goetheanum)", "en": "Accessible WC (Goetheanum)"},
+     [[196.0, 142.0]], {"symbol": "wc-rollstuhl", "farbe": "blau"}),
+    ("wc-g-wickeltisch", "WC", "eingaenge",
+     {"de": "Wickeltisch (Goetheanum)", "en": "Baby Changing (Goetheanum)"},
+     [[199.5, 138.5]], {"symbol": "wickelraum", "farbe": "blau"}),
+    ("wc-g-kombi", "WC", "eingaenge",
+     {"de": "WC Damen · barrierefrei · Wickeltisch (Goetheanum)",
+      "en": "WC Women · Accessible · Baby Changing (Goetheanum)"},
+     [[192.5, 141.0]], {"symbol": ["wc-damen", "wc-rollstuhl", "wickelraum"], "farbe": "blau"}),
+    ("wc-s-herren", "WC", "eingaenge",
+     {"de": "WC Herren (Schreinerei)", "en": "WC Men (Schreinerei)"},
+     [[222.0, 82.0]], {"symbol": "wc-herren", "farbe": "blau"}),
+    ("wc-s-damen", "WC", "eingaenge",
+     {"de": "WC Damen (Schreinerei)", "en": "WC Women (Schreinerei)"},
+     [[227.0, 85.5]], {"symbol": "wc-damen", "farbe": "blau"}),
 
     # Sektionen (Buchstaben wie auf dem Willkommensschild):
     ("s-allgemein", "a", "sektionen",
@@ -203,10 +222,11 @@ WILLKOMMEN = [
     ("s-jugend", "e", "sektionen",
      {"de": "Jugendsektion", "en": "Youth Section"},
      [[192.92, 109.33]]),
-    # Vom Auftraggeber aufs Blatt justiert (8. Juli 2026) — Pfeil entfällt.
+    # Lage vom Auftraggeber justiert; der Pfeil bleibt — das Haus wird vom
+    # Blatt angeschnitten und liegt weiter hinten im Weg.
     ("s-medizin", "f", "sektionen",
      {"de": "Medizinische Sektion", "en": "Medical Section"},
-     [[270.95, 125.81]]),
+     [[270.95, 125.81]], {"pfeil": "rechts"}),
     ("s-landwirtschaft", "g", "sektionen",
      {"de": "Sektion für Landwirtschaft", "en": "Section for Agriculture"},
      [[124.94, 121.64]], {"gebaeude": "campusbau-46"}),


### PR DESCRIPTION
Runde 12 der Test-Rückmeldungen zum Kartentool:

- **Symbol-Marker grösser** (Faktor 1.25, Pikto 1.5 × Radius); **mehrere Piktos teilen sich eine Pille**. WC-Angebot neu: Goetheanum trennt Herren von Damen/barrierefrei/Wickeltisch — die drei **versuchsweise einzeln UND kombiniert** (Platzprobe des Auftraggebers); Schreinerei Herren/Damen getrennt. Alle justierbar (✥ + Lagen-Export); Icons `wc-herren`/`wc-damen`/`wickelraum` aus den Originalen v2.7. Breite Pillen laufen in der Legende linksbündig, der Text weicht aus.
- **Medizinische Sektion trägt wieder den Aussenpfeil** (Haus wird vom Blatt angeschnitten, liegt weiter hinten im Weg).
- **Eigene Marken beginnen in der Legende fest in Spalte 2** (manueller Spaltenwechsel) — klar getrennt vom Standard-Inventar.
- **Editor zweizeilig für eigene Marken** (Titel oben, Werkzeuge unten) — lange Beschriftungen brechen nicht mehr in Buchstabentürme.
- **Campus-Logo justierbar:** Grundbreite 24 mm (minimal grösser), Grössenregler 60–200 %, ‹Logo platzieren› setzt die Mitte per Klick, ‹Standardlage› stellt rechts oben wieder her; Lage/Grösse wandern in Speicher und .karte.json.

Verifikation: Playwright (Pille auf Karte + Legende, Spalte-2-Umbruch, zweizeilige Zeilen, Logo-Skala/-Platzierung, Medizin-Pfeil), PDF-Zoom der WC-Marker. typo-check/ds-lint grün (100 %).

Regeln: G25, B01–B04, DS01/DS02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgMfxisgg9yjRqFZhd6wuC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgMfxisgg9yjRqFZhd6wuC)_