### PR TITLE
Signatur-Generator: Fundament relativ einbinden (Custom-Domain-Fix)

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -6,12 +6,13 @@
 <title>E-Mail-Signatur · Goetheanum</title>
 <meta name="description" content="E-Mail-Signatur-Generator – schlichte, Dark-Mode-feste Text-Signatur nach der gemeinsamen Goetheanum-Vorlage. Kein Bild, keine Tabelle." />
 <meta name="robots" content="noindex" />
-<link rel="icon" type="image/svg+xml" href="https://phtok.github.io/goeloggen/assets/logos/goetheanum-mark-blue.svg" />
+<link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
 
-<!-- Fundament – eine Quelle der Wahrheit (Schriften v2.7, Tokens, Hell/Dunkel, Navigation). -->
-<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/tokens.css" />
-<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/base.css" />
-<link rel="stylesheet" href="https://phtok.github.io/goeloggen/design-system/nav.css" />
+<!-- Fundament – eine Quelle der Wahrheit (Schriften v2.7, Tokens, Hell/Dunkel, Navigation).
+     Relative Pfade: funktionieren auf der Custom-Domain (Root) UND unter phtok.github.io/goeloggen/. -->
+<link rel="stylesheet" href="../../design-system/tokens.css" />
+<link rel="stylesheet" href="../../design-system/base.css" />
+<link rel="stylesheet" href="../../design-system/nav.css" />
 
 <style>
   /* Nur werkzeug-eigene Gestaltung; alles Gemeinsame kommt aus base.css/tokens.css. */
@@ -95,9 +96,7 @@
 <body>
 
 <!-- Globale Navigation (Kopf + Menü + Hell/Dunkel) aus dem Fundament. -->
-<script src="https://phtok.github.io/goeloggen/design-system/nav.js"
-        data-root="https://phtok.github.io/goeloggen/"
-        data-variant="werkzeug"></script>
+<script src="../../design-system/nav.js" data-root="../../" data-section="generatoren" data-active="signatur"></script>
 
 <main class="wrap">
   <section>


### PR DESCRIPTION
**Fix:** Die Seite war auf `werkzeuge.goetheanum.ch` komplett **ungestylt**, weil ich das Fundament (tokens/base/nav) versehentlich per **absoluter** `phtok.github.io/goeloggen/…`-URL eingebunden hatte (aus dem Starter kopiert).

Die Site läuft über die **Custom-Domain** (`CNAME` = werkzeuge.goetheanum.ch) im **Root** — dort gibt es kein `/goeloggen/`-Präfix, also liefen die Absolut-URLs ins Leere (404 → kein CSS/JS → Serifen-Rohtext).

**Jetzt relativ**, exakt wie alle anderen Apps:
- `../../design-system/tokens.css` · `base.css` · `nav.css`
- `nav.js` mit `data-root="../../" data-section="generatoren" data-active="signatur"`
- Favicon `../../assets/logos/…`

Relative Pfade funktionieren auf **beiden** Auslieferungen (Custom-Domain-Root und `phtok.github.io/goeloggen/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_