### PR TITLE
Signatur-Generator: Apple-Grafik, HTML-Ansicht raus, Empfehlungen neu (2-spaltig, nummeriert)

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -78,35 +78,17 @@
   /* Empfehlungen: Lesetext, linksbündig (Titel NICHT rechts). */
   .empf-head h2{font-size:var(--t-h2)}
   .empf-head p{color:var(--muted);font-size:var(--t-small);margin-top:var(--s1)}
-  .empf{font-family:var(--font-text);max-width:60ch;margin-top:var(--s4)}
-  .empf h3{font-family:var(--font-display);font-weight:var(--w-strong);font-size:var(--t-h3);margin:var(--s6) 0 var(--s2)}
-  .empf h3:first-of-type{margin-top:0}
-  .empf p{font-size:var(--t-small);line-height:1.6;color:var(--ink);margin:0 0 var(--s3)}
-  .empf p.dim{color:var(--muted)}
+  .empf{font-family:var(--font-text);margin-top:var(--s2)}
   .empf a{color:var(--gold-ink);text-decoration:none}
   .empf a:hover{text-decoration:underline}
-  .empf .rule{border:0;border-top:1px solid var(--line-soft);margin:var(--s6) 0}
+  @media(min-width:720px){.empf{columns:2;column-gap:var(--s8)}}
+  .empf-item{break-inside:avoid;margin:0 0 var(--s6)}
+  .empf-item h3{font-family:var(--font-display);font-weight:var(--w-strong);font-size:var(--t-h3);margin:0 0 var(--s2);display:flex;gap:.5ch;align-items:baseline}
+  .empf-item .num{color:var(--gold-ink)}
+  .empf-item p{font-size:var(--t-small);line-height:1.6;color:var(--ink);margin:0 0 var(--s2);max-width:46ch}
 
-  /* Apple-Mail-Skizze (theme-aware, Haus-Tokens) */
-  .amv{width:100%;max-width:600px;height:auto;display:block;margin-top:var(--s4)}
-  .amv .win{fill:var(--paper);stroke:var(--line);stroke-width:1.5}
-  .amv .panel{fill:var(--soft);stroke:var(--line-soft)}
-  .amv .sel{fill:color-mix(in srgb,var(--gold) 20%,transparent)}
-  .amv .selmid{fill:color-mix(in srgb,var(--ink) 8%,transparent)}
-  .amv .mini{fill:var(--field-bg);stroke:var(--line)}
-  .amv .dot{fill:var(--muted);opacity:.4}
-  .amv .div{stroke:var(--line-soft)}
-  .amv .chip{fill:none;stroke:var(--line)}
-  .amv .chip.on{fill:none;stroke:var(--gold);stroke-width:2}
-  .amv .ic{fill:color-mix(in srgb,var(--muted) 30%,transparent)}
-  .amv .ln{stroke:var(--muted);stroke-width:6;stroke-linecap:round;opacity:.32}
-  .amv .ln.b{stroke:var(--ink);opacity:.82}
-  .amv .ln.blue{stroke:var(--blue);opacity:.9}
-  .amv .box{fill:var(--paper);stroke:var(--ink);stroke-width:1.6;opacity:.85}
-  .amv .check{fill:none;stroke:var(--ink);stroke-width:2.2;stroke-linecap:round;stroke-linejoin:round}
-  .amv .mark{fill:none;stroke:var(--gold-ink);stroke-width:2.5}
-  .amv text{font-family:var(--font-text)}
-  .amv .t{fill:var(--ink)} .amv .tm{fill:var(--muted)} .amv .tg{fill:var(--gold-ink)}
+  /* Apple-Mail-Skizze (eigenständige Farben = Artefakt/Screenshot). */
+  .amv{width:100%;max-width:600px;height:auto;display:block;margin-top:var(--s4)} /* ds-ok */
 
   /* Empfehlungs-Vergleich: aufgeräumt vs. überladen (theme-aware) */
   .empf-ill{width:100%;max-width:760px;height:auto;display:block;margin:var(--s4) 0 var(--s6)}
@@ -130,6 +112,11 @@
   .empf-ill .badge-p{stroke:var(--on-accent);stroke-width:2.4;fill:none;stroke-linecap:round;stroke-linejoin:round}
   .empf-ill .cap{font-family:var(--font-display);font-weight:var(--w-deutlich)}
   .empf-ill .cap.ok{fill:var(--ok)} .empf-ill .cap.bad{fill:var(--bad)}
+  .empf-ill .msghl{fill:color-mix(in srgb,var(--gold) 16%,transparent)}
+  .empf-ill .msg{stroke:var(--ink);stroke-width:7;stroke-linecap:round;opacity:.9}
+  .empf-ill .under{stroke:var(--gold-ink);stroke-width:4;stroke-linecap:round}
+  .empf-ill .lost{stroke:var(--muted);stroke-width:3;stroke-linecap:round}
+  .empf-ill .lostcap{fill:var(--bad);font-family:var(--font-text);opacity:.85}
 
   .privacy{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);line-height:1.5;margin-top:var(--s3)}
 
@@ -253,9 +240,9 @@
               <strong>Apple Mail:</strong> Damit Fettung und Farben erscheinen, muss die Standardschrift aus sein –
               Mail → Einstellungen → Signaturen; unter der Vorschau das Häkchen
               ‹Standardschriftart für E-Mails verwenden› entfernen.
-              <svg class="amv" viewBox="0 0 820 470" font-family="inherit" role="img" aria-label="Apple Mail, Signaturen: das Kaestchen ‹Standardschriftart fuer E-Mails verwenden› unter der Vorschau abwaehlen – Haeckchen entfernen.">
-<defs><filter id="g" x="-15%" y="-40%" width="130%" height="180%"><feGaussianBlur stdDeviation="4"/></filter></defs>
-<rect x="8" y="8" width="804" height="454" rx="14" class="win" /><circle cx="34" cy="32" r="4" class="dot"/><circle cx="50" cy="32" r="4" class="dot"/><circle cx="66" cy="32" r="4" class="dot"/><text x="410.0" y="37" font-size="13" class="tm" text-anchor="middle">Signaturen</text><rect x="56.44444444444444" y="54" width="28" height="20" rx="6" class="chip" /><rect x="141.33333333333331" y="54" width="28" height="20" rx="6" class="chip" /><rect x="226.22222222222223" y="54" width="28" height="20" rx="6" class="chip" /><rect x="311.1111111111111" y="54" width="28" height="20" rx="6" class="chip" /><rect x="396.0" y="54" width="28" height="20" rx="6" class="chip" /><rect x="480.8888888888889" y="54" width="28" height="20" rx="6" class="chip on" /><rect x="565.7777777777777" y="54" width="28" height="20" rx="6" class="chip" /><rect x="650.6666666666666" y="54" width="28" height="20" rx="6" class="chip" /><rect x="735.5555555555555" y="54" width="28" height="20" rx="6" class="chip" /><text x="494.8888888888889" y="88" font-size="11" class="tm" text-anchor="middle">Signaturen</text><line x1="20" y1="100" x2="800" y2="100" class="div"/><rect x="24" y="116" width="210" height="256" rx="8" class="panel" /><rect x="30" y="126" width="198" height="70.66666666666667" rx="7" class="sel" /><rect x="40" y="148.33333333333334" width="34" height="34" rx="8" class="ic" /><line x1="84" y1="159.33333333333334" x2="210" y2="159.33333333333334" class="ln b"/><line x1="84" y1="175.33333333333334" x2="174" y2="175.33333333333334" class="ln"/><rect x="40" y="227.00000000000003" width="34" height="34" rx="8" class="ic" /><line x1="84" y1="238.00000000000003" x2="210" y2="238.00000000000003" class="ln"/><line x1="84" y1="254.00000000000003" x2="174" y2="254.00000000000003" class="ln"/><rect x="40" y="305.6666666666667" width="34" height="34" rx="8" class="ic" /><line x1="84" y1="316.6666666666667" x2="210" y2="316.6666666666667" class="ln"/><line x1="84" y1="332.6666666666667" x2="174" y2="332.6666666666667" class="ln"/><rect x="246" y="116" width="168" height="256" rx="8" class="panel" /><rect x="248" y="118" width="164" height="34" rx="0" class="selmid" /><line x1="262" y1="136.0" x2="390" y2="136.0" class="ln b"/><line x1="248" y1="152" x2="412" y2="152" class="div"/><line x1="262" y1="170.0" x2="390" y2="170.0" class="ln"/><line x1="248" y1="186" x2="412" y2="186" class="div"/><rect x="248" y="380" width="30" height="24" rx="6" class="mini" /><text x="263" y="397" font-size="16" class="tm" text-anchor="middle">+</text><rect x="280" y="380" width="30" height="24" rx="6" class="mini" /><text x="295" y="396" font-size="16" class="tm" text-anchor="middle">–</text><rect x="428" y="116" width="368" height="256" rx="8" class="panel" /><line x1="446" y1="142" x2="658" y2="142" class="ln"/><line x1="446" y1="164" x2="578" y2="164" class="ln"/><line x1="446" y1="190" x2="548" y2="190" class="ln b"/><line x1="446" y1="210" x2="628" y2="210" class="ln"/><line x1="446" y1="236" x2="538" y2="236" class="ln blue"/><line x1="446" y1="256" x2="668" y2="256" class="ln"/><line x1="446" y1="274" x2="608" y2="274" class="ln"/><line x1="446" y1="294" x2="548" y2="294" class="ln blue"/><rect x="422" y="366" width="380" height="40" rx="10" class="mark" filter="url(#g)"/><rect x="422" y="366" width="380" height="40" rx="10" class="mark" /><rect x="430" y="374" width="20" height="20" rx="4" class="box" /><path class="check" d="M434 384 l4 4 l8 -10"/><text x="460" y="389" font-size="14" class="t" text-anchor="start">Standardschrift für E-Mails verwenden</text><text x="422" y="426" font-size="15" class="tg" text-anchor="start" font-weight="700">→ Häkchen entfernen</text>
+              <svg class="amv" viewBox="0 0 780 450" font-family="-apple-system,Helvetica,Arial,sans-serif" role="img" aria-label="Apple Mail, Einstellungen, Signaturen: das blaue Kaestchen ‹Standardschriftart fuer E-Mails verwenden› unter der Vorschau abwaehlen – Haeckchen entfernen.">
+<defs><filter id="g" x="-10%" y="-40%" width="120%" height="180%"><feGaussianBlur stdDeviation="4"/></filter></defs>
+<rect x="6" y="6" width="768" height="438" rx="14" fill="#f5f5f7" stroke="#c9ccd0" stroke-width="1.5" /><circle cx="30" cy="30" r="7" fill="#ff5f57"/><circle cx="50" cy="30" r="7" fill="#febc2e"/><circle cx="70" cy="30" r="7" fill="#28c840"/><text x="390.0" y="35" font-size="13" fill="#8a8f96" font-weight="600" text-anchor="middle">Signaturen</text><rect x="51.66666666666666" y="58" width="26" height="18" rx="5" fill="none" stroke="#c2c6cc" stroke-width="1.6" /><rect x="133.0" y="58" width="26" height="18" rx="5" fill="none" stroke="#c2c6cc" stroke-width="1.6" /><rect x="214.33333333333331" y="58" width="26" height="18" rx="5" fill="none" stroke="#c2c6cc" stroke-width="1.6" /><rect x="295.6666666666667" y="58" width="26" height="18" rx="5" fill="none" stroke="#c2c6cc" stroke-width="1.6" /><rect x="377.0" y="58" width="26" height="18" rx="5" fill="none" stroke="#c2c6cc" stroke-width="1.6" /><rect x="438.66666666666663" y="52" width="65.33333333333333" height="34" rx="7" fill="#e6e7ea" stroke="none" stroke-width="1" /><rect x="458.3333333333333" y="58" width="26" height="18" rx="5" fill="none" stroke="#8a8f96" stroke-width="1.6" /><rect x="539.6666666666666" y="58" width="26" height="18" rx="5" fill="none" stroke="#c2c6cc" stroke-width="1.6" /><rect x="620.9999999999999" y="58" width="26" height="18" rx="5" fill="none" stroke="#c2c6cc" stroke-width="1.6" /><rect x="702.3333333333333" y="58" width="26" height="18" rx="5" fill="none" stroke="#c2c6cc" stroke-width="1.6" /><text x="471.3333333333333" y="98" font-size="10.5" fill="#1d1d1f" font-weight="600" text-anchor="middle">Signaturen</text><line x1="18" y1="110" x2="762" y2="110" stroke="#dcdee2" stroke-width="1" stroke-linecap="round" opacity="1"/><rect x="22" y="124" width="200" height="232" rx="8" fill="#ffffff" stroke="#dcdee2" stroke-width="1" /><rect x="28" y="132" width="188" height="66.0" rx="7" fill="#d9e7fb" stroke="none" stroke-width="1" /><rect x="36" y="153.0" width="30" height="30" rx="7" fill="#e6ac55" stroke="none" stroke-width="1" /><line x1="76" y1="162.0" x2="202" y2="162.0" stroke="#1d1d1f" stroke-width="6" stroke-linecap="round" opacity="0.85"/><line x1="76" y1="179.0" x2="166" y2="179.0" stroke="#8a8f96" stroke-width="5" stroke-linecap="round" opacity="0.5"/><rect x="36" y="225.0" width="30" height="30" rx="7" fill="#cdd1d6" stroke="none" stroke-width="1" /><line x1="76" y1="234.0" x2="202" y2="234.0" stroke="#b9bec4" stroke-width="6" stroke-linecap="round" opacity="0.4"/><line x1="76" y1="251.0" x2="166" y2="251.0" stroke="#8a8f96" stroke-width="5" stroke-linecap="round" opacity="0.5"/><rect x="36" y="297.0" width="30" height="30" rx="7" fill="#cdd1d6" stroke="none" stroke-width="1" /><line x1="76" y1="306.0" x2="202" y2="306.0" stroke="#b9bec4" stroke-width="6" stroke-linecap="round" opacity="0.4"/><line x1="76" y1="323.0" x2="166" y2="323.0" stroke="#8a8f96" stroke-width="5" stroke-linecap="round" opacity="0.5"/><rect x="232" y="124" width="150" height="232" rx="8" fill="#ffffff" stroke="#dcdee2" stroke-width="1" /><rect x="234" y="126" width="146" height="34" rx="0" fill="#d9e7fb" stroke="none" stroke-width="1" /><line x1="246" y1="144.0" x2="360" y2="144.0" stroke="#1d1d1f" stroke-width="6" stroke-linecap="round" opacity="0.85"/><line x1="234" y1="160" x2="380" y2="160" stroke="#eef0f2" stroke-width="1" stroke-linecap="round" opacity="1"/><line x1="246" y1="178.0" x2="360" y2="178.0" stroke="#b9bec4" stroke-width="6" stroke-linecap="round" opacity="0.5"/><line x1="234" y1="194" x2="380" y2="194" stroke="#eef0f2" stroke-width="1" stroke-linecap="round" opacity="1"/><rect x="234" y="364" width="28" height="22" rx="6" fill="#f0f1f3" stroke="#dcdee2" stroke-width="1" /><text x="248" y="380" font-size="15" fill="#8a8f96" font-weight="400" text-anchor="middle">+</text><rect x="264" y="364" width="28" height="22" rx="6" fill="#f0f1f3" stroke="#dcdee2" stroke-width="1" /><text x="278" y="379" font-size="15" fill="#8a8f96" font-weight="400" text-anchor="middle">–</text><rect x="396" y="124" width="362" height="232" rx="8" fill="#ffffff" stroke="#dcdee2" stroke-width="1" /><line x1="412" y1="150" x2="646" y2="150" stroke="#b9bec4" stroke-width="5" stroke-linecap="round" opacity="0.35"/><line x1="412" y1="172" x2="566" y2="172" stroke="#b9bec4" stroke-width="5" stroke-linecap="round" opacity="0.35"/><line x1="412" y1="198" x2="526" y2="198" stroke="#1d1d1f" stroke-width="6" stroke-linecap="round" opacity="0.82"/><line x1="412" y1="220" x2="606" y2="220" stroke="#b9bec4" stroke-width="5" stroke-linecap="round" opacity="0.35"/><line x1="412" y1="246" x2="516" y2="246" stroke="#2f6fc0" stroke-width="6" stroke-linecap="round" opacity="0.9"/><line x1="412" y1="268" x2="646" y2="268" stroke="#b9bec4" stroke-width="5" stroke-linecap="round" opacity="0.35"/><line x1="412" y1="286" x2="586" y2="286" stroke="#b9bec4" stroke-width="5" stroke-linecap="round" opacity="0.35"/><line x1="412" y1="308" x2="526" y2="308" stroke="#2f6fc0" stroke-width="6" stroke-linecap="round" opacity="0.9"/><g filter="url(#g)"><rect x="392" y="352" width="370" height="40" rx="10" fill="none" stroke="#ff9500" stroke-width="3.5"/></g><rect x="392" y="352" width="370" height="40" rx="10" fill="none" stroke="#ff9500" stroke-width="2.5" /><rect x="398" y="360" width="20" height="20" rx="4" fill="#1a73e8" stroke="none" stroke-width="1" /><path d="M403 370 l4 4 l8 -9" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/><text x="428" y="375" font-size="14" fill="#1d1d1f" font-weight="400" text-anchor="start">Standardschrift für E-Mails verwenden</text><text x="392" y="414" font-size="15" fill="#b4560a" font-weight="700" text-anchor="start">→ Häkchen entfernen</text>
 </svg>
             </div>
           </details>
@@ -269,22 +256,10 @@
                   blähen jede Mail auf und werden vielerorts blockiert.</li>
                 <li><strong>Keine festen Textfarben:</strong> der Text erbt die Theme-Farbe des Programms und bleibt
                   hell wie dunkel lesbar; das Markenblau ist eine mailtaugliche, kontraststarke Variante.</li>
-                <li><strong>Wiedererkennung</strong> entsteht über Schriftzug, Farbe und klare Hierarchie – nicht über
-                  fragile Grafik.</li>
               </ul>
-              Für echte Grafiken in der Hausschrift gibt es die
-              <a href="https://grafik.goetheanum.ch">weiteren Werkzeuge</a>.
             </div>
           </details>
 
-          <details class="code-details">
-            <summary>HTML-Code anzeigen</summary>
-            <div class="code-wrap">
-              <pre class="code" id="codeOut"></pre>
-              <button type="button" class="copybtn" id="copyCode2">Kopieren</button>
-            </div>
-            <div class="hint">Nur nötig, wenn das Mailprogramm ausschliesslich HTML-Quelltext akzeptiert. Sonst reicht ‹Signatur kopieren›.</div>
-          </details>
         </div>
       </div>
     </div>
@@ -292,65 +267,49 @@
 
   <section id="empfehlungen">
     <div class="empf-head">
-      <span class="kicker">E-Mail am Goetheanum · Empfehlungen</span>
-      <h2>Klare Mails, klarer Auftritt</h2>
-      <p>Wenige Mittel, präzise gesetzt – so wird aus jeder Nachricht ein guter Auftritt des Hauses und deine Stimme zugleich.</p>
+      <span class="kicker">E-Mail am Goetheanum</span>
+      <h2>Diese Mail wird gelesen</h2>
+      <p>Wenige Mittel, präzise gesetzt – damit ankommt, was du sagen willst.</p>
     </div>
-    <svg class="empf-ill" viewBox="0 0 860 430" role="img" aria-label="Vergleich: links eine aufgeraeumte E-Mail mit schlanker Signatur, rechts eine ueberladene mit Werbebildern, Spruechen und ueberladener Signatur."><rect x="24" y="20" width="380" height="360" rx="12" class="win" /><line x1="46" y1="52" x2="144" y2="52" class="lnm"/><line x1="174" y1="52" x2="324" y2="52" class="ln"/><line x1="46" y1="80" x2="274" y2="80" class="ln b"/><line x1="46" y1="120" x2="364" y2="120" class="ln"/><line x1="46" y1="142" x2="334" y2="142" class="ln"/><line x1="46" y1="164" x2="284" y2="164" class="ln"/><line x1="46" y1="186" x2="244" y2="186" class="ln"/><line x1="46" y1="236" x2="94" y2="236" class="lnfaint"/><line x1="46" y1="262" x2="174" y2="262" class="ln b"/><line x1="46" y1="282" x2="144" y2="282" class="ln blue"/><line x1="46" y1="302" x2="224" y2="302" class="ln"/><circle cx="370" cy="44" r="13" class="badge-ok"/><path class="badge-p" d="M364 44 l4 5 l8 -10"/><text x="214.0" y="406" font-size="15" class="cap ok" text-anchor="middle" font-weight="600">aufgeräumt · kommt an</text><rect x="456" y="20" width="380" height="360" rx="12" class="win" /><line x1="478" y1="52" x2="576" y2="52" class="lnm"/><line x1="606" y1="52" x2="756" y2="52" class="ln"/><rect x="478" y="70" width="336" height="26" rx="5" class="banner" /><text x="490" y="88" font-size="13" class="bnr" text-anchor="start" font-weight="700">AKTION!!!</text><line x1="478" y1="120" x2="776" y2="120" class="ln"/><line x1="478" y1="140" x2="736" y2="140" class="ln"/><rect x="478" y="156" width="120" height="72" rx="6" class="img" /><path class="glyph" d="M486 220 l38.4 -36.0 l26.4 20.160000000000004 l19.2 -15.84 l36.0 31.68"/><circle cx="506.8" cy="177.6" r="4" class="glyphdot"/><rect x="608" y="156" width="120" height="72" rx="6" class="img" /><path class="glyph" d="M616 220 l38.4 -36.0 l26.4 20.160000000000004 l19.2 -15.84 l36.0 31.68"/><circle cx="636.8" cy="177.6" r="4" class="glyphdot"/><text x="742" y="180" font-size="13" class="quote">„Sei du</text><text x="742" y="198" font-size="13" class="quote">selbst die</text><text x="742" y="216" font-size="13" class="quote">Änderung…"</text><rect x="478" y="244" width="336" height="20" rx="4" class="banner2" /><rect x="478" y="278" width="46" height="46" rx="6" class="logo" /><text x="501" y="306" font-size="10" class="logot" text-anchor="middle" font-weight="700">LOGO</text><line x1="536" y1="286" x2="686" y2="286" class="ln b"/><line x1="536" y1="304" x2="656" y2="304" class="ln blue"/><line x1="536" y1="320" x2="706" y2="320" class="ln"/><circle cx="796" cy="300" r="8" class="soc"/><circle cx="774" cy="300" r="8" class="soc"/><circle cx="752" cy="300" r="8" class="soc"/><circle cx="730" cy="300" r="8" class="soc"/><line x1="478" y1="340" x2="756" y2="340" class="lnfaint"/><line x1="478" y1="352" x2="806" y2="352" class="lnfaint"/><line x1="478" y1="364" x2="756" y2="364" class="lnfaint"/><line x1="478" y1="376" x2="806" y2="376" class="lnfaint"/><circle cx="802" cy="44" r="13" class="badge-bad"/><path class="badge-p" d="M796 39 l12 10 M808 39 l-12 10"/><text x="646.0" y="406" font-size="15" class="cap bad" text-anchor="middle" font-weight="600">überladen · bricht &amp; nervt</text></svg>
+    <svg class="empf-ill" viewBox="0 0 756 548" role="img" aria-label="Vergleich: links eine aufgeraeumte E-Mail mit einer klaren Botschaft, rechts eine ueberladene, in der die Botschaft zwischen Werbebildern, Spruechen und ueberladener Signatur verschwindet."><rect x="22" y="20" width="328" height="486" rx="12" class="win" /><line x1="44" y1="54" x2="132" y2="54" class="lnm"/><line x1="162" y1="54" x2="292" y2="54" class="ln"/><line x1="44" y1="82" x2="252" y2="82" class="ln b"/><rect x="52" y="204" width="268" height="64" rx="8" class="msghl" /><line x1="70" y1="230" x2="302" y2="230" class="msg"/><line x1="70" y1="250" x2="254" y2="250" class="msg"/><line x1="70" y1="266" x2="172" y2="266" class="under"/><line x1="44" y1="410" x2="82" y2="410" class="lnfaint"/><line x1="44" y1="434" x2="172" y2="434" class="ln b"/><line x1="44" y1="454" x2="142" y2="454" class="ln blue"/><circle cx="320" cy="42" r="14" class="badge-ok"/><path class="badge-p" d="M314 42 l4 5 l8 -10"/><text x="186.0" y="532" font-size="16" class="cap ok" text-anchor="middle" font-weight="700">Eine klare Botschaft</text><rect x="406" y="20" width="328" height="486" rx="12" class="win" /><line x1="428" y1="54" x2="516" y2="54" class="lnm"/><line x1="546" y1="54" x2="676" y2="54" class="ln"/><rect x="428" y="72" width="284" height="24" rx="5" class="banner" /><text x="440" y="89" font-size="13" class="bnr" text-anchor="start" font-weight="700">AKTION!!!</text><rect x="428" y="110" width="284" height="66" rx="6" class="img" /><path class="glyph" d="M436 168 l85.2 -33.0 l62.48 18.48 l45.44 -13.200000000000001 l79.52000000000001 26.400000000000002"/><circle cx="496.15999999999997" cy="129.8" r="4" class="glyphdot"/><text x="430" y="206" font-size="13" class="quote">„Sei du selbst die Änderung…"</text><rect x="428" y="224" width="284" height="18" rx="4" class="banner2" /><g opacity="0.28"><line x1="428" y1="264" x2="556" y2="264" class="lost"/><line x1="428" y1="278" x2="526" y2="278" class="lost"/></g><text x="568" y="276" font-size="11" class="lostcap" text-anchor="start">↑ die Botschaft</text><rect x="428" y="296" width="284" height="58" rx="6" class="img" /><path class="glyph" d="M436 346 l85.2 -29.0 l62.48 16.240000000000002 l45.44 -11.600000000000001 l79.52000000000001 23.200000000000003"/><circle cx="496.15999999999997" cy="313.4" r="4" class="glyphdot"/><rect x="428" y="372" width="44" height="44" rx="6" class="logo" /><text x="450" y="399" font-size="9" class="logot" text-anchor="middle" font-weight="700">LOGO</text><line x1="484" y1="380" x2="636" y2="380" class="ln b"/><line x1="484" y1="396" x2="606" y2="396" class="ln blue"/><line x1="484" y1="412" x2="656" y2="412" class="ln"/><circle cx="702" cy="392" r="7" class="soc"/><circle cx="682" cy="392" r="7" class="soc"/><circle cx="662" cy="392" r="7" class="soc"/><circle cx="642" cy="392" r="7" class="soc"/><line x1="428" y1="434" x2="664" y2="434" class="lnfaint"/><line x1="428" y1="446" x2="708" y2="446" class="lnfaint"/><line x1="428" y1="458" x2="664" y2="458" class="lnfaint"/><line x1="428" y1="470" x2="708" y2="470" class="lnfaint"/><line x1="428" y1="482" x2="664" y2="482" class="lnfaint"/><circle cx="704" cy="42" r="14" class="badge-bad"/><path class="badge-p" d="M698 37 l12 10 M710 37 l-12 10"/><text x="570.0" y="532" font-size="16" class="cap bad" text-anchor="middle" font-weight="700">Wo ist die Botschaft?</text></svg>
     <div class="empf">
-      <h3>Grundsatz</h3>
-      <p>Jede E-Mail aus dem Goetheanum ist ein Auftritt des Hauses — und zugleich die Stimme eines Menschen.
-        Diese Empfehlungen sorgen für Einheitlichkeit nach aussen und lassen Freiheit im Detail. Sie sind ein
-        Angebot: Das Signatur-Werkzeug macht den empfohlenen Weg zum einfachsten.</p>
-      <p><em>Deine Eingaben bleiben in deinem Browser gespeichert — nichts verlässt dein Gerät.</em></p>
-
-      <hr class="rule">
-      <h3>Die Signatur</h3>
-      <p>Es gibt eine Signatur — deine. Zwei Zeilen gehören dazu, alles Weitere wählst du selbst.</p>
-      <p><strong>Der Kern</strong> — Name und Goetheanum. Das genügt bereits.</p>
-      <p><strong>Die Wahlmodule</strong> — Funktion, Sektion oder Abteilung, Telefon, Mobil, Website. Du entscheidest,
-        welche Angaben du mitschickst. Eine Telefonnummer, die du nicht in jeder Mail sehen willst, gehört nicht in die Signatur.</p>
-      <p><strong>Antworten und interne Mails</strong> dürfen ohne Signatur ausgehen: Wer miteinander im Austausch steht,
-        kennt sich. In Outlook lässt sich das für Antworten fest einstellen; in Apple Mail ist es ein Handgriff beim Schreiben.</p>
-
-      <hr class="rule">
-      <h3>Das PS</h3>
-      <p>Wer auf eine Veranstaltung oder ein Angebot hinweisen möchte, tut das in einer PS-Zeile — direkt unter dem
-        Mailtext, über den Adressdaten.</p>
-      <p>Die Form: <strong>ein Satz, ein Link, kein Bild, befristet.</strong></p>
-      <p>Das PS pflegst du selbst im Generator, passend zu deinen Anlässen und Empfängern. Setze ein Ablaufdatum —
-        der Generator legt dir dazu eine Erinnerung in deinen Kalender. Ein aktuelles PS wirkt; ein abgelaufenes wirkt gegen dich.</p>
-      <p>Die PS-Zeile kann auch in den Signatur-Einstellungen des Mailprogramms bearbeitet werden, zur Sicherung der
-        technischen Empfehlungen lohnt sich der Weg zum Editor.</p>
-
-      <hr class="rule">
-      <h3>Warum ohne Bild?</h3>
-      <p>Bilder in Signaturen erscheinen in Apple Mail als Anhang — bei jeder einzelnen Mail. Die Büroklammer soll aber
-        bedeuten: <em>Hier ist ein Dokument für dich.</em> Diese Sphäre halten wir frei. Dazu kommt: Bilder brechen im
-        Dark Mode, blähen jede Mail auf und werden von vielen Programmen blockiert. Eine reine Text-Signatur kommt
-        überall so an, wie sie gemeint ist — hell wie dunkel.</p>
-      <p>Aus demselben Grund erledigt der Generator Schrift und Farbe von selbst: eine Mail-Variante des
-        Goetheanum-Blaus, die auf hellem und dunklem Grund lesbar bleibt, und Systemschriften, die jedes Mailprogramm
-        beherrscht. Darum muss sich niemand kümmern.</p>
-
-      <hr class="rule">
-      <h3>Was wir weglassen</h3>
-      <p><strong>Rechtserklärungen und Vertraulichkeitshinweise.</strong> Sie sind für uns rechtlich nicht erforderlich
-        und sagen dem Empfänger nichts — sie machen Mails nur länger.</p>
-      <p><strong>Amtsnummern und Registerangaben.</strong> Gehören auf Briefpapier und Website, nicht unter jede Nachricht.</p>
-      <p><strong>Zitate, Sprüche, Banner.</strong> Die Signatur bleibt schlank. Was du sagen willst, gehört in die Mail — oder ins PS.</p>
-
-      <hr class="rule">
-      <h3>Empfehlungen für die Mail selbst</h3>
-      <p><strong>Der Betreff sagt, worum es geht.</strong> Konkret genug, dass die Mail in einem Jahr wiedergefunden wird.
-        Bewährt haben sich Zusätze wie <em>[Info]</em> oder <em>[Bitte um Antwort bis …]</em>, wenn sie stimmen.</p>
-      <p><strong>Eine Sache pro Mail.</strong> Zwei Anliegen sind zwei Mails — sie lassen sich getrennt beantworten,
-        weiterleiten und erledigen.</p>
-      <p><strong>An heisst: von dir wird etwas erwartet. CC heisst: zur Kenntnis.</strong> Wer im CC steht, muss nicht antworten.</p>
-      <p><strong>Sag, was du brauchst.</strong> Eine Antwort? Bis wann? Oder nur Information? Ein Halbsatz am Ende erspart Nachfragen.</p>
-
-      <hr class="rule">
-      <p class="dim"><em>Fragen und Anregungen an die Kommunikation. Diese Empfehlungen wachsen mit der Praxis.</em></p>
+      <div class="empf-item">
+        <h3><span class="num">1</span> Wer sind wir?</h3>
+        <p>Jede E-Mail aus dem Goetheanum ist ein Auftritt des Goetheanum — und zugleich die Stimme eines Menschen. Diese Empfehlungen sorgen für eine sichtbare, öffentliche Haltung und lassen persönliche Freiheit im Detail.</p>
+      </div>
+      <div class="empf-item">
+        <h3><span class="num">2</span> Das bin ich</h3>
+        <p>Es gibt eine Signatur — deine. Zwei Zeilen gehören dazu, alles Weitere wählst du selbst.</p>
+        <p><strong>Der Kern</strong> — Name und Goetheanum. Das genügt bereits.</p>
+        <p><strong>Die Wahlmodule</strong> — Funktion, Sektion oder Abteilung, Telefon, Mobil, Website. Du entscheidest, welche Angaben du mitschickst. Eine Telefonnummer, die du nicht in jeder Mail sehen willst, gehört nicht in die Signatur.</p>
+      </div>
+      <div class="empf-item">
+        <h3><span class="num">3</span> Meistgelesen</h3>
+        <p>Wer auf eine Veranstaltung oder ein Angebot hinweisen möchte, tut das in einer PS-Zeile — direkt unter dem Mailtext, über den Adressdaten.</p>
+        <p>Die Form: <strong>ein Satz, ein Link, kein Bild, befristet.</strong></p>
+        <p>Das PS pflegst du selbst im Generator, passend zu deinen Anlässen und Empfängern. Setze ein Ablaufdatum — der Generator legt dir dazu eine Erinnerung in deinen Kalender. Ein aktuelles PS wirkt.</p>
+      </div>
+      <div class="empf-item">
+        <h3><span class="num">4</span> Bildersturm?</h3>
+        <p>Bilder in Signaturen erscheinen in Apple Mail als Anhang — mit Büroklammer, bei jeder einzelnen Mail. Doch die Büroklammer soll etwas anderes versprechen: <em>Hier ist ein Dokument für dich.</em> Diese Sphäre halten wir frei. Dazu kommt: Bilder brechen im Dark Mode, blähen jede Mail auf und werden von vielen Programmen blockiert. Eine reine Text-Signatur kommt überall so an, wie sie gemeint ist — hell wie dunkel.</p>
+      </div>
+      <div class="empf-item">
+        <h3><span class="num">5</span> Nicht nötig?</h3>
+        <p><strong>Juristerei.</strong> Rechtserklärungen und Vertraulichkeitshinweise sind für uns rechtlich nicht erforderlich und sagen dem Empfänger nichts — sie machen Mails nur länger.</p>
+        <p><strong>Zahlenkolonnen.</strong> Amtsnummern und Registerangaben gehören auf Briefpapier und Website, nicht unter jede Nachricht.</p>
+        <p><strong>Sinnsprüche.</strong> Zitate, Sprüche, Banner: Die Signatur bleibt schlank. Was du sagen willst, gehört in die Mail — oder ins PS.</p>
+      </div>
+      <div class="empf-item">
+        <h3><span class="num">6</span> Bevor du sendest</h3>
+        <p><strong>Wiedergefunden!</strong> Der Betreff sagt, worum es geht — konkret genug, dass die Mail in einem Jahr wiedergefunden wird. Bewährt haben sich Zusätze wie <em>[Info]</em> oder <em>[Bitte um Antwort bis …]</em>, wenn sie stimmen.</p>
+        <p><strong>Ein Anliegen kommt an.</strong> Eine Sache pro Mail. Zwei Anliegen sind zwei Mails — sie lassen sich getrennt beantworten, weiterleiten und erledigen.</p>
+        <p><strong>Du musst nicht antworten.</strong> An heisst: von dir wird etwas erwartet. CC heisst: zur Kenntnis. Wer im CC steht, muss nicht antworten.</p>
+        <p><strong>Sag, was du brauchst.</strong> Eine Antwort? Bis wann? Oder nur Information? Ein Halbsatz am Ende erspart Nachfragen.</p>
+      </div>
+      <div class="empf-item">
+        <h3><span class="num">7</span> Ausschalten</h3>
+        <p>Antworten und interne Mails dürfen ohne Signatur ausgehen: Wer miteinander im Austausch steht, kennt sich. In Outlook lässt sich das für Antworten fest einstellen; in Apple Mail ist es ein Handgriff beim Schreiben.</p>
+      </div>
     </div>
   </section>
 </main>
@@ -459,7 +418,6 @@ function render() {
   const sig = buildSignature();
   state.plain = sig.text;
   document.getElementById("sigPreview").innerHTML = sig.html;
-  document.getElementById("codeOut").textContent = sig.html;
   updatePsCount();
 }
 
@@ -605,20 +563,6 @@ document.getElementById("copyPlain").addEventListener("click", function () {
   } else { flash(this, "Nicht möglich"); }
 });
 
-function copyCode(btn) {
-  const text = document.getElementById("codeOut").textContent;
-  if (navigator.clipboard) {
-    navigator.clipboard.writeText(text).then(() => flash(btn, "Kopiert ✓"), () => selectFallback(btn));
-  } else { selectFallback(btn); }
-}
-function selectFallback(btn) {
-  const r = document.createRange();
-  r.selectNodeContents(document.getElementById("codeOut"));
-  const sel = window.getSelection(); sel.removeAllRanges(); sel.addRange(r);
-  let done = false; try { done = document.execCommand("copy"); } catch (e) {}
-  flash(btn, done ? "Kopiert ✓" : "Markiert – Strg/Cmd+C");
-}
-document.getElementById("copyCode2").addEventListener("click", function () { copyCode(this); track("codecopy", {}); });
 
 /* ---------- Anonyme Nutzungsstatistik (Supabase, insert-only) ---------- */
 const TRACK_URL = "https://dagcsnfrlbpxcmdimnrw.supabase.co/rest/v1/signatur_events";


### PR DESCRIPTION
Zweite Feedback-Runde – Grafiken, Aufräumen, Empfehlungen neu.

**Grafiken**
- **Apple-Mail-Skizze** jetzt mit vertrautem **Apple-Farbschema** (Ampel-Punkte, blaue Auswahl & blauer Haken, hellgraues Fenster), weiter schematisch; Kästchen **angehakt** mit leuchtendem **‹→ Häkchen entfernen›**.
- **Vergleichs-Illustration hochformatig**: links **eine klare Botschaft** (hervorgehoben, viel Ruhe), rechts **verschwindet das Wesentliche** zwischen Werbebildern, Sprüchen und überladener Signatur (‹↑ die Botschaft› zeigt, wie sie untergeht).

**Struktur**
- **HTML-Code-Ansicht komplett entfernt** (Klapper + zugehöriges JS) — die Haupt- und ‹Nur Text›-Kopie decken alles ab.
- **‹Hinweis für Apple Mail›** ist bereits in ‹Anleitung› und erscheint direkt beim Aufklappen.
- **Warum-Klapper:** letzter Punkt (Wiedererkennung / weitere Werkzeuge) gestrichen.

**Empfehlungen — neu getextet & gestaltet**
- Neuer Titel **‹Diese Mail wird gelesen›**; alle Zwischentitel angespitzt: **1 Wer sind wir? · 2 Das bin ich · 3 Meistgelesen · 4 Bildersturm? · 5 Nicht nötig? · 6 Bevor du sendest · 7 Ausschalten**.
- Textänderungen: ‹Auftritt des Goetheanum›; ‹sichtbare, öffentliche Haltung … persönliche Freiheit›; Büroklammer sprachlich vermittelt; harte/redundante Sätze entfernt; Schlusssatz gelöscht; Datenschutz-Satz nur noch oben in der Editor-Box.
- **Desktop: zwei Spalten, nummeriert** (die „Gebote"). Zeilenmass dadurch schmaler (siehe unten).

**Zeilenbreite / Linter:** Der Lesetext lief vorher bei ~60ch (Hausmass `--measure` = 62ch, also am oberen Rand). Durch die zwei Spalten + `max-width:46ch` je Absatz liegt er jetzt komfortabel im Bereich der Hausregel **G10 (45–75, ideal ~66)**.

> Offen/zur Rückmeldung: kleine Bilder je Abschnitt (Idee) — mache ich gern als Folgeschritt. Und Apple Mail ist von dir bereits **positiv getestet** 👍

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_