### PR TITLE
Zeitband: Kürzel-Pflicht, Bearbeiten, Flyer-Zeile; Generator: neue Quellen

### DIFF
--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -173,6 +173,8 @@
   .zr.sichtbarkeit{background:var(--gold)} .zr.aktivierung{background:var(--blue)}
   .zr.wirkung{background:var(--ok)} .zr.bindung{background:var(--muted)}
   .zb-legende{display:flex;flex-wrap:wrap;gap:var(--s2) var(--s4);margin-top:var(--s3);font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted)}
+  .medit{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);background:none;border:0;cursor:pointer;padding:4px 6px;min-height:var(--tap)}
+  .medit:hover{color:var(--blue)} td.act{text-align:right;white-space:nowrap}
   .zb-form{margin-top:var(--s5)}
   .zb-form summary{cursor:pointer;font-family:var(--font-text);font-weight:600;color:var(--ink);min-height:var(--tap);display:flex;align-items:center}
   .zb-form .grid{display:grid;grid-template-columns:repeat(3,1fr);gap:var(--s4);margin-top:var(--s4)}
@@ -326,7 +328,7 @@
     </div>
     <div class="zb-legende" id="zbLegende"></div>
 
-    <details class="zb-form">
+    <details class="zb-form" id="mfForm">
       <summary>Massnahme eintragen</summary>
       <div class="card soft">
         <div class="grid">
@@ -340,6 +342,7 @@
               <option value="social">Social Media</option>
               <option value="newsletter">Newsletter</option>
               <option value="mailer">Mailing / Post</option>
+              <option value="flyer">Flyer</option>
               <option value="popup">Popup</option>
               <option value="website">Website</option>
               <option value="empfehlung">Empfehlung</option>
@@ -360,23 +363,15 @@
             <input type="text" id="mfTitel" placeholder="z. B. Reel Ernst Zürcher · Instagram" />
           </label>
           <label class="field">
-            <span class="lab">Reichweite (optional)</span>
-            <input type="number" id="mfReichweite" min="0" placeholder="Impressionen" />
-          </label>
-          <label class="field">
-            <span class="lab">Klicks (optional)</span>
-            <input type="number" id="mfKlicks" min="0" placeholder="Klicks" />
-          </label>
-          <label class="field">
-            <span class="lab">Kosten in CHF (optional)</span>
-            <input type="number" id="mfKosten" min="0" step="0.01" placeholder="0.00" />
+            <span class="lab">Kürzel – wer steht dahinter?</span>
+            <input type="text" id="mfWer" placeholder="z. B. pt" autocomplete="off" />
           </label>
         </div>
         <div style="display:flex;gap:var(--s3);align-items:center;flex-wrap:wrap;margin-top:var(--s4)">
           <button class="btn primary" type="button" id="mfBtn">Eintragen</button>
           <span class="said" id="mfSaid"></span>
         </div>
-        <p class="provisorisch" style="margin-top:var(--s3)">Für alle Kampagnen-Beteiligten offen – Social trägt Posts und Reichweiten ein, Redaktion Newsletter und Inserate. Zahlen dürfen später nachgetragen werden (einfach denselben Eintrag ergänzen lassen oder Philipp melden).</p>
+        <p class="provisorisch" style="margin-top:var(--s3)">Für alle Kampagnen-Beteiligten offen. Reichweite, Klicks und Kosten werden gesammelt nachgetragen (CSV an Philipp oder per Bearbeiten-Knopf im Protokoll unten).</p>
       </div>
     </details>
   </section>
@@ -385,7 +380,7 @@
     <div class="shead"><h2>Massnahmen-Protokoll</h2><p>Jede Massnahme mit Datum, Aufgabe, Kosten, Reichweite und Klicks – damit aus der Aktion eine lesbare Geschichte wird statt eines Datenhaufens.</p></div>
     <div class="tablewrap">
       <table class="tarif">
-        <thead><tr><th>Datum</th><th>Massnahme</th><th>Kanal</th><th class="num">Kosten</th><th class="num">Reichweite</th><th class="num">Klicks</th></tr></thead>
+        <thead><tr><th>Datum</th><th>Massnahme</th><th>Kanal</th><th class="num">Kosten</th><th class="num">Reichweite</th><th class="num">Klicks</th><th></th></tr></thead>
         <tbody id="massnahmenBody"><tr><td class="empty" colspan="6">lädt …</td></tr></tbody>
       </table>
     </div>
@@ -628,7 +623,7 @@
     { name: 'Schlussspurt',  von: '2026-08-03', bis: '2026-08-08' }
   ];
   var ZB_KANAELE = [
-    ['social', 'Social'], ['newsletter', 'Newsletter'], ['mailer', 'Mailing/Post'],
+    ['social', 'Social'], ['newsletter', 'Newsletter'], ['mailer', 'Mailing/Post'], ['flyer', 'Flyer'],
     ['popup', 'Popup'], ['website', 'Website'], ['empfehlung', 'Empfehlung'], ['andere', 'Anderes']
   ];
   var ROLLEN_LABEL = { sichtbarkeit:'Sichtbarkeit', aktivierung:'Aktivierung', wirkung:'Wirkung', bindung:'Bindung' };
@@ -693,6 +688,7 @@
           var d = new Date(m.tag + 'T00:00:00');
           if (d < von || d > bis) return;
           var det = [ROLLEN_LABEL[m.rolle] || ''];
+          if (m.ersteller) det.push('Kürzel ' + m.ersteller);
           if (m.reichweite) det.push('Reichweite ' + Number(m.reichweite).toLocaleString('de-CH'));
           if (m.klicks) det.push('Klicks ' + Number(m.klicks).toLocaleString('de-CH'));
           if (m.kosten) det.push('Kosten ' + Number(m.kosten).toLocaleString('de-CH'));
@@ -714,53 +710,82 @@
     }).join('') + '<span>Jeder Punkt = eine Massnahme; Details beim Überfahren.</span>';
   }
 
-  // Eintragen: offener Schreibweg (Muster Link-Register), erscheint sofort überall.
+  // Eintragen/Bearbeiten: offener Schreibweg (Muster Link-Register),
+  // erscheint sofort überall. Bearbeiten lädt die Zeile über den Knopf im Protokoll.
   el('mfTag').value = new Date().toISOString().slice(0, 10);
   el('mfBtn').addEventListener('click', function(){
     var sagen = function(msg, bad){ var s = el('mfSaid'); s.textContent = msg; s.style.color = bad ? 'var(--bad)' : 'var(--ok)'; };
     var titel = (el('mfTitel').value || '').trim();
-    if (!el('mfTag').value || !titel){ sagen('Datum und Massnahme sind Pflicht.', true); return; }
-    fetch(SB + '/rest/v1/rpc/sommer2026_massnahme_eintragen', {
+    var wer = (el('mfWer').value || '').trim();
+    if (!el('mfTag').value || !titel || !wer){ sagen('Datum, Massnahme und Kürzel sind Pflicht.', true); return; }
+    var istEdit = mfEditId != null;
+    var params = {
+      p_tag: el('mfTag').value, p_massnahme: titel,
+      p_kanal: el('mfKanal').value, p_rolle: el('mfRolle').value,
+      p_ersteller: wer, p_kosten: null, p_reichweite: null, p_klicks: null
+    };
+    if (istEdit) { params.p_id = mfEditId; } else { params.p_zielgruppe = null; }
+    fetch(SB + '/rest/v1/rpc/' + (istEdit ? 'sommer2026_massnahme_aendern' : 'sommer2026_massnahme_eintragen'), {
       method: 'POST',
       headers: { 'Content-Type':'application/json', 'apikey':KEY, 'Authorization':'Bearer ' + KEY },
-      body: JSON.stringify({
-        p_tag: el('mfTag').value, p_massnahme: titel,
-        p_kanal: el('mfKanal').value, p_rolle: el('mfRolle').value,
-        p_zielgruppe: null,
-        p_kosten: el('mfKosten').value ? Number(el('mfKosten').value) : null,
-        p_reichweite: el('mfReichweite').value ? Number(el('mfReichweite').value) : null,
-        p_klicks: el('mfKlicks').value ? Number(el('mfKlicks').value) : null
-      })
+      body: JSON.stringify(params)
     }).then(function(r){ if(!r.ok) throw new Error(r.status); return r.json(); })
       .then(function(ergebnis){
         if (ergebnis === 'ok'){
-          sagen('Eingetragen – erscheint im Zeitband und im Protokoll.');
-          el('mfTitel').value = ''; el('mfReichweite').value = ''; el('mfKlicks').value = ''; el('mfKosten').value = '';
+          sagen(istEdit ? 'Geändert.' : 'Eingetragen – erscheint im Zeitband und im Protokoll.');
+          mfZuruecksetzen();
           rpc('sommer2026_massnahmen_public').then(function(rows){ renderZeitband(rows); renderMassnahmen(rows); }).catch(function(){});
         } else { sagen('Datum und Massnahme prüfen.', true); }
       })
-      .catch(function(){ sagen('Eintragen nicht erreichbar.', true); });
+      .catch(function(){ sagen(istEdit ? 'Ändern nicht erreichbar.' : 'Eintragen nicht erreichbar.', true); });
   });
 
   function renderMassnahmen(rows){
     var body = el('massnahmenBody'); body.innerHTML = '';
     if(!rows || !rows.length){
-      body.innerHTML = '<tr><td class="empty" colspan="6">Noch keine Massnahmen erfasst – das Protokoll wird gepflegt, sobald die Aktionen laufen.</td></tr>';
+      body.innerHTML = '<tr><td class="empty" colspan="7">Noch keine Massnahmen erfasst – das Protokoll wird gepflegt, sobald die Aktionen laufen.</td></tr>';
       return;
     }
     rows.forEach(function(r){
       var tag = r.tag ? new Date(r.tag + 'T00:00:00').toLocaleDateString('de-CH', { day:'numeric', month:'numeric' }) : '–';
       var kanal = (KANAL_LABEL[r.kanal] || r.kanal || '') + (r.rolle && ROLLE_LABEL[r.rolle] ? ' · ' + ROLLE_LABEL[r.rolle] : '');
       var tr = document.createElement('tr');
-      tr.innerHTML = '<td></td><td></td><td></td><td class="num"></td><td class="num"></td><td class="num"></td>';
+      tr.innerHTML = '<td></td><td></td><td></td><td class="num"></td><td class="num"></td><td class="num"></td><td class="act"></td>';
       tr.children[0].textContent = tag;
-      tr.children[1].textContent = r.massnahme || '';
+      tr.children[1].textContent = (r.massnahme || '') + (r.ersteller ? ' · ' + r.ersteller : '');
       tr.children[2].textContent = kanal;
       tr.children[3].textContent = (r.kosten != null) ? eur(r.kosten) : '–';
       tr.children[4].textContent = (r.reichweite != null) ? fmt(r.reichweite) : '–';
       tr.children[5].textContent = (r.klicks != null) ? fmt(r.klicks) : '–';
+      var edit = document.createElement('button');
+      edit.type = 'button'; edit.className = 'medit'; edit.textContent = 'Bearbeiten';
+      edit.addEventListener('click', function(){ massnahmeBearbeiten(r); });
+      tr.children[6].appendChild(edit);
       body.appendChild(tr);
     });
+  }
+
+  // Bearbeiten: Zeile in die Maske laden; Speichern ändert nur die Kernfelder,
+  // vorhandene Zahlen (Kosten/Reichweite/Klicks) bleiben unangetastet.
+  var mfEditId = null;
+  function massnahmeBearbeiten(r){
+    mfEditId = r.id;
+    var d = el('mfForm'); if (d) d.open = true;
+    el('mfTag').value = r.tag || '';
+    el('mfTitel').value = r.massnahme || '';
+    el('mfKanal').value = r.kanal || 'andere';
+    el('mfRolle').value = r.rolle || 'wirkung';
+    el('mfWer').value = r.ersteller || '';
+    el('mfBtn').textContent = 'Änderung speichern';
+    el('mfSaid').textContent = 'Bearbeitung von «' + (r.massnahme || '') + '» – Speichern übernimmt.';
+    el('mfSaid').style.color = 'var(--muted)';
+    d.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }
+  function mfZuruecksetzen(){
+    mfEditId = null;
+    el('mfTitel').value = ''; el('mfWer').value = '';
+    el('mfTag').value = new Date().toISOString().slice(0, 10);
+    el('mfBtn').textContent = 'Eintragen';
   }
 
   // ── Kosten und Wirkung ─────────────────────────────────────────────────────

--- a/apps/utm-generator/index.html
+++ b/apps/utm-generator/index.html
@@ -117,7 +117,8 @@
             <option value="linkedin"></option><option value="youtube"></option>
             <option value="nl-ws"></option><option value="nl-tv"></option>
             <option value="mailing"></option><option value="inserat"></option>
-            <option value="google"></option>
+            <option value="google"></option><option value="goetheanum"></option>
+            <option value="dasgoetheanum"></option><option value="flyer"></option>
           </datalist>
         </label>
 
@@ -328,7 +329,8 @@
   var MEDIUM_VORSCHLAG = {
     instagram:'social', facebook:'social', linkedin:'social', youtube:'social',
     'nl-ws':'email', 'nl-tv':'email', mailing:'email',
-    inserat:'print', google:'cpc'
+    inserat:'print', flyer:'print', google:'cpc',
+    goetheanum:'popup', dasgoetheanum:'popup'
   };
   var mediumWarAutomatisch = false;
   el('medium').addEventListener('input', function(){ mediumWarAutomatisch = false; });

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -106,7 +106,7 @@ create table if not exists public.sommer2026_massnahmen (
   created_at  timestamptz not null default now(),
   tag         date not null,                              -- Datum der Massnahme
   massnahme   text not null,                              -- z. B. «Auftaktnewsletter»
-  kanal       text not null default 'andere' check (kanal in ('newsletter','mailer','social','popup','website','empfehlung','andere')),
+  kanal       text not null default 'andere' check (kanal in ('newsletter','mailer','flyer','social','popup','website','empfehlung','andere')),
   rolle       text not null default 'wirkung' check (rolle in ('sichtbarkeit','aktivierung','wirkung','bindung')),  -- Hauptaufgabe
   zielgruppe  text,
   botschaft   text,
@@ -114,6 +114,7 @@ create table if not exists public.sommer2026_massnahmen (
   kosten      numeric,                                    -- Aufwand
   reichweite  bigint,                                     -- Sichtbarkeit (Impressionen)
   klicks      bigint,                                     -- Aktivierung
+  ersteller   text,                                       -- Kürzel: wer steht dahinter
   beobachtung text,                                       -- INTERN (nicht im RPC)
   entscheidung text                                       -- INTERN (nicht im RPC)
 );
@@ -132,9 +133,9 @@ $$;
 
 -- Massnahmen-Protokoll, kuratiert (ohne interne Freitext-Spalten)
 create or replace function public.sommer2026_massnahmen_public()
-returns table(tag date, massnahme text, kanal text, rolle text, kosten numeric, reichweite bigint, klicks bigint)
+returns table(id bigint, tag date, massnahme text, kanal text, rolle text, ersteller text, kosten numeric, reichweite bigint, klicks bigint)
 language sql security definer set search_path to 'public' as $$
-  select tag, massnahme, kanal, rolle, kosten, reichweite, klicks
+  select id, tag, massnahme, kanal, rolle, ersteller, kosten, reichweite, klicks
     from public.sommer2026_massnahmen
    order by tag, id;
 $$;
@@ -145,7 +146,8 @@ $$;
 -- und Wirkungskette im Cockpit.
 create or replace function public.sommer2026_massnahme_eintragen(
   p_tag date, p_massnahme text, p_kanal text, p_rolle text,
-  p_zielgruppe text, p_kosten numeric, p_reichweite bigint, p_klicks bigint)
+  p_zielgruppe text, p_kosten numeric, p_reichweite bigint, p_klicks bigint,
+  p_ersteller text default null)
 returns text language plpgsql security definer set search_path to 'public' as $$
 declare
   v_kanal text; v_rolle text;
@@ -154,15 +156,45 @@ begin
     return 'unvollstaendig';
   end if;
   v_kanal := lower(coalesce(p_kanal, ''));
-  if v_kanal not in ('newsletter','mailer','social','popup','website','empfehlung','andere') then v_kanal := 'andere'; end if;
+  if v_kanal not in ('newsletter','mailer','flyer','social','popup','website','empfehlung','andere') then v_kanal := 'andere'; end if;
   v_rolle := lower(coalesce(p_rolle, ''));
   if v_rolle not in ('sichtbarkeit','aktivierung','wirkung','bindung') then v_rolle := 'wirkung'; end if;
-  insert into public.sommer2026_massnahmen (tag, massnahme, kanal, rolle, zielgruppe, kosten, reichweite, klicks)
-  values (p_tag, trim(p_massnahme), v_kanal, v_rolle, nullif(trim(coalesce(p_zielgruppe,'')), ''), p_kosten, p_reichweite, p_klicks);
+  insert into public.sommer2026_massnahmen (tag, massnahme, kanal, rolle, zielgruppe, kosten, reichweite, klicks, ersteller)
+  values (p_tag, trim(p_massnahme), v_kanal, v_rolle, nullif(trim(coalesce(p_zielgruppe,'')), ''), p_kosten, p_reichweite, p_klicks,
+          nullif(trim(coalesce(p_ersteller,'')), ''));
   return 'ok';
 end;
 $$;
-grant execute on function public.sommer2026_massnahme_eintragen(date, text, text, text, text, numeric, bigint, bigint) to anon, authenticated;
+grant execute on function public.sommer2026_massnahme_eintragen(date, text, text, text, text, numeric, bigint, bigint, text) to anon, authenticated;
+
+-- Bearbeiten (Migration «sommer2026_massnahmen_kuerzel_flyer_bearbeiten»):
+-- nur übergebene Werte ändern, vorhandene Zahlen bleiben erhalten.
+create or replace function public.sommer2026_massnahme_aendern(
+  p_id bigint, p_tag date, p_massnahme text, p_kanal text, p_rolle text,
+  p_ersteller text, p_kosten numeric, p_reichweite bigint, p_klicks bigint)
+returns text language plpgsql security definer set search_path to 'public' as $$
+declare
+  v_kanal text; v_rolle text; n int;
+begin
+  v_kanal := lower(coalesce(p_kanal, ''));
+  if v_kanal not in ('newsletter','mailer','flyer','social','popup','website','empfehlung','andere') then v_kanal := null; end if;
+  v_rolle := lower(coalesce(p_rolle, ''));
+  if v_rolle not in ('sichtbarkeit','aktivierung','wirkung','bindung') then v_rolle := null; end if;
+  update public.sommer2026_massnahmen set
+    tag        = coalesce(p_tag, tag),
+    massnahme  = coalesce(nullif(trim(coalesce(p_massnahme,'')), ''), massnahme),
+    kanal      = coalesce(v_kanal, kanal),
+    rolle      = coalesce(v_rolle, rolle),
+    ersteller  = coalesce(nullif(trim(coalesce(p_ersteller,'')), ''), ersteller),
+    kosten     = coalesce(p_kosten, kosten),
+    reichweite = coalesce(p_reichweite, reichweite),
+    klicks     = coalesce(p_klicks, klicks)
+  where id = p_id;
+  get diagnostics n = row_count;
+  return case when n > 0 then 'ok' else 'unbekannt' end;
+end;
+$$;
+grant execute on function public.sommer2026_massnahme_aendern(bigint, date, text, text, text, text, numeric, bigint, bigint) to anon, authenticated;
 
 -- Wirkungstrichter: Sichtbarkeit → Aktivierung → Wirkung → Bindung
 create or replace function public.sommer2026_trichter()


### PR DESCRIPTION
Vier Team-Wünsche in einem Zug:

- **Kürzel-Pflicht**: Jede Massnahme trägt, wer dahintersteht — Pflichtfeld in der Maske, sichtbar im Protokoll (`Massnahme · pt`) und im Chip-Tooltip.
- **Bearbeiten**: Knopf je Protokollzeile lädt den Eintrag in die Maske; «Änderung speichern» ändert nur die Kernfelder, vorhandene Zahlen bleiben (neue RPC `sommer2026_massnahme_aendern`, live verifiziert).
- **Flyer**: eigene Zeile im Zeitband, Option in der Maske, Constraint erweitert.
- **Maske verschlankt**: die optionalen Zahlenfelder (Reichweite/Klicks/Kosten) sind raus — Nachtrag per Bearbeiten oder gesammelt per CSV.
- **Generator**: Quellen `goetheanum`/`dasgoetheanum` (Medium-Vorschlag `popup` für Webseiten-Popups) und `flyer` (`print`).

Migration `sommer2026_massnahmen_kuerzel_flyer_bearbeiten` angewandt und live getestet (Eintragen mit Kürzel + Flyer ✓, Ändern ✓, Probe entfernt); `schema.sql` nachgezogen. ds-lint 100 %, typo-check konform, Screenshot geprüft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_