### PR TITLE
Kartentool-Learnings ins System aufgenommen: Werkzeugwissen, belegte Werte, Icon-Befund

### DIFF
--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -37,6 +37,26 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ## [Unveröffentlicht]
 
+### Kartentool-Learnings aufgenommen (Werkzeugwissen + belegte Werte)
+- **Was:** Neues Nachschlagewerk `docs/werkzeugwissen.md` (SVG-/Druck-Export-/
+  UI-Bauwissen); Quelle `docs/learnings-kartentool.md` (14 verifizierte
+  Testrunden). Kernregeln: Icons auf die **Tintenbox** zentrieren (Einzeldateien
+  tragen keine einheitliche viewBox — nachgeprüft: nur 46 von 81 Dateien haben
+  die Standardbox); in Export-SVGs **kein `text-anchor="middle"`** und **keine
+  OpenType-Feature-Abhängigkeit** (PDF-Renderer ignorieren beides — Breiten und
+  Ziffern-Slots selbst setzen); Kontur-Zwillinge entfernen, Fugen mit
+  Eigenkontur in Füllfarbe dichten.
+- **Belegte Werte:** Druck-Tinten auf Papierweiss gerechnet — `#4e4f4a` 8.26:1,
+  `#6e6f6a` 5.07:1 (Token-Kandidat `--ink-print-leise`, aufgenommen sobald ein
+  zweites Druckwerkzeug ihn braucht), `#767771` 4.52:1. Die Hausschrift führt
+  `tnum`/`lnum` als GSUB-Features — G25 über `font-variant-numeric` greift auch
+  in der Hausschrift (nur nicht im PDF-Export).
+- **Bestätigt:** Die `.step-num`-Sitzkorrektur (translateY 8 %) wurde im
+  Kartentool unabhängig pixelverifiziert; Vermerk am Kommentar in `base.css`.
+- **Offen (Ratifizierung):** Normalisierung der Icon-Einzeldateien auf eine
+  einheitliche viewBox über die fontfix-Pipeline — als Aufgabe vermerkt; bis
+  dahin gilt die Tintenbox-Regel für Konsumenten.
+
 ### Neuer Font «Goetheanum Pfeile» – Pfeile & Kompass ohne PUA-Umweg
 - Die Pfeile/Kompass lagen im Icon-Font im **Zeichen-Privatbereich (PUA)** und waren
   nur über Option/Alt oder die Glyphenpalette erreichbar; eine installierbare

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -98,7 +98,8 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
    Ascent/Descent-Ungleichgewichts der Schrift optisch zu hoch. 8% ist am
    Goetheanum-Schriftschnitt (Laut/680) empirisch vermessen (Pixel-Analyse der
    Tinten-Bounding-Box gegen die geometrische Kreismitte) und deckt sich mit den
-   Font-Metriken (hhea ascent 750 / descent −250 vs. Ziffern-Tintenmitte ≈ 330/1000). */
+   Font-Metriken (hhea ascent 750 / descent −250 vs. Ziffern-Tintenmitte ≈ 330/1000).
+   Unabhängig pixelverifiziert im Kartentool (7/2026, docs/werkzeugwissen.md). */
 .step-num{display:inline-flex;align-items:center;justify-content:center;flex:none;
   width:1.6em;height:1.6em;min-width:1.6em;border-radius:999px;
   font-weight:var(--w-strong);font-size:.72em;

--- a/docs/learnings-kartentool.md
+++ b/docs/learnings-kartentool.md
@@ -1,0 +1,123 @@
+# Learnings aus dem Kartentool-Bau — Rückfluss ins Design-System
+
+Quelle: Bau- und Testrunden des Kartentools (`apps/karten-generator/`),
+Juli 2026, 14 Rückmelderunden mit pixel- und PDF-verifizierten Befunden.
+Ratifizierung durch den Auftraggeber steht aus — diese Datei ist die
+Vorlage für die Aufnahme (CHANGELOG-Einträge, Token-Kandidaten,
+Beipackzettel-Hinweise) in einer eigenen Design-System-Session.
+
+## 1. Icons v2.7: Einzeldateien sind nicht einheitlich normiert
+
+**Befund.** Die Standard-viewBox der Icon-Einzeldateien ist
+`16.2 -983.8 967.6 967.6` — aber nicht alle Dateien tragen sie.
+Gemessen: `wc-rollstuhl.svg` hat `-0.6 -845.1 817.5 817.5`.
+Wer stur auf die Standardbox skaliert (`scale(g/967.6)`,
+`translate(-500 500)`), setzt solche Icons schief und zu klein —
+so geschehen beim Rollstuhl-Marker des Kartentools.
+
+**Bewährte Abhilfe (im Kartentool im Einsatz).** Konsumenten zentrieren
+Icons auf ihre **Tintenbox** statt auf die viewBox: Inhalt in ein `<g>`
+laden, `getBBox()` messen, Skala = Zielmass / max(Tintenbreite,
+Tintenhöhe), Translation so, dass die Tintenmitte auf dem Zielpunkt
+liegt. Feine Strichzeichnungen lassen sich mit einem leichten
+Konturauftrag in gleicher Farbe kräftigen (`stroke` = `fill`,
+Strichstärke ≈ 0.09 mm im Zielmass).
+
+**Empfohlener Rückfluss.**
+- Entweder: fontfix-Pipeline (`tools/goetheanum-fontfix/`) normalisiert
+  die Einzeldateien auf eine einheitliche viewBox (idempotent, aus
+  sauberem Stand — dann alle Webfonts/ZIPs neu packen).
+- Oder: Beipackzettel/README der Icons schreibt die Tintenbox-Zentrierung
+  als Konsumentenregel fest.
+
+**Nebenbefund.** `wc-gruppe.svg` ist das fertige Sammel-Piktogramm
+(Dame, Herr, Wickelkind, Rollstuhl, WC-Schriftzug) — für ‹alle
+Toiletten›-Marken braucht es keine Einzel-Icon-Kombination.
+
+## 2. Druck-Export: `text-anchor="middle"` ist nicht druckfest
+
+**Befund.** Der SVG→PDF-Renderer (svg2pdf) misst Textbreiten für die
+Mittel-Verankerung mit fremden Metriken. Im Browser sass alles mittig,
+im PDF verrutschten zweistellige Markerzahlen und die Gebäudenamen
+(‹Goetheanum›, ‹Schreinerei›) um mehrere Millimeter.
+
+**Bewährte Abhilfe.** Text in Export-SVGs **start-verankert selbst
+zentrieren**:
+- Marker-Zeichen: Vorschubtabelle aus der TTF vermessen (fontTools,
+  `hmtx`-Advances je Glyphe in em) und je Zeichen selbst positionieren.
+- Freitexte (Gebäudenamen): Breite zur Laufzeit per Canvas messen
+  (`ctx.font = '100px <Familie>'`, `measureText`), vorher
+  `document.fonts.load(...)` abwarten — sonst misst die Ausweichschrift.
+Nachgemessen: Goetheanum-Label-Mitte im PDF exakt auf Soll.
+
+**Empfohlener Rückfluss.** Als Konstruktionsregel ins Werkzeugwissen
+des Design-Systems (überall, wo SVG→PDF exportiert wird): *Kein
+`text-anchor="middle"`/`end` in Export-SVGs; Breiten selbst messen.*
+
+## 3. Gerechneter ‹Leise-Tinte auf Weiss›-Wert für den Druck
+
+**Befund.** Für Strukturbeiwerk auf Papierweiss (Kategorie-Titel der
+Kartenlegende) fehlte ein leiser Tintenton mit belegtem Kontrast.
+Gerechnet (WCAG-Relativleuchtdichte):
+
+| Ton       | Kontrast auf #ffffff | Verwendung |
+|-----------|----------------------|------------|
+| `#4e4f4a` | 8.26 : 1             | Volltinte (Karten-Lesetexte) |
+| `#6e6f6a` | **5.07 : 1**         | leises Strukturbeiwerk, B02-fest für Lesetext |
+| `#767771` | 4.52 : 1             | Untergrenze, nur mit Bedacht |
+
+**Empfohlener Rückfluss.** `#6e6f6a` als Token-Kandidat
+(z. B. `--ink-print-leise`) aufnehmen, sobald ein zweites Druckwerkzeug
+ihn braucht; bis dahin als belegter Wert im CHANGELOG.
+
+## 4. `.step-num`: Messwerte bestätigt, zweistellig geklärt
+
+**Befund.** Die in `base.css` dokumentierte Sitz-Korrektur (translateY
+8 %, Tintenmitte der Ziffern ≈ 330/1000 über der Grundlinie) wurde im
+Kartentool unabhängig pixelverifiziert — sie stimmt exakt. Für
+zweistellige Zahlen trägt der feste Kreis (1.6 em) die Proportion
+0.72 em problemlos; im Kartenmassstab hat sich für Marker
+**Grad = 0.5 × Kreisdurchmesser** bewährt (eine Spur kräftiger als
+0.72/1.6 = 0.45), mit selbst gesetzten Vorschüben (siehe Befund 2).
+
+**Zusatz.** Die Goetheanum-Schnitte führen `tnum`/`lnum` als
+GSUB-Features (geprüft an Laut) — die G25-Umsetzung über
+`font-variant-numeric` greift also auch in der Hausschrift. Der
+Standardsatz ist proportional (`1` = 0.433 em, `8` = 0.62 em);
+PDF-Renderer ignorieren Features — im Druck-Export darum nie auf
+`tabular-nums` verlassen, sondern Slots selbst setzen.
+
+## 5. Flächenkarten ohne Linien: zwei Bau-Muster
+
+**Befund A — Kontur-Zwillinge.** Die Quell-Illustrator-Karte legt um
+viele Flächen separate Strich-Zwillinge (identische Geometrie als
+`fill="none"`-Pfad, teils mit angehängtem Schlusspunkt — exakte
+d-Duplikat-Erkennung reicht nicht). Für die Flächen-Sprache des Hauses
+(‹keine Linien, nur Kontraste›) müssen sie raus: 341 Strichpfade
+entfernt, Erkennung über (transform, d)-Abgleich + Grössenschwelle
+(< 10 mm = Kontur-Rest, kein Weg). Achtung Zahlen-Parser: Werte wie
+`-.255` (führender Dezimalpunkt) brauchen `-?(?:\d+\.?\d*|\.\d+)`.
+
+**Befund B — Fugendichtung.** Stossen gefüllte Flächen exakt aneinander,
+entstehen beim Rastern (Bildschirm wie PDF-Viewer) haarfeine helle
+Fugen. Abhilfe: jede Fläche trägt eine **Eigenkontur in ihrer
+Füllfarbe** (`stroke` = `fill`, 0.35 pt) — unsichtbar, dichtet die
+Fugen, folgt jeder Umfärbung.
+
+**Empfohlener Rückfluss.** Beide Muster als Werkzeugwissen für künftige
+Karten-/Grafik-Werkzeuge dokumentieren (nicht base.css — es ist
+SVG-Bauwissen, kein Seitenstil).
+
+## 6. Kleinere UI-Befunde aus den Testrunden (bereits umgesetzt)
+
+- Zeilen mit vielen Werkzeugknöpfen (je 44-px-Ziele, B04) brechen
+  schmale Titel in Buchstabentürme — Abhilfe: zweizeilige Zeile
+  (Titel oben in voller Breite, Werkzeuge unten), statt die
+  Fingerziele zu verkleinern.
+- Gruppen-Sammelschalter (‹alle an/aus›) gehören in den Gruppenkopf,
+  brauchen aber ein eigenes Element neben dem Aufklapp-Knopf
+  (verschachtelte Buttons sind unzulässig) — Muster `.group-head`
+  mit `.object-group-title` (flex:1) + `.group-toggle`.
+- Kategorie-Titel in Listen/Legenden: Unterscheidung mit genau einem
+  Merkmal (G01) — leiser, gleicher Grad, gleiche Einrückung wie die
+  Einträge.

--- a/docs/werkzeugwissen.md
+++ b/docs/werkzeugwissen.md
@@ -1,0 +1,87 @@
+# Werkzeugwissen — Bauwissen für SVG, Druck-Export und Werkzeug-UI
+
+Konstruktionsregeln aus verifizierter Praxis (Quelle: Kartentool-Bau,
+Juli 2026, 14 pixel- und PDF-verifizierte Testrunden — siehe
+`docs/learnings-kartentool.md`). Dieses Wissen gehört nicht in `base.css`
+(es ist kein Seitenstil), sondern hierher: Wer ein Werkzeug baut, das SVG
+setzt oder PDF exportiert, liest zuerst diese Seite.
+
+## SVG · Icons einsetzen
+
+**Auf die Tintenbox zentrieren, nie auf die viewBox.** Die
+Icon-Einzeldateien tragen **keine einheitliche viewBox** (verifiziert am
+6. Juli 2026: nur 46 von 81 Dateien haben die Standardbox
+`16.2 -983.8 967.6 967.6`; `wc-rollstuhl.svg` etwa hat
+`-0.6 -845.1 817.5 817.5`, die Badges und die WC-Familie weichen stark
+ab). Wer stur auf die Standardbox skaliert, setzt solche Icons schief und
+zu klein. Bewährte Abhilfe: Inhalt in ein `<g>` laden, per `getBBox()` die
+Tintenbox messen, Skala = Zielmass / max(Tintenbreite, Tintenhöhe),
+Translation so, dass die **Tintenmitte** auf dem Zielpunkt liegt. Feine
+Strichzeichnungen lassen sich mit leichtem Konturauftrag in gleicher Farbe
+kräftigen (`stroke` = `fill`, Strichstärke ≈ 0.09 mm im Zielmass).
+
+**Nebenbefund:** `wc-gruppe.svg` ist das fertige Sammel-Piktogramm (Dame,
+Herr, Wickelkind, Rollstuhl, WC-Schriftzug) — für ‹alle Toiletten› keine
+Einzel-Icons kombinieren.
+
+## Druck-Export (SVG → PDF)
+
+**Kein `text-anchor="middle"`/`end` in Export-SVGs.** PDF-Renderer
+(svg2pdf u. a.) messen Textbreiten mit fremden Metriken — im Browser sitzt
+alles mittig, im PDF verrutschen Zahlen und Namen um Millimeter. Regel:
+Text **start-verankert selbst zentrieren**:
+- Marker-Zeichen: Vorschubtabelle aus der TTF vermessen (fontTools,
+  `hmtx`-Advances je Glyphe in em) und je Zeichen selbst positionieren.
+- Freitexte: Breite zur Laufzeit per Canvas messen
+  (`ctx.measureText` mit `100px <Familie>`), vorher
+  `document.fonts.load(…)` abwarten — sonst misst die Ausweichschrift.
+
+**Nie auf OpenType-Features verlassen.** PDF-Renderer ignorieren
+`font-variant-numeric` und GSUB-Features. Die Hausschrift führt `tnum`/
+`lnum` (geprüft an Laut; Standardsatz proportional: ‹1› = 0.433 em,
+‹8› = 0.62 em) — im Web greift G25 also auch in der Hausschrift, im
+**Druck-Export** aber Ziffern-Slots selbst setzen.
+
+**Ziffern in Kreis-Marken:** Die `.step-num`-Sitzkorrektur aus `base.css`
+(translateY 8 %, Tintenmitte ≈ 330/1000) ist unabhängig pixelverifiziert.
+Für Karten-Marker hat sich Grad = 0.5 × Kreisdurchmesser bewährt (eine
+Spur kräftiger als die UI-Proportion 0.45); zweistellige Zahlen trägt der
+feste Kreis problemlos.
+
+## Flächen-Sprache (‹keine Linien, nur Kontraste›)
+
+**Kontur-Zwillinge entfernen.** Illustrator-Quellen legen um Flächen oft
+separate Strich-Zwillinge (identische Geometrie als `fill="none"`-Pfad,
+teils mit angehängtem Schlusspunkt — exakte d-Duplikat-Erkennung reicht
+nicht). Erkennung über (transform, d)-Abgleich plus Grössenschwelle
+(< 10 mm = Kontur-Rest, kein Weg). Achtung Zahlen-Parser: Werte wie
+`-.255` (führender Dezimalpunkt) brauchen `-?(?:\d+\.?\d*|\.\d+)`.
+
+**Fugendichtung.** Stossen gefüllte Flächen exakt aneinander, entstehen
+beim Rastern haarfeine helle Fugen (Bildschirm wie PDF-Viewer). Abhilfe:
+jede Fläche trägt eine **Eigenkontur in ihrer Füllfarbe** (`stroke` =
+`fill`, 0.35 pt) — unsichtbar, dichtet die Fugen, folgt jeder Umfärbung.
+
+## Druck-Tinten auf Papierweiss (gerechnet)
+
+| Ton       | Kontrast auf #ffffff | Verwendung |
+|-----------|----------------------|------------|
+| `#4e4f4a` | 8.26:1               | Volltinte (Karten-Lesetexte) |
+| `#6e6f6a` | 5.07:1               | leises Strukturbeiwerk, B02-fest für Lesetext |
+| `#767771` | 4.52:1               | Untergrenze, nur mit Bedacht |
+
+`#6e6f6a` ist Token-Kandidat (`--ink-print-leise`), sobald ein zweites
+Druckwerkzeug ihn braucht — bis dahin gilt er als belegter Wert.
+
+## Werkzeug-UI-Muster (verifiziert im Kartentool)
+
+- **Zweizeilige Werkzeugzeile:** Viele 44-px-Ziele (B04) in einer Zeile
+  brechen schmale Titel in Buchstabentürme — Titel oben in voller Breite,
+  Werkzeuge darunter; nie die Fingerziele verkleinern.
+- **Gruppen-Sammelschalter** (‹alle an/aus›) gehören in den Gruppenkopf,
+  aber als **eigenes Element** neben dem Aufklapp-Knopf — verschachtelte
+  Buttons sind unzulässig. Muster: `.group-head` mit Titel (flex:1) +
+  Toggle. Kandidat für `base.css`, sobald ein zweites Werkzeug es braucht.
+- **Kategorie-Titel in Listen/Legenden:** Unterscheidung mit genau einem
+  Merkmal (G01) — leiser, gleicher Grad, gleiche Einrückung wie die
+  Einträge.

--- a/icons.html
+++ b/icons.html
@@ -200,6 +200,7 @@
           <li><b>PNG</b><span>Für schnelle Verwendung in Office und Präsentationen – fester Pixelrahmen.</span></li>
         </ul>
         <p style="margin-top:14px">Im Fließtext oder als Aufzählungszeichen ist der Webfont am leichtesten; für ein einzelnes großes Symbol im Layout die SVG oder das PDF.</p>
+        <p class="note" style="margin-top:10px">Hinweis für Werkzeuge, die SVGs programmatisch setzen: Die Einzeldateien tragen <b style="font-weight:var(--w-deutlich)">keine einheitliche viewBox</b> — auf die Tintenbox zentrieren (per <code>getBBox()</code>), nicht auf die viewBox. Details im <a href="https://github.com/phtok/goeloggen/blob/main/docs/werkzeugwissen.md">Werkzeugwissen</a>.</p>
       </div>
 
     </div>


### PR DESCRIPTION
## Worum es geht

Die Learnings aus dem Kartentool-Bau (14 pixel- und PDF-verifizierte
Testrunden) fliessen ins System zurück — nach dem Haus-Atem: **verifiziert,
dann aufgenommen**. Quelle mit abgelegt: `docs/learnings-kartentool.md`.

## Aufgenommen

- **`docs/werkzeugwissen.md` (neu)** — Bauwissen für SVG, Druck-Export und
  Werkzeug-UI als Konstruktionsregeln: Icons auf die **Tintenbox** zentrieren;
  in Export-SVGs **kein `text-anchor="middle"`** und **keine
  OpenType-Feature-Abhängigkeit** (PDF-Renderer ignorieren beides — Breiten
  und Ziffern-Slots selbst setzen); Kontur-Zwillinge entfernen, **Fugendichtung**
  per Eigenkontur in Füllfarbe; Zweizeilen-Werkzeugzeile, `group-head`-Muster
  (keine verschachtelten Buttons), G01-Kategorietitel.
- **Belegte Druck-Tinten** (gerechnet): `#4e4f4a` 8.26:1 · **`#6e6f6a` 5.07:1**
  (Token-Kandidat `--ink-print-leise`, Aufnahme sobald ein zweites
  Druckwerkzeug ihn braucht) · `#767771` 4.52:1.
- **`.step-num`-Verifikation** am base.css-Kommentar vermerkt; die
  Hausschrift führt `tnum`/`lnum` als GSUB-Features (G25 greift auch dort —
  nur nicht im PDF-Export).

## Icon-Befund: nachgeprüft und grösser als gemeldet

Das Learnings-Papier mass eine abweichende Datei — der Scan zeigt: **nur 46
von 81** Einzeldateien tragen die Standard-viewBox; WC-Familie, Badges und
einige Icon-Reihen weichen stark ab.

- **Jetzt:** Konsumenten-Hinweis auf `icons.html` (Einzeldatei-Panel) +
  Tintenbox-Regel im Werkzeugwissen.
- **Offen (Ratifizierung):** Normalisierung über die fontfix-Pipeline
  (Regeneration aus dem Font, PNG/PDF/ZIP neu) — als Aufgabe #25 vermerkt,
  da sie verteilte Assets ändert.

## Prüfung

Typo-Check konform (nur nbsp-Hinweise), ds-lint 100 % (icons.html), Typo-Sync
synchron, CHANGELOG-Eintrag unter [Unveröffentlicht].

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_