### PR TITLE
Signatur-Generator v2: div/br-Markup, Dark-Mode-fest, PS-Modul mit .ics

### DIFF
--- a/apps/signatur-generator/TESTING.md
+++ b/apps/signatur-generator/TESTING.md
@@ -1,59 +1,48 @@
-# Signatur-Generator — Test-Matrix
+# Signatur-Generator v2 — Test-Matrix
 
-Das Tool verspricht: funktioniert in Outlook (Windows/Mac), Apple Mail und Gmail.
-Diese Datei deckt das ab. E-Mail-HTML rendert in jedem Client anders — vor
-grösseren Änderungen am Signatur-Output (`buildSignature()`) bitte real gegenprüfen.
+Das Tool erzeugt eine **reine Text-Signatur** (`div`/`<br>`, alle Stile inline,
+kein Bild, keine Tabelle, kein `<style>`, keine Hintergrundfarbe). Ziel: übersteht
+das Einfügen unverändert und bleibt **hell wie dunkel** lesbar.
 
-Kurz testen heisst: **echte E-Mail an sich selbst senden** und in den unten
-genannten Clients öffnen. Vorschau im Generator ≠ Realität im Client.
+E-Mail-HTML rendert je Client anders — vor grösseren Änderungen an
+`buildSignature()` bitte real gegenprüfen: **echte Testmail an sich selbst**,
+in den unten genannten Clients öffnen. Vorschau ≠ Realität.
 
-## Clients (Minimal-Matrix)
+## Akzeptanz je Client (einfügen + Testmail, hell UND dunkel)
 
-| # | Client | Engine | Priorität |
-|---|--------|--------|-----------|
-| 1 | Outlook 365 **Windows** | Word | **kritisch** (häufigste Brüche) |
-| 2 | Outlook **Mac** | WebKit | hoch |
-| 3 | Apple Mail (macOS) | WebKit | hoch |
-| 4 | Gmail **Web** | eigenes Sanitizing | hoch |
-| 5 | Gmail **App** (iOS/Android) | — | mittel |
-| 6 | iOS Mail | WebKit | mittel |
+| Client | Einfügen | Empfang Hell | Empfang Dunkel |
+|---|---|---|---|
+| Apple Mail (macOS) | ☐ | ☐ | ☐ |
+| Mail (iOS/iPadOS) | ☐ | ☐ | ☐ |
+| Outlook neu (Mac/Windows) | ☐ | ☐ | ☐ |
+| Outlook klassisch (Windows) | ☐ | ☐ | ☐ |
+| Outlook Web | ☐ | ☐ | ☐ |
+| Gmail Web | ☐ | ☐ | ☐ |
 
-## Workflow pro Client
+Workflow: ‹Signatur kopieren› → im Client unter Einstellungen → Signaturen
+einfügen. Apple Mail: ggf. ‹Standardschriftart für E-Mails verwenden› deaktivieren.
 
-1. ‹Signatur kopieren› klicken.
-2. In den Signatur-Einstellungen des Clients einfügen
-   (Outlook Win alternativ: ‹.htm laden› → Datei nach
-   `%APPDATA%\Microsoft\Signatures`).
-3. Neue Mail + Antwort erstellen, an sich selbst senden, im Zielclient öffnen.
+## Prüfpunkte
 
-## Prüfpunkte (das sind die bekannten Outlook-Bruchstellen)
-
-- [ ] **Layout**: Person links (Name → Funktion → Kontakt), Organisation rechts
-      (Goetheanum → Gesellschaft → Adresse), dazwischen der blaue Trennbalken.
-- [ ] **Blauer Trennbalken** ist sichtbar, durchgehend, 2px, klappt nicht weg
-      (Spacer-Zelle, nicht `border`).
-- [ ] **Abstände** (Funktion → Kontakt) stimmen
-      (Spacer-Zeilen, nicht `<br><br>` — Word staucht/dehnt sonst).
-- [ ] **Spaltenbreiten** stabil, kein Umbruch/Verrutschen, keine ungewollte
-      Volldehnung über die Mailbreite.
-- [ ] **Eine Grösse**: Arial 10.5pt durchgängig, **kein** Fett, **kein**
-      Goetheanum-Webfont im Output.
-- [ ] **Farben** (einziges Auszeichnungsmittel): Name dunkel, Funktion/Adresse grau,
-      Kontakt-Links **und** Organisations-Hauptzeile (Goetheanum) im Goetheanum-Blau.
-- [ ] **Links** funktionieren: `mailto:`, Website, `tel:` (auf Mobile).
-- [ ] **Lang- und Kurz-Variante** je einzeln prüfen.
-- [ ] **Dark Mode** des Clients: Signatur bleibt lesbar (Apple Mail/iOS invertieren gern).
-- [ ] **Antwort/Weiterleitung**: Signatur bleibt intakt (Outlook reflowt Tabellen).
+- [ ] **Kein Anhang-Symbol (Büroklammer)** beim Empfänger — d. h. wirklich kein Bild im Markup.
+- [ ] **Fliesstext ohne feste Farbe:** Name/Funktion/Adresse erscheinen im Dark Mode hell, im Light Mode dunkel (erben Theme).
+- [ ] **Keine Grautöne**, keine Trennlinie, keine Hintergrundfarbe.
+- [ ] **Mail-Blau** (`#4183B4`) für ‹Goetheanum› und Web-Links — lesbar auf hellem UND dunklem Grund (Kontrast 4.09:1 / 4.07:1, im Code dokumentiert).
+- [ ] **Hierarchie** über Grösse/Gewicht: Name in 600, Adresse eine Stufe kleiner.
+- [ ] **Links** funktionieren: Website (`https`), Telefon/Mobil (`tel:`), PS-Link.
+- [ ] **‹Nur Text kopieren›** liefert saubere Klartext-Fassung (Zeilenumbrüche, keine HTML-Reste).
+- [ ] **PS-Modul:** 120-Zeichen-Zähler, Darstellung `PS: … — Link`, ‹Erinnerung in den Kalender› lädt eine `.ics`, die in Apple Kalender und Outlook korrekt öffnet; abgelaufenes PS zeigt beim Laden einen Hinweis.
+- [ ] **Vorschau Hell/Dunkel** schaltet den Bühnen-Hintergrund; gerendert wird exakt das kopierte Markup.
 
 ## Funktion / Rollout
 
-- [ ] `localStorage`: Eingaben überstehen ein Reload.
+- [ ] `localStorage` (`goe-signatur-v3`): Eingaben überstehen ein Reload; alte Versionen erzeugen keinen kaputten Zustand.
 - [ ] Query-Prefill: `?name=Test&role=Probe` füllt die Felder.
 - [ ] ‹Beispiel einfügen› / ‹Felder leeren› funktionieren.
-- [ ] Mehrere URLs (je Zeile eine) werden zu einzelnen Links; ‹www.› entfällt in der Anzeige.
+- [ ] Mehrzeilige Felder (Funktion, Website, PS) wachsen mit dem Inhalt.
+- [ ] Empfehlungen erscheinen als Textabschnitt unter dem Generator.
 
-## Bekannte Grenzen
+## Nicht-Ziele
 
-- **Responsive** ist bewusst kein Ziel (Clients ignorieren `@media` weitgehend).
-- `.htm`-Download ist **klassisches** Outlook (Windows) spezifisch; das *neue* Outlook nutzt
-  den Signatures-Ordner nicht. Für neues Outlook, Apple Mail, Gmail: ‹Signatur kopieren›.
+- Kein Backend für die Signatur, keine Datenübertragung von Eingaben (nur anonyme, insert-only Nutzungsstatistik ohne Eingaben).
+- Keine Mehrfach-/Kurzvariante, kein `.htm`-Download, kein Logo-/Bild-Upload.

--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -4,202 +4,226 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Goetheanum E-Mail-Signatur</title>
-<meta name="description" content="E-Mail-Signatur-Generator – erzeugt Outlook-robustes, table-basiertes HTML mit Inline-CSS nach der gemeinsamen Goetheanum-Vorlage." />
+<meta name="description" content="E-Mail-Signatur-Generator – erzeugt eine schlichte, Dark-Mode-feste Text-Signatur nach der gemeinsamen Goetheanum-Vorlage. Kein Bild, keine Tabelle." />
 <meta name="robots" content="noindex" />
 <link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
-<script src="../../assets/goe-orgs.js"></script>
-<link rel="stylesheet" href="../../design-system/tokens.css" />
-<link rel="stylesheet" href="../../design-system/base.css" />
-<link rel="stylesheet" href="../../design-system/nav.css" />
 <style>
-  /* Goetheanum Variable Font – gleiche Herkunft (relativ), kein Fremd-Host/Redirect. */
+  /* Goetheanum Variable Font – nur fürs Seiten-Chrome (nicht in der Signatur) */
   @font-face{
     font-family:"Goetheanum";
-    src:url("../../assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Variabel-v2.7.woff2") format("woff2"),
-        url("../../assets/fonts/goetheanum/Webfonts/woff/Goetheanum-Variabel-v2.7.woff") format("woff");
+    src:url("https://phtok.github.io/goeloggen/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Variabel-v2.5.woff2") format("woff2"),
+        url("https://phtok.github.io/goeloggen/assets/fonts/goetheanum/Webfonts/woff/Goetheanum-Variabel-v2.5.woff") format("woff");
     font-weight:190 725; font-style:normal; font-display:swap;
   }
 
-  /* Farben, Schrift, Maße, Hell-Dunkel kommen aus tokens.css/base.css.
-     Hier nur das werkzeug-eigene Layout – keine eigenen Farbwerte, kein eigenes :root.
-     Ausnahme: die Signatur-Vorschau (.mail-stage) bleibt bewusst weiss/fest, weil sie
-     eine E-Mail abbildet (die beim Empfänger immer auf Weiss steht). */
-  /* Mobil: kompakter, volle Breite, kein horizontales Überlaufen */
+  :root{
+    --ink:#23272b; --muted:#737a80; --line:rgba(20,24,28,.10); --line-soft:rgba(20,24,28,.055);
+    --gold:#d7ab68; --gold-deep:#a07a33; --blue:#0061a9; --paper:#fff; --soft:#faf8f4; --maxw:1080px;
+    --bad:#b3261e;
+    --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s6:24px; --s8:32px;
+    --r-control:10px; --r-card:14px; --header-h:58px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--paper);color:var(--ink);font-family:"Goetheanum","Helvetica Neue",Arial,sans-serif;font-weight:440;
+       letter-spacing:normal;font-kerning:normal;text-rendering:optimizeLegibility;-webkit-font-smoothing:antialiased;line-height:1.5}
+  .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
+  a{color:inherit}
+  .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+  a:focus-visible,button:focus-visible,summary:focus-visible{outline:2px solid var(--blue);outline-offset:2px}
+
+  header{position:sticky;top:0;z-index:30;background:rgba(255,255,255,.9);backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--line)}
+  .bar{display:flex;align-items:center;justify-content:space-between;height:var(--header-h)}
+  .brand{display:flex;align-items:center;gap:var(--s3);text-decoration:none}
+  .brand .wm{font-family:"Goetheanum";font-weight:440;font-size:27px;line-height:1;color:#8a9097;letter-spacing:.005em}
+  nav.top{display:flex;gap:22px}
+  nav.top a{color:var(--muted);text-decoration:none;font-size:13.5px}
+  nav.top a:hover{color:var(--gold-deep)}
+
+  section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
+  main > section:first-of-type{border-top:0}
+  .shead{display:flex;align-items:baseline;justify-content:space-between;gap:var(--s8);margin-bottom:var(--s4);flex-wrap:wrap}
+  .shead h2{font-family:"Goetheanum";font-weight:680;font-size:clamp(22px,3vw,30px);line-height:1.05;flex:0 0 auto}
+  .shead p{color:var(--muted);font-size:14px;line-height:1.5;max-width:62ch;flex:1 1 360px}
+
+  .work{display:grid;grid-template-columns:1fr;gap:var(--s6);align-items:start}
+  @media(min-width:880px){.work{grid-template-columns:minmax(360px,460px) 1fr}}
+  @media(min-width:880px){.preview-col{position:sticky;top:calc(var(--header-h) + var(--s4));align-self:start}}
+
+  .card{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6)}
+  .card.soft{background:var(--soft)}
+
+  .tabs{display:inline-flex;gap:var(--s2)}
+  .tabs button{font:inherit;font-size:13px;color:var(--muted);background:none;border:1px solid var(--line);border-radius:999px;padding:6px 14px;cursor:pointer;transition:.15s}
+  .tabs button[aria-pressed="true"]{color:var(--gold-deep);border-color:var(--gold)}
+
+  .fold{border-top:1px solid var(--line-soft);margin-bottom:var(--s3);padding-top:var(--s3)}
+  .fold>summary{font-family:"Goetheanum";font-weight:680;font-size:15px;color:var(--ink);cursor:pointer;list-style:none;display:flex;justify-content:space-between;align-items:center;gap:var(--s2)}
+  .fold>summary::-webkit-details-marker{display:none}
+  .fold>summary .sub{font-family:"Helvetica Neue",Arial,sans-serif;font-weight:400;font-size:12.5px;color:var(--muted);margin-left:auto}
+  .fold>summary::after{content:"+";color:var(--muted);font-size:18px;line-height:1;width:1em;text-align:center}
+  .fold[open]>summary::after{content:"–"}
+  .fold-body{display:grid;gap:var(--s3);margin-top:var(--s3)}
+
+  .code-details{margin-top:var(--s4)}
+  .code-details>summary{font-size:13px;color:var(--muted);cursor:pointer;list-style:none}
+  .code-details>summary::-webkit-details-marker{display:none}
+  .code-details>summary::before{content:"▸ ";color:var(--gold-deep)}
+  .code-details[open]>summary::before{content:"▾ "}
+
+  .fset{border:0;display:grid;gap:var(--s3);margin-bottom:var(--s3)}
+  .field{display:grid;gap:var(--s1)}
+  .field > .lab{font-size:13px;color:var(--muted);letter-spacing:.01em;display:flex;justify-content:space-between;align-items:baseline;gap:8px}
+  .field input,.field textarea{
+    width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:14.5px;font-weight:400;line-height:1.35;color:var(--ink);
+    background:#fff;border:1px solid var(--line);border-radius:var(--r-control);padding:8px 11px;outline:none;transition:border-color .15s,box-shadow .15s;
+  }
+  .field textarea{resize:vertical;min-height:44px}
+  .field input::placeholder,.field textarea::placeholder{color:#aeb4b9;font-weight:400}
+  .field input:focus,.field textarea:focus{border-color:var(--blue);box-shadow:0 0 0 3px rgba(0,97,169,.16)}
+  .lab .sublab{font-weight:400;font-size:11.5px;color:var(--muted)}
+  .counter{font-variant-numeric:tabular-nums;font-size:11.5px;color:var(--muted)}
+  .counter.over{color:var(--bad)}
+  .expiry-note{font-size:13px;color:#8a5a12;background:#fbf3e2;border:1px solid #ead9b0;border-radius:var(--r-control);padding:8px 11px;margin-bottom:var(--s3)}
+
+  .btnrow{display:flex;gap:var(--s3);flex-wrap:wrap;align-items:center;margin-top:var(--s6)}
+  .btn{display:inline-block;text-decoration:none;font:inherit;font-size:13.5px;padding:9px 15px;border-radius:var(--r-control);border:1px solid var(--line);color:var(--ink);background:#fff;text-align:center;cursor:pointer;transition:.15s}
+  .btn:hover{border-color:var(--gold-deep)}
+  .btn.primary{background:var(--gold);border-color:var(--gold);color:#3a2d10}
+  .btn.primary:hover{background:#c59f56}
+  .btn.ok{background:#3f7d46;border-color:#3f7d46;color:#fff}
+  .btn.ghost{color:var(--muted)}
+  .btn.small{font-size:12.5px;padding:7px 12px}
+  .hint{font-size:14.5px;color:#565b60;line-height:1.55;margin-top:var(--s3);max-width:64ch}
+  .hint strong{color:var(--ink);font-weight:440}
+  .hint a{color:var(--gold-deep);text-decoration:none}
+  .hint a:hover{text-decoration:underline}
+  .hint ul{margin:var(--s3) 0 0;padding-left:18px;display:grid;gap:var(--s2)}
+
+  .stage-head{display:flex;align-items:center;justify-content:space-between;gap:var(--s3);margin-bottom:var(--s3);flex-wrap:wrap}
+  .stage-lab{font-size:13px;color:var(--muted)}
+  .scroll-hint{display:none}
+  .mail-stage{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);box-shadow:0 10px 30px rgba(20,24,28,.06);overflow-x:auto}
+  .mail-stage.light{background:#ffffff;color:#111}
+  .mail-stage.dark{background:#1e1e1e;color:#e8e8e8;border-color:#333}
+  .mail-body{font-size:13px;line-height:1.5}
+  .mail-greeting{opacity:.6;margin-bottom:14px}
+
+  .code-wrap{position:relative;margin-top:var(--s3)}
+  pre.code{margin:0;background:#1f2428;color:#e8eef2;border-radius:var(--r-card);padding:var(--s4);overflow:auto;
+    font:12.5px/1.55 ui-monospace,Menlo,Consolas,monospace;border:1px solid #3a4148;white-space:pre-wrap;word-break:break-word;max-height:320px}
+  .copybtn{position:absolute;top:11px;right:11px;font:inherit;font-size:11.5px;border:1px solid #3a4148;background:#2b3137;color:#e8eef2;border-radius:var(--r-control);padding:5px 10px;cursor:pointer}
+  .copybtn:hover{background:#343b42}
+
+  /* Empfehlungen (Text unter dem Generator) */
+  .empf{max-width:60ch}
+  .empf h3{font-family:"Goetheanum";font-weight:680;font-size:18px;margin:var(--s6) 0 var(--s2)}
+  .empf h3:first-of-type{margin-top:0}
+  .empf p{font-size:15px;line-height:1.6;color:var(--ink);margin:0 0 var(--s3)}
+  .empf p.dim{color:var(--muted)}
+  .empf .lead{color:var(--muted)}
+  .empf a{color:var(--gold-deep);text-decoration:none}
+  .empf a:hover{text-decoration:underline}
+  .empf .rule{border:0;border-top:1px solid var(--line-soft);margin:var(--s6) 0}
+  .empf .tool{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:13.5px}
+  .empf em{color:var(--muted)}
+
+  footer{border-top:1px solid var(--line);padding:var(--s8) 0 60px;color:var(--muted);font-size:12.5px}
+  .frow{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap}
+  .frow strong{color:var(--ink);font-weight:400}
+
   @media(max-width:560px){
     .wrap{padding:0 16px}
     section{padding:var(--s6) 0}
     .shead{gap:var(--s2)}
     .card{padding:var(--s4)}
     .mail-stage{padding:var(--s3)}
-    .scroll-hint{display:block;font-size:var(--t-micro);color:var(--muted);margin-top:6px}
     .brand .wm{font-size:22px}
     nav.top{gap:14px}
-    nav.top a{font-size:var(--t-small)}
+    nav.top a{font-size:13px}
     .nav-hide-sm{display:none}
-    /* iOS zoomt Felder mit Schrift < 16px beim Fokus – das verhindern */
-    .field input,.field textarea,.field select{font-size:16px}
+    .field input,.field textarea{font-size:16px}
+    .scroll-hint{display:block;font-size:12px;color:var(--muted);margin-top:6px}
   }
-
-  section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
-  main > section:first-of-type{border-top:0}
-  .shead{display:flex;align-items:baseline;justify-content:space-between;gap:var(--s8);margin-bottom:var(--s4);flex-wrap:wrap}
-  .shead h2{flex:0 0 auto}
-  .shead p{color:var(--muted);font-size:14px;line-height:1.5;max-width:62ch;flex:1 1 360px}
-
-  .work{display:grid;grid-template-columns:1fr;gap:var(--s6);align-items:start}
-  @media(min-width:880px){.work{grid-template-columns:minmax(360px,460px) 1fr}}
-  /* Vorschau bleibt beim Scrollen der Eingabemaske sichtbar */
-  @media(min-width:880px){.preview-col{position:sticky;top:calc(var(--header-h) + var(--s4));align-self:start}}
-
-  .card{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6)}
-  .card.soft{background:var(--soft)}
-
-  .tabs{display:inline-flex;gap:var(--s2);margin-bottom:var(--s6)}
-  .tabs button{font:inherit;font-size:var(--t-small);color:var(--muted);background:none;border:1px solid var(--line);border-radius:999px;padding:7px 16px;cursor:pointer;transition:.15s}
-  .tabs button[aria-pressed="true"]{color:var(--gold-ink);border-color:var(--gold)}
-
-  /* Einklappbarer Abschnitt (Standards) */
-  .fold{border-top:1px solid var(--line-soft);margin-bottom:var(--s3);padding-top:var(--s3)}
-  .fold>summary{font-family:"Goetheanum";font-weight:680;font-size:15px;color:var(--ink);cursor:pointer;list-style:none;display:flex;justify-content:space-between;align-items:center;gap:var(--s2)}
-  .fold>summary::-webkit-details-marker{display:none}
-  .fold>summary .sub{font-family:"Helvetica Neue",Arial,sans-serif;font-weight:400;font-size:var(--t-micro);color:var(--muted);margin-left:auto}
-  .fold>summary::after{content:"+";color:var(--muted);font-size:18px;line-height:1;width:1em;text-align:center}
-  .fold[open]>summary::after{content:"–"}
-  .fold-body{display:grid;gap:var(--s3);margin-top:var(--s3)}
-
-  .code-details{margin-top:var(--s4)}
-  .code-details>summary{font-size:var(--t-small);color:var(--muted);cursor:pointer;list-style:none}
-  .code-details>summary::-webkit-details-marker{display:none}
-  .code-details>summary::before{content:"▸ ";color:var(--gold-ink)}
-  .code-details[open]>summary::before{content:"▾ "}
-
-  .fset{border:0;display:grid;gap:var(--s3);margin-bottom:var(--s3)}
-  .field{display:grid;gap:var(--s1)}
-  .field > .lab{font-size:var(--t-small);color:var(--muted);letter-spacing:.01em}
-  /* Felder: 16px (B03, kein iOS-Zoom), Fläche aus dem Token (kippt mit Hell/Dunkel). */
-  .field input{
-    width:100%;font-family:"Helvetica Neue",Arial,sans-serif;
-    font-size:16px;font-weight:400;line-height:1.35;color:var(--ink);
-    background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);
-    padding:9px 11px;outline:none;transition:border-color .15s,box-shadow .15s;
-  }
-  .field input::placeholder{color:var(--muted);font-weight:400;opacity:.7}
-  .field input:focus{border-color:var(--blue);box-shadow:0 0 0 3px color-mix(in srgb,var(--blue) 22%,transparent)}
-  .field input.invalid{border-color:var(--bad);box-shadow:0 0 0 3px color-mix(in srgb,var(--bad) 20%,transparent)}
-  .field textarea{width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.35;color:var(--ink);background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);padding:9px 11px;outline:none;resize:vertical;min-height:48px;transition:border-color .15s,box-shadow .15s}
-  .field textarea::placeholder{color:var(--muted);font-weight:400;opacity:.7}
-  .field textarea:focus{border-color:var(--blue);box-shadow:0 0 0 3px color-mix(in srgb,var(--blue) 22%,transparent)}
-  .lab .sublab{font-weight:400;font-size:var(--t-micro);color:var(--muted);margin-left:6px}
-  .field-msg{font-size:var(--t-micro);color:var(--bad);min-height:0}
-  .field select{width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:16px;color:var(--ink);background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);padding:9px 11px;outline:none;cursor:pointer;transition:border-color .15s,box-shadow .15s}
-  .field select:focus{border-color:var(--blue);box-shadow:0 0 0 3px color-mix(in srgb,var(--blue) 22%,transparent)}
-
-  .btnrow{display:flex;gap:var(--s3);flex-wrap:wrap;align-items:center;margin-top:var(--s6)}
-  /* .btn (inkl. .primary/.ok/.ghost + Hover) kommt vollständig aus base.css. */
-  .hint{margin-top:var(--s3);max-width:64ch}  /* Grösse/Farbe aus base.css */
-  .hint strong{color:var(--ink);font-weight:440}
-  .hint a{color:var(--gold-ink);text-decoration:none}
-  .hint ul{margin:var(--s3) 0 0;padding-left:18px;display:grid;gap:var(--s2)}
-  .hint code{font-family:var(--font-mono);font-size:var(--t-micro);background:var(--soft);border:1px solid var(--line-soft);border-radius:5px;padding:1px 5px}
-
-  .stage-lab{font-size:var(--t-small);color:var(--muted);margin-bottom:var(--s3)}
-  .scroll-hint{display:none}
-  .mail-stage{background:#fff;border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);box-shadow:0 10px 30px rgba(20,24,28,.06);overflow-x:auto}  /* # ds-ok: E-Mail-Leinwand ist immer weiss (Artefakt) */
-  /* base.css setzt th,td (Padding, Rahmen) – das verfälscht die E-Mail-Tabellen der
-     Vorschau: die 2px-Trennlinie würde mit Padding zum blauen Rechteck. Hier zurücksetzen,
-     damit nur die Inline-Stile der echten Signatur-Tabelle gelten. */
-  .mail-stage table{border-collapse:collapse}
-  .mail-stage td,.mail-stage th{padding:0;border:0}
-  .mail-body{font-family:Arial,Helvetica,sans-serif;font-size:10pt;color:#999;line-height:1.5}  /* # ds-ok: Signaturtext wie in der echten E-Mail (Artefakt) */
-
-  .code-wrap{position:relative;margin-top:var(--s3)}
-  /* Konsole (Fläche/Farbe/Schrift) aus base.css pre.code – hier nur Verortung. */
-  pre.code{margin:0;border-radius:var(--r-card);padding:var(--s4);white-space:pre-wrap;word-break:break-word;max-height:320px}
-  .copybtn{position:absolute;top:11px;right:11px;font:inherit;font-size:var(--t-micro);border:1px solid var(--code-bg2);background:var(--code-bg2);color:var(--code-ink);border-radius:var(--r-control);padding:5px 10px;cursor:pointer}
-  .copybtn:hover{filter:brightness(1.25)}
-
-  /* Anleitung: Entscheidungshilfe + Schritt-für-Schritt */
-  .choose{display:grid;gap:var(--s4);grid-template-columns:1fr;margin-bottom:var(--s6)}
-  @media(min-width:760px){.choose{grid-template-columns:1fr 1fr}}
-  .choose .opt{border:1px solid var(--line);border-radius:var(--r-card);padding:16px 18px;background:var(--soft)}
-  /* Kicker-artiges Label – normal, nicht versal (G05). */
-  .choose .opt .who{color:var(--gold-ink);font-size:var(--t-micro);letter-spacing:.04em;margin-bottom:6px}
-  .choose .opt h3{font-family:"Goetheanum";font-weight:680;font-size:15px;margin-bottom:6px}
-  .choose .opt p{font-size:var(--t-small);color:var(--muted);line-height:1.55}
-  .guide details{border-top:1px solid var(--line-soft);padding:var(--s4) 0}
-  .guide details:first-of-type{border-top:0;padding-top:0}
-  .guide summary{font-family:"Goetheanum";font-weight:680;font-size:15px;cursor:pointer;list-style:none;display:flex;align-items:center;gap:var(--s2)}
-  .guide summary::-webkit-details-marker{display:none}
-  .guide summary .tag{font-family:"Helvetica Neue",Arial,sans-serif;font-weight:400;font-size:var(--t-micro);color:var(--muted);margin-left:auto}
-  .guide summary::after{content:"+";color:var(--muted);font-size:18px;width:1em;text-align:center}
-  .guide details[open] summary::after{content:"–"}
-  .guide ol{margin:var(--s4) 0 2px;padding-left:20px;display:grid;gap:var(--s2)}
-  .guide li{font-size:14px;line-height:1.5;color:var(--ink)}
-  .guide code{font-family:var(--font-mono);font-size:var(--t-micro);background:var(--soft);border:1px solid var(--line-soft);border-radius:5px;padding:1px 5px}
-  .guide .note{font-size:var(--t-small);color:var(--muted);line-height:1.5;margin-top:6px}
-  .guide a{color:var(--gold-ink);text-decoration:none}
-  .guide a:hover{text-decoration:underline}
-
-  footer{border-top:1px solid var(--line);padding:var(--s8) 0 60px;color:var(--muted);font-size:var(--t-small)}
-  .frow{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap}
-  .frow strong{color:var(--ink);font-weight:400}
 </style>
 </head>
 <body>
 
-<script src="../../design-system/nav.js" data-root="../../" data-section="generatoren" data-active="signatur"></script>
+<header><div class="wrap bar">
+  <a class="brand" href="https://grafik.goetheanum.ch" aria-label="Zur Grafikseite – grafik.goetheanum.ch">
+    <span class="wm">Goetheanum</span>
+  </a>
+  <nav class="top">
+    <a href="#empfehlungen" class="nav-hide-sm">Empfehlungen</a>
+    <a href="https://grafik.goetheanum.ch">Weitere Werkzeuge</a>
+  </nav>
+</div></header>
 
 <main class="wrap">
   <section>
     <div class="shead">
       <h2>Signatur erstellen</h2>
-      <p>Eigene Angaben eintragen, fertige Signatur kopieren. Erzeugt Outlook-robustes,
-        table-basiertes HTML mit Inline-CSS nach der gemeinsamen Vorlage – individuell
-        gepflegt, einheitlich im Bild. Funktioniert in Outlook (Windows/Mac), Apple Mail
-        und Gmail. Eingaben bleiben lokal im Browser.</p>
+      <p>Eigene Angaben eintragen, fertige Signatur kopieren. Reiner Text – kein Bild, keine Tabelle;
+        kommt in Apple Mail, Outlook und Gmail unverändert an und bleibt hell wie dunkel lesbar.
+        Deine Eingaben bleiben in deinem Browser gespeichert – nichts verlässt dein Gerät.</p>
     </div>
 
     <div class="work">
       <!-- Formular -->
       <div class="card soft">
-        <div class="tabs" id="variant" role="group" aria-label="Signatur-Variante">
-          <button type="button" data-variant="long" aria-pressed="true">Lang</button>
-          <button type="button" data-variant="short" aria-pressed="false">Kurz (Antwort)</button>
-        </div>
-
         <fieldset class="fset">
-          <label class="field"><span class="lab">Name</span>
+          <label class="field"><span class="lab"><span>Name</span></span>
             <input type="text" id="name" placeholder="Edith Maryon" autocomplete="name" />
           </label>
-          <label class="field"><span class="lab">Funktion / Bereich / Sektion <span class="sublab">zweizeilig möglich</span></span>
+          <label class="field"><span class="lab"><span>Funktion / Bereich / Sektion</span> <span class="sublab">optional, je Zeile eine</span></span>
             <textarea id="role" rows="2" placeholder="Sektion für Bildende Künste&#10;Visual Art Section"></textarea>
           </label>
-          <label class="field"><span class="lab">Telefon</span>
+          <label class="field"><span class="lab"><span>Telefon</span> <span class="sublab">optional</span></span>
             <input type="tel" id="phone" placeholder="+41 61 706 44 21" autocomplete="tel" />
           </label>
-          <label class="field"><span class="lab">Website <span class="sublab">mehrere möglich, je Zeile</span></span>
+          <label class="field"><span class="lab"><span>Mobil</span> <span class="sublab">optional</span></span>
+            <input type="tel" id="mobile" placeholder="+41 79 000 00 00" autocomplete="tel" />
+          </label>
+          <label class="field"><span class="lab"><span>Website</span> <span class="sublab">optional, mehrere je Zeile</span></span>
             <textarea id="web" rows="2" placeholder="goetheanum.ch"></textarea>
           </label>
         </fieldset>
 
         <details class="fold">
-          <summary>Standards <span class="sub">meist unverändert</span></summary>
+          <summary>Organisation &amp; Adresse <span class="sub">meist unverändert</span></summary>
           <div class="fold-body">
-            <label class="field"><span class="lab">Organisation – Hauptzeile <span class="sublab">erscheint blau</span></span>
+            <label class="field"><span class="lab"><span>Organisation – Hauptzeile</span> <span class="sublab">erscheint blau</span></span>
               <input type="text" id="org1" placeholder="Goetheanum" />
             </label>
-            <label class="field"><span class="lab">Organisation – Unterzeile</span>
+            <label class="field"><span class="lab"><span>Organisation – Unterzeile</span></span>
               <input type="text" id="org2" placeholder="Allgemeine Anthroposophische Gesellschaft" />
             </label>
-            <label class="field"><span class="lab">Strasse / Nr.</span>
+            <label class="field"><span class="lab"><span>Strasse / Nr.</span></span>
               <input type="text" id="street" placeholder="Rüttiweg 45" />
             </label>
-            <label class="field"><span class="lab">PLZ / Ort</span>
+            <label class="field"><span class="lab"><span>PLZ / Ort</span></span>
               <input type="text" id="city" placeholder="4143 Dornach" />
             </label>
-            <label class="field"><span class="lab">Land</span>
+            <label class="field"><span class="lab"><span>Land</span></span>
               <input type="text" id="country" placeholder="Schweiz" />
             </label>
+          </div>
+        </details>
+
+        <details class="fold">
+          <summary>PS – befristeter Hinweis <span class="sub">optional</span></summary>
+          <div class="fold-body">
+            <label class="field"><span class="lab"><span>PS-Text</span> <span class="counter" id="psCount">0/120</span></span>
+              <textarea id="ps" rows="2" maxlength="120" placeholder="Am 20. September: Tag der offenen Tür."></textarea>
+            </label>
+            <label class="field"><span class="lab"><span>Link</span> <span class="sublab">optional</span></span>
+              <input type="url" id="pslink" placeholder="goetheanum.ch/tag-der-offenen-tuer" />
+            </label>
+            <label class="field"><span class="lab"><span>Gültig bis</span> <span class="sublab">für die Erinnerung</span></span>
+              <input type="date" id="psuntil" />
+            </label>
+            <div class="btnrow" style="margin-top:0">
+              <button type="button" class="btn small" id="icsBtn">Erinnerung in den Kalender</button>
+            </div>
           </div>
         </details>
 
@@ -212,46 +236,35 @@
       <!-- Vorschau + Ausgabe -->
       <div class="preview-col">
         <div class="card">
-          <div class="stage-lab">Vorschau</div>
-          <div class="mail-stage">
+          <div class="stage-head">
+            <span class="stage-lab">Vorschau</span>
+            <div class="tabs" id="mode" role="group" aria-label="Vorschau-Hintergrund">
+              <button type="button" data-mode="light" aria-pressed="true">Hell</button>
+              <button type="button" data-mode="dark" aria-pressed="false">Dunkel</button>
+            </div>
+          </div>
+          <div class="mail-stage light" id="mailStage">
             <div class="mail-body">
+              <div class="mail-greeting">Mit besten Grüssen<br />…</div>
               <div id="sigPreview"></div>
             </div>
           </div>
-          <p class="scroll-hint" aria-hidden="true">↔ In Originalgrösse – seitwärts wischen für die rechte Spalte.</p>
+          <p class="scroll-hint" aria-hidden="true">↔ In Originalgrösse – seitwärts wischen, falls nötig.</p>
 
           <div class="btnrow">
             <button type="button" class="btn primary" id="copyRich">Signatur kopieren</button>
-            <button type="button" class="btn" id="download">.htm laden</button>
+            <button type="button" class="btn" id="copyPlain">Nur Text kopieren</button>
           </div>
           <span class="sr-only" id="copyStatus" aria-live="polite"></span>
-          <div class="hint">
-            <strong>Welcher Knopf?</strong>
-            Im Normalfall ‹Signatur kopieren› und im Signatur-Editor des Mailprogramms einfügen
-            (Outlook Mac, Apple Mail, Gmail, auch Outlook Windows). ‹.htm laden› nur für
-            Outlook&nbsp;Windows. Schritt für Schritt:
-            <a href="#anleitung">↓ So wird daraus eine Signatur</a>.
-          </div>
 
-          <details class="code-details" id="carryover">
-            <summary>Design kommt nicht mit?</summary>
-            <div class="hint">
-              Kommt beim Empfänger nur nackter Text an, liegt es fast immer an einer dieser drei
-              Stellen – der Reihe nach prüfen:
-              <ul>
-                <li><strong>Formatierung beim Einfügen behalten.</strong> Normal einfügen mit
-                  <code>Strg</code>/<code>Cmd&nbsp;+&nbsp;V</code> – <em>nicht</em>
-                  <code>Umschalt&nbsp;+&nbsp;Cmd&nbsp;+&nbsp;V</code> und kein ‹Als Text einfügen›.
-                  Ohne Formatierung kommen nur die Wörter, ohne Farben und Aufbau.</li>
-                <li><strong>Apple Mail.</strong> In den Signatur-Einstellungen das Häkchen
-                  ‹Standardschriftart immer verwenden› <em>entfernen</em> – sonst überschreibt Mail
-                  die Signatur mit der Standardschrift und das Design geht verloren.</li>
-                <li><strong>Klassisches Outlook (Windows).</strong> Verliert das Einfügen die
-                  Formatierung, stattdessen ‹.htm laden› und die Datei in den Signaturordner legen
-                  (<a href="#anleitung">Schritt für Schritt</a>).</li>
-              </ul>
-            </div>
-          </details>
+          <div class="hint">
+            <strong>Kopieren → im Mailprogramm unter Einstellungen → Signaturen einfügen → fertig.</strong>
+            Detaillierte Anleitungen:
+            <a href="https://support.apple.com/de-ch/guide/mail/mail11943/mac" target="_blank" rel="noopener">Apple Mail (Mac)</a> ·
+            <a href="https://support.microsoft.com/de-de/office/8ee5d4f4-68fd-464a-a1c1-0e1c80bb27f2" target="_blank" rel="noopener">Outlook</a>.
+            <br>Hinweis für Apple Mail: Falls die Signatur ihre Form verliert, deaktiviere unter dem Signaturfeld
+            die Option ‹Standardschriftart für E-Mails verwenden›.
+          </div>
 
           <details class="code-details">
             <summary>HTML-Code anzeigen</summary>
@@ -259,29 +272,22 @@
               <pre class="code" id="codeOut"></pre>
               <button type="button" class="copybtn" id="copyCode2">Kopieren</button>
             </div>
-            <div class="hint">
-              Nur nötig, wenn das Mailprogramm kein direktes Einfügen erlaubt und stattdessen
-              den HTML-Quelltext braucht. Für die meisten reicht ‹Signatur kopieren›.
-            </div>
+            <div class="hint">Nur nötig, wenn das Mailprogramm ausschliesslich HTML-Quelltext akzeptiert. Sonst reicht ‹Signatur kopieren›.</div>
           </details>
 
           <details class="code-details">
-            <summary>Warum kein Logo, kein Bild, keine Hausschrift?</summary>
+            <summary>Warum reiner Text – kein Bild?</summary>
             <div class="hint">
-              Bewusst schlicht – damit die Signatur überall ankommt:
+              Bewusst schlicht – damit die Signatur überall gleich ankommt:
               <ul>
-                <li><strong>Logos &amp; Bilder</strong> werden von
-                  Mailprogrammen standardmässig blockiert und erscheinen dann als leerer Platzhalter; sie
-                  blähen jede Nachricht auf, rutschen in den Anhang und brechen in Dark&nbsp;Mode, Antworten
-                  und auf dem Handy.</li>
-                <li><strong>Die Hausschrift</strong> ist bei den
-                  Empfängern nicht installiert und wird in E-Mails ohnehin durch eine Ersatzschrift ersetzt.
-                  Eine systemsichere Schrift (Arial/Helvetica) sieht dafür überall zuverlässig gleich aus.</li>
-                <li><strong>Wiedererkennung</strong> entsteht hier
-                  robust über das Markenblau, klare Hierarchie und den Schriftzug ‹Goetheanum› – statt über
+                <li><strong>Bilder</strong> erscheinen in Apple Mail als Anhang (Büroklammer), brechen im Dark Mode,
+                  blähen jede Mail auf und werden vielerorts blockiert.</li>
+                <li><strong>Keine festen Textfarben:</strong> der Text erbt die Theme-Farbe des Programms und bleibt
+                  hell wie dunkel lesbar; das Markenblau ist eine mailtaugliche, kontraststarke Variante.</li>
+                <li><strong>Wiedererkennung</strong> entsteht über Schriftzug, Farbe und klare Hierarchie – nicht über
                   fragile Grafik.</li>
               </ul>
-              Für echte Grafiken in der Hausschrift (Folien, Profile, Logos) gibt es die
+              Für echte Grafiken in der Hausschrift gibt es die
               <a href="https://grafik.goetheanum.ch">weiteren Werkzeuge</a>.
             </div>
           </details>
@@ -290,103 +296,62 @@
     </div>
   </section>
 
-  <section id="anleitung">
-    <div class="shead">
-      <h2>So wird daraus eine Signatur</h2>
-      <p>Zwei Wege, ein Ergebnis. In den meisten Fällen genügt Kopieren.</p>
-    </div>
+  <section id="empfehlungen">
+    <div class="shead"><h2>Empfehlungen</h2><p>E-Mail am Goetheanum – Entwurf, Stand Juli 2026.</p></div>
+    <div class="empf">
+      <h3>Grundsatz</h3>
+      <p>Jede E-Mail aus dem Goetheanum ist ein Auftritt des Hauses — und zugleich die Stimme eines Menschen.
+        Diese Empfehlungen sorgen für Einheitlichkeit nach aussen und lassen Freiheit im Detail. Sie sind ein
+        Angebot: Das Signatur-Werkzeug macht den empfohlenen Weg zum einfachsten.</p>
+      <p><em>Deine Eingaben bleiben in deinem Browser gespeichert — nichts verlässt dein Gerät.</em></p>
 
-    <div class="choose">
-      <div class="opt">
-        <div class="who">Normalfall</div>
-        <h3>‹Signatur kopieren›</h3>
-        <p>Für neues Outlook, Outlook (Mac), Apple Mail und Gmail. Legt die fertige,
-          formatierte Signatur in die Zwischenablage; du fügst sie im Signatur-Editor des
-          Programms ein (Strg/Cmd&nbsp;+&nbsp;V). Nichts wird verschickt, alles bleibt lokal.</p>
-      </div>
-      <div class="opt">
-        <div class="who">Nur klassisches Outlook (Windows)</div>
-        <h3>‹.htm laden›</h3>
-        <p>Lädt eine Datei für den Outlook-Signaturordner – nützlich, wenn das Einfügen die
-          Formatierung verliert. Achtung: Das <em>neue</em> Outlook und Apple Mail/Gmail nutzen
-          diese Datei nicht; dort einfach kopieren.</p>
-      </div>
-    </div>
+      <hr class="rule">
+      <h3>Die Signatur</h3>
+      <p>Es gibt eine Signatur — deine. Zwei Zeilen gehören dazu, alles Weitere wählst du selbst.</p>
+      <p><strong>Der Kern</strong> — Name und Goetheanum. Das genügt bereits.</p>
+      <p><strong>Die Wahlmodule</strong> — Funktion, Sektion oder Abteilung, Telefon, Mobil, Website. Du entscheidest,
+        welche Angaben du mitschickst. Eine Telefonnummer, die du nicht in jeder Mail sehen willst, gehört nicht in die Signatur.</p>
+      <p><strong>Antworten und interne Mails</strong> dürfen ohne Signatur ausgehen: Wer miteinander im Austausch steht,
+        kennt sich. In Outlook lässt sich das für Antworten fest einstellen; in Apple Mail ist es ein Handgriff beim Schreiben.</p>
 
-    <div class="guide card">
-      <p class="note" style="margin:0 0 4px">Menübezeichnungen ändern sich je nach Version – bei
-        Abweichungen gilt die jeweils verlinkte Hersteller-Anleitung.</p>
+      <hr class="rule">
+      <h3>Das PS</h3>
+      <p>Wer auf eine Veranstaltung oder ein Angebot hinweisen möchte, tut das in einer PS-Zeile — direkt unter dem
+        Mailtext, über den Adressdaten.</p>
+      <p>Die Form: <strong>ein Satz, ein Link, kein Bild, befristet.</strong></p>
+      <p>Das PS pflegst du selbst im Generator, passend zu deinen Anlässen und Empfängern. Setze ein Ablaufdatum —
+        der Generator legt dir dazu eine Erinnerung in deinen Kalender. Ein aktuelles PS wirkt; ein abgelaufenes wirkt gegen dich.</p>
+      <p>Die PS-Zeile kann auch in den Signatur-Einstellungen des Mailprogramms bearbeitet werden, zur Sicherung der
+        technischen Empfehlungen lohnt sich der Weg zum Editor.</p>
 
-      <details open>
-        <summary>Neues Outlook – Windows <span class="tag">kopieren</span></summary>
-        <ol>
-          <li>‹Signatur kopieren› klicken. <span class="note">(Neues Outlook erkennst du am Schalter ‹Neues Outlook› oben rechts.)</span></li>
-          <li>Einstellungen (Zahnrad) → <em>Konten</em> → <em>Signaturen</em>.</li>
-          <li>‹Neue Signatur›, Namen vergeben, ins Feld einfügen (Strg&nbsp;+&nbsp;V), speichern.</li>
-          <li>Als Standard für neue Mails und Antworten wählen.</li>
-        </ol>
-        <p class="note">Das neue Outlook nutzt <strong>nicht</strong> den
-          <code>%APPDATA%</code>-Ordner – ‹.htm laden› funktioniert hier nicht.
-          Offizielle Anleitung:
-          <a href="https://support.microsoft.com/de-de/office/how-to-add-and-change-an-email-signature-in-outlook-8ee5d4f4-68fd-464a-a1c1-0e1c80bb27f2" target="_blank" rel="noopener">Microsoft Support</a>.</p>
-      </details>
+      <hr class="rule">
+      <h3>Warum ohne Bild?</h3>
+      <p>Bilder in Signaturen erscheinen in Apple Mail als Anhang — bei jeder einzelnen Mail. Die Büroklammer soll aber
+        bedeuten: <em>Hier ist ein Dokument für dich.</em> Diese Sphäre halten wir frei. Dazu kommt: Bilder brechen im
+        Dark Mode, blähen jede Mail auf und werden von vielen Programmen blockiert. Eine reine Text-Signatur kommt
+        überall so an, wie sie gemeint ist — hell wie dunkel.</p>
+      <p>Aus demselben Grund erledigt der Generator Schrift und Farbe von selbst: eine Mail-Variante des
+        Goetheanum-Blaus, die auf hellem und dunklem Grund lesbar bleibt, und Systemschriften, die jedes Mailprogramm
+        beherrscht. Darum muss sich niemand kümmern.</p>
 
-      <details>
-        <summary>Klassisches Outlook – Windows <span class="tag">kopieren oder ‹.htm›</span></summary>
-        <ol>
-          <li><strong>Variante kopieren:</strong> neue Mail → Menü ‹Nachricht› → ‹Signatur› →
-            ‹Signaturen…› → ‹Neu› → einfügen (Strg&nbsp;+&nbsp;V).</li>
-          <li><strong>Variante Datei:</strong> ‹.htm laden›; Explorer öffnen, in die Adresszeile
-            <code>%APPDATA%\Microsoft\Signatures</code> eingeben, Datei dort ablegen.</li>
-          <li>Outlook → Datei → Optionen → E-Mail → ‹Signaturen…› – Signatur erscheint, als
-            Standard zuweisen.</li>
-        </ol>
-        <p class="note">Offizielle Anleitung:
-          <a href="https://support.microsoft.com/de-de/office/how-to-add-and-change-an-email-signature-in-outlook-8ee5d4f4-68fd-464a-a1c1-0e1c80bb27f2" target="_blank" rel="noopener">Microsoft Support</a>.</p>
-      </details>
+      <hr class="rule">
+      <h3>Was wir weglassen</h3>
+      <p><strong>Rechtserklärungen und Vertraulichkeitshinweise.</strong> Sie sind für uns rechtlich nicht erforderlich
+        und sagen dem Empfänger nichts — sie machen Mails nur länger.</p>
+      <p><strong>Amtsnummern und Registerangaben.</strong> Gehören auf Briefpapier und Website, nicht unter jede Nachricht.</p>
+      <p><strong>Zitate, Sprüche, Banner.</strong> Die Signatur bleibt schlank. Was du sagen willst, gehört in die Mail — oder ins PS.</p>
 
-      <details>
-        <summary>Outlook – Mac <span class="tag">kopieren</span></summary>
-        <ol>
-          <li>‹Signatur kopieren› klicken.</li>
-          <li>Outlook → Einstellungen → <em>Signaturen</em> → ‹+›.</li>
-          <li>In das Bearbeitungsfeld einfügen (Cmd&nbsp;+&nbsp;V), Konto zuweisen.</li>
-        </ol>
-        <p class="note">Offizielle Anleitung:
-          <a href="https://support.microsoft.com/de-de/office/how-to-add-and-change-an-email-signature-in-outlook-8ee5d4f4-68fd-464a-a1c1-0e1c80bb27f2" target="_blank" rel="noopener">Microsoft Support</a>.</p>
-      </details>
+      <hr class="rule">
+      <h3>Empfehlungen für die Mail selbst</h3>
+      <p><strong>Der Betreff sagt, worum es geht.</strong> Konkret genug, dass die Mail in einem Jahr wiedergefunden wird.
+        Bewährt haben sich Zusätze wie <em>[Info]</em> oder <em>[Bitte um Antwort bis …]</em>, wenn sie stimmen.</p>
+      <p><strong>Eine Sache pro Mail.</strong> Zwei Anliegen sind zwei Mails — sie lassen sich getrennt beantworten,
+        weiterleiten und erledigen.</p>
+      <p><strong>An heisst: von dir wird etwas erwartet. CC heisst: zur Kenntnis.</strong> Wer im CC steht, muss nicht antworten.</p>
+      <p><strong>Sag, was du brauchst.</strong> Eine Antwort? Bis wann? Oder nur Information? Ein Halbsatz am Ende erspart Nachfragen.</p>
 
-      <details>
-        <summary>Apple Mail – Mac <span class="tag">kopieren</span></summary>
-        <ol>
-          <li>‹Signatur kopieren› klicken.</li>
-          <li>Mail → Einstellungen → <em>Signaturen</em> → Konto wählen → ‹+›.</li>
-          <li><strong>Wichtig:</strong> Häkchen ‹Standardschriftart immer verwenden› <em>entfernen</em> –
-            sonst geht die Formatierung verloren.</li>
-          <li>In das rechte Feld einfügen (Cmd&nbsp;+&nbsp;V).</li>
-        </ol>
-        <p class="note">Offizielle Anleitung:
-          <a href="https://support.apple.com/de-ch/guide/mail/create-and-use-email-signatures-mail11943/mac" target="_blank" rel="noopener">Apple Support</a>.</p>
-      </details>
-
-      <details>
-        <summary>Gmail – Web <span class="tag">kopieren</span></summary>
-        <ol>
-          <li>‹Signatur kopieren› klicken.</li>
-          <li>Zahnrad → ‹Alle Einstellungen anzeigen› → Tab ‹Allgemein› → Abschnitt ‹Signatur›.</li>
-          <li>‹Neu erstellen›, Namen vergeben, ins Feld einfügen (Strg/Cmd&nbsp;+&nbsp;V).</li>
-          <li>Ganz unten ‹Änderungen speichern›.</li>
-        </ol>
-        <p class="note">Offizielle Anleitung:
-          <a href="https://support.google.com/mail/answer/8395?hl=de&co=GENIE.Platform%3DDesktop" target="_blank" rel="noopener">Google Support</a>.</p>
-      </details>
-
-      <details>
-        <summary>Handy – iOS / Android <span class="tag">Hinweis</span></summary>
-        <p class="note">Mobile Mail-Apps zeigen formatierte Signaturen kaum zuverlässig.
-          Empfehlung: die <em>Kurz</em>-Variante als einfachen Text in der App-Signatur eintragen –
-          oder die Desktop-Signatur über das Konto synchronisieren lassen.</p>
-      </details>
+      <hr class="rule">
+      <p class="dim"><em>Fragen und Anregungen an die Kommunikation. Diese Empfehlungen wachsen mit der Praxis.</em></p>
     </div>
   </section>
 </main>
@@ -400,132 +365,120 @@
 "use strict";
 
 /* ---------- Konstanten ---------- */
-// Markenblau: einzige Quelle ist das Org-/Logo-System (goetheanum-orgs.js).
-const BRAND_BLUE = (window.ORGS && ORGS.goetheanum && ORGS.goetheanum.color) || "#0061a9";
-// Farbsystem des Signatur-Outputs (Arial). Hausregel: eine Auszeichnung – nur Farbe,
-// eine Schriftgrösse. Köpfe farbig (Name dunkel, Goetheanum/Verweise blau), Rest ruhig grau.
-const SIG = { name: "#1a1a1a", sub: "#767676" };
+// Mail-Blau: aufgehellte Variante des Goetheanum-Markenblaus #0061a9 (gleicher Farbton).
+// WCAG-Kontrast 4.09:1 gegen #FFFFFF und 4.07:1 gegen #1E1E1E – lesbar auf hellem UND dunklem Grund.
+const MAIL_BLUE = "#4183B4";
+const CFONT = "-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif";
 
-const FIELDS = ["name","role","org1","org2","street","city","country","phone","web"];
-const STORE_KEY = "goe-signatur-v2";
+const FIELDS = ["name","role","phone","mobile","web","org1","org2","street","city","country","ps","pslink","psuntil"];
+const STORE_KEY = "goe-signatur-v3";
 
 const EXAMPLE = {
   name: "Edith Maryon",
   role: "Sektion für Bildende Künste\nVisual Art Section",
+  phone: "+41 61 706 44 21",
+  mobile: "",
+  web: "goetheanum.ch",
   org1: "Goetheanum",
   org2: "Allgemeine Anthroposophische Gesellschaft",
   street: "Rüttiweg 45",
   city: "4143 Dornach",
   country: "Schweiz",
-  phone: "+41 61 706 44 21",
-  web: "goetheanum.ch"
+  ps: "",
+  pslink: "",
+  psuntil: ""
 };
 
-const state = { variant: "long" };
+const state = { mode: "light", plain: "" };
 const els = {};
 FIELDS.forEach(k => { els[k] = document.getElementById(k); });
 
 /* ---------- Helfer ---------- */
 function esc(s) {
-  return String(s || "")
-    .replace(/&/g, "&amp;").replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  return String(s || "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 const val = k => els[k].value.trim();
 const webHref = w => !w ? "" : (/^https?:\/\//i.test(w) ? w : "https://" + w);
 const telHref = p => "tel:" + String(p || "").replace(/[^\d+]/g, "");
+const stripWww = w => String(w).replace(/^https?:\/\//i, "").replace(/^www\./i, "").replace(/\/+$/, "");
 
-/* ---------- Signatur-HTML (Outlook-robust: Spacer-Zellen, feste Breiten) ---------- */
-const FONT = "Arial,Helvetica,sans-serif";
-
-// Baut eine Spalte als verschachtelte Tabelle. items: {html} oder {gap:px}.
-// Eine Grösse für alles (10.5pt); Grundton grau, Köpfe/Verweise setzen ihre Farbe per span.
-function colTable(items) {
-  const rows = items.map(it =>
-    it.gap != null
-      ? `<tr><td height="${it.gap}" style="height:${it.gap}px;font-size:0;line-height:0;mso-line-height-rule:exactly;">&nbsp;</td></tr>`
-      : `<tr><td style="font-family:${FONT};font-size:10.5pt;line-height:1.5;color:${SIG.sub};">${it.html}</td></tr>`
-  ).join("");
-  return `<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;">${rows}</table>`;
-}
-
-function phoneCell() {
-  return `<a href="${telHref(val("phone"))}" style="color:${BRAND_BLUE};text-decoration:none;">${esc(val("phone"))}</a>`;
-}
-
+/* ---------- Signatur: einfaches div/br-Markup, alle Stile inline ---------- */
+// Keine Tabellen, keine <p>, kein Bild, keine Hintergrundfarbe. Fliesstext ohne color
+// (erbt Theme des Mailprogramms → Dark-Mode-fest); Mail-Blau nur für Goetheanum und Web-Links.
 function buildSignature() {
-  const name = val("name"), phone = val("phone");
+  const rows = []; // {html, text} oder {gap:true}
+  const push = (html, text) => rows.push({ html, text });
+  const gap = () => rows.push({ gap: true });
 
-  // Kurz (Antwort): Name + Telefon. Eine Grösse, Farbe als einziges Merkmal.
-  if (state.variant === "short") {
-    const items = [];
-    if (name) items.push({ html: `<span style="color:${SIG.name};">${esc(name)}</span>` });
-    if (phone) items.push({ html: phoneCell() });
-    return colTable(items.length ? items : [{ html: "&nbsp;" }]);
+  // PS zuoberst, mit Leerzeile zum Adressblock
+  const ps = val("ps"), pslink = val("pslink");
+  if (ps) {
+    let h = "PS: " + esc(ps), t = "PS: " + ps;
+    if (pslink) {
+      const d = stripWww(pslink);
+      h += " — <a href=\"" + esc(webHref(pslink)) + "\" style=\"color:" + MAIL_BLUE + ";text-decoration:none;\">" + esc(d) + "</a>";
+      t += " — " + d;
+    }
+    push(h, t); gap();
   }
 
-  // Linke Spalte: Person – Name (dunkel), Funktion (grau), Kontakt (blaue Verweise).
-  const L = [];
-  if (name) L.push({ html: `<span style="color:${SIG.name};">${esc(name)}</span>` });
-  val("role").split(/\r?\n/).map(s => s.trim()).filter(Boolean).forEach(line => {
-    L.push({ html: esc(line) });
+  // Person
+  if (val("name")) push("<span style=\"font-weight:600;\">" + esc(val("name")) + "</span>", val("name"));
+  val("role").split(/\r?\n/).map(s => s.trim()).filter(Boolean).forEach(l => push(esc(l), l));
+
+  // Organisation
+  const hasName = rows.some(r => !r.gap);
+  if (val("org1") || val("org2")) { if (hasName) gap(); }
+  if (val("org1")) push("<span style=\"color:" + MAIL_BLUE + ";\">" + esc(val("org1")) + "</span>", val("org1"));
+  if (val("org2")) push(esc(val("org2")), val("org2"));
+
+  // Adresse (eine Stufe kleiner)
+  [val("street"), val("city"), val("country")].filter(Boolean).forEach(a =>
+    push("<span style=\"font-size:12px;\">" + esc(a) + "</span>", a));
+
+  // Kontakt: Telefonnummern als tel:-Link, aber Theme-Farbe (inherit) – dark-mode-fest
+  if (val("phone")) push("<a href=\"" + telHref(val("phone")) + "\" style=\"color:inherit;text-decoration:none;\">" + esc(val("phone")) + "</a>", val("phone"));
+  if (val("mobile")) push("<a href=\"" + telHref(val("mobile")) + "\" style=\"color:inherit;text-decoration:none;\">" + esc(val("mobile")) + "</a>", val("mobile"));
+
+  // Web-Links in Mail-Blau, www entfällt in der Anzeige
+  val("web").split(/\r?\n/).map(s => s.trim()).filter(Boolean).forEach(w => {
+    const d = stripWww(w);
+    push("<a href=\"" + esc(webHref(w)) + "\" style=\"color:" + MAIL_BLUE + ";text-decoration:none;\">" + esc(d) + "</a>", d);
   });
-  const contact = [];
-  if (phone) contact.push({ html: phoneCell() });
-  // URLs: ‹www.› in der Anzeige weglassen (Link bleibt vollständig), kleiner Abstand zum Telefon.
-  const webs = val("web").split(/\r?\n/).map(s => s.trim()).filter(Boolean);
-  if (webs.length && contact.length) contact.push({ gap: 6 });
-  webs.forEach(w => {
-    const disp = w.replace(/^https?:\/\//i, "").replace(/^www\./i, "").replace(/\/+$/, "");
-    contact.push({ html: `<a href="${esc(webHref(w))}" style="color:${BRAND_BLUE};text-decoration:none;">${esc(disp)}</a>` });
-  });
-  if (contact.length) {
-    if (L.length) L.push({ gap: 10 });
-    contact.forEach(c => L.push(c));
-  }
 
-  // Rechte Spalte: Organisation – Hauptzeile (blau) + Unterzeile/Adresse (grau).
-  const R = [];
-  if (val("org1")) R.push({ html: `<span style="color:${BRAND_BLUE};">${esc(val("org1"))}</span>` });
-  if (val("org2")) R.push({ html: esc(val("org2")) });
-  [val("street"), val("city"), val("country")].forEach(t => { if (t) R.push({ html: esc(t) }); });
+  // in Zeilen umsetzen, führende/abschliessende Leerzeilen trimmen
+  const hl = [], tl = [];
+  rows.forEach(r => { if (r.gap) { hl.push(""); tl.push(""); } else { hl.push(r.html); tl.push(r.text); } });
+  while (hl.length && hl[0] === "") { hl.shift(); tl.shift(); }
+  while (hl.length && hl[hl.length - 1] === "") { hl.pop(); tl.pop(); }
 
-  // Ohne Organisations-/Adressdaten: einspaltig, ohne Trennlinie.
-  if (!R.length) return colTable(L.length ? L : [{ html: "&nbsp;" }]);
-
-  const LW = 250, RW = 240, PAD = 24;
-  const total = LW + RW + PAD * 2 + 2;
-  return (
-    `<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="${total}" ` +
-    `style="border-collapse:collapse;font-family:${FONT};">` +
-    `<tr>` +
-    `<td width="${LW}" valign="top" style="width:${LW}px;padding:0 ${PAD}px 0 0;vertical-align:top;">${colTable(L)}</td>` +
-    `<td width="2" style="width:2px;min-width:2px;background:${BRAND_BLUE};font-size:0;line-height:0;mso-line-height-rule:exactly;">&nbsp;</td>` +
-    `<td width="${RW}" valign="top" style="width:${RW}px;padding:0 0 0 ${PAD}px;vertical-align:top;">${colTable(R)}</td>` +
-    `</tr></table>`
-  );
+  const html = "<div style=\"font-family:" + CFONT + ";font-size:13px;line-height:1.5;\">" + (hl.join("<br>") || "&nbsp;") + "</div>";
+  const text = tl.join("\n");
+  return { html, text };
 }
 
 function render() {
-  const html = buildSignature();
-  document.getElementById("sigPreview").innerHTML = html;
-  document.getElementById("codeOut").textContent = html;
+  const sig = buildSignature();
+  state.plain = sig.text;
+  document.getElementById("sigPreview").innerHTML = sig.html;
+  document.getElementById("codeOut").textContent = sig.html;
+  updatePsCount();
 }
 
 /* ---------- Persistenz + Prefill ---------- */
 function save() {
   try {
-    const data = { variant: state.variant };
+    const data = { mode: state.mode };
     FIELDS.forEach(k => { data[k] = els[k].value; });
     localStorage.setItem(STORE_KEY, JSON.stringify(data));
-  } catch (e) { /* z. B. privater Modus – ignorieren */ }
+  } catch (e) {}
 }
 function loadStored() {
   try {
     const data = JSON.parse(localStorage.getItem(STORE_KEY) || "null");
     if (!data) return false;
     FIELDS.forEach(k => { if (typeof data[k] === "string") els[k].value = data[k]; });
-    if (data.variant) setVariant(data.variant, false);
+    if (data.mode) setMode(data.mode, false);
     return true;
   } catch (e) { return false; }
 }
@@ -533,128 +486,128 @@ function applyQuery() {
   const q = new URLSearchParams(location.search);
   let any = false;
   FIELDS.forEach(k => { if (q.has(k)) { els[k].value = q.get(k); any = true; } });
-  if (q.has("variant")) { setVariant(q.get("variant") === "short" ? "short" : "long", false); any = true; }
   return any;
 }
 function setFields(obj) { FIELDS.forEach(k => { els[k].value = obj[k] || ""; }); }
 
-/* ---------- Variante ---------- */
-function setVariant(v, doRender) {
-  state.variant = (v === "short") ? "short" : "long";
-  document.querySelectorAll("#variant button").forEach(b => {
-    b.setAttribute("aria-pressed", b.getAttribute("data-variant") === state.variant ? "true" : "false");
-  });
-  if (doRender !== false) render();
+/* ---------- Vorschau hell/dunkel ---------- */
+function setMode(m, doSave) {
+  state.mode = (m === "dark") ? "dark" : "light";
+  const stage = document.getElementById("mailStage");
+  stage.classList.toggle("dark", state.mode === "dark");
+  stage.classList.toggle("light", state.mode === "light");
+  document.querySelectorAll("#mode button").forEach(b =>
+    b.setAttribute("aria-pressed", b.getAttribute("data-mode") === state.mode ? "true" : "false"));
+  if (doSave !== false) save();
 }
-document.getElementById("variant").addEventListener("click", e => {
-  const btn = e.target.closest("button[data-variant]");
-  if (!btn) return;
-  setVariant(btn.getAttribute("data-variant"));
-  save();
+document.getElementById("mode").addEventListener("click", e => {
+  const b = e.target.closest("button[data-mode]"); if (!b) return;
+  setMode(b.getAttribute("data-mode"));
+});
+
+/* ---------- PS: Zähler, Ablauf-Hinweis, .ics ---------- */
+function updatePsCount() {
+  const n = els.ps.value.length, el = document.getElementById("psCount");
+  el.textContent = n + "/120";
+  el.classList.toggle("over", n >= 120);
+}
+function todayISO() {
+  const d = new Date(); const p = x => String(x).padStart(2, "0");
+  return d.getFullYear() + "-" + p(d.getMonth() + 1) + "-" + p(d.getDate());
+}
+function checkExpiry() {
+  const until = val("psuntil");
+  const old = document.getElementById("expiryNote");
+  if (old) old.remove();
+  if (until && val("ps") && until < todayISO()) {
+    const note = document.createElement("div");
+    note.className = "expiry-note"; note.id = "expiryNote";
+    note.textContent = "Dein PS ist abgelaufen – aktualisieren oder das PS-Modul leeren?";
+    const form = document.querySelector(".card.soft");
+    form.insertBefore(note, form.firstChild);
+  }
+}
+function icsFor(dateStr) {
+  const dt = dateStr.replace(/-/g, "");
+  const uid = Math.random().toString(36).slice(2) + Date.now().toString(36) + "@werkzeuge.goetheanum.ch";
+  const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d+/, "");
+  return [
+    "BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:-//Goetheanum//Signatur-Generator//DE",
+    "BEGIN:VEVENT", "UID:" + uid, "DTSTAMP:" + stamp, "DTSTART;VALUE=DATE:" + dt,
+    "SUMMARY:PS in der E-Mail-Signatur aktualisieren",
+    "DESCRIPTION:Dein PS ist heute abgelaufen. Aktualisieren: https://werkzeuge.goetheanum.ch/apps/signatur-generator/",
+    "BEGIN:VALARM", "TRIGGER:-PT9H", "ACTION:DISPLAY", "DESCRIPTION:PS in der E-Mail-Signatur aktualisieren",
+    "END:VALARM", "END:VEVENT", "END:VCALENDAR"
+  ].join("\r\n");
+}
+document.getElementById("icsBtn").addEventListener("click", function () {
+  const until = val("psuntil");
+  if (!until) { flash(this, "Bitte Datum wählen"); return; }
+  const blob = new Blob([icsFor(until)], { type: "text/calendar" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob); a.download = "ps-erinnerung.ics";
+  document.body.appendChild(a); a.click(); document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(a.href), 2000);
+  flash(this, "Geladen ✓");
 });
 
 /* ---------- Eingaben verdrahten ---------- */
-// Mehrzeilige Felder (Funktion, mehrere URLs) wachsen mit dem Inhalt mit.
-function autoGrow(el) {
-  if (!el || el.tagName !== "TEXTAREA") return;
-  el.style.height = "auto";
-  el.style.height = el.scrollHeight + "px";
-}
-function growAll() { autoGrow(els.role); autoGrow(els.web); }
-function onInput() { render(); growAll(); save(); }
+function autoGrow(el) { if (!el || el.tagName !== "TEXTAREA") return; el.style.height = "auto"; el.style.height = el.scrollHeight + "px"; }
+function growAll() { autoGrow(els.role); autoGrow(els.web); autoGrow(els.ps); }
+function onInput() { render(); growAll(); checkExpiry(); save(); }
 FIELDS.forEach(k => els[k].addEventListener("input", onInput));
 
-document.getElementById("fillExample").addEventListener("click", () => {
-  setFields(EXAMPLE);
-  onInput();
-});
-document.getElementById("clearAll").addEventListener("click", () => {
-  setFields({});
-  onInput();
-});
+document.getElementById("fillExample").addEventListener("click", () => { setFields(EXAMPLE); onInput(); });
+document.getElementById("clearAll").addEventListener("click", () => { setFields({}); onInput(); });
 
 /* ---------- Status / Kopier-Feedback ---------- */
 function flash(btn, label) {
   const old = btn.textContent;
-  btn.textContent = label;
-  btn.classList.add("ok");
+  btn.textContent = label; btn.classList.add("ok");
   document.getElementById("copyStatus").textContent = label;
   setTimeout(() => { btn.textContent = old; btn.classList.remove("ok"); }, 1400);
 }
 
-// Rückfall ohne ClipboardItem: die gerenderte Vorschau als Auswahl kopieren. Der Browser
-// serialisiert die Auswahl mitsamt Inline-Stilen als text/html – das Design bleibt erhalten
-// (anders als beim blossen HTML-Quelltext). Nur im direkten Klick zuverlässig (Nutzergeste).
-function copyRenderedRich() {
-  const node = document.getElementById("sigPreview");
-  const r = document.createRange();
-  r.selectNodeContents(node);
-  const sel = window.getSelection();
-  sel.removeAllRanges();
-  sel.addRange(r);
-  let done = false;
-  try { done = document.execCommand("copy"); } catch (e) {}
-  sel.removeAllRanges();
-  return done;
-}
-
+// Clipboard: text/html UND text/plain, direkt im Klick-Handler (Safari)
 document.getElementById("copyRich").addEventListener("click", function () {
-  const html = buildSignature();
-  const ok = () => { flash(this, "Kopiert ✓"); track("copy", { variant: state.variant }); };
+  const sig = buildSignature();
   if (navigator.clipboard && window.ClipboardItem) {
     const item = new ClipboardItem({
-      "text/html": new Blob([html], { type: "text/html" }),
-      "text/plain": new Blob([document.getElementById("sigPreview").innerText], { type: "text/plain" })
+      "text/html": new Blob([sig.html], { type: "text/html" }),
+      "text/plain": new Blob([sig.text], { type: "text/plain" })
     });
     navigator.clipboard.write([item]).then(
-      ok,
-      () => { if (copyRenderedRich()) ok(); else flash(this, "Bitte HTML-Code nutzen"); }
+      () => { flash(this, "Kopiert ✓"); track("copy", {}); },
+      () => flash(this, "Bitte HTML-Code nutzen")
     );
-  } else if (copyRenderedRich()) {
-    ok();
   } else {
     flash(this, "Bitte HTML-Code nutzen");
   }
+});
+
+document.getElementById("copyPlain").addEventListener("click", function () {
+  const t = buildSignature().text;
+  if (navigator.clipboard) {
+    navigator.clipboard.writeText(t).then(() => { flash(this, "Kopiert ✓"); track("plaincopy", {}); }, () => flash(this, "Nicht möglich"));
+  } else { flash(this, "Nicht möglich"); }
 });
 
 function copyCode(btn) {
   const text = document.getElementById("codeOut").textContent;
   if (navigator.clipboard) {
     navigator.clipboard.writeText(text).then(() => flash(btn, "Kopiert ✓"), () => selectFallback(btn));
-  } else {
-    selectFallback(btn);
-  }
+  } else { selectFallback(btn); }
 }
 function selectFallback(btn) {
   const r = document.createRange();
   r.selectNodeContents(document.getElementById("codeOut"));
-  const sel = window.getSelection();
-  sel.removeAllRanges();
-  sel.addRange(r);
-  let done = false;
-  try { done = document.execCommand("copy"); } catch (e) {}
+  const sel = window.getSelection(); sel.removeAllRanges(); sel.addRange(r);
+  let done = false; try { done = document.execCommand("copy"); } catch (e) {}
   flash(btn, done ? "Kopiert ✓" : "Markiert – Strg/Cmd+C");
 }
 document.getElementById("copyCode2").addEventListener("click", function () { copyCode(this); track("codecopy", {}); });
 
-document.getElementById("download").addEventListener("click", function () {
-  const doc = `<!doctype html><html><head><meta charset="utf-8"></head><body>${buildSignature()}</body></html>`;
-  const blob = new Blob([doc], { type: "text/html" });
-  const a = document.createElement("a");
-  a.href = URL.createObjectURL(blob);
-  const base = (val("name") || "signatur").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
-  a.download = "signatur-" + (base || "goetheanum") + ".htm";
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  setTimeout(() => URL.revokeObjectURL(a.href), 2000);
-  flash(this, "Geladen ✓");
-  track("download", { variant: state.variant });
-});
-
 /* ---------- Anonyme Nutzungsstatistik (Supabase, insert-only) ---------- */
-// Nur auf der Live-Site. Gezählt werden anonyme Summen – keine Eingaben des
-// Nutzers, keine IP, kein Drittdienst (eigenes Backend). Vgl. statistik.html.
 const TRACK_URL = "https://dagcsnfrlbpxcmdimnrw.supabase.co/rest/v1/signatur_events";
 const TRACK_KEY = "sb_publishable_SXhY0mrhXjdTnjbJ5Uobtg_zAXW_xGY";
 const TRACK_ON = location.hostname === "phtok.github.io";
@@ -677,24 +630,19 @@ function track(event, payload) {
 }
 let activeSec = 0;
 if (TRACK_ON) {
-  track("visit", {
-    ref: (document.referrer || "").slice(0, 200), lang: navigator.language || "",
-    w: screen.width, h: screen.height, mob: /Mobi|Android|iPhone|iPad/.test(navigator.userAgent)
-  });
-  setInterval(() => {
-    if (document.visibilityState === "visible") { activeSec += 30; track("heartbeat", { t: activeSec }); }
-  }, 30000);
+  track("visit", { ref: (document.referrer || "").slice(0, 200), lang: navigator.language || "", w: screen.width, h: screen.height, mob: /Mobi|Android|iPhone|iPad/.test(navigator.userAgent) });
+  setInterval(() => { if (document.visibilityState === "visible") { activeSec += 30; track("heartbeat", { t: activeSec }); } }, 30000);
   addEventListener("pagehide", () => track("leave", { t: activeSec }));
 }
 
 /* ---------- Start ---------- */
 const hadStored = loadStored();
 const hadQuery = applyQuery();
-// Beim ersten Öffnen das Beispiel einfügen (frei änderbar); gespeicherte Daten haben Vorrang.
 if (!hadStored && !hadQuery) setFields(EXAMPLE);
-setVariant(state.variant, false);
+setMode(state.mode, false);
 render();
 growAll();
+checkExpiry();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Setzt den Umbau-Auftrag aus dem Zip (`claude-code-prompt-signatur-generator.md`) um — **Signatur-Generator v2**, radikale Vereinfachung, Dark-Mode-fest.

### Was sich ändert (bewusst gegenüber v1)
- **Markup Tabelle → `div`/`<br>`**, alle Stile **inline**, **kein Bild, keine Tabelle, kein `<style>`, keine Hintergrundfarbe** → übersteht Apple Mail & Signatur-Editoren.
- **Dark-Mode-fest ohne Media Queries:** Fliesstext **ohne `color`** (erbt Theme → hell/dunkel), **keine Grautöne**; Hierarchie über **Grösse/Gewicht** (Name 600, Adresse kleiner).
- **Mail-Blau `#4183B4`** — gleicher Farbton wie `#0061a9`, aufgehellt; **Kontrast 4.09:1 auf #FFFFFF und 4.07:1 auf #1E1E1E** (im Code dokumentiert), nur für ‹Goetheanum› + Web-Links.
- **Eine Signatur** (Lang/Kurz entfernt — Statistik: Kurz 0×), **`.htm`-Download entfernt**.
- **Clipboard `text/html` + `text/plain`**, zusätzlicher **‹Nur Text kopieren›**-Button.
- **Neues PS-Modul:** 120 Zeichen + Zähler, Link, ‹gültig bis› mit **`.ics`-Kalendererinnerung** (VALARM −9 h) und Ablauf-Hinweis beim Laden.
- **Eine minimale Anleitung** (ein Satz + Apple/Outlook-Links).
- **Vorschau Hell/Dunkel** (gleiche Quelle wie der Kopier-Output).
- **Empfehlungen** als Textabschnitt **unter dem Generator** (inkl. der beiden neuen Sätze: Datenschutz & PS-Editor).
- Feld **Mobil** ergänzt; Fold **‹Organisation & Adresse›** (das Wort „Standard" entfällt).
- Anonyme Statistik erhalten (Event `plaincopy` zur RLS-Whitelist ergänzt); `localStorage → v3`.

### Offen: reale Client-Tests
Die Akzeptanzmatrix (Apple Mail/iOS, Outlook neu/klassisch/Web, Gmail — je hell **und** dunkel, plus `.ics`) lässt sich hier nicht ausführen. Siehe `TESTING.md`. **Empfehlung:** nach dem Deploy eine Testmail an dich selbst, in den Clients prüfen — ich fixe umgehend, falls irgendwo etwas bricht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_