### PR TITLE
Signatur: Zeilenabstand 1.3 + Kontaktblock mit Leerzeile abgesetzt

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -462,6 +462,9 @@ function buildSignature() {
   const addr = [val("street"), val("city"), val("country")].filter(Boolean).join(" · ");
   if (addr) push(esc(addr), addr);
 
+  // Kontaktblock (Telefon/Mobil/Web) mit Leerzeile von Organisation/Adresse absetzen
+  if ((val("phone") || val("mobile") || val("web").trim()) && rows.some(r => !r.gap)) gap();
+
   // Kontakt: Telefonnummern als tel:-Link, aber Theme-Farbe (inherit) – dark-mode-fest
   if (val("phone")) push("<a href=\"" + telHref(val("phone")) + "\" style=\"color:inherit;text-decoration:none;\">" + esc(val("phone")) + "</a>", val("phone"));
   if (val("mobile")) push("<a href=\"" + telHref(val("mobile")) + "\" style=\"color:inherit;text-decoration:none;\">" + esc(val("mobile")) + "</a>", val("mobile"));
@@ -477,7 +480,7 @@ function buildSignature() {
   while (hl.length && hl[0] === "") { hl.shift(); tl.shift(); }
   while (hl.length && hl[hl.length - 1] === "") { hl.pop(); tl.pop(); }
 
-  const html = "<div style=\"font-family:" + CFONT + ";font-size:12px;line-height:1.5;\">" + (hl.join("<br>") || "&nbsp;") + "</div>";
+  const html = "<div style=\"font-family:" + CFONT + ";font-size:12px;line-height:1.3;\">" + (hl.join("<br>") || "&nbsp;") + "</div>";
   const text = tl.join("\n");
   return { html, text };
 }


### PR DESCRIPTION
Zwei Signatur-Korrekturen.

**Zeilenabstand → 1.3**
- Näher an den Mail-Standards: Clients rendern den Mailtext um 1.2–1.35; die Signatur soll nicht luftiger wirken als ihr Umfeld.
- **Regelkonform:** Die Signatur ist **Konsultation** (Hausregel G27 — springendes Lesen kurzer Datenzeilen), nicht linearer Lesetext; das ≥1.5-Minimum bindet nur den Mengentext.

**Kontaktblock abgesetzt (Bug)**
- Zwischen Adresse und Kontakt fehlte die Leerzeile komplett — ohne Telefonnummer klebte die Web-URL direkt an der Postadresse (gut gesehen; mit Nummer fiel es nur weniger auf).
- Jetzt wird der Kontaktblock (Telefon/Mobil/Web) **immer** mit einer Leerzeile abgesetzt, egal welche Felder gefüllt sind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_