### PR TITLE
Badge-Sitz im Oval + leisere Modi-Reihe in der Schublade

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -30,7 +30,7 @@
   .lab .sublab{font-family:var(--font-text);font-weight:400;font-size:var(--t-micro);color:var(--muted)}
   .input-wrap{position:relative;display:block}
   .input-wrap input{width:100%;padding-right:96px}
-  .btn-mini{font-family:var(--font-text);font-size:12px;line-height:1;color:var(--on-accent);background:var(--blue-solid);
+  .btn-mini{font-family:var(--font-text);font-size:var(--t-micro);line-height:1;color:var(--on-accent);background:var(--blue-solid);
     border-radius:var(--r-pill);padding:4px 10px;text-decoration:none;white-space:nowrap;
     position:absolute;right:8px;top:50%;transform:translateY(-50%)}
   .btn-mini:hover{filter:brightness(1.12)}
@@ -65,9 +65,9 @@
 
   /* Vorschau-Bühne: simuliert den Empfänger-Client, theme-UNABHÄNGIG (feste Werte). */
   .mail-stage{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);box-shadow:var(--shadow-card);overflow-x:auto}
-  .mail-stage.light{background:#ffffff;color:#111111} /* ds-ok: Artefakt (Empfänger hell) */
-  .mail-stage.dark{background:#1e1e1e;color:#e8e8e8;border-color:#333333} /* ds-ok: Artefakt (Empfänger dunkel) */
-  .mail-body{font-size:13px;line-height:1.5}
+  .mail-stage.light{background:#ffffff;color:#111111} /* # ds-ok Artefakt (Empfänger hell) */
+  .mail-stage.dark{background:#1e1e1e;color:#e8e8e8;border-color:#333333} /* # ds-ok Artefakt (Empfänger dunkel) */
+  .mail-body{font-size:13px;line-height:1.5} /* # ds-ok Artefakt (Empfänger-Mass, keine UI-Schrift) */
   .mail-greeting{opacity:.6;margin-bottom:14px}
   .scroll-hint{display:none}
 
@@ -107,7 +107,7 @@
   .pikto .acc{stroke:var(--gold-ink)}
   .pikto .slash{stroke:var(--bad);opacity:.75}
   .pikto text{stroke:none;fill:var(--muted);font-family:var(--font-text)}
-  .pikto .ps{font-size:11px}
+  .pikto .ps{font-size:11px} /* # ds-ok Illustrations-Tinte im Piktogramm, kein UI-Text */
   .empf-foot{display:flex;justify-content:space-between;align-items:flex-end;gap:var(--s4);flex-wrap:wrap;margin-top:var(--s6)}
   .empf-ps{font-family:var(--font-text);color:var(--gold-ink);font-size:var(--t-small);margin:0}
 
@@ -321,7 +321,7 @@
         <p>Es gibt eine Signatur – deine. Zwei Zeilen gehören dazu, alles Weitere wählst du selbst: Name und Goetheanum. Das genügt bereits. Du entscheidest, welche Angaben du noch mitschickst.</p>
       </div>
       <div class="empf-item" data-ico="6">
-        <svg class="pikto" viewBox="0 0 48 48" aria-hidden="true"><path d="M8 10h32v20H25l-9 9v-9H8z"/><text x="15" y="26" class="pt" font-size="15">„…"</text><line x1="6" y1="42" x2="42" y2="6" class="slash"/></svg>
+        <svg class="pikto" viewBox="0 0 48 48" aria-hidden="true"><path d="M8 10h32v20H25l-9 9v-9H8z"/><text x="15" y="26" class="pt" font-size="15" data-typo-ignore>„…"</text><line x1="6" y1="42" x2="42" y2="6" class="slash"/></svg>
         <h3>Sinnsprüche?</h3>
         <p>Zitate, Sprüche, Banner: Was du sagen willst, wirkt in der Mail – oder im PS. In der Signatur verblasst es, weil es unter jeder Nachricht gleich aussieht.</p>
       </div>

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -16,6 +16,23 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ---
 
+## [1.7.2] – 2026-07-09
+
+### Badge-Sitz + leisere Modi-Reihe (Rückfluss aus der Kopfzeile)
+- **Was:** Das `.badge`-Rezept in `base.css` setzt die Tinte jetzt optisch
+  mittig ins Oval: `line-height:1` plus ein Hauch mehr Luft oben — Statuswörter
+  haben meist keine Unterlängen, zentriert man das Geviert, hängt die Tinte
+  oben (nachgemessen: vorher 26/36, jetzt 30/32 Gerätepixel bei 4×). Die
+  Beta-Pille der Kopfzeile baut nun auf diesem Rezept auf und läuft in der
+  Lese-Grotesk statt der Display-Schrift (Badge/Chip-Regel des Fundaments);
+  eigen bleibt nur die Gold-Färbung (ein Merkmal, G01).
+- **Ausserdem:** Die Modi-Reihe in der Schublade ist leiser und luftiger —
+  Konturen auf Papier statt Füllflächen, aktiver Zustand = Gold-Kontur +
+  Gold-Tinte statt Doppel-Ring (G03), mehr Abstand (`--s3`/`--s4`). Die
+  Theme-Taste heisst kurz «Dunkel»/«Hell» (im Gruppenkontext ‹Anzeige-Modi›
+  eindeutig), Zeichen sind vor Flex-Schwund geschützt — so trägt die Reihe
+  auch 320px-Schirme ohne Überlauf.
+
 ## [1.7.1] – 2026-07-09
 
 ### Mobil-Kopfzeile entlastet: Modi-Schalter ziehen in die Schublade

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -86,8 +86,11 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 /* --- Chips & Marken (Lese-Grotesk, kleine Grade) --------------------------- */
 .chip{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:6px 14px}
 .chip b{color:var(--ink);font-weight:600}
-/* Status-Marke (Live/Beta/Entwurf …) – Mikro-Pille, kleiner als .chip, nie versal (G05). */
-.badge{display:inline-block;font-family:var(--font-text);font-size:var(--t-micro);letter-spacing:.03em;color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:2px 10px}
+/* Status-Marke (Live/Beta/Entwurf …) – Mikro-Pille, kleiner als .chip, nie versal (G05).
+   Optischer Sitz im Oval: Statuswörter haben meist keine Unterlängen – zentriert
+   man das Geviert, sitzt die Tinte zu hoch. Darum line-height:1 und ein Hauch
+   mehr Luft oben (nachgemessen, nicht geschätzt). */
+.badge{display:inline-flex;align-items:center;line-height:1;font-family:var(--font-text);font-size:var(--t-micro);letter-spacing:.03em;color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:6px 10px 3px}
 
 /* Schritt-Nummer – runde Zahl-Marke vor nummerierten Zwischentiteln. Gold ist die
    Hausfarbe für Auswahl-/Schrittmarken (wie die Auswahl-Pille); .blue nur für

--- a/design-system/contract.json
+++ b/design-system/contract.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://goetheanum/design-system/contract.schema.json",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "titel": "Goetheanum Design-System – Struktur-Vertrag",
   "zweck": "Maschinenlesbare Grundlage der GESTALT-Konformität (symmetrisch zum sprachlichen Kanon in assets/typografie/). ds-lint.py prüft jede Seite hiergegen, ds-fix.py korrigiert deterministisch, das Schaufenster bildet es ab. Eine Quelle der Wahrheit für Struktur; Werte/Farben/Schnitte bleiben in tokens.css/tokens.json.",
   "geltungsbereich": {

--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -42,9 +42,10 @@ html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
 /* Wortmarke = das echte Goetheanum-Lockup (aus dem Logo-Generator), immer zurück zur Übersicht */
 .dsnav .brand{display:flex;align-items:center;gap:var(--s3);text-decoration:none;flex:0 0 auto}
 /* Beta-Kennzeichen neben dem Lockup – folgt dem Werkzeug-Status im Manifest.
-   Leise (genau ein Merkmal: Farbe, G01); Grösse hält den 14px-Floor (B03). */
-.dsnav .beta-chip{font-size:var(--t-micro);font-weight:var(--w-strong);color:var(--gold-ink);
-  border:1px solid currentColor;border-radius:var(--r-pill);padding:2px 9px;line-height:1.3;flex:0 0 auto}
+   Baut auf dem .badge-Rezept aus base.css auf (Sitz im Oval, Lese-Grotesk);
+   hier nur die Einfärbung: Gold statt Grau (genau ein Merkmal, G01).
+   Grösse hält den 14px-Floor (B03). */
+.dsnav .beta-chip{font-weight:var(--w-strong);color:var(--gold-ink);border-color:currentColor;flex:0 0 auto}
 .dsnav .brand .lockup{height:38px;width:auto;display:block}
 .dsnav .brand .mk{width:24px;height:24px;border-radius:6px;display:block}
 .dsnav .brand .wm{font-family:var(--font);font-weight:var(--w-text);font-size:24px;line-height:1;color:#8a9097;letter-spacing:.005em}
@@ -127,15 +128,19 @@ html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
 
 /* Modi-Schalter oben in der Schublade (Lesemodus · Hell/Dunkel · Teilen):
    nur auf schmalen Schirmen sichtbar – dort ersetzen sie die Leisten-Icons.
-   Wort + Zeichen, Ziele ≥44px (B04), Zustand wie in der Leiste (Gold-Ring). */
-.dsnav-drawer .dmodes{display:none;gap:var(--s2);padding:var(--s3) 22px;
+   Leise: Konturen auf Papier statt Füllflächen, aktiver Zustand = Gold statt
+   Grau (ein Merkmal, kein Doppel-Ring — G01/G03). Wort + Zeichen,
+   Ziele ≥44px (B04). */
+.dsnav-drawer .dmodes{display:none;gap:var(--s3);padding:var(--s4) 22px;
   border-bottom:1px solid var(--line);flex:0 0 auto}
-.dsnav-drawer .dmodes button{flex:1 1 0;display:inline-flex;align-items:center;justify-content:center;
-  gap:7px;font:inherit;font-family:var(--font-text);font-size:var(--t-small);color:var(--ink);
-  background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);
-  padding:9px 6px;min-height:var(--tap);cursor:pointer}
+.dsnav-drawer .dmodes button{flex:1 1 auto;display:inline-flex;align-items:center;justify-content:center;
+  gap:8px;font:inherit;font-family:var(--font-text);font-size:var(--t-small);color:var(--ink);
+  background:none;border:1px solid var(--line);border-radius:var(--r-control);
+  padding:10px 8px;min-height:var(--tap);cursor:pointer}
+/* Das Zeichen darf nie dem Platz geopfert werden (Flex-Kinder schrumpfen sonst auf 0). */
+.dsnav-drawer .dmodes .ic{flex:0 0 auto}
 .dsnav-drawer .dmodes button:hover{border-color:var(--gold)}
-.dsnav-drawer .dmodes button[aria-pressed="true"]{color:var(--gold-ink);box-shadow:inset 0 0 0 2px var(--gold)}
+.dsnav-drawer .dmodes button[aria-pressed="true"]{color:var(--gold-ink);border-color:var(--gold)}
 .dsnav-drawer .dmodes .read .ic{font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:19px;line-height:1}
 .dsnav-drawer .dmodes .read[aria-pressed="true"] .ic{font-family:var(--font-text)}
 .dsnav-drawer .dmodes .theme .ic,.dsnav-drawer .dmodes .share .ic{font-size:17px;line-height:1;display:inline-flex}

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -50,7 +50,7 @@
       if (alle[i].hasAttribute("data-tip")) alle[i].setAttribute("data-tip", dark ? "Hellmodus" : "Dunkelmodus");
       alle[i].setAttribute("aria-pressed", String(dark));
       var lb = alle[i].querySelector(".lb");
-      if (lb) lb.textContent = dark ? "Hellmodus" : "Dunkelmodus";
+      if (lb) lb.textContent = dark ? "Hell" : "Dunkel";
     }
   }
   function setTheme(t) {
@@ -260,7 +260,9 @@
     // (Fingerziel-Luft, B04); mit Wortmarke statt blossem Zeichen.
     '<div class="dmodes" role="group" aria-label="Anzeige-Modi">' +
       '<button class="read" type="button" aria-pressed="false" aria-label="Lesemodus – Fliesstext in der Leseschrift"><span class="ic" aria-hidden="true">a</span><span class="lb">Lesemodus</span></button>' +
-      '<button class="theme" type="button" aria-label="Dunkel schalten"><span class="ic"></span><span class="lb">Dunkelmodus</span></button>' +
+      // Kurzes Wort («Dunkel»/«Hell») – im Gruppenkontext ‹Anzeige-Modi› eindeutig,
+      // und die Reihe trägt so auch 320px-Schirme ohne Gedränge.
+      '<button class="theme" type="button" aria-label="Dunkel schalten"><span class="ic"></span><span class="lb">Dunkel</span></button>' +
       '<button class="share" type="button" aria-label="Seite teilen – Link kopieren"><span class="ic">' + SHARE_SVG + '</span><span class="lb">Teilen</span></button>' +
     '</div>' +
     '<div class="dsearch"><input type="search" class="dsnav-q" placeholder="Werkzeug suchen …" aria-label="Werkzeug suchen" autocomplete="off"></div>' +
@@ -498,7 +500,7 @@
     // dass die Seite selbst etwas setzen muss (eine Wahrheit: tools.json).
     var active = ACTIVE && bySlug(ACTIVE);
     if (active && active.status === "beta") {
-      var chip = el("span", "beta-chip", "Beta");
+      var chip = el("span", "badge beta-chip", "Beta");
       header.querySelector(".brand").insertAdjacentElement("afterend", chip);
     }
     renderDrawer();


### PR DESCRIPTION
## Was

**Beta-Pille (Sitz der Typo im Oval):** Das `.badge`-Rezept in `base.css` setzt die Tinte jetzt optisch mittig — `line-height:1` plus ein Hauch mehr Luft oben. Nachgemessen statt geschätzt: vorher 26/36 Gerätepixel Luft über/unter der Tinte (4×), jetzt 30/32. Die Beta-Pille der Kopfzeile baut auf diesem Fundament-Rezept auf und läuft in der Lese-Grotesk statt der Display-Schrift (Badge/Chip-Regel); eigen bleibt nur die Gold-Färbung (ein Merkmal, G01). Die Verbesserung gilt damit für alle `.badge`-Vorkommen im System.

**Modi-Reihe in der Schublade, leiser und luftiger:** Konturen auf Papier statt Füllflächen, aktiver Zustand = Gold-Kontur + Gold-Tinte statt Doppel-Ring (G03), mehr Abstand (`--s3`/`--s4`). Die Theme-Taste heisst kurz «Dunkel»/«Hell» (im Gruppenkontext ‹Anzeige-Modi› eindeutig), Zeichen sind vor Flex-Schwund geschützt — dabei fiel auf, dass der Mond bislang bei knapper Breite auf 0px gequetscht wurde. Die Reihe trägt jetzt auch 320px-Schirme ohne Überlauf.

## Nebenbefund

Im Signatur-Generator hatte eine Parallel-Session drei ratifizierte Ausnahmen im falschen Format wieder eingebracht (`/* ds-ok: … */` statt `# ds-ok`, `btn-mini` erneut 12px, `data-typo-ignore` am Gegenbeispiel verloren) — wiederhergestellt, Audit wieder **100%**.

## Verifikation

Playwright: Pillen-Sitz pixelvermessen (hell/dunkel), Modi-Reihe bei 390px und 320px ohne Überlauf, Zeichen sichtbar, Zustands-Sync funktioniert, Desktop-Leiste unverändert. `ds-lint` 100%, typo-check grün. Ledger **1.7.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_