### PR TITLE
ingest-paperform: Platzhalter blockieren die UTM-Fallbacks nicht mehr

### DIFF
--- a/services/sommer-zaehler/ingest-paperform/index.ts
+++ b/services/sommer-zaehler/ingest-paperform/index.ts
@@ -45,10 +45,12 @@ function cleanUtm(v: any): string | null {
 function utmFromBody(body: any): { src: string | null; med: string | null; camp: string | null; cont: string | null; land: string | null } {
   const out = { src: null as string | null, med: null as string | null, camp: null as string | null, cont: null as string | null, land: null as string | null };
   // 1) Versteckte Formularfelder mit Key utm_source/… (Prefill aus der URL).
+  // Platzhalter («none» …) sofort bereinigen, damit sie die Fallbacks
+  // (device.utm_* und URL-Parameter) nicht blockieren.
   const data = Array.isArray(body?.data) ? body.data : [];
   for (const f of data) {
     const k = String(f?.custom_key || f?.key || f?.title || "").toLowerCase();
-    const v = (f?.value ?? "").toString();
+    const v = cleanUtm(f?.value);
     if (!v) continue;
     if (k === "utm_source") out.src = out.src || v;
     else if (k === "utm_medium") out.med = out.med || v;
@@ -57,10 +59,10 @@ function utmFromBody(body: any): { src: string | null; med: string | null; camp:
   }
   // 2) Paperform-eigenes Tracking (device.utm_*), das die URL automatisch aufnimmt.
   const d = (body && typeof body.device === "object") ? body.device : {};
-  out.src = out.src || d.utm_source || null;
-  out.med = out.med || d.utm_medium || null;
-  out.camp = out.camp || d.utm_campaign || null;
-  out.cont = out.cont || d.utm_content || null;
+  out.src = out.src || cleanUtm(d.utm_source);
+  out.med = out.med || cleanUtm(d.utm_medium);
+  out.camp = out.camp || cleanUtm(d.utm_campaign);
+  out.cont = out.cont || cleanUtm(d.utm_content);
   try {
     if (d.url) { const url = new URL(String(d.url)); out.land = url.searchParams.get("_d") || (url.host + (url.pathname === "/" ? "" : url.pathname)); }
   } catch { /* keine URL */ }


### PR DESCRIPTION
Die neuen EN-Formulare (`sommer2026-chf-en`, `sommer2026-eur-en`) haben noch zufällige Pre-fill-Keys → ihre versteckten Felder liefern den Default «none». Bisher blockierte das den Rückgriff auf `device.utm_*` und die URL-Parameter der Popup-URL.

Jetzt werden Feldwerte sofort bereinigt (`cleanUtm` beim Einsammeln), sodass die UTMs aus der `device.url` nachgezogen werden. **Deployt als v9 und live verifiziert:** «none»-Felder + UTM-tragende Popup-URL → volles Tupel korrekt erkannt (`hao/test/summer26_trial/test_wos_en` + Landing-Host).

Damit ist der End-to-End-Test der EN-Landing nicht mehr von der manuellen Key-Umbenennung in Paperform abhängig (die bleibt als Kür empfohlen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_