### PR TITLE
Kartentool-Feinlagen + Design-System v1.6.0: Werkzeugwissen aufgenommen

### DIFF
--- a/apps/karten-generator/app.js
+++ b/apps/karten-generator/app.js
@@ -22,7 +22,9 @@ const MARKER_FARBEN = {
 const FARB_ZYKLUS = ["rot", "blau", "gruen", "grau", "gold"];
 const TINTE = "#4e4f4a";
 // Leise Druck-Tinte für Strukturbeiwerk (Kategorie-Titel der Legende):
-// gerechnet 5.07:1 auf Weiss (B02, ≥4.5:1 für Lesetext).
+// = Token --ink-print-leise (tokens.css, seit v1.6.0), gerechnet 5.07:1
+// auf Weiss (B02, ≥4.5:1 für Lesetext); hier als Hex, weil der Wert in
+// den PDF-Export wandert (Print-SVG kennt keine CSS-Variablen).
 const TINTE_LEISE = "#6e6f6a";
 
 // Schriftrollen: Sprache (Titel, Legende, Gebäudenamen) in der Hausschrift
@@ -413,7 +415,8 @@ function ortMarker(ort) {
 // justierten Lagen lassen sich exportieren und wandern in die Vorlage.
 function ortJustierbar(ort) {
   return ort.kategorie === "sektionen" || ort.kategorie === "gaerten"
-    || ort.kategorie === "verkehr" || ort.id.indexOf("wc-") === 0;
+    || ort.kategorie === "verkehr" || ort.id.indexOf("wc-") === 0
+    || ort.id === "b-zugang";  // Überlappung mit dem Südeingang ausgleichbar
 }
 
 function ortBeweglich(ort) {

--- a/apps/karten-generator/index.html
+++ b/apps/karten-generator/index.html
@@ -211,8 +211,10 @@
     .marken-farbe.gewaehlt { border-color: var(--ink); }
 
     .preview-shell { display: flex; flex-direction: column; gap: var(--s3); min-width: 0; }
-    .preview-top { display: flex; align-items: center; justify-content: space-between; gap: var(--s3); flex-wrap: wrap; }
-    .preview-note { font-size: var(--t-small); color: var(--muted); }
+    /* Format-Notiz rechtsbündig an die Zoom-Knöpfe angeschlossen
+       (Entscheid Auftraggeber, 8. Juli 2026) — etwas Luft dazwischen. */
+    .preview-top { display: flex; align-items: center; justify-content: flex-end; gap: var(--s4); flex-wrap: wrap; }
+    .preview-note { font-size: var(--t-small); color: var(--muted); text-align: right; }
     .zoom-controls { display: flex; align-items: center; gap: var(--s2); }
     .zoom-controls button { min-width: var(--tap); min-height: var(--tap); }
     .zoom-value { font-size: var(--t-small); color: var(--muted); min-width: 4ch; font-variant-numeric: tabular-nums; }

--- a/apps/karten-generator/orte.js
+++ b/apps/karten-generator/orte.js
@@ -248,8 +248,8 @@ const ORTE = [
     },
     "positionen": [
       [
-        285.0,
-        196.0
+        281.24,
+        201.56
       ]
     ],
     "pfeil": "unten-rechts"

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -16,6 +16,27 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ---
 
+## [1.6.0] – 2026-07-08
+
+### Werkzeugwissen + Druck-Tinte (Rückfluss aus dem Kartentool)
+- **Was:** Neues Dokument `design-system/werkzeugwissen.md` — Konstruktions-
+  regeln für Werkzeuge, die drucken und zeichnen: kein `text-anchor="middle"`
+  in Export-SVGs (Breiten selbst messen: TTF-Vorschubtabellen, Canvas nur als
+  Rückfall), Icons auf die Tintenbox statt die viewBox zentrieren,
+  Kontur-Zwillinge entfernen + Fugendichtung (`stroke` = `fill`) für
+  Flächengrafik, `.step-num`-Masse im Kartenmassstab (Grad 0.5 × ⌀,
+  Piktos 1.26 × r), Token-Treue auch für Abstände (erfundene `var(--…)`
+  fallen still auf 0). Dazu neues Token **`--ink-print-leise:#6e6f6a`** —
+  leises Strukturbeiwerk auf Papierweiss, gerechnet 5.07:1 (B02-fest).
+- **Warum:** 18 Rückmelderunden Kartentool haben Bauwissen erzeugt, das
+  sonst in der Session verloren ginge (Entscheid Auftraggeber, 8. Juli 2026:
+  ‹direkt einarbeiten›). Der `--s5`-Vorfall (nicht existierendes
+  Abstands-Token, still auf 0 zurückgefallen) zeigt eine DS02-Lücke —
+  Kandidat für `ds-lint`: unbekannte `var(--…)`-Namen melden.
+- **Wirkung:** Werkzeugwissen ist Fundament (gilt für jedes künftige
+  Druck-/Grafik-Werkzeug); `--ink-print-leise` ersetzt den bisher nur im
+  Kartentool notierten Hex-Wert. `contract.json` → Version 1.6.0.
+
 ## [1.5.0] – 2026-07-06
 
 ### Bild-Ebene + Logo-Disziplin (DS08)

--- a/design-system/contract.json
+++ b/design-system/contract.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://goetheanum/design-system/contract.schema.json",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "titel": "Goetheanum Design-System – Struktur-Vertrag",
   "zweck": "Maschinenlesbare Grundlage der GESTALT-Konformität (symmetrisch zum sprachlichen Kanon in assets/typografie/). ds-lint.py prüft jede Seite hiergegen, ds-fix.py korrigiert deterministisch, das Schaufenster bildet es ab. Eine Quelle der Wahrheit für Struktur; Werte/Farben/Schnitte bleiben in tokens.css/tokens.json.",
   "geltungsbereich": {

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -69,6 +69,11 @@
   --bad:#b3261e;         /* Fehler/Warnung */
   --ok:#3f7d46;          /* Erfolg/Bestätigung – Weiss drauf (--on-accent) */
   --on-accent:#fff;      /* Text auf Blau/Gold-Flächen */
+  --ink-print-leise:#6e6f6a; /* leises Strukturbeiwerk auf PAPIERWEISS (Druckwerke:
+                                Kategorie-Titel in Legenden u. ä.) – 5.07:1, B02-fest
+                                für Lesetext; gerechnet im Kartentool, Juli 2026.
+                                Theme-fest: gilt fürs gedruckte Blatt, nicht für
+                                Bildschirmflächen (dort --muted). */
 
   /* --- Code-Konsole (eigenständige, THEME-FESTE Fläche – gleich in Hell/Dunkel,
      wie eine Entwickler-Konsole; Syntaxpalette für Dunkel ausgelegt). --------- */

--- a/design-system/werkzeugwissen.md
+++ b/design-system/werkzeugwissen.md
@@ -1,0 +1,90 @@
+# Werkzeugwissen — Konstruktionsregeln für Werkzeuge, die drucken und zeichnen
+
+Dieses Wissen gehört zum Design-System, aber nicht in `base.css`: Es sind
+**Bau-Regeln für Werkzeuge** (SVG-Grafik, PDF-Export, Icon-Konsum), keine
+Seitenstile. Quelle: Bau- und Testrunden des Kartentools
+(`apps/karten-generator/`), Juli 2026 — pixel- und PDF-verifiziert,
+ratifiziert vom Auftraggeber (8. Juli 2026). Ledger-Eintrag: Version 1.6.0.
+
+## 1. Druck-Export: `text-anchor="middle"` ist nicht druckfest
+
+Der SVG→PDF-Renderer (svg2pdf) misst Textbreiten für die Mittel-Verankerung
+mit fremden Metriken: Im Browser sitzt alles mittig, im PDF verrutschen
+Texte um Millimeter. **Regel für Export-SVGs: kein `text-anchor="middle"`
+oder `end` — Breiten selbst messen, start-verankert selbst zentrieren.**
+
+- Feste Zeichenvorräte (Markerzeichen): Vorschubtabelle aus der TTF
+  vermessen (fontTools, `hmtx`-Advances je Glyphe in em, upm beachten)
+  und je Zeichen selbst positionieren. Deterministisch und ladeunabhängig.
+- Freitexte: Breite zur Laufzeit per Canvas messen (`ctx.font`,
+  `measureText`), vorher `document.fonts.load(...)` abwarten — sonst
+  misst die Ausweichschrift. Nur als Rückfall für Zeichen ausserhalb
+  der Tabelle.
+- PDF-Renderer ignorieren OpenType-Features: `tabular-nums` (G25) im
+  Druck-Export nie voraussetzen — Ziffern-Slots selbst setzen.
+
+## 2. Icons v2.7: auf die Tintenbox zentrieren, nicht auf die viewBox
+
+Die Icon-Einzeldateien sind nicht einheitlich normiert (Standard-viewBox
+`16.2 -983.8 967.6 967.6`, aber z. B. `wc-rollstuhl.svg` trägt
+`-0.6 -845.1 817.5 817.5`). Wer stur auf die Standardbox skaliert, setzt
+solche Icons schief und zu klein. **Regel: Konsumenten zentrieren Icons
+auf ihre Tintenbox** — Inhalt in ein `<g>` laden, `getBBox()` messen,
+Skala = Zielmass / max(Tintenbreite, Tintenhöhe), Tintenmitte auf den
+Zielpunkt. Feine Strichzeichnungen mit Konturauftrag in gleicher Farbe
+kräftigen (`stroke` = `fill`, ≈ 0.09 mm im Zielmass).
+
+`wc-gruppe.svg` ist das fertige Sammel-Piktogramm (Dame, Herr, Wickelkind,
+Rollstuhl, WC-Schriftzug) — für ‹alle Toiletten› keine Einzel-Icons kombinieren.
+
+## 3. Flächengrafik ohne Linien: zwei Bau-Muster
+
+- **Kontur-Zwillinge entfernen:** Illustrator-Quellkarten legen um Flächen
+  separate Strich-Zwillinge (identische Geometrie als `fill="none"`-Pfad,
+  teils mit angehängtem Schlusspunkt oder als Haarlinie ≤ 0.5 pt). Für die
+  Flächen-Sprache des Hauses (‹keine Linien, nur Kontraste›) müssen sie
+  raus: Erkennung über (transform, d)-Abgleich, Grössenschwelle und
+  Strichstärke. Achtung Zahlen-Parser: Werte wie `-.255` brauchen
+  `-?(?:\d+\.?\d*|\.\d+)`.
+- **Fugendichtung:** Stossen gefüllte Flächen exakt aneinander, entstehen
+  beim Rastern haarfeine helle Fugen. Jede Fläche trägt eine Eigenkontur
+  in ihrer Füllfarbe (`stroke` = `fill`, 0.35 pt) — unsichtbar, dichtet
+  die Fugen, folgt jeder Umfärbung.
+
+## 4. Leise Tinte auf Papierweiss: `--ink-print-leise`
+
+Für Strukturbeiwerk auf dem gedruckten Blatt (Kategorie-Titel in Legenden)
+gilt der gerechnete Ton `#6e6f6a` (**5.07:1** auf Weiss, B02-fest für
+Lesetext) — als Token `--ink-print-leise` im Fundament. Volltinte der
+Karten-Lesetexte: `#4e4f4a` (8.26:1). Untergrenze `#767771` (4.52:1) nur
+mit Bedacht.
+
+## 5. `.step-num` im Kartenmassstab
+
+Die dokumentierte Sitz-Korrektur (Tintenmitte der Ziffern ≈ 330/1000 über
+der Grundlinie) ist unabhängig pixelverifiziert — sie stimmt. Für Marker
+im Kartenmassstab hat sich **Grad = 0.5 × Kreisdurchmesser** bewährt
+(kräftiger als die 0.72/1.6-Proportion der Web-Komponente); Einzel-Piktos
+im Kreis laufen mit **1.26 × Radius** (Luft zum Rand, optisch der
+Ziffernsitz). Zweistellige Zahlen brauchen selbst gesetzte Vorschübe
+(siehe 1.).
+
+## 6. Token-Treue gilt auch für Abstände
+
+Ein erfundenes Token (`var(--s5)` — die Skala führt s1–s4, s6, s8) fällt
+**still auf 0 zurück**: kein Fehler, nur gequetschtes Layout. DS02 meint
+auch Abstands- und Grössen-Tokens, nicht nur Farben; im Zweifel die Skala
+in `tokens.css` nachschlagen. (Kandidat für `ds-lint`: unbekannte
+`var(--…)`-Namen melden.)
+
+## 7. UI-Muster aus den Testrunden
+
+- Zeilen mit vielen 44-px-Werkzeugknöpfen (B04) brechen schmale Titel in
+  Buchstabentürme — zweizeilige Zeile (Titel oben in voller Breite,
+  Werkzeuge unten), nie die Fingerziele verkleinern.
+- Gruppen-Sammelschalter gehören in den Gruppenkopf als **eigenes**
+  Element neben dem Aufklapp-Knopf (verschachtelte Buttons sind
+  unzulässig) — Muster `.group-head` mit Titel (flex:1) + Schalter.
+- Kategorie-Titel in Listen/Legenden: Unterscheidung mit genau einem
+  Merkmal (G01) — leiser (`--ink-print-leise` im Druck), gleicher Grad,
+  gleiche Einrückung wie die Einträge.

--- a/tools/karten/extract-marker-positionen.py
+++ b/tools/karten/extract-marker-positionen.py
@@ -203,9 +203,10 @@ WILLKOMMEN = [
     # eigener Verkehrs-Ort mit Buchstabe B (Entscheid Auftraggeber,
     # 8. Juli 2026); bisher nur Beiwerk-Zeile des Speisehauses. Der Pfeil
     # zeigt nach aussen (die Haltestelle liegt Richtung Blattrand).
+    # Lage vom Auftraggeber justiert (Faust-Karte, 8. Juli 2026).
     ("f-bus", "B", "verkehr",
      {"de": "Bushaltestelle", "en": "Bus Stop"},
-     [[285.0, 196.0]], {"pfeil": "unten-rechts"}),
+     [[281.24, 201.56]], {"pfeil": "unten-rechts"}),
 
     # Vitalshop (der Laden im Speisehaus) — eigener Verkehrs-Ort mit
     # Buchstabe V (Entscheid Auftraggeber, 8. Juli 2026); Lage beim


### PR DESCRIPTION
Runde 19 — Feinlagen aus der Faust-Karte plus der beschlossene Direkt-Rückfluss ins Design-System:

**Kartentool**
- Die vom Auftraggeber justierte **Bus-Lage in die Vorlage gebacken** (281.24, 201.56) — künftige Karten starten mit der richtigen Haltestellen-Position.
- **Format-Notiz rechtsbündig an die Zoom-Knöpfe** angeschlossen, mit `--s4` Luft dazwischen.
- **b-zugang im Backend justierbar** — im Faust-PDF überlappt die Rollstuhl-Marke die ‹2› des Südeingangs; das lässt sich jetzt mit ✥ ausgleichen.

**Design-System (v1.6.0, der Atem)**
- Neues Dokument `design-system/werkzeugwissen.md`: Konstruktionsregeln für Druck-/Grafik-Werkzeuge — kein `text-anchor="middle"` in Export-SVGs (Breiten selbst messen), Icons auf die Tintenbox zentrieren, Kontur-Zwillinge + Fugendichtung, `.step-num`-Masse im Kartenmassstab, Token-Treue auch für Abstände (der `--s5`-Vorfall als DS02-Lücke dokumentiert).
- Neues Token `--ink-print-leise: #6e6f6a` (leises Strukturbeiwerk auf Papierweiss, gerechnet 5.07:1, B02-fest); der Kartentool-Wert verweist jetzt auf das Token.
- CHANGELOG-Eintrag 1.6.0, `contract.json` → 1.6.0.

Gates: typo-check, typo-sync und ds-lint grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgMfxisgg9yjRqFZhd6wuC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgMfxisgg9yjRqFZhd6wuC)_