### PR TITLE
Startseite: Campus-Karte veröffentlicht — Card, Karussell, neue Ordnung; Editor tiefer mit Beta; Seelenkalender intern

### DIFF
--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -41,6 +41,10 @@ html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
 
 /* Wortmarke = das echte Goetheanum-Lockup (aus dem Logo-Generator), immer zurück zur Übersicht */
 .dsnav .brand{display:flex;align-items:center;gap:var(--s3);text-decoration:none;flex:0 0 auto}
+/* Beta-Kennzeichen neben dem Lockup – folgt dem Werkzeug-Status im Manifest.
+   Leise (genau ein Merkmal: Farbe, G01); Grösse hält den 14px-Floor (B03). */
+.dsnav .beta-chip{font-size:var(--t-micro);font-weight:var(--w-strong);color:var(--gold-ink);
+  border:1px solid currentColor;border-radius:var(--r-pill);padding:2px 9px;line-height:1.3;flex:0 0 auto}
 .dsnav .brand .lockup{height:38px;width:auto;display:block}
 .dsnav .brand .mk{width:24px;height:24px;border-radius:6px;display:block}
 .dsnav .brand .wm{font-family:var(--font);font-weight:var(--w-text);font-size:24px;line-height:1;color:#8a9097;letter-spacing:.005em}

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -397,9 +397,12 @@
     return g;
   }
 
-  // Öffentliche Reihenfolge (flach) – wie die Startseite. Unbekannte ans Ende.
-  var FLAT_ORDER = ["logo-generator", "signatur", "editor", "visitenkarten", "icons", "schriften",
-    "sektionsfarben", "uebersetzungen", "wallpaper", "powerpoint", "typografie", "design-system"];
+  // Öffentliche Reihenfolge (flach) – wie die Startseite; nur der Editor
+  // steht tiefer, direkt vor Wallpaper (noch nicht reif — Entscheid
+  // Auftraggeber, 8. Juli 2026). Unbekannte ans Ende.
+  var FLAT_ORDER = ["logo-generator", "signatur", "visitenkarten", "schriften", "icons",
+    "uebersetzungen", "sektionsfarben", "typografie", "karten", "powerpoint",
+    "editor", "wallpaper", "design-system"];
   var PUBLIC_CATS = WORLDS.reduce(function (a, w) { return a.concat(w.cats); }, []);
 
   function renderDrawer() {
@@ -442,6 +445,14 @@
       a.href = t ? resolveHref(t.href) : HOME;
       worldsNav.appendChild(a);
     });
+    // Beta-Kennzeichen in der Kopfzeile: folgt dem Status im Manifest —
+    // Seiten mit status "beta" tragen die Marke neben dem Lockup, ohne
+    // dass die Seite selbst etwas setzen muss (eine Wahrheit: tools.json).
+    var active = ACTIVE && bySlug(ACTIVE);
+    if (active && active.status === "beta") {
+      var chip = el("span", "beta-chip", "Beta");
+      header.querySelector(".brand").insertAdjacentElement("afterend", chip);
+    }
     renderDrawer();
   }).catch(function () {
     drawerBody.innerHTML = '<p style="padding:22px;color:var(--muted)">Werkzeugliste konnte nicht geladen werden.</p>';

--- a/index.html
+++ b/index.html
@@ -14,9 +14,10 @@
   @font-face{font-family:"G Icons";src:url("assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Icons-v2.7.woff2") format("woff2");font-display:block}
 
   /* Startseite: nur die Karten – kein Hero, keine Überschriften, keine Erklärungen.
-     Spürbar Atem unter dem Header. main.wrap, sonst gewinnt .wrap (0 26px) und der
-     Abstand oben bliebe wirkungslos – nur top/bottom setzen, 26px seitlich bleiben. */
-  main.wrap{padding-top:clamp(64px,9vw,120px);padding-bottom:clamp(40px,6vw,64px)}
+     Atem unter dem Header, aber knapp (‹über dem Karussell zu viel Luft› –
+     Entscheid Auftraggeber, 8. Juli 2026). main.wrap, sonst gewinnt .wrap (0 26px)
+     und der Abstand oben bliebe wirkungslos – nur top/bottom setzen. */
+  main.wrap{padding-top:clamp(36px,5vw,60px);padding-bottom:clamp(40px,6vw,64px)}
   .grid{display:grid;gap:var(--s4);grid-template-columns:repeat(auto-fill,minmax(230px,1fr))}
 
   .tile{position:relative;display:flex;flex-direction:column;gap:var(--s3);border:1px solid var(--line);
@@ -78,6 +79,16 @@
   .thumb .ed i:nth-child(1){width:100%}
   .thumb .ed i.mk{background:var(--gold-ink);width:44%}
   .thumb .ed i:nth-child(3){width:82%}
+  /* Campus-Karte: Mini-Karte – Campusblau, weisse Wege, Bau, zwei Marken.
+     Physische Kartenfarben (gedrucktes Artefakt), keine Theme-Flächen. */
+  .thumb .map{position:relative;width:82px;height:58px;border-radius:7px;overflow:hidden;display:block;background:#8abfe5} /* # ds-ok: Kartenfarbe Campus (Artefakt) */
+  .thumb .map b{position:absolute;background:#fff;border-radius:3px} /* # ds-ok: Wege weiss (Artefakt) */
+  .thumb .map b:nth-child(1){width:120%;height:7px;left:-10%;top:33px;transform:rotate(-13deg)}
+  .thumb .map b:nth-child(2){width:7px;height:80%;left:50px;top:-4px;transform:rotate(21deg)}
+  .thumb .map .bau{position:absolute;width:24px;height:17px;left:13px;top:9px;border-radius:3px;transform:rotate(-7deg);background:#0067b2} /* # ds-ok: Goetheanum-Blau (Artefakt) */
+  .thumb .map .m1,.thumb .map .m2{position:absolute;width:12px;height:12px;border-radius:50%;border:1.6px solid #fff} /* # ds-ok: Markenrand weiss (Artefakt) */
+  .thumb .map .m1{background:var(--gold-deep);left:52px;top:10px}
+  .thumb .map .m2{background:#ec5f6c;left:22px;top:36px} /* # ds-ok: Markerrot der Karte (Artefakt) */
 
   /* Entdecker-Karussell – Hinweis auf weniger Bekanntes, oben über den Karten. */
   .carousel{position:relative;margin-bottom:var(--s8);border:1px solid var(--line);
@@ -137,9 +148,11 @@
 (function(){
   // Karten flach nach Priorität (keine Kategorien); Unbekannte ans Ende.
   // Webfont wohnt jetzt in Schriften, Zeichen in Logos – darum keine eigene Karte.
-  var ORDER = ["logo-generator","schriften","icons","sektionsfarben",
-    "signatur","visitenkarten","powerpoint","typografie",
-    "uebersetzungen","wallpaper","editor","design-system"];
+  // Neue Ordnung (Entscheid Auftraggeber, 8. Juli 2026).
+  var ORDER = ["logo-generator","signatur","visitenkarten","schriften",
+    "icons","uebersetzungen","sektionsfarben","typografie",
+    "karten","editor","powerpoint","wallpaper",
+    "design-system"];
   // Entdecker-Karussell: ausgewählte Werkzeuge, je ein Teaser.
   // Alle öffentlichen Karten – geordnet von der breitesten Zielgruppe zur kleinsten:
   // erst die täglichen Werkzeuge für alle (Signatur, Wallpaper, Präsentation, Karte),
@@ -147,6 +160,7 @@
   // Design-System steht bewusst am Ende (kleinste, spezialisierte Gruppe).
   var DISCOVER = [
     {slug:"signatur",       line:"Die Mail-Signatur im Hausbild – Angaben eintragen, Block kopieren, einsetzen."},
+    {slug:"karten",         line:"Die Campus-Karte für Veranstaltungen – Orte wählen, eigene Marken setzen, druckfertiges Vektor-PDF in A4 oder A3."},
     {slug:"wallpaper",      line:"Elf Goetheanum-Hintergründe für den Desktop, frei zum Herunterladen."},
     {slug:"powerpoint",     line:"Präsentationsvorlage im Hausbild – mit eingebetteten Schriften, sofort loslegen."},
     {slug:"visitenkarten",  line:"Die eigene Visitenkarte im Hausbild – ausfüllen, Vorschau, Druckdatei."},
@@ -174,7 +188,8 @@
     "wallpaper":       '<img src="assets/wallpaper/goetheanum-wallpaper-48.jpg" alt="" style="width:100%;height:100%;object-fit:cover;border-radius:8px">', // ein Motiv
     "powerpoint":      '<span class="ppt"><b></b><i></i><i></i></span>', // eine Folie mit Titel
     "uebersetzungen":  '<span class="tr"><i>DE</i><i>EN</i><i>FR</i><i>ES</i></span>', // vier Sprachen
-    "editor":          '<span class="ed"><i></i><i class="mk"></i><i></i></span>' // Text mit offener Frage
+    "editor":          '<span class="ed"><i></i><i class="mk"></i><i></i></span>', // Text mit offener Frage
+    "karten":          '<span class="map"><b></b><b></b><span class="bau"></span><i class="m1"></i><i class="m2"></i></span>' // Mini-Campus mit Marken
   };
   function visual(t){
     var v = VISUAL[t.slug] || ('<span class="spec">' + (t.title || "?").slice(0, 1) + '</span>');

--- a/tools.json
+++ b/tools.json
@@ -182,11 +182,11 @@
     },
     {
       "slug": "karten",
-      "cat": "vorbereitung",
-      "status": "beta",
+      "cat": "generatoren",
+      "status": "live",
       "tag": "Campus",
-      "title": "Kartentool",
-      "short": "Karten",
+      "title": "Campus-Karte",
+      "short": "Campus-Karte",
       "href": "apps/karten-generator/",
       "desc": "Lagepläne des Goetheanum-Geländes von Fall zu Fall beschriften und als Vektor-PDF ausgeben — A4/A3 quer, wahlweise mit Beschnitt und Schnittmarken, Kartenfarben je Variante, Parkflächen einfärbbar.",
       "such": "Karte Kartierung Campus Gelände Lageplan PDF A3 Schnittmarken Beschnitt Parkflächen"
@@ -413,7 +413,7 @@
     {
       "slug": "seelenkalender",
       "cat": "anwendung",
-      "status": "beta",
+      "status": "intern",
       "tag": "Neu",
       "title": "Seelenkalender",
       "short": "Seelenkalender",


### PR DESCRIPTION
Die Campus-Karte geht ins Frontend:

- **Campus-Karte live** (tools.json: `status: live`, `cat: generatoren`, Titel ‹Campus-Karte›). Eigene **Card mit Mini-Karten-Visual** — Campusblau, weisse Wege, ein Bau, zwei Marken (Gold + Kartenrot); physische Artefaktfarben, per `# ds-ok` ratifiziert. Dazu die **Karussell-Folie direkt nach der Signatur**.
- **Neue Card-Ordnung:** Logos, Signatur, Visitenkarte, Schriften, Icons, Übersetzungen, Sektionsfarben, Typografie, Campus-Karte, Editor, PowerPoint-Vorlage, Wallpaper, Design-System.
- **Luft über dem Karussell reduziert** (padding-top 36–60 px statt 64–120 px).
- **Menü:** gleiche Ordnung, nur der Goetheanum-Editor tiefer — direkt vor Wallpaper. Die **Kopfzeile trägt jetzt statusgetrieben ein Beta-Kennzeichen** (aus tools.json, keine Seiten-Konfiguration): der Editor zeigt es, die Campus-Karte als live nicht.
- **Seelenkalender ins Backend:** `status: intern` — verschwindet aus Startseite und öffentlichem Menü, bleibt in der Intern-Ansicht und im Hub.

Durchgeklickt und verifiziert: Card-Reihenfolge, Karussell-Folgen, Menü-Reihenfolge, Beta-Chip auf der Editor-Seite (14 px, B03), kein Chip auf der Karten-Seite, Seelenkalender nicht im öffentlichen Menü. Gates grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgMfxisgg9yjRqFZhd6wuC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgMfxisgg9yjRqFZhd6wuC)_