### PR TITLE
Kartentool: Toiletten vereinfacht (Breitfeld mit Gruppen-Icon, WC-Textmarke), Gruppentitel-Feld nach oben, Logo per Pfeiltasten

### DIFF
--- a/apps/karten-generator/app.js
+++ b/apps/karten-generator/app.js
@@ -185,11 +185,12 @@ function ikonBoxenMessen() {
 
 // Symbol in Zielgrösse (mm, längere Tintenkante) mit Tintenmitte auf (x, y);
 // leichter Konturauftrag in gleicher Farbe kräftigt die feinen Stege.
-function symbolMarkup(name, x, y, groesse, farbe) {
+function symbolMarkup(name, x, y, groesse, farbe, maxHoehe) {
   const inhalt = ikonen[name];
   const box = ikonBoxen[name];
   if (!inhalt || !box) return "";
-  const skala = groesse / Math.max(box.width, box.height);
+  let skala = groesse / Math.max(box.width, box.height);
+  if (maxHoehe) skala = Math.min(groesse / box.width, maxHoehe / box.height);
   const tx = x - (box.x + box.width / 2) * skala;
   const ty = y - (box.y + box.height / 2) * skala;
   const auftrag = (0.09 / skala).toFixed(1);  // ~0.09 mm Fettung
@@ -444,7 +445,7 @@ const LAUT_VORSCHUB = {
   "5": 0.577, "6": 0.609, "7": 0.539, "8": 0.62, "9": 0.609,
   "a": 0.509, "b": 0.508, "c": 0.402, "d": 0.509, "e": 0.463,
   "f": 0.324, "g": 0.479, "h": 0.518, "i": 0.239, "j": 0.239,
-  "k": 0.475, "l": 0.24, "m": 0.789, "P": 0.546
+  "k": 0.475, "l": 0.24, "m": 0.789, "P": 0.546, "W": 0.858, "C": 0.497
 };
 
 function zentrierterText(x, y, text, groesse, farbe) {
@@ -468,12 +469,14 @@ function zentrierterText(x, y, text, groesse, farbe) {
 const SYMBOL_FAKTOR = 1.25;
 
 function markenBreite(ort, r) {
+  if (ort.legendeText) return 2 * r;      // Legende zeigt die Textmarke
+  if (ort.symbol && ort.feldBreite) return ort.feldBreite * (r / 2.03);
   if (!ort.symbol || !Array.isArray(ort.symbol)) return 2 * r * (ort.symbol ? SYMBOL_FAKTOR : 1);
   const rr = r * SYMBOL_FAKTOR;
   return rr * 1.55 * (ort.symbol.length - 1) + 2 * rr;
 }
 
-function markenKreis(x, y, hex, text, r, symbol) {
+function markenKreis(x, y, hex, text, r, symbol, feldBreite) {
   // Kreiszahl nach dem Sonderelement des Design-Systems (.step-num):
   // Hausschrift Laut, fester Kreis, Tintenmitte der Ziffern auf der
   // Kreismitte (ZIFFERN_SITZ). Grad = 0.5 × Durchmesser — eine Spur
@@ -481,6 +484,15 @@ function markenKreis(x, y, hex, text, r, symbol) {
   // den Kreis, ohne ihn zu sprengen (Entscheid Auftraggeber, 8. Juli 2026).
   // Symbol-Marken (z. B. WCs) tragen Piktos statt Ziffer — einzeln im
   // grösseren Kreis, mehrere nebeneinander in einer Pille.
+  if (symbol && feldBreite) {
+    // Breites Feld (z. B. Toiletten): das fertige Gruppen-Icon läuft
+    // eingepasst über die ganze Pille — Figuren bleiben erkennbar.
+    const b = feldBreite * (r / 2.03);
+    const h = r * 2.75;
+    return `<rect x="${(x - b / 2).toFixed(3)}" y="${(y - h / 2).toFixed(3)}"`
+      + ` width="${b.toFixed(3)}" height="${h.toFixed(3)}" rx="${(h / 2).toFixed(3)}" fill="${hex}" />`
+      + symbolMarkup(symbol, x, y, b - h * 0.7, "#ffffff", h * 0.72);
+  }
   if (symbol) {
     const symbole = Array.isArray(symbol) ? symbol : [symbol];
     const rr = r * SYMBOL_FAKTOR;
@@ -619,7 +631,7 @@ function ortMarkup(ort) {
   }
   ortPositionen(ort).forEach(([px, py]) => {
     const [x, y] = anp(px, py);
-    teile += markenKreis(x, y, hex, ortMarker(ort), 2.03, ort.symbol);
+    teile += markenKreis(x, y, hex, ortMarker(ort), 2.03, ort.symbol, ort.feldBreite);
     if (ort.pfeil) teile += pfeilMarkup(x, y, 2.03, hex, ort.pfeil);
   });
   return teile;
@@ -667,6 +679,14 @@ function legendeZeilen() {
   const mitKoepfen = kategorien.size > 1;
   aktive.forEach((ort) => {
     const kategorie = ort.kategorie || "eigene";
+    // Gleiche Zeilen zusammenlegen: zwei Toiletten-Marker auf der Karte
+    // brauchen nur EINE Legendenzeile (gleicher Text, gleiche Marke).
+    if (vorher && (vorher.kategorie || "eigene") === kategorie
+      && ortLabel(vorher) === ortLabel(ort)
+      && (vorher.legendeText || vorher.marker) === (ort.legendeText || ort.marker)) {
+      vorher = ort;
+      return;
+    }
     if (mitKoepfen && (!vorher || (vorher.kategorie || "eigene") !== kategorie)) {
       if (vorher) zeilen.push({ typ: "abstand", hoehe: L.gruppe * 0.6 });
       // Eigene (veranstaltungsspezifische) Marken beginnen in Spalte 2 —
@@ -750,9 +770,13 @@ function legendeMarkup() {
     if (ort.art === "treppe") {
       teile += treppenBadge(x, y - 0.9, ort.marker, "treppe", hex, true);
     } else {
-      // Breite Symbol-Pillen linksbündig zur Spalte, Text weicht aus.
+      // Breite Symbol-Pillen linksbündig zur Spalte, Text weicht aus;
+      // Orte mit legendeText (Toiletten) zeigen in der Liste die
+      // schlichte Textmarke statt des Kartenfelds.
       const b = markenBreite(ort, 2.03);
-      teile += markenKreis(x - 2.03 + b / 2, y - 0.9, hex, ortMarker(ort), 2.03, ort.symbol);
+      teile += markenKreis(x - 2.03 + b / 2, y - 0.9, hex,
+        ort.legendeText || ortMarker(ort), 2.03,
+        ort.legendeText ? null : ort.symbol);
       textX = x + Math.max(L.labelAbstand, b - 2.03 + 1.6);
     }
     zeile.zeilenTexte.forEach((text, index) => {
@@ -1297,6 +1321,9 @@ function renderOptionen() {
 
   document.getElementById("logo-skala").value = String(Math.round(state.logo.skala * 100));
   document.getElementById("logo-wert").textContent = `${Math.round(state.logo.skala * 100)}%`;
+  document.getElementById("logo-lage").textContent = state.logo.x == null
+    ? "Standard (rechts oben)"
+    : `${state.logo.x.toFixed(1)} × ${state.logo.y.toFixed(1)} mm`;
 }
 
 /* ---------- Zoom (nur Bildschirm-Vorschau) ---------- */
@@ -1615,14 +1642,25 @@ document.getElementById("logo-skala").addEventListener("change", () => {
   renderOptionen();
   speichern();
 });
-document.getElementById("logo-platzieren").addEventListener("click", () => {
-  state.platzierenLogo = true;
-  state.platzieren = null;
-  state.platzierenOrt = null;
-  renderVorschau();
-  eigeneHint.textContent = "Logo — neue Stelle in der Vorschau anklicken (Mitte). ‹Esc› bricht ab.";
-  printSvg.scrollIntoView({ behavior: "smooth", block: "nearest" });
-});
+// Logo mit Pfeiltasten verschieben (1-mm-Schritte); die Anzeige nennt die
+// Mitte in Blatt-mm — so lassen sich finale Koordinaten durchgeben.
+function logoVerschieben(dx, dy) {
+  if (!logoInhalt) return;
+  if (state.logo.x == null || state.logo.y == null) {
+    const breite = 24 * state.logo.skala;
+    const hoehe = breite * logoInhalt.hoehe / logoInhalt.breite;
+    state.logo.x = SZENE.breite - 10.5 - breite / 2;
+    state.logo.y = 6.5 + hoehe / 2;
+  }
+  state.logo.x = Math.round((state.logo.x + dx) * 10) / 10;
+  state.logo.y = Math.round((state.logo.y + dy) * 10) / 10;
+  render();
+}
+
+document.getElementById("logo-links").addEventListener("click", () => logoVerschieben(-1, 0));
+document.getElementById("logo-rechts").addEventListener("click", () => logoVerschieben(1, 0));
+document.getElementById("logo-hoch").addEventListener("click", () => logoVerschieben(0, -1));
+document.getElementById("logo-runter").addEventListener("click", () => logoVerschieben(0, 1));
 document.getElementById("logo-reset").addEventListener("click", () => {
   state.logo = { x: null, y: null, skala: 1 };
   render();

--- a/apps/karten-generator/index.html
+++ b/apps/karten-generator/index.html
@@ -285,6 +285,9 @@
 
       <fieldset>
         <legend>Eigene Marke</legend>
+        <label class="lab" for="eigene-titel">Gruppentitel in der Legende (Spalte 2)</label>
+        <input id="eigene-titel" type="text" placeholder="Eigene Marken" />
+        <label class="lab" for="eigene-label">Neue Marke</label>
         <input id="eigene-label" type="text" placeholder="Beschriftung, z. B. Festbühne" />
         <div class="marken-farben" id="eigene-farben"></div>
         <div class="button-row">
@@ -292,9 +295,7 @@
         </div>
         <div class="hint" id="eigene-hint">Erst Beschriftung eingeben, dann in der Vorschau die Stelle anklicken. ‹Esc› bricht ab.</div>
         <div class="object-list" id="eigene-liste"></div>
-        <input id="eigene-titel" type="text" placeholder="Eigene Marken" />
-        <div class="hint">Gruppentitel dieser Einträge in der Legende — frei benennbar,
-          z. B. ‹Festorte›. ▲▼ an den Einträgen sortiert die Reihenfolge.</div>
+        <div class="hint">▲▼ an den Einträgen sortiert die Reihenfolge in der Legende.</div>
       </fieldset>
 
       <fieldset>
@@ -320,11 +321,14 @@
           <span class="zoom-value" id="logo-wert">100%</span>
         </div>
         <div class="button-row">
-          <button id="logo-platzieren" type="button" class="btn">Logo platzieren</button>
+          <button id="logo-links" type="button" class="btn" title="Logo nach links">◀</button>
+          <button id="logo-hoch" type="button" class="btn" title="Logo nach oben">▲</button>
+          <button id="logo-runter" type="button" class="btn" title="Logo nach unten">▼</button>
+          <button id="logo-rechts" type="button" class="btn" title="Logo nach rechts">▶</button>
           <button id="logo-reset" type="button" class="btn">Standardlage</button>
         </div>
-        <div class="hint">Klick auf ‹Logo platzieren›, dann in der Vorschau die
-          neue Mitte anklicken. Standard: rechts oben.</div>
+        <div class="hint">Pfeile verschieben das Logo in 1-mm-Schritten.
+          Mitte: <span id="logo-lage">Standard (rechts oben)</span></div>
       </fieldset>
 
       <fieldset>

--- a/apps/karten-generator/orte.js
+++ b/apps/karten-generator/orte.js
@@ -164,134 +164,42 @@ const ORTE = [
     "symbol": "wc-rollstuhl"
   },
   {
-    "id": "wc-g-herren",
+    "id": "wc-goetheanum",
     "marker": "WC",
     "art": "orientierung",
     "kategorie": "eingaenge",
-    "farbe": "blau",
+    "farbe": "gold",
     "label": {
-      "de": "WC Herren (Goetheanum)",
-      "en": "WC Men (Goetheanum)"
+      "de": "Toiletten",
+      "en": "Toilets"
     },
     "positionen": [
       [
-        188.5,
-        150.8
+        197.5,
+        125.5
       ]
     ],
-    "symbol": "wc-herren"
+    "symbol": "wc-gruppe",
+    "feldBreite": 13,
+    "legendeText": "WC"
   },
   {
-    "id": "wc-g-damen",
+    "id": "wc-schreinerei",
     "marker": "WC",
     "art": "orientierung",
     "kategorie": "eingaenge",
-    "farbe": "blau",
+    "farbe": "gold",
     "label": {
-      "de": "WC Damen (Goetheanum)",
-      "en": "WC Women (Goetheanum)"
+      "de": "Toiletten",
+      "en": "Toilets"
     },
     "positionen": [
       [
-        192.5,
-        145.5
+        224.5,
+        83.5
       ]
     ],
-    "symbol": "wc-damen"
-  },
-  {
-    "id": "wc-g-rollstuhl",
-    "marker": "WC",
-    "art": "orientierung",
-    "kategorie": "eingaenge",
-    "farbe": "blau",
-    "label": {
-      "de": "WC barrierefrei (Goetheanum)",
-      "en": "Accessible WC (Goetheanum)"
-    },
-    "positionen": [
-      [
-        196.0,
-        142.0
-      ]
-    ],
-    "symbol": "wc-rollstuhl"
-  },
-  {
-    "id": "wc-g-wickeltisch",
-    "marker": "WC",
-    "art": "orientierung",
-    "kategorie": "eingaenge",
-    "farbe": "blau",
-    "label": {
-      "de": "Wickeltisch (Goetheanum)",
-      "en": "Baby Changing (Goetheanum)"
-    },
-    "positionen": [
-      [
-        199.5,
-        138.5
-      ]
-    ],
-    "symbol": "wickelraum"
-  },
-  {
-    "id": "wc-g-kombi",
-    "marker": "WC",
-    "art": "orientierung",
-    "kategorie": "eingaenge",
-    "farbe": "blau",
-    "label": {
-      "de": "WC Damen · barrierefrei · Wickeltisch (Goetheanum)",
-      "en": "WC Women · Accessible · Baby Changing (Goetheanum)"
-    },
-    "positionen": [
-      [
-        192.5,
-        141.0
-      ]
-    ],
-    "symbol": [
-      "wc-damen",
-      "wc-rollstuhl",
-      "wickelraum"
-    ]
-  },
-  {
-    "id": "wc-s-herren",
-    "marker": "WC",
-    "art": "orientierung",
-    "kategorie": "eingaenge",
-    "farbe": "blau",
-    "label": {
-      "de": "WC Herren (Schreinerei)",
-      "en": "WC Men (Schreinerei)"
-    },
-    "positionen": [
-      [
-        222.0,
-        82.0
-      ]
-    ],
-    "symbol": "wc-herren"
-  },
-  {
-    "id": "wc-s-damen",
-    "marker": "WC",
-    "art": "orientierung",
-    "kategorie": "eingaenge",
-    "farbe": "blau",
-    "label": {
-      "de": "WC Damen (Schreinerei)",
-      "en": "WC Women (Schreinerei)"
-    },
-    "positionen": [
-      [
-        227.0,
-        85.5
-      ]
-    ],
-    "symbol": "wc-damen"
+    "legendeText": "WC"
   },
   {
     "id": "f46",

--- a/tools/karten/extract-marker-positionen.py
+++ b/tools/karten/extract-marker-positionen.py
@@ -178,33 +178,20 @@ WILLKOMMEN = [
      {"de": "Barrierefreier Zugang", "en": "Barrier-free access"},
      [[222.5, 130.6]], {"symbol": "wc-rollstuhl"}),
 
-    # WCs (Original-Piktos, blau statt Eingangs-Gold): Goetheanum trennt
-    # Herren von Damen/barrierefrei/Wickeltisch — die drei versuchsweise
-    # einzeln UND kombiniert (Platzprobe des Auftraggebers); Schreinerei
-    # klassisch getrennt. Startlagen sind Setzungen — alle justierbar
-    # (✥), der Lagen-Export liefert die Feinkoordinaten zurück.
-    ("wc-g-herren", "WC", "eingaenge",
-     {"de": "WC Herren (Goetheanum)", "en": "WC Men (Goetheanum)"},
-     [[188.5, 150.8]], {"symbol": "wc-herren", "farbe": "blau"}),
-    ("wc-g-damen", "WC", "eingaenge",
-     {"de": "WC Damen (Goetheanum)", "en": "WC Women (Goetheanum)"},
-     [[192.5, 145.5]], {"symbol": "wc-damen", "farbe": "blau"}),
-    ("wc-g-rollstuhl", "WC", "eingaenge",
-     {"de": "WC barrierefrei (Goetheanum)", "en": "Accessible WC (Goetheanum)"},
-     [[196.0, 142.0]], {"symbol": "wc-rollstuhl", "farbe": "blau"}),
-    ("wc-g-wickeltisch", "WC", "eingaenge",
-     {"de": "Wickeltisch (Goetheanum)", "en": "Baby Changing (Goetheanum)"},
-     [[199.5, 138.5]], {"symbol": "wickelraum", "farbe": "blau"}),
-    ("wc-g-kombi", "WC", "eingaenge",
-     {"de": "WC Damen · barrierefrei · Wickeltisch (Goetheanum)",
-      "en": "WC Women · Accessible · Baby Changing (Goetheanum)"},
-     [[192.5, 141.0]], {"symbol": ["wc-damen", "wc-rollstuhl", "wickelraum"], "farbe": "blau"}),
-    ("wc-s-herren", "WC", "eingaenge",
-     {"de": "WC Herren (Schreinerei)", "en": "WC Men (Schreinerei)"},
-     [[222.0, 82.0]], {"symbol": "wc-herren", "farbe": "blau"}),
-    ("wc-s-damen", "WC", "eingaenge",
-     {"de": "WC Damen (Schreinerei)", "en": "WC Women (Schreinerei)"},
-     [[227.0, 85.5]], {"symbol": "wc-damen", "farbe": "blau"}),
+    # Toiletten (Entscheid Auftraggeber, 8. Juli 2026): keine Unter-
+    # gliederung. Goetheanum = breites Feld mit dem fertigen Gruppen-Icon
+    # ‹wc-gruppe› (Dame, Herr, Wickelkind, Rollstuhl, WC-Schriftzug —
+    # alles integriert), passt zwischen die Fahrstühle; Schreinerei =
+    # schlichter ‹WC›-Textkreis. In der Legende beide als ‹WC›-Marke mit
+    # dem Text ‹Toiletten› (gleiche Zeilen legt die Legende zusammen).
+    # Gold wie die Kategorie; justierbar (✥), Lagen-Export liefert
+    # die Feinkoordinaten zurück.
+    ("wc-goetheanum", "WC", "eingaenge",
+     {"de": "Toiletten", "en": "Toilets"},
+     [[197.5, 125.5]], {"symbol": "wc-gruppe", "feldBreite": 13, "legendeText": "WC"}),
+    ("wc-schreinerei", "WC", "eingaenge",
+     {"de": "Toiletten", "en": "Toilets"},
+     [[224.5, 83.5]], {"legendeText": "WC"}),
 
     # Sektionen (Buchstaben wie auf dem Willkommensschild):
     ("s-allgemein", "a", "sektionen",


### PR DESCRIPTION
Runde 13 der Test-Rückmeldungen zum Kartentool:

- **Toiletten ohne Untergliederung:** Goetheanum = **breites Feld** (goldene Pille, 13 mm — passt zwischen die Fahrstühle) mit dem fertigen Gruppen-Icon `wc-gruppe` (Dame, Herr, Wickelkind, Rollstuhl, WC-Schriftzug integriert), eingepasst in natürlichen Proportionen. Schreinerei = schlichter **‹WC›-Textkreis** (W/C-Vorschübe aus der Laut-TTF ergänzt). In der **Legende** zeigen beide die ‹WC›-Textmarke in Gold mit dem Text ‹Toiletten›; **gleiche Zeilen werden zusammengelegt** (eine Zeile für beide Marker). Beide justierbar (✥ + Lagen-Export).
- **Eigene Marken:** das Feld ‹Gruppentitel in der Legende (Spalte 2)› steht beschriftet **zuoberst** in der Box; auch die neue Marke trägt ein Label.
- **Logo:** Klick-Platzierung ersetzt durch **Pfeiltasten** (1-mm-Schritte) mit mm-Anzeige der Mitte — finale Koordinaten lassen sich direkt ablesen und durchgeben.

Verifikation: Playwright (eine Toiletten-Zeile, Breitfeld, zwei WC-Marken, Logo-Readout), PDF-Zooms von Breitfeld, Schreinerei-WC und Legende. typo-check/ds-lint grün (100 %).

Regeln: G01, G25, B01–B04, DS01/DS02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgMfxisgg9yjRqFZhd6wuC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgMfxisgg9yjRqFZhd6wuC)_