### PR TITLE
Kurz-URLs für alle Werkzeuge + Empfehlungen-Feinschliff (Card, Lede, PDF-Piktogramme)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -59,6 +59,9 @@ jobs:
           # Zielseite). Zentral gepflegt in sektionen.json.
           if [ -f sektionen.json ]; then python3 tools/build_sections.py _site; fi
 
+          # Kurz-URLs je Werkzeug: /<slug>/ -> /apps/<ordner>/ (aus tools.json).
+          if [ -f tools/build_tool_aliases.py ]; then python3 tools/build_tool_aliases.py _site; fi
+
           touch _site/.nojekyll
 
       - name: Setup Pages

--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -79,8 +79,9 @@
     background:var(--code-bg2);color:var(--code-ink);border-radius:var(--r-control);padding:5px 10px;cursor:pointer}
 
   /* Empfehlungen: Lesetext, linksbündig (Titel NICHT rechts). */
+  .empf-card{border-top:3px solid var(--gold)}
   .empf-top{display:flex;gap:var(--s8);align-items:flex-start;justify-content:space-between;flex-wrap:wrap}
-  .empf-head{flex:1 1 340px;max-width:52ch}
+  .empf-head{flex:1 1 340px;max-width:46ch}
   .empf-head h2{font-size:var(--t-h2)}
   .empf-head p{color:var(--muted);font-size:var(--t-small);margin-top:var(--s1)}
   .empf{font-family:var(--font-text);margin-top:var(--s2)}
@@ -281,14 +282,14 @@
   </section>
 
   <section id="empfehlungen">
-    <div class="card soft">
+    <div class="card soft empf-card">
     <div class="empf-top">
       <div class="empf-head">
         <span class="kicker">E-Mail am Goetheanum</span>
         <h2>Diese Mail wird gelesen</h2>
         <p>Jede E-Mail aus dem Goetheanum ist ein Auftritt des Goetheanum – und zugleich
-          die Stimme eines Menschen. Diese Empfehlungen sorgen für eine sichtbare,
-          öffentliche Haltung und geben Dir persönliche Freiheit im Detail.</p>
+          die Stimme eines Menschen. Diese elf Empfehlungen sorgen für eine sichtbare,
+          öffentliche Haltung und wahren Dir persönliche Freiheit im Detail.</p>
       </div>
       <svg class="empf-ill" viewBox="0 0 400 205" role="img" aria-label="Links: eine E-Mail mit einer Botschaft. Rechts: eine ueberladene E-Mail, in der die Botschaft untergeht."><rect x="22" y="12" width="166" height="150" rx="14" class="win" /><line x1="52" y1="74" x2="158" y2="74" class="ln bb"/><line x1="52" y1="104" x2="118" y2="104" class="ln blueb"/><circle cx="162" cy="38" r="13" class="badge-ok"/><path class="badge-p" d="M156 38 l4 5 l8 -10"/><text x="105.0" y="195" font-size="14" class="cap ok" text-anchor="middle" font-weight="700">Eine Botschaft</text><rect x="212" y="12" width="166" height="150" rx="14" class="win" /><rect x="234" y="34" width="122" height="18" rx="5" class="banner" /><rect x="234" y="62" width="52" height="36" rx="6" class="img" /><path class="glyph" d="M239 92 l14 -16 l9 8 l8 -8 l12 16"/><line x1="296" y1="70" x2="354" y2="70" class="ln"/><line x1="296" y1="88" x2="340" y2="88" class="ln"/><line x1="234" y1="114" x2="354" y2="114" class="ln"/><rect x="234" y="128" width="22" height="22" rx="5" class="logo" /><circle cx="350" cy="139" r="6" class="soc"/><circle cx="332" cy="139" r="6" class="soc"/><circle cx="314" cy="139" r="6" class="soc"/><circle cx="352" cy="38" r="13" class="badge-bad"/><path class="badge-p" d="M346 33 l12 10 M358 33 l-12 10"/><text x="295.0" y="195" font-size="14" class="cap bad" text-anchor="middle" font-weight="700">Wo ist die Botschaft?</text></svg>
     </div>
@@ -296,17 +297,17 @@
       <div class="empf-item">
         <svg class="pikto" viewBox="0 0 48 48" aria-hidden="true"><rect x="6" y="10" width="36" height="28" rx="4"/><circle cx="16" cy="21" r="4"/><path d="M10.5 32c1.5-4.5 9.5-4.5 11 0"/><line x1="27" y1="18" x2="38" y2="18"/><line x1="27" y1="25" x2="36" y2="25" class="acc"/></svg>
         <h3><span class="num">1</span> Das bin ich</h3>
-        <p>Es gibt eine Signatur – deine. Zwei Zeilen gehören dazu, alles Weitere wählst du selbst: <strong>Der Kern</strong> – Name und Goetheanum. Das genügt bereits. <strong>Die Wahlmodule</strong> – Funktion, Sektion oder Abteilung, Telefon, Mobil, Website. Du entscheidest, welche Angaben du mitschickst. Eine Telefonnummer, die du nicht in jeder Mail sehen willst, gehört nicht in die Signatur.</p>
+        <p>Es gibt eine Signatur – deine. Zwei Zeilen gehören dazu, alles Weitere wählst du selbst: Name und Goetheanum. Das genügt bereits. Du entscheidest, welche Angaben du noch mitschickst.</p>
       </div>
       <div class="empf-item">
         <svg class="pikto" viewBox="0 0 48 48" aria-hidden="true"><path d="M5 24c5.5-8 13-12 19-12s13.5 4 19 12c-5.5 8-13 12-19 12S10.5 32 5 24z"/><circle cx="24" cy="24" r="5" class="acc"/></svg>
         <h3><span class="num">2</span> Meistgelesen</h3>
-        <p>Wer auf eine Veranstaltung oder ein Angebot hinweisen möchte, tut das in einer PS-Zeile – direkt unter dem Mailtext, über den Adressdaten. Diese wird statistisch meist als Erstes gelesen. Je kürzer die Zeile und die ganze Mail, umso stärker wirkt sie. Die Form: <strong>ein Satz, ein Link, kein Bild, befristet.</strong> Das PS pflegst du selbst im Generator, passend zu deinen Anlässen und Empfängern. Setz ein Ablaufdatum – der Generator legt dir dazu eine Erinnerung in deinen Kalender. Ein aktuelles PS wirkt.</p>
+        <p>Das PS wird meist als Erstes gelesen. Hier ist der beste Platz für den Hinweis auf eine Veranstaltung. Setz Dir ein Ablaufdatum – der Generator legt eine Erinnerung in deinen Kalender.</p>
       </div>
       <div class="empf-item">
         <svg class="pikto" viewBox="0 0 48 48" aria-hidden="true"><rect x="7" y="12" width="24" height="19" rx="3"/><path d="M10 28l6-7 4 4 3-3 5 6"/><path class="acc" d="M40 13v15a5 5 0 0 1-10 0V16a3 3 0 0 1 6 0v11"/><line x1="6" y1="42" x2="42" y2="6" class="slash"/></svg>
         <h3><span class="num">3</span> Bildersturm?</h3>
-        <p>Bilder in Signaturen erscheinen in Apple Mail als Anhang – mit Büroklammer, bei jeder einzelnen Mail. Doch die Büroklammer soll etwas anderes versprechen: <em>Hier ist ein Dokument für dich.</em> Eine Text-Signatur hält dieses Versprechen: Wo eine Büroklammer erscheint, wartet wirklich ein Dokument. Dazu kommt: Bilder brechen im Dark Mode, blähen jede Mail auf und werden von vielen Programmen blockiert. Eine reine Text-Signatur kommt überall so an, wie sie gemeint ist – hell wie dunkel.</p>
+        <p>Bilder in Signaturen erscheinen als Anhang. Der Subtext verspricht: <em>Hier ist ein Dokument für dich.</em> Eine Text-Signatur hält dieses Versprechen: Hier wartet wirklich ein Dokument und keine Werbung.</p>
       </div>
       <div class="empf-item">
         <svg class="pikto" viewBox="0 0 48 48" aria-hidden="true"><text x="15" y="35" class="pt" font-size="30">§</text><line x1="9" y1="40" x2="39" y2="8" class="slash"/></svg>
@@ -535,7 +536,7 @@ function icsFor(dateStr) {
     "BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:-//Goetheanum//Signatur-Generator//DE",
     "BEGIN:VEVENT", "UID:" + uid, "DTSTAMP:" + stamp, "DTSTART;VALUE=DATE:" + dt,
     "SUMMARY:PS in der E-Mail-Signatur aktualisieren",
-    "DESCRIPTION:Dein PS ist heute abgelaufen. Aktualisieren: https://werkzeuge.goetheanum.ch/apps/signatur",
+    "DESCRIPTION:Dein PS ist heute abgelaufen. Aktualisieren: https://werkzeuge.goetheanum.ch/signatur",
     "BEGIN:VALARM", "TRIGGER:-PT9H", "ACTION:DISPLAY", "DESCRIPTION:PS in der E-Mail-Signatur aktualisieren",
     "END:VALARM", "END:VEVENT", "END:VCALENDAR"
   ].join("\r\n");
@@ -671,7 +672,41 @@ function buildEmpfPdf(d, fontBytes) {
     fxn(cx - k) + " " + fxn(cy - r) + " " + fxn(cx - r) + " " + fxn(cy - k) + " " + fxn(cx - r) + " " + fxn(cy) + " c f"); };
   const GREEN = "0.25 0.56 0.37", RED = "0.75 0.27 0.23", BLUEC = "0 0.38 0.66",
         INKS = "0.14 0.15 0.17", GRAYL = "0.80 0.81 0.83", BORD = "0.87 0.88 0.89",
-        GOLDF = "0.91 0.82 0.69", IMGF = "0.93 0.93 0.94";
+        GOLDF = "0.91 0.82 0.69", IMGF = "0.93 0.93 0.94",
+        GRAYI = "0.55 0.57 0.60", GOLDS = "0.54 0.40 0.16";
+  const sCirc = (cx, cy, r, c, lw) => { const k = 0.5523 * r; ops.push(c + " RG " + (lw || 1) + " w " +
+    fxn(cx - r) + " " + fxn(cy) + " m " +
+    fxn(cx - r) + " " + fxn(cy + k) + " " + fxn(cx - k) + " " + fxn(cy + r) + " " + fxn(cx) + " " + fxn(cy + r) + " c " +
+    fxn(cx + k) + " " + fxn(cy + r) + " " + fxn(cx + r) + " " + fxn(cy + k) + " " + fxn(cx + r) + " " + fxn(cy) + " c " +
+    fxn(cx + r) + " " + fxn(cy - k) + " " + fxn(cx + k) + " " + fxn(cy - r) + " " + fxn(cx) + " " + fxn(cy - r) + " c " +
+    fxn(cx - k) + " " + fxn(cy - r) + " " + fxn(cx - r) + " " + fxn(cy - k) + " " + fxn(cx - r) + " " + fxn(cy) + " c S"); };
+  // Mini-Piktogramme wie auf der Seite (vereinfacht), 12pt-Box links vom Titel
+  const icon = (n, x, yb) => {
+    const y0 = yb - 2.5, path = p => ops.push(p);
+    switch (n) {
+      case "1": sRt(x, y0, 12, 9, GRAYI, 1); fCirc(x + 3, y0 + 4.5, 1.4, GRAYI);
+        sLn(x + 6.5, y0 + 6, x + 10.5, y0 + 6, 1, GRAYI); sLn(x + 6.5, y0 + 3, x + 9.5, y0 + 3, 1, GOLDS); break;
+      case "2": path(GRAYI + " RG 1 w " + fxn(x) + " " + fxn(y0 + 4.5) + " m " +
+          fxn(x + 3) + " " + fxn(y0 + 9) + " " + fxn(x + 9) + " " + fxn(y0 + 9) + " " + fxn(x + 12) + " " + fxn(y0 + 4.5) + " c S");
+        path(GRAYI + " RG 1 w " + fxn(x) + " " + fxn(y0 + 4.5) + " m " +
+          fxn(x + 3) + " " + fxn(y0) + " " + fxn(x + 9) + " " + fxn(y0) + " " + fxn(x + 12) + " " + fxn(y0 + 4.5) + " c S");
+        fCirc(x + 6, y0 + 4.5, 1.6, GOLDS); break;
+      case "3": sRt(x, y0, 11, 8, GRAYI, 1); sLn(x - 0.5, y0 - 1, x + 12, y0 + 9.5, 1.1, RED); break;
+      case "4": T(x + 2, y0, "\u00a7", 10, "F1", GRAYI + " rg"); sLn(x, y0 - 1.5, x + 10, y0 + 9, 1.1, RED); break;
+      case "5": T(x + 0.5, y0 + 4.5, "012", 5, "F1", GRAYI + " rg"); T(x + 0.5, y0 - 0.5, "345", 5, "F1", GRAYI + " rg");
+        sLn(x + 9.5, y0 - 1.5, x + 13, y0 + 9, 1.1, RED); break;
+      case "6": sRt(x, y0 + 1.5, 11, 7, GRAYI, 1); sLn(x + 2.5, y0 + 1.5, x + 2.5, y0 - 0.8, 1, GRAYI);
+        fCirc(x + 4, y0 + 5, 0.9, GRAYI); fCirc(x + 7, y0 + 5, 0.9, GRAYI);
+        sLn(x - 0.5, y0 - 1.5, x + 12, y0 + 10, 1.1, RED); break;
+      case "7": sCirc(x + 4.5, y0 + 5, 3.2, GOLDS, 1.2); sLn(x + 7, y0 + 2.5, x + 10.5, y0 - 0.5, 1.4, GOLDS); break;
+      case "8": sCirc(x + 6.5, y0 + 4, 4, GRAYI, 1); fCirc(x + 6.5, y0 + 4, 1.3, GOLDS);
+        sLn(x - 1, y0 + 10, x + 4.5, y0 + 6, 1.1, GRAYI); break;
+      case "9": sRt(x, y0, 11, 7.5, GRAYI, 1);
+        path(GRAYI + " RG 1 w 1 J " + fxn(x) + " " + fxn(y0 + 7.5) + " m " + fxn(x + 5.5) + " " + fxn(y0 + 3.5) + " l " + fxn(x + 11) + " " + fxn(y0 + 7.5) + " l S"); break;
+      case "10": sRt(x, y0 + 1, 11, 7.5, GRAYI, 1); T(x + 2.6, y0 + 3, "?!", 5.5, "F2", GRAYI + " rg"); break;
+      case "11": sCirc(x + 6, y0 + 3.5, 4, GOLDS, 1.3); sLn(x + 6, y0 + 5, x + 6, y0 + 9.5, 1.3, GRAYI); break;
+    }
+  };
 
   // Illustration oben rechts – dasselbe Motiv wie auf der Seite (eine Botschaft vs. Gedraenge)
   const IW = 86, IH = 74, IGAP = 14;
@@ -702,15 +737,16 @@ function buildEmpfPdf(d, fontBytes) {
   let y = H - M - 8;
   T(M, y, "ELF EMPFEHLUNGEN", 8.5, HAUS, GOLD, 0.9); y -= 32;
   T(M, y, "Diese Mail wird gelesen", 22, HAUS, INK); y -= 22;
-  for (const l of pdfWrap(d.lede, 268, 9.5, false)) { T(M, y, l, 9.5, "F1", MUT); y -= 14; }
+  for (const l of pdfWrap(d.lede, colW, 9.5, false)) { T(M, y, l, 9.5, "F1", MUT); y -= 14; }
   const top = Math.min(y, illuBottom) - 22, bottom = M + 34;
   let cx = M, cy = top;
   for (const it of d.items) {
     const bodyLines = it.body.flatMap(p => pdfWrap(p, colW, 8.8, false).concat(["\u0000"])); bodyLines.pop();
     const blockH = 17 + bodyLines.length * 12.6 + 16;
     if (cy - blockH < bottom && cx === M) { cx = M + colW + GAP; cy = top; }
-    T(cx, cy, it.num, 11, HAUS, GOLD);
-    T(cx + gW(it.num, 11) + 7, cy, it.title, 11, HAUS, INK);
+    icon(it.num, cx, cy);
+    T(cx + 18, cy, it.num, 11, HAUS, GOLD);
+    T(cx + 18 + gW(it.num, 11) + 7, cy, it.title, 11, HAUS, INK);
     cy -= 17;
     for (const l of bodyLines) {
       if (l === "\u0000") { cy -= 5; continue; }
@@ -719,7 +755,7 @@ function buildEmpfPdf(d, fontBytes) {
     cy -= 16;
   }
   if (d.ps) T(cx, cy, d.ps, 8.8, "F1", GOLD);
-  T(M, M - 20, "werkzeuge.goetheanum.ch/apps/signatur", 7.5, "F1", MUT);
+  T(M, M - 20, "werkzeuge.goetheanum.ch/signatur", 7.5, "F1", MUT);
   const stamp = "Stand Juli 2026";
   T(W - M - hStrW(stamp, 7.5, false), M - 20, stamp, 7.5, "F1", MUT);
 

--- a/tools/build_tool_aliases.py
+++ b/tools/build_tool_aliases.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Kurz-URLs je Werkzeug: legt im Publish-Ordner /<slug>/ als Weiterleitung
+auf das Werkzeug unter apps/… an (aus tools.json, nur live/beta).
+
+  werkzeuge.goetheanum.ch/signatur  ->  /apps/signatur-generator/
+
+Relative Ziele (../…), damit die Aliasse auf der Custom-Domain (Root) UND
+unter phtok.github.io/goeloggen/ funktionieren. Bestehende Dateien/Ordner
+werden nie überschrieben (Kollisionen, z. B. logo-generator.html, gewinnen).
+Aufruf: python3 tools/build_tool_aliases.py _site
+"""
+import json, sys, pathlib
+
+STUB = """<!doctype html><html lang="de-CH"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<meta http-equiv="refresh" content="0; url={t}">
+<script>location.replace("{t}"+location.search+location.hash)</script>
+<title>Weiterleitung</title></head>
+<body><p>Weiterleitung … <a href="{t}">hier klicken</a>.</p></body></html>
+"""
+
+def main(site: str) -> None:
+    root = pathlib.Path(site)
+    data = json.load(open("tools.json", encoding="utf-8"))
+    tools = data["tools"] if isinstance(data, dict) else data
+    for t in tools:
+        slug, href, status = t.get("slug", ""), t.get("href", ""), t.get("status", "")
+        if not slug or not href.startswith("apps/") or status not in ("live", "beta"):
+            continue
+        if (root / slug).exists() or (root / f"{slug}.html").exists():
+            print(f"alias übersprungen (Kollision): /{slug}")
+            continue
+        target = "../" + (href if href.endswith("/") else href + "/")
+        d = root / slug
+        d.mkdir(parents=True)
+        (d / "index.html").write_text(STUB.format(t=target), encoding="utf-8")
+        print(f"alias: /{slug}/ -> {href}")
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "_site")


### PR DESCRIPTION
Setzt die Runde um: **Deploy-Zeit-Aliasse** + Empfehlungen-Feinschliff.

**Kurz-URLs für alle Werkzeuge (Option 1)**
- Neues `tools/build_tool_aliases.py` + Workflow-Schritt: beim Deploy entsteht je Werkzeug **`/<slug>/`** als Weiterleitung auf `apps/…` — gespeist aus `tools.json` (live/beta), **relative** Ziele (funktioniert auf der Custom-Domain **und** unter `phtok.github.io/goeloggen/`), Kollisionen (z. B. `logo-generator.html`) werden übersprungen.
- Ab dem nächsten Deploy gilt: **`werkzeuge.goetheanum.ch/signatur`**, `/visitenkarten`, `/karten`, `/gtv-naming` … Das Repo bleibt unverändert strukturiert.
- PDF-Fusszeile und `.ics`-Link nutzen die kürzeste Form.

**Gebote-Card jetzt sichtbar**
- Die Card war zu subtil (`--soft` auf Weiss). Jetzt trägt sie eine **goldene Oberkante (3 px)** — unübersehbar als eigenes „Ding", ohne laut zu werden.

**Lede = Spaltenbreite**
- Web `46ch`, PDF `colW` — kürzere Zeilen, mehr Luft für die Illustration daneben.

**Gekürzte Texte 1–3** (wie vorgegeben): Das bin ich · Meistgelesen · Bildersturm?; Lede: „Diese **elf** Empfehlungen … **wahren** Dir persönliche Freiheit im Detail."

**PDF: Piktogramme**
- Alle **elf Mini-Piktogramme** (vereinfachte Vektor-Fassungen der Web-Icons: Ausweis, Auge, Bild⃠, §⃠, Ziffern⃠, Zitat⃠, Lupe, Zielscheibe, Umschlag, ?!, Power) stehen links der Item-Titel — lockert und öffnet die Seite.
- pypdf-verifiziert: 1 Seite, Satzspiegel hält, Hausschrift eingebettet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_