### PR TITLE
Signatur-Generator: Apple-Mail-Hinweis mit beschrifteter Schema-Grafik

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -87,6 +87,22 @@
   .empf a:hover{text-decoration:underline}
   .empf .rule{border:0;border-top:1px solid var(--line-soft);margin:var(--s6) 0}
 
+  /* Schematische Apple-Mail-Illustration (theme-aware, keine Screenshots) */
+  .amv{width:100%;max-width:520px;height:auto;display:block;margin-top:var(--s4)}
+  .amv .win{fill:var(--paper);stroke:var(--line);stroke-width:1.5}
+  .amv .panel{fill:var(--soft);stroke:var(--line-soft)}
+  .amv .row{fill:color-mix(in srgb,var(--gold) 22%,transparent)}
+  .amv .dot{fill:var(--muted);opacity:.45}
+  .amv .ln{stroke:var(--muted);stroke-width:6;stroke-linecap:round;opacity:.35}
+  .amv .ln.b{stroke:var(--ink);opacity:.75}
+  .amv .ln.blue{stroke:var(--blue);opacity:.9}
+  .amv .box{fill:none;stroke:var(--ink);stroke-width:1.5;opacity:.7}
+  .amv .check{fill:none;stroke:var(--blue);stroke-width:2.4;stroke-linecap:round;stroke-linejoin:round}
+  .amv .mark{fill:none;stroke:var(--gold-ink);stroke-width:2.5}
+  .amv text{font-family:var(--font-text)}
+  .amv .t{fill:var(--ink)}
+  .amv .tg{fill:var(--gold-ink);font-weight:600}
+
   @media(max-width:560px){
     .mail-stage{padding:var(--s4)}
     .scroll-hint{display:block;font-size:var(--t-micro);color:var(--muted);margin-top:6px}
@@ -210,8 +226,30 @@
           <details class="code-details">
             <summary>Hinweis für Apple Mail</summary>
             <div class="hint">
-              Falls die Signatur nach dem Einfügen ihre Form verliert, deaktiviere unter dem Signaturfeld
-              die Option ‹Standardschriftart für E-Mails verwenden›.
+              <strong>Wichtig:</strong> Damit Fettung und Farben erscheinen, muss die Standardschrift aus sein.
+              Mail → Einstellungen → Signaturen; unter dem Signaturfeld das Häkchen
+              ‹Standardschriftart für E-Mails verwenden› entfernen.
+              <svg class="amv" viewBox="0 0 560 320" role="img"
+                   aria-label="Apple Mail, Einstellungen, Signaturen: unter dem Signaturfeld die Option ‹Standardschriftart für E-Mails verwenden› deaktivieren – Häkchen entfernen.">
+                <rect class="win" x="8" y="8" width="544" height="304" rx="14"/>
+                <circle class="dot" cx="30" cy="28" r="4"/><circle class="dot" cx="44" cy="28" r="4"/><circle class="dot" cx="58" cy="28" r="4"/>
+                <rect class="panel" x="24" y="48" width="150" height="236" rx="8"/>
+                <rect class="row" x="36" y="64" width="126" height="22" rx="5"/>
+                <line class="ln" x1="48" y1="106" x2="150" y2="106"/>
+                <line class="ln" x1="48" y1="132" x2="140" y2="132"/>
+                <line class="ln" x1="48" y1="158" x2="150" y2="158"/>
+                <rect class="panel" x="190" y="48" width="346" height="150" rx="8"/>
+                <line class="ln b" x1="206" y1="74" x2="320" y2="74"/>
+                <line class="ln blue" x1="206" y1="98" x2="300" y2="98"/>
+                <line class="ln" x1="206" y1="122" x2="360" y2="122"/>
+                <line class="ln" x1="206" y1="142" x2="330" y2="142"/>
+                <line class="ln" x1="206" y1="166" x2="300" y2="166"/>
+                <rect class="box" x="206" y="228" width="18" height="18" rx="4"/>
+                <path class="check" d="M210 237 l4 4 l7 -9"/>
+                <text class="t" x="236" y="242" font-size="15">Standardschriftart für E-Mails verwenden</text>
+                <rect class="mark" x="196" y="220" width="346" height="34" rx="9"/>
+                <text class="tg" x="206" y="286" font-size="15">→ Häkchen entfernen</text>
+              </svg>
             </div>
           </details>
 


### PR DESCRIPTION
Macht die versteckte, aber **nötige** Apple-Mail-Einstellung auffindbar.

Wichtiger Befund (von Dir bestätigt): Die Option **‹Standardschriftart für E-Mails verwenden›** muss **aus** sein — sonst zeigt Apple Mail **weder Fettung noch Farben**. Das gilt auch für die aktuelle einspaltige Signatur, nicht nur für ein Zweispalten-Layout.

**Umsetzung:** Der Klapper **‹Hinweis für Apple Mail›** enthält jetzt eine **theme-aware Schema-Grafik** (Inline-SVG, kein Screenshot — ändert sich nicht mit macOS-Versionen, bleibt im Hausbild): Signaturen-Fenster mit markiertem Kästchen und ‹→ Häkchen entfernen›. Text stellt den Zusammenhang klar (Fettung/Farben ↔ Standardschrift aus).

Vorschau der Grafik (hell gerendert):

Layout geprüft (SVG paarig, JS valide). Kein Screenshot nötig; die Zeichnung nutzt die Haus-Tokens und flippt in Hell/Dunkel mit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_