### PR TITLE
Menü: Backstage-Welt «Kampagne» + Sicherheitsnetz für neue Kategorien

### DIFF
--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -123,10 +123,13 @@
       intro: "Fertige Vorlagen zum Übernehmen – Wallpaper, Präsentationen.", cats: ["anwendung"] }
   ];
   // Nur intern zusätzlich – die Backstage-Welten (A/B/C-Qualifizierung).
+  // Kuratierte Reihenfolge; Manifest-Kategorien, die hier fehlen, laufen beim
+  // Laden automatisch als eigene Backstage-Welt hinten nach (Sicherheitsnetz).
   var INTERN_EXTRA = [
     { id: "vorbereitung", label: "In Vorbereitung", intro: "In Arbeit – noch nicht freigegeben.", cats: ["vorbereitung"] },
     { id: "ligaturen", label: "Ligaturen", intro: "Die Kiste nur für die Ligaturen.", cats: ["ligaturen"] },
     { id: "schriftpflege", label: "Schriftpflege", intro: "Grotesk, Gewichte und Mischsatz prüfen.", cats: ["schriftpflege"] },
+    { id: "kampagne", label: "Kampagne", intro: "Kampagnen planen, verlinken, mailen, zählen.", cats: ["kampagne"] },
     { id: "statistik", label: "Statistik", intro: "Nutzungszahlen aller Werkzeuge.", cats: ["statistik"] },
     { id: "schau", label: "Schau & Mockups", intro: "Präsentations-Mockups und Studien.", cats: ["schau"] },
     { id: "geparkt", label: "Geparktes", intro: "Konzepte, die später kommen.", cats: ["geparkt"] },
@@ -468,6 +471,15 @@
   // --- Manifest laden --------------------------------------------------------
   fetch(TOOLS).then(function (r) { return r.json(); }).then(function (m) {
     ALL = m.tools || [];
+    // Sicherheitsnetz: Manifest-Kategorien ohne Welt werden automatisch eigene
+    // Backstage-Welten (Titel/Intro aus tools.json) — eine neue Kategorie im
+    // Manifest verschwindet damit nie mehr stillschweigend aus dem Menü.
+    var known = WORLDS.concat(INTERN_EXTRA).reduce(function (a, w) { return a.concat(w.cats); }, []);
+    (m.categories || []).forEach(function (c) {
+      if (c && c.id && known.indexOf(c.id) === -1) {
+        INTERN_EXTRA.push({ id: c.id, label: c.title || c.id, intro: c.intro || "", cats: [c.id] });
+      }
+    });
     PRIMARY.forEach(function (p) {
       var t = bySlug(p.slug);
       var a = el("a", null, p.label);


### PR DESCRIPTION
Mit #314 wanderten Sommer-Zähler, UTM-Link-Generator, Marketing-Maschine und Mail-Editor in die neue tools.json-Kategorie «kampagne» — die **hartkodierten Welten in `design-system/nav.js`** kannten diese Kategorie nicht, darum verschwanden die vier Werkzeuge aus dem Menü (auch aus der Backstage-Suche). Der interne Hub (`start/`) rendert dynamisch aus tools.json und zeigte sie weiterhin.

Zwei Griffe, eine Datei (`design-system/nav.js`):
- **Kuratierte Backstage-Welt «Kampagne»** vor «Statistik» (erst die Aktion, dann die Zahl).
- **Sicherheitsnetz beim Manifest-Laden:** Kategorien aus tools.json, die keine Welt kennt, werden automatisch eigene Backstage-Welten (Titel/Intro aus dem Manifest) — eine neue Kategorie verschwindet damit nie mehr stillschweigend aus dem Menü.

Geprüft im Chromium: Backstage-Menü zeigt «Kampagne» mit allen vier Werkzeugen, die Menü-Suche findet den Mail-Editor, das öffentliche Menü bleibt unverändert (vier Welten, flache Liste); Negativ-Probe mit einer Fantasie-Kategorie erzeugt die Auto-Welt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFAMLwWjDa2oei2ExhV5fG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFAMLwWjDa2oei2ExhV5fG)_