### PR TITLE
Signatur-Generator: auf Design-System umstellen + Feedback-Runde

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -3,160 +3,101 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Goetheanum E-Mail-Signatur</title>
-<meta name="description" content="E-Mail-Signatur-Generator – erzeugt eine schlichte, Dark-Mode-feste Text-Signatur nach der gemeinsamen Goetheanum-Vorlage. Kein Bild, keine Tabelle." />
+<title>E-Mail-Signatur · Goetheanum</title>
+<meta name="description" content="E-Mail-Signatur-Generator – schlichte, Dark-Mode-feste Text-Signatur nach der gemeinsamen Goetheanum-Vorlage. Kein Bild, keine Tabelle." />
 <meta name="robots" content="noindex" />
-<link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
+<link rel="icon" type="image/svg+xml" href="https://phtok.github.io/goeloggen/assets/logos/goetheanum-mark-blue.svg" />
+
+<!-- Fundament – eine Quelle der Wahrheit (Schriften v2.7, Tokens, Hell/Dunkel, Navigation). -->
+<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/tokens.css" />
+<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/base.css" />
+<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/nav.css" />
+
 <style>
-  /* Goetheanum Variable Font – nur fürs Seiten-Chrome (nicht in der Signatur) */
-  @font-face{
-    font-family:"Goetheanum";
-    src:url("https://phtok.github.io/goeloggen/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Variabel-v2.5.woff2") format("woff2"),
-        url("https://phtok.github.io/goeloggen/assets/fonts/goetheanum/Webfonts/woff/Goetheanum-Variabel-v2.5.woff") format("woff");
-    font-weight:190 725; font-style:normal; font-display:swap;
-  }
+  /* Nur werkzeug-eigene Gestaltung; alles Gemeinsame kommt aus base.css/tokens.css. */
+  .lede{max-width:60ch}
 
-  :root{
-    --ink:#23272b; --muted:#737a80; --line:rgba(20,24,28,.10); --line-soft:rgba(20,24,28,.055);
-    --gold:#d7ab68; --gold-deep:#a07a33; --blue:#0061a9; --paper:#fff; --soft:#faf8f4; --maxw:1080px;
-    --bad:#b3261e;
-    --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s6:24px; --s8:32px;
-    --r-control:10px; --r-card:14px; --header-h:58px;
-  }
-  *{box-sizing:border-box;margin:0;padding:0}
-  body{background:var(--paper);color:var(--ink);font-family:"Goetheanum","Helvetica Neue",Arial,sans-serif;font-weight:440;
-       letter-spacing:normal;font-kerning:normal;text-rendering:optimizeLegibility;-webkit-font-smoothing:antialiased;line-height:1.5}
-  .wrap{max-width:var(--maxw);margin:0 auto;padding:0 26px}
-  a{color:inherit}
-  .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
-  a:focus-visible,button:focus-visible,summary:focus-visible{outline:2px solid var(--blue);outline-offset:2px}
-
-  header{position:sticky;top:0;z-index:30;background:rgba(255,255,255,.9);backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--line)}
-  .bar{display:flex;align-items:center;justify-content:space-between;height:var(--header-h)}
-  .brand{display:flex;align-items:center;gap:var(--s3);text-decoration:none}
-  .brand .wm{font-family:"Goetheanum";font-weight:440;font-size:27px;line-height:1;color:#8a9097;letter-spacing:.005em}
-  nav.top{display:flex;gap:22px}
-  nav.top a{color:var(--muted);text-decoration:none;font-size:13.5px}
-  nav.top a:hover{color:var(--gold-deep)}
-
-  section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
-  main > section:first-of-type{border-top:0}
-  .shead{display:flex;align-items:baseline;justify-content:space-between;gap:var(--s8);margin-bottom:var(--s4);flex-wrap:wrap}
-  .shead h2{font-family:"Goetheanum";font-weight:680;font-size:clamp(22px,3vw,30px);line-height:1.05;flex:0 0 auto}
-  .shead p{color:var(--muted);font-size:14px;line-height:1.5;max-width:62ch;flex:1 1 360px}
-
-  .work{display:grid;grid-template-columns:1fr;gap:var(--s6);align-items:start}
+  .work{display:grid;grid-template-columns:1fr;gap:var(--s6);align-items:start;margin-top:var(--s6)}
   @media(min-width:880px){.work{grid-template-columns:minmax(360px,460px) 1fr}}
   @media(min-width:880px){.preview-col{position:sticky;top:calc(var(--header-h) + var(--s4));align-self:start}}
 
-  .card{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6)}
-  .card.soft{background:var(--soft)}
-
-  .tabs{display:inline-flex;gap:var(--s2)}
-  .tabs button{font:inherit;font-size:13px;color:var(--muted);background:none;border:1px solid var(--line);border-radius:999px;padding:6px 14px;cursor:pointer;transition:.15s}
-  .tabs button[aria-pressed="true"]{color:var(--gold-deep);border-color:var(--gold)}
+  .fset{border:0;display:grid;gap:var(--s3);margin-bottom:var(--s3)}
+  .field > .lab{display:flex;justify-content:space-between;align-items:baseline;gap:var(--s2)}
+  .lab .sublab{font-family:var(--font-text);font-weight:400;font-size:var(--t-micro);color:var(--muted)}
+  .counter{font-family:var(--font-text);font-variant-numeric:tabular-nums;font-size:var(--t-micro);color:var(--muted)}
+  .counter.over{color:var(--bad)}
+  .expiry-note{font-family:var(--font-text);font-size:var(--t-small);color:var(--gold-ink);background:var(--soft);
+    border:1px solid var(--line);border-radius:var(--r-control);padding:var(--s2) var(--s3);margin-bottom:var(--s3)}
 
   .fold{border-top:1px solid var(--line-soft);margin-bottom:var(--s3);padding-top:var(--s3)}
-  .fold>summary{font-family:"Goetheanum";font-weight:680;font-size:15px;color:var(--ink);cursor:pointer;list-style:none;display:flex;justify-content:space-between;align-items:center;gap:var(--s2)}
+  .fold>summary{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:var(--t-small);color:var(--ink);
+    cursor:pointer;list-style:none;display:flex;justify-content:space-between;align-items:center;gap:var(--s2)}
   .fold>summary::-webkit-details-marker{display:none}
-  .fold>summary .sub{font-family:"Helvetica Neue",Arial,sans-serif;font-weight:400;font-size:12.5px;color:var(--muted);margin-left:auto}
+  .fold>summary .sub{font-family:var(--font-text);font-weight:400;font-size:var(--t-micro);color:var(--muted);margin-left:auto}
   .fold>summary::after{content:"+";color:var(--muted);font-size:18px;line-height:1;width:1em;text-align:center}
   .fold[open]>summary::after{content:"–"}
   .fold-body{display:grid;gap:var(--s3);margin-top:var(--s3)}
 
-  .code-details{margin-top:var(--s4)}
-  .code-details>summary{font-size:13px;color:var(--muted);cursor:pointer;list-style:none}
-  .code-details>summary::-webkit-details-marker{display:none}
-  .code-details>summary::before{content:"▸ ";color:var(--gold-deep)}
-  .code-details[open]>summary::before{content:"▾ "}
-
-  .fset{border:0;display:grid;gap:var(--s3);margin-bottom:var(--s3)}
-  .field{display:grid;gap:var(--s1)}
-  .field > .lab{font-size:13px;color:var(--muted);letter-spacing:.01em;display:flex;justify-content:space-between;align-items:baseline;gap:8px}
-  .field input,.field textarea{
-    width:100%;font-family:"Helvetica Neue",Arial,sans-serif;font-size:14.5px;font-weight:400;line-height:1.35;color:var(--ink);
-    background:#fff;border:1px solid var(--line);border-radius:var(--r-control);padding:8px 11px;outline:none;transition:border-color .15s,box-shadow .15s;
-  }
-  .field textarea{resize:vertical;min-height:44px}
-  .field input::placeholder,.field textarea::placeholder{color:#aeb4b9;font-weight:400}
-  .field input:focus,.field textarea:focus{border-color:var(--blue);box-shadow:0 0 0 3px rgba(0,97,169,.16)}
-  .lab .sublab{font-weight:400;font-size:11.5px;color:var(--muted)}
-  .counter{font-variant-numeric:tabular-nums;font-size:11.5px;color:var(--muted)}
-  .counter.over{color:var(--bad)}
-  .expiry-note{font-size:13px;color:#8a5a12;background:#fbf3e2;border:1px solid #ead9b0;border-radius:var(--r-control);padding:8px 11px;margin-bottom:var(--s3)}
-
   .btnrow{display:flex;gap:var(--s3);flex-wrap:wrap;align-items:center;margin-top:var(--s6)}
-  .btn{display:inline-block;text-decoration:none;font:inherit;font-size:13.5px;padding:9px 15px;border-radius:var(--r-control);border:1px solid var(--line);color:var(--ink);background:#fff;text-align:center;cursor:pointer;transition:.15s}
-  .btn:hover{border-color:var(--gold-deep)}
-  .btn.primary{background:var(--gold);border-color:var(--gold);color:#3a2d10}
-  .btn.primary:hover{background:#c59f56}
-  .btn.ok{background:#3f7d46;border-color:#3f7d46;color:#fff}
-  .btn.ghost{color:var(--muted)}
-  .btn.small{font-size:12.5px;padding:7px 12px}
-  .hint{font-size:14.5px;color:#565b60;line-height:1.55;margin-top:var(--s3);max-width:64ch}
-  .hint strong{color:var(--ink);font-weight:440}
-  .hint a{color:var(--gold-deep);text-decoration:none}
-  .hint a:hover{text-decoration:underline}
-  .hint ul{margin:var(--s3) 0 0;padding-left:18px;display:grid;gap:var(--s2)}
+  .btn.small{font-size:var(--t-micro);padding:7px 12px;min-height:0}
 
   .stage-head{display:flex;align-items:center;justify-content:space-between;gap:var(--s3);margin-bottom:var(--s3);flex-wrap:wrap}
-  .stage-lab{font-size:13px;color:var(--muted)}
-  .scroll-hint{display:none}
-  .mail-stage{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);box-shadow:0 10px 30px rgba(20,24,28,.06);overflow-x:auto}
-  .mail-stage.light{background:#ffffff;color:#111}
-  .mail-stage.dark{background:#1e1e1e;color:#e8e8e8;border-color:#333}
+  .stage-lab{color:var(--muted);font-size:var(--t-small)}
+  .tabs{display:inline-flex;gap:var(--s2)}
+  .tabs button{font:inherit;font-size:var(--t-micro);color:var(--muted);background:none;border:1px solid var(--line);
+    border-radius:var(--r-pill);padding:5px 13px;cursor:pointer;transition:.15s}
+  .tabs button[aria-pressed="true"]{color:var(--gold-ink);border-color:var(--gold)}
+
+  /* Vorschau-Bühne: simuliert den Empfänger-Client, theme-UNABHÄNGIG (feste Werte). */
+  .mail-stage{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);box-shadow:var(--shadow-card);overflow-x:auto}
+  .mail-stage.light{background:#ffffff;color:#111111} /* ds-ok: Artefakt (Empfänger hell) */
+  .mail-stage.dark{background:#1e1e1e;color:#e8e8e8;border-color:#333333} /* ds-ok: Artefakt (Empfänger dunkel) */
   .mail-body{font-size:13px;line-height:1.5}
   .mail-greeting{opacity:.6;margin-bottom:14px}
+  .scroll-hint{display:none}
 
+  .hint{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);line-height:1.55;max-width:64ch}
+  .hint strong{color:var(--ink);font-weight:600}
+  .hint a{color:var(--gold-ink);text-decoration:none}
+  .hint a:hover{text-decoration:underline}
+  .hint ul{margin:var(--s2) 0 0;padding-left:18px;display:grid;gap:var(--s2)}
+
+  .code-details{margin-top:var(--s4)}
+  .code-details>summary{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:var(--t-small);color:var(--ink);cursor:pointer;list-style:none;display:flex;align-items:center;gap:var(--s2)}
+  .code-details>summary::-webkit-details-marker{display:none}
+  .code-details>summary::before{content:"▸ ";color:var(--gold-ink)}
+  .code-details[open]>summary::before{content:"▾ "}
+  .code-details .hint{margin-top:var(--s3)}
   .code-wrap{position:relative;margin-top:var(--s3)}
-  pre.code{margin:0;background:#1f2428;color:#e8eef2;border-radius:var(--r-card);padding:var(--s4);overflow:auto;
-    font:12.5px/1.55 ui-monospace,Menlo,Consolas,monospace;border:1px solid #3a4148;white-space:pre-wrap;word-break:break-word;max-height:320px}
-  .copybtn{position:absolute;top:11px;right:11px;font:inherit;font-size:11.5px;border:1px solid #3a4148;background:#2b3137;color:#e8eef2;border-radius:var(--r-control);padding:5px 10px;cursor:pointer}
-  .copybtn:hover{background:#343b42}
+  pre.code{margin:0;background:var(--code-bg);color:var(--code-ink);border-radius:var(--r-card);padding:var(--s4);overflow:auto;
+    font:12.5px/1.55 var(--font-mono);white-space:pre-wrap;word-break:break-word;max-height:320px}
+  .copybtn{position:absolute;top:11px;right:11px;font:inherit;font-size:var(--t-micro);border:1px solid var(--code-bg2);
+    background:var(--code-bg2);color:var(--code-ink);border-radius:var(--r-control);padding:5px 10px;cursor:pointer}
 
-  /* Empfehlungen (Text unter dem Generator) */
-  .empf{max-width:60ch}
-  .empf h3{font-family:"Goetheanum";font-weight:680;font-size:18px;margin:var(--s6) 0 var(--s2)}
+  /* Empfehlungen: Lesetext, linksbündig (Titel NICHT rechts). */
+  .empf-head h2{font-size:var(--t-h2)}
+  .empf-head p{color:var(--muted);font-size:var(--t-small);margin-top:var(--s1)}
+  .empf{font-family:var(--font-text);max-width:60ch;margin-top:var(--s4)}
+  .empf h3{font-family:var(--font-display);font-weight:var(--w-strong);font-size:var(--t-h3);margin:var(--s6) 0 var(--s2)}
   .empf h3:first-of-type{margin-top:0}
-  .empf p{font-size:15px;line-height:1.6;color:var(--ink);margin:0 0 var(--s3)}
+  .empf p{font-size:var(--t-small);line-height:1.6;color:var(--ink);margin:0 0 var(--s3)}
   .empf p.dim{color:var(--muted)}
-  .empf .lead{color:var(--muted)}
-  .empf a{color:var(--gold-deep);text-decoration:none}
+  .empf a{color:var(--gold-ink);text-decoration:none}
   .empf a:hover{text-decoration:underline}
   .empf .rule{border:0;border-top:1px solid var(--line-soft);margin:var(--s6) 0}
-  .empf .tool{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:13.5px}
-  .empf em{color:var(--muted)}
-
-  footer{border-top:1px solid var(--line);padding:var(--s8) 0 60px;color:var(--muted);font-size:12.5px}
-  .frow{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap}
-  .frow strong{color:var(--ink);font-weight:400}
 
   @media(max-width:560px){
-    .wrap{padding:0 16px}
-    section{padding:var(--s6) 0}
-    .shead{gap:var(--s2)}
-    .card{padding:var(--s4)}
-    .mail-stage{padding:var(--s3)}
-    .brand .wm{font-size:22px}
-    nav.top{gap:14px}
-    nav.top a{font-size:13px}
-    .nav-hide-sm{display:none}
-    .field input,.field textarea{font-size:16px}
-    .scroll-hint{display:block;font-size:12px;color:var(--muted);margin-top:6px}
+    .mail-stage{padding:var(--s4)}
+    .scroll-hint{display:block;font-size:var(--t-micro);color:var(--muted);margin-top:6px}
   }
 </style>
 </head>
 <body>
 
-<header><div class="wrap bar">
-  <a class="brand" href="https://grafik.goetheanum.ch" aria-label="Zur Grafikseite – grafik.goetheanum.ch">
-    <span class="wm">Goetheanum</span>
-  </a>
-  <nav class="top">
-    <a href="#empfehlungen" class="nav-hide-sm">Empfehlungen</a>
-    <a href="https://grafik.goetheanum.ch">Weitere Werkzeuge</a>
-  </nav>
-</div></header>
+<!-- Globale Navigation (Kopf + Menü + Hell/Dunkel) aus dem Fundament. -->
+<script src="https://phtok.github.io/goeloggen/design-system/nav.js"
+        data-root="https://phtok.github.io/goeloggen/"
+        data-variant="werkzeug"></script>
 
 <main class="wrap">
   <section>
@@ -213,10 +154,10 @@
           <summary>PS – befristeter Hinweis <span class="sub">optional</span></summary>
           <div class="fold-body">
             <label class="field"><span class="lab"><span>PS-Text</span> <span class="counter" id="psCount">0/120</span></span>
-              <textarea id="ps" rows="2" maxlength="120" placeholder="Am 20. September: Tag der offenen Tür."></textarea>
+              <textarea id="ps" rows="2" maxlength="120" placeholder="Faust 1+2 · drei mal im Sommer 2027"></textarea>
             </label>
             <label class="field"><span class="lab"><span>Link</span> <span class="sublab">optional</span></span>
-              <input type="url" id="pslink" placeholder="goetheanum.ch/tag-der-offenen-tuer" />
+              <input type="url" id="pslink" placeholder="www.faust.jetzt" />
             </label>
             <label class="field"><span class="lab"><span>Gültig bis</span> <span class="sublab">für die Erinnerung</span></span>
               <input type="date" id="psuntil" />
@@ -257,22 +198,22 @@
           </div>
           <span class="sr-only" id="copyStatus" aria-live="polite"></span>
 
-          <div class="hint">
-            <strong>Kopieren → im Mailprogramm unter Einstellungen → Signaturen einfügen → fertig.</strong>
-            Detaillierte Anleitungen:
-            <a href="https://support.apple.com/de-ch/guide/mail/mail11943/mac" target="_blank" rel="noopener">Apple Mail (Mac)</a> ·
-            <a href="https://support.microsoft.com/de-de/office/8ee5d4f4-68fd-464a-a1c1-0e1c80bb27f2" target="_blank" rel="noopener">Outlook</a>.
-            <br>Hinweis für Apple Mail: Falls die Signatur ihre Form verliert, deaktiviere unter dem Signaturfeld
-            die Option ‹Standardschriftart für E-Mails verwenden›.
-          </div>
+          <details class="code-details">
+            <summary>Anleitung</summary>
+            <div class="hint">
+              <strong>Kopieren → im Mailprogramm unter Einstellungen → Signaturen einfügen → fertig.</strong>
+              Detaillierte Anleitungen:
+              <a href="https://support.apple.com/de-ch/guide/mail/mail11943/mac" target="_blank" rel="noopener">Apple Mail (Mac)</a> ·
+              <a href="https://support.microsoft.com/de-de/office/8ee5d4f4-68fd-464a-a1c1-0e1c80bb27f2" target="_blank" rel="noopener">Outlook</a>.
+            </div>
+          </details>
 
           <details class="code-details">
-            <summary>HTML-Code anzeigen</summary>
-            <div class="code-wrap">
-              <pre class="code" id="codeOut"></pre>
-              <button type="button" class="copybtn" id="copyCode2">Kopieren</button>
+            <summary>Hinweis für Apple Mail</summary>
+            <div class="hint">
+              Falls die Signatur nach dem Einfügen ihre Form verliert, deaktiviere unter dem Signaturfeld
+              die Option ‹Standardschriftart für E-Mails verwenden›.
             </div>
-            <div class="hint">Nur nötig, wenn das Mailprogramm ausschliesslich HTML-Quelltext akzeptiert. Sonst reicht ‹Signatur kopieren›.</div>
           </details>
 
           <details class="code-details">
@@ -291,13 +232,25 @@
               <a href="https://grafik.goetheanum.ch">weiteren Werkzeuge</a>.
             </div>
           </details>
+
+          <details class="code-details">
+            <summary>HTML-Code anzeigen</summary>
+            <div class="code-wrap">
+              <pre class="code" id="codeOut"></pre>
+              <button type="button" class="copybtn" id="copyCode2">Kopieren</button>
+            </div>
+            <div class="hint">Nur nötig, wenn das Mailprogramm ausschliesslich HTML-Quelltext akzeptiert. Sonst reicht ‹Signatur kopieren›.</div>
+          </details>
         </div>
       </div>
     </div>
   </section>
 
   <section id="empfehlungen">
-    <div class="shead"><h2>Empfehlungen</h2><p>E-Mail am Goetheanum – Entwurf, Stand Juli 2026.</p></div>
+    <div class="empf-head">
+      <h2>Empfehlungen</h2>
+      <p>E-Mail am Goetheanum – Entwurf, Stand Juli 2026.</p>
+    </div>
     <div class="empf">
       <h3>Grundsatz</h3>
       <p>Jede E-Mail aus dem Goetheanum ist ein Auftritt des Hauses — und zugleich die Stimme eines Menschen.
@@ -356,9 +309,9 @@
   </section>
 </main>
 
-<footer><div class="wrap frow">
-  <span><strong>Goetheanum Grafik</strong> · E-Mail-Signatur-Generator</span>
-  <span>Allgemeine Anthroposophische Gesellschaft</span>
+<footer class="ds-footer"><div class="wrap frow">
+  <span><strong>Goetheanum</strong> · Hausgrafik · E-Mail-Signatur</span>
+  <span><a href="https://grafik.goetheanum.ch">Weitere Werkzeuge</a></span>
 </div></footer>
 
 <script>
@@ -367,7 +320,7 @@
 /* ---------- Konstanten ---------- */
 // Mail-Blau: aufgehellte Variante des Goetheanum-Markenblaus #0061a9 (gleicher Farbton).
 // WCAG-Kontrast 4.09:1 gegen #FFFFFF und 4.07:1 gegen #1E1E1E – lesbar auf hellem UND dunklem Grund.
-const MAIL_BLUE = "#4183B4";
+const MAIL_BLUE = "#4183B4"; // ds-ok: Artefakt-Farbe im Mail-Output (theme-unabhängig)
 const CFONT = "-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif";
 
 const FIELDS = ["name","role","phone","mobile","web","org1","org2","street","city","country","ps","pslink","psuntil"];
@@ -410,7 +363,7 @@ function buildSignature() {
   const push = (html, text) => rows.push({ html, text });
   const gap = () => rows.push({ gap: true });
 
-  // PS zuoberst, mit Leerzeile zum Adressblock
+  // PS zuoberst, danach ein Trennzeichen und eine Leerzeile zur Signatur
   const ps = val("ps"), pslink = val("pslink");
   if (ps) {
     let h = "PS: " + esc(ps), t = "PS: " + ps;
@@ -419,22 +372,22 @@ function buildSignature() {
       h += " — <a href=\"" + esc(webHref(pslink)) + "\" style=\"color:" + MAIL_BLUE + ";text-decoration:none;\">" + esc(d) + "</a>";
       t += " — " + d;
     }
-    push(h, t); gap();
+    push(h, t); gap(); push("_", "_"); gap();
   }
 
   // Person
   if (val("name")) push("<span style=\"font-weight:600;\">" + esc(val("name")) + "</span>", val("name"));
   val("role").split(/\r?\n/).map(s => s.trim()).filter(Boolean).forEach(l => push(esc(l), l));
 
-  // Organisation
-  const hasName = rows.some(r => !r.gap);
-  if (val("org1") || val("org2")) { if (hasName) gap(); }
-  if (val("org1")) push("<span style=\"color:" + MAIL_BLUE + ";\">" + esc(val("org1")) + "</span>", val("org1"));
+  // Organisation – Goetheanum fett und blau (wie der Name im Gewicht)
+  const hasPerson = rows.some(r => !r.gap && r.text !== "_");
+  if (val("org1") || val("org2")) { if (hasPerson) gap(); }
+  if (val("org1")) push("<span style=\"font-weight:600;color:" + MAIL_BLUE + ";\">" + esc(val("org1")) + "</span>", val("org1"));
   if (val("org2")) push(esc(val("org2")), val("org2"));
 
-  // Adresse (eine Stufe kleiner)
-  [val("street"), val("city"), val("country")].filter(Boolean).forEach(a =>
-    push("<span style=\"font-size:12px;\">" + esc(a) + "</span>", a));
+  // Adresse auf EINER Zeile (mit Mittelpunkt), eine Stufe kleiner
+  const addr = [val("street"), val("city"), val("country")].filter(Boolean).join(" · ");
+  if (addr) push("<span style=\"font-size:12px;\">" + esc(addr) + "</span>", addr);
 
   // Kontakt: Telefonnummern als tel:-Link, aber Theme-Farbe (inherit) – dark-mode-fest
   if (val("phone")) push("<a href=\"" + telHref(val("phone")) + "\" style=\"color:inherit;text-decoration:none;\">" + esc(val("phone")) + "</a>", val("phone"));
@@ -446,7 +399,6 @@ function buildSignature() {
     push("<a href=\"" + esc(webHref(w)) + "\" style=\"color:" + MAIL_BLUE + ";text-decoration:none;\">" + esc(d) + "</a>", d);
   });
 
-  // in Zeilen umsetzen, führende/abschliessende Leerzeilen trimmen
   const hl = [], tl = [];
   rows.forEach(r => { if (r.gap) { hl.push(""); tl.push(""); } else { hl.push(r.html); tl.push(r.text); } });
   while (hl.length && hl[0] === "") { hl.shift(); tl.shift(); }
@@ -490,7 +442,7 @@ function applyQuery() {
 }
 function setFields(obj) { FIELDS.forEach(k => { els[k].value = obj[k] || ""; }); }
 
-/* ---------- Vorschau hell/dunkel ---------- */
+/* ---------- Vorschau hell/dunkel (unabhängig vom Seiten-Theme) ---------- */
 function setMode(m, doSave) {
   state.mode = (m === "dark") ? "dark" : "light";
   const stage = document.getElementById("mailStage");
@@ -568,7 +520,6 @@ function flash(btn, label) {
   setTimeout(() => { btn.textContent = old; btn.classList.remove("ok"); }, 1400);
 }
 
-// Clipboard: text/html UND text/plain, direkt im Klick-Handler (Safari)
 document.getElementById("copyRich").addEventListener("click", function () {
   const sig = buildSignature();
   if (navigator.clipboard && window.ClipboardItem) {
@@ -584,7 +535,6 @@ document.getElementById("copyRich").addEventListener("click", function () {
     flash(this, "Bitte HTML-Code nutzen");
   }
 });
-
 document.getElementById("copyPlain").addEventListener("click", function () {
   const t = buildSignature().text;
   if (navigator.clipboard) {


### PR DESCRIPTION
Stellt den Signatur-Generator auf das **gemeinsame Design-System** um und setzt die Feedback-Runde um.

### Design-System + Schriften (behebt die fehlenden Schriften)
- Bindet `design-system/tokens.css`, `base.css`, `nav.css`, `nav.js` per absoluter URL ein (statt eigenem Chrome). Damit kommen **Schriften v2.7**, Tokens, **Hell/Dunkel** und die globale Navigation automatisch.
- Ursache der in Chrome fehlenden Schriften: die Seite lud noch eine **fest verdrahtete v2.5-Font-URL**, die es nicht mehr gibt. Jetzt über das Fundament → propagiert künftig automatisch.

### Inhaltliche Feedbacks
- **Trennzeichen ‹_›** mit Leerzeile davor/danach zwischen **PS** und Signatur.
- **PS-Platzhalter:** ‹Faust 1+2 · drei mal im Sommer 2027› / Link ‹www.faust.jetzt›.
- **Gesellschaftsadresse auf einer Zeile:** Rüttiweg 45 · 4143 Dornach · Schweiz.
- **Klapper-Reihenfolge getauscht:** erst ‹Warum reiner Text – kein Bild?›, dann ‹HTML-Code anzeigen›.
- **Goetheanum fett (600)** wie der Name, zusätzlich Mail-Blau.
- **Anleitung** und **‹Hinweis für Apple Mail›** sind jetzt eigene Klapper.
- **Empfehlungs-Untertitel linksbündig** (nicht mehr rechts).

Vorschau-Bühne bleibt bewusst theme-**unabhängig** (Hell/Dunkel-Umschalter simuliert den Empfänger), Mail-Blau/Bühnenfarben als Artefakte mit `ds-ok` markiert. JS validiert.

> Reale Client-Tests (Apple Mail/Outlook/iOS, hell/dunkel, .ics) weiterhin offen – siehe `TESTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_