### PR TITLE
Signatur-Generator: ‹Nur Text kopieren› als Ghost-Knopf

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -193,7 +193,7 @@
 
           <div class="btnrow">
             <button type="button" class="btn primary" id="copyRich">Signatur kopieren</button>
-            <button type="button" class="btn" id="copyPlain">Nur Text kopieren</button>
+            <button type="button" class="btn ghost" id="copyPlain">Nur Text kopieren</button>
           </div>
           <span class="sr-only" id="copyStatus" aria-live="polite"></span>
 


### PR DESCRIPTION
‹Nur Text kopieren› wird ein **Ghost-Knopf** — zurückhaltend, damit **‹Signatur kopieren›** die klare Primäraktion bleibt. Die Funktion (reines Textformat erzwingen) bleibt erhalten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_