### PR TITLE
Kartentool: Jugendsektionshaus an den Strassen-Anschnitt mit Pfeil nach aussen

### DIFF
--- a/apps/karten-generator/orte.js
+++ b/apps/karten-generator/orte.js
@@ -1029,10 +1029,11 @@ const ORTE = [
     },
     "positionen": [
       [
-        292.0,
-        192.5
+        289.6,
+        202.2
       ]
-    ]
+    ],
+    "pfeil": "unten-rechts"
   },
   {
     "id": "h-friedwart",

--- a/tools/karten/extract-marker-positionen.py
+++ b/tools/karten/extract-marker-positionen.py
@@ -287,9 +287,12 @@ WILLKOMMEN = [
     ("h-eurythmie", "53", "haeuser",
      {"de": "Eurythmiehaus", "en": "Eurythmiehaus"},
      [[268.5, 97.0]]),
+    # Das Haus selbst liegt ausserhalb des Blatts — Marke am Strassen-
+    # Anschnitt unten rechts (wie die Bushaltestelle), Pfeil nach aussen
+    # (Entscheid Auftraggeber, 8. Juli 2026).
     ("h-jugendhaus", "54", "haeuser",
      {"de": "Jugendsektionshaus", "en": "House of the Youth Section"},
-     [[292.0, 192.5]]),
+     [[289.6, 202.2]], {"pfeil": "unten-rechts"}),
     ("h-friedwart", "55", "haeuser",
      {"de": "Gästehaus Friedwart", "en": "Guesthouse Friedwart"},
      [[118.0, 202.5]], {"pfeil": "unten-links"}),


### PR DESCRIPTION
Das Jugendsektionshaus liegt ausserhalb des Blatts — die Marke sass bisher fälschlich auf einem fremden Gebäude am rechten Rand. Neu steht sie am Strassen-Anschnitt unten rechts (289.6, 202.2) mit Pfeil nach aussen (unten-rechts), nach dem Muster der Bushaltestelle. Sichtgeprüft: frei von Bus-Marke und Bus-Pfeil, der eigene Pfeil bleibt im Blatt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgMfxisgg9yjRqFZhd6wuC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgMfxisgg9yjRqFZhd6wuC)_