### PR TITLE
Mobil-Kopfzeile: Modi-Schalter in die Schublade

### DIFF
--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -16,6 +16,19 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ---
 
+## [1.7.1] – 2026-07-09
+
+### Mobil-Kopfzeile entlastet: Modi-Schalter ziehen in die Schublade
+- **Was:** Auf ≤720px verlassen die drei Modi-Schalter (Lesemodus ·
+  Hell/Dunkel · Teilen) die Leiste und stehen als eigene Reihe `.dmodes`
+  ganz oben in der Schublade — mit Wort **und** Zeichen beschriftet,
+  Ziele ≥44px (B04), Beschriftung `--t-small` (B03). Die Leiste trägt
+  mobil nur noch Marke + Menü. `nav.js` hält beide Button-Sätze
+  (Leiste/Schublade) im selben Zustand; Desktop unverändert.
+- **Warum:** Nach dem Zuwachs auf drei Schalter blieb zwischen Marke und
+  Menüknopf kein Platz mehr zum Dreifachtipp (Feedback-Geste); die
+  reinen Zeichen-Knöpfe waren mobil zudem schwer deutbar.
+
 ## [1.7.0] – 2026-07-09
 
 ### DS09: Fundament relativ einbinden – Wächter gegen den Custom-Domain-Bruch

--- a/design-system/contract.json
+++ b/design-system/contract.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://goetheanum/design-system/contract.schema.json",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "titel": "Goetheanum Design-System – Struktur-Vertrag",
   "zweck": "Maschinenlesbare Grundlage der GESTALT-Konformität (symmetrisch zum sprachlichen Kanon in assets/typografie/). ds-lint.py prüft jede Seite hiergegen, ds-fix.py korrigiert deterministisch, das Schaufenster bildet es ab. Eine Quelle der Wahrheit für Struktur; Werte/Farben/Schnitte bleiben in tokens.css/tokens.json.",
   "geltungsbereich": {

--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -103,7 +103,10 @@ html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
 
 @media(max-width:720px){
   .dsnav .worlds{display:none}
-  .dsnav .read{margin-left:auto}   /* Schalter-Cluster (Lesemodus·Theme·Menü) zusammen nach rechts */
+  /* Fingerziel-Luft (B04): die drei Modi-Schalter ziehen in die Schublade
+     (.dmodes) – die Leiste behält nur Marke + Menü. */
+  .dsnav .read,.dsnav .share,.dsnav .theme{display:none}
+  .dsnav .all{margin-left:auto}
 }
 
 /* --- Schublade ------------------------------------------------------------- */
@@ -121,6 +124,23 @@ html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
 .dsnav-drawer .dhead .t{font-weight:var(--w-strong);font-size:15px}
 .dsnav-drawer .close{font:inherit;font-size:22px;line-height:1;color:var(--muted);background:none;border:0;cursor:pointer;padding:4px}
 .dsnav-drawer .close:hover{color:var(--ink)}
+
+/* Modi-Schalter oben in der Schublade (Lesemodus · Hell/Dunkel · Teilen):
+   nur auf schmalen Schirmen sichtbar – dort ersetzen sie die Leisten-Icons.
+   Wort + Zeichen, Ziele ≥44px (B04), Zustand wie in der Leiste (Gold-Ring). */
+.dsnav-drawer .dmodes{display:none;gap:var(--s2);padding:var(--s3) 22px;
+  border-bottom:1px solid var(--line);flex:0 0 auto}
+.dsnav-drawer .dmodes button{flex:1 1 0;display:inline-flex;align-items:center;justify-content:center;
+  gap:7px;font:inherit;font-family:var(--font-text);font-size:var(--t-small);color:var(--ink);
+  background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);
+  padding:9px 6px;min-height:var(--tap);cursor:pointer}
+.dsnav-drawer .dmodes button:hover{border-color:var(--gold)}
+.dsnav-drawer .dmodes button[aria-pressed="true"]{color:var(--gold-ink);box-shadow:inset 0 0 0 2px var(--gold)}
+.dsnav-drawer .dmodes .read .ic{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:19px;line-height:1}
+.dsnav-drawer .dmodes .read[aria-pressed="true"] .ic{font-family:var(--font-text)}
+.dsnav-drawer .dmodes .theme .ic,.dsnav-drawer .dmodes .share .ic{font-size:17px;line-height:1;display:inline-flex}
+.dsnav-drawer .dmodes .share.ok{color:var(--ok)}
+@media(max-width:720px){.dsnav-drawer .dmodes{display:flex}}
 
 /* Suche im Menü – filtert die Werkzeugliste live */
 .dsnav-drawer .dsearch{padding:var(--s3) 22px;border-bottom:1px solid var(--line);flex:0 0 auto}

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -42,12 +42,16 @@
   var SHARE_SVG = '<svg viewBox="0 0 24 24" width="17" height="17" aria-hidden="true" style="display:block" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 14V3.6M8.2 7.2 12 3.4l3.8 3.8"/><path d="M5.5 11.5v8h13v-8"/></svg>';
   var CHECK_SVG = '<svg viewBox="0 0 24 24" width="17" height="17" aria-hidden="true" style="display:block" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12.5 4.5 4.5L19 7.5"/></svg>';
   function updateThemeBtn() {
-    if (!themeBtn) return;
     var dark = document.documentElement.getAttribute("data-theme") === "dark";
-    themeBtn.querySelector(".ic").innerHTML = dark ? SUN_SVG : MOON_SVG;
-    themeBtn.setAttribute("aria-label", dark ? "Hell schalten" : "Dunkel schalten");
-    themeBtn.setAttribute("data-tip", dark ? "Hellmodus" : "Dunkelmodus");
-    themeBtn.setAttribute("aria-pressed", String(dark));
+    var alle = document.querySelectorAll(".dsnav .theme, .dsnav-drawer .theme");
+    for (var i = 0; i < alle.length; i++) {
+      alle[i].querySelector(".ic").innerHTML = dark ? SUN_SVG : MOON_SVG;
+      alle[i].setAttribute("aria-label", dark ? "Hell schalten" : "Dunkel schalten");
+      if (alle[i].hasAttribute("data-tip")) alle[i].setAttribute("data-tip", dark ? "Hellmodus" : "Dunkelmodus");
+      alle[i].setAttribute("aria-pressed", String(dark));
+      var lb = alle[i].querySelector(".lb");
+      if (lb) lb.textContent = dark ? "Hellmodus" : "Dunkelmodus";
+    }
   }
   function setTheme(t) {
     try { localStorage.setItem(THEME_KEY, t); } catch (e) {}
@@ -64,10 +68,12 @@
   var READ_KEY = "goeRead", readBtn = null;
   function getRead() { try { return localStorage.getItem(READ_KEY) === "easy" ? "easy" : ""; } catch (e) { return ""; } }
   function updateReadBtn() {
-    if (!readBtn) return;
     var on = document.documentElement.getAttribute("data-read") === "easy";
-    readBtn.setAttribute("aria-pressed", String(on));
-    readBtn.setAttribute("aria-label", on ? "Lesemodus ausschalten" : "Lesemodus – Fliesstext in der Leseschrift");
+    var alle = document.querySelectorAll(".dsnav .read, .dsnav-drawer .read");
+    for (var i = 0; i < alle.length; i++) {
+      alle[i].setAttribute("aria-pressed", String(on));
+      alle[i].setAttribute("aria-label", on ? "Lesemodus ausschalten" : "Lesemodus – Fliesstext in der Leseschrift");
+    }
   }
   function setRead(on) {
     try { localStorage.setItem(READ_KEY, on ? "easy" : "off"); } catch (e) {}
@@ -249,6 +255,14 @@
   drawer.innerHTML =
     '<div class="dhead"><span class="t">Navigation</span>' +
       '<button class="close" type="button" aria-label="Schliessen">×</button></div>' +
+    // Modi-Schalter (Lesemodus · Hell/Dunkel · Teilen): auf schmalen Schirmen
+    // ziehen sie aus der Kopfzeile hierher – die Leiste behält nur Marke + Menü
+    // (Fingerziel-Luft, B04); mit Wortmarke statt blossem Zeichen.
+    '<div class="dmodes" role="group" aria-label="Anzeige-Modi">' +
+      '<button class="read" type="button" aria-pressed="false" aria-label="Lesemodus – Fliesstext in der Leseschrift"><span class="ic" aria-hidden="true">a</span><span class="lb">Lesemodus</span></button>' +
+      '<button class="theme" type="button" aria-label="Dunkel schalten"><span class="ic"></span><span class="lb">Dunkelmodus</span></button>' +
+      '<button class="share" type="button" aria-label="Seite teilen – Link kopieren"><span class="ic">' + SHARE_SVG + '</span><span class="lb">Teilen</span></button>' +
+    '</div>' +
     '<div class="dsearch"><input type="search" class="dsnav-q" placeholder="Werkzeug suchen …" aria-label="Werkzeug suchen" autocomplete="off"></div>' +
     '<div class="body"></div>' +
     '<div class="foot"><a href="mailto:philipp.tok@goetheanum.ch?subject=Feedback%20Goetheanum%20Werkzeuge">Feedback geben</a> · <a href="' + ROOT + 'design-system/">Design-System</a></div>';
@@ -283,7 +297,7 @@
     }
     return location.href.split("#")[0];
   }
-  var shareBtn = header.querySelector(".share");
+  function wireShare(shareBtn) {
   shareBtn.addEventListener("click", function () {
     var url = shareUrl();
     var done = function () {
@@ -300,16 +314,21 @@
       navigator.clipboard.writeText(url).then(done, function () {});
     }
   });
+  }
+  wireShare(header.querySelector(".share"));
+  wireShare(drawer.querySelector(".dmodes .share"));
 
-  var themeBtn = header.querySelector(".theme");
-  themeBtn.addEventListener("click", function () {
+  function toggleTheme() {
     setTheme(document.documentElement.getAttribute("data-theme") === "dark" ? "light" : "dark");
-  });
+  }
+  header.querySelector(".theme").addEventListener("click", toggleTheme);
+  drawer.querySelector(".dmodes .theme").addEventListener("click", toggleTheme);
   updateThemeBtn();
-  readBtn = header.querySelector(".read");
-  readBtn.addEventListener("click", function () {
+  function toggleRead() {
     setRead(document.documentElement.getAttribute("data-read") !== "easy");
-  });
+  }
+  header.querySelector(".read").addEventListener("click", toggleRead);
+  drawer.querySelector(".dmodes .read").addEventListener("click", toggleRead);
   updateReadBtn();
   var worldsNav = header.querySelector(".worlds");
   var drawerBody = drawer.querySelector(".body");


### PR DESCRIPTION
## Was

Auf ≤720px verlassen die drei Modi-Schalter (Lesemodus · Hell/Dunkel · Teilen) die Kopfzeile und stehen als eigene Reihe `.dmodes` ganz oben in der Schublade — jetzt mit Wort **und** Zeichen beschriftet. Die Leiste trägt mobil nur noch Marke + Menü.

## Warum

Nach dem Zuwachs auf drei Schalter blieb zwischen Marke und Menüknopf kein Platz mehr für den Dreifachtipp (Feedback-Geste). Die reinen Zeichen-Knöpfe waren mobil zudem schwer deutbar — in der Schublade ist Platz für die Beschriftung.

## Regeln

- **B04** Fingerziele ≥44px (`--tap`) für alle drei Schubladen-Schalter
- **B03** Beschriftung in `--t-small`, nichts unter dem Floor
- Zustands-Sync: `nav.js` hält Leisten- und Schubladen-Buttons gemeinsam aktuell (aria-pressed, Label Hell-/Dunkelmodus, Lesemodus-Zeichen)

## Verifikation

Playwright (390×844 und 1280×900): mobil sind read/share/theme in der Leiste unsichtbar, 161px Luft zwischen Marke und Menü; Schublade zeigt die drei Schalter, Klicks schalten Theme/Lesemodus korrekt und syncen die Labels; Desktop unverändert. `ds-lint` 100%.

Ledger **1.7.1**, Vertragsversion mitgezogen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_