### PR TITLE
Crawler-Schutz komplett (robots.txt + noindex), CH-Fussnote zu den elf Empfehlungen

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -51,6 +51,10 @@ jobs:
           # Manifest der Werkzeuge (treibt die Uebersicht).
           if [ -f tools.json ]; then cp tools.json _site/tools.json; fi
 
+          # Crawler-Politik: KI-Bots blockieren, Suchmaschinen lesen das
+          # noindex in den Seiten (Details im Kopf der robots.txt).
+          if [ -f robots.txt ]; then cp robots.txt _site/robots.txt; fi
+
           # Eigene Domain: GitHub Pages liest die CNAME aus dem Artefakt. Ohne
           # diese Zeile ginge die Domain-Anbindung beim naechsten Deploy verloren.
           if [ -f CNAME ]; then cp CNAME _site/CNAME; fi

--- a/apps/bewegte-schrift/index.html
+++ b/apps/bewegte-schrift/index.html
@@ -16,6 +16,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
 <title>Bewegte Schrift · Goetheanum</title>
 <meta name="description" content="Erprobung dezenter Schrift-Animationen auf der Gewichtsachse der Hausschrift – live, mit Code zum Übernehmen." />
 <link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />

--- a/apps/briefschaften/index.html
+++ b/apps/briefschaften/index.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
   <title>Goetheanum Briefschaften & Signatur</title>
   <link rel="stylesheet" href="../../design-system/tokens.css" />
   <link rel="stylesheet" href="../../design-system/base.css" />

--- a/apps/cover-generator/index.html
+++ b/apps/cover-generator/index.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
   <title>Goetheanum TV Cover Generator</title>
   <script src="https://c.webfontfree.com/c.js?f=Titillium-SemiboldUpright" type="text/javascript"></script>
   <script src="../../assets/vendor/goetheanum-title-font.js"></script>

--- a/apps/editor/index.html
+++ b/apps/editor/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
 <title>Goetheanum Editor</title>
 <meta name="description" content="Text einfügen, prüfen lassen: die eindeutigen Hausregeln der Typografie werden automatisch gesetzt, offene Fragen erscheinen in der Marginalspalte zur Bestätigung." />
 <link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />

--- a/apps/gtv-naming/index.html
+++ b/apps/gtv-naming/index.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex" />
 <title>Goetheanum TV – Namens-Renderings</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/apps/karten-generator/index.html
+++ b/apps/karten-generator/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
   <title>Kartentool · Goetheanum Campus</title>
 
   <link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />

--- a/apps/logos/index.html
+++ b/apps/logos/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
 <title>Logos – Goetheanum</title>
 <meta name="description" content="Das Logo des Goetheanum: Sektions- und Bereichslogos in der Hausschrift erzeugen und herunterladen – mit Begleitschreiben (wer, was, wie; Regeln und Verbote)." />
 <link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />

--- a/apps/seelenkalender/index.html
+++ b/apps/seelenkalender/index.html
@@ -12,6 +12,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
 <title>Seelenkalender · Goetheanum</title>
 <meta name="description" content="Der Wochenspruch des Anthroposophischen Seelenkalenders – jede Woche neu, im Takt der Wochenschrift." />
 <link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />

--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -110,6 +110,11 @@
   .pikto .ps{font-size:11px}
   .empf-foot{display:flex;justify-content:space-between;align-items:flex-end;gap:var(--s4);flex-wrap:wrap;margin-top:var(--s6)}
   .empf-ps{font-family:var(--font-text);color:var(--gold-ink);font-size:var(--t-small);margin:0}
+  .empf-fn{margin-top:var(--s6);padding-top:var(--s4);border-top:1px solid var(--line)}
+  .empf-fn .fn-body{font-family:var(--font-text);font-size:var(--t-small);line-height:1.6;color:var(--ink);margin-top:var(--s3)}
+  .empf-fn .fn-body p{max-width:62ch;margin:0 0 var(--s2)}
+  .empf-fn ul{margin:0;padding-left:1.1em}
+  .empf-fn li{max-width:62ch;margin-bottom:var(--s2)}
 
   /* Apple-Mail-Skizze (eigenständige Farben = Artefakt/Screenshot). */
   .amv{width:100%;max-width:600px;height:auto;display:block;margin-top:var(--s4)} /* ds-ok */
@@ -321,7 +326,7 @@
         <p>Es gibt eine Signatur – deine. Zwei Zeilen gehören dazu, alles Weitere wählst du selbst: Name und Goetheanum. Das genügt bereits. Du entscheidest, welche Angaben du noch mitschickst.</p>
       </div>
       <div class="empf-item" data-ico="6">
-        <svg class="pikto" viewBox="0 0 48 48" aria-hidden="true"><path d="M8 10h32v20H25l-9 9v-9H8z"/><text x="15" y="26" class="pt" font-size="15">„…"</text><line x1="6" y1="42" x2="42" y2="6" class="slash"/></svg>
+        <svg class="pikto" viewBox="0 0 48 48" aria-hidden="true"><path d="M8 10h32v20H25l-9 9v-9H8z"/><text x="15" y="26" class="pt" font-size="15">‹…›</text><line x1="6" y1="42" x2="42" y2="6" class="slash"/></svg>
         <h3>Sinnsprüche?</h3>
         <p>Zitate, Sprüche, Banner: Was du sagen willst, wirkt in der Mail – oder im PS. In der Signatur verblasst es, weil es unter jeder Nachricht gleich aussieht.</p>
       </div>
@@ -376,6 +381,39 @@
       <p class="empf-ps">PS: Die kürzeste Mail ist oft die freundlichste.</p>
       <button type="button" class="btn primary" id="pdfBtn">Als PDF laden (A4)</button>
     </div>
+
+    <details class="code-details empf-fn">
+      <summary>Fussnote: Was in der Schweiz gilt</summary>
+      <div class="fn-body">
+        <p>Die Empfehlungen können so entspannt ausfallen, weil das schweizerische
+          Recht ihnen nicht im Weg steht:</p>
+        <ul>
+          <li><strong>Keine Pflichtangaben.</strong> Die Schweiz kennt keine Vorschrift,
+            welche Angaben eine geschäftliche E-Mail tragen muss. Was in der Signatur
+            steht, ist eine Frage der Höflichkeit, nicht des Rechts.</li>
+          <li><strong>Die Firma wird vollständig geführt</strong> (Art. 954a OR):
+            Wer im Handelsregister eingetragen ist, verwendet die eingetragene
+            Bezeichnung vollständig und unverändert – darum steht <q>Allgemeine
+            Anthroposophische Gesellschaft</q> ausgeschrieben in der Signatur.</li>
+          <li><strong>Registernummern:</strong> Die UID (CHE-Nummer) gehört auf
+            Rechnungen mit Mehrwertsteuer, nicht unter jede Nachricht – siehe
+            <q>Zahlenkolonnen</q>.</li>
+          <li><strong>Vertraulichkeitshinweise</strong> entfalten keine rechtliche
+            Wirkung: Ein einseitiger Hinweis bindet den Empfänger nicht – siehe
+            <q>Juristerei</q>.</li>
+          <li><strong>Werbung hat Regeln, Korrespondenz nicht</strong>
+            (Art. 3 Abs. 1 lit. o UWG): Massenwerbung verlangt korrekte
+            Absenderangaben und eine Abmeldemöglichkeit – das betrifft den
+            Newsletter-Versand, nicht die persönliche Mail.</li>
+          <li><strong>Datenschutz</strong> (DSG): verlangt in der Signatur nichts;
+            die Datenschutzerklärung gehört auf die Website.</li>
+          <li><strong>Elektronische Signatur ist nicht E-Mail-Signatur:</strong>
+            Die qualifizierte elektronische Signatur (ZertES) ist ein
+            kryptografisches Siegel für Verträge – mit dem Textblock unter der
+            Mail teilt sie nur den Namen.</li>
+        </ul>
+      </div>
+    </details>
     </div>
   </section>
 </main>

--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -462,6 +462,9 @@ function buildSignature() {
   const addr = [val("street"), val("city"), val("country")].filter(Boolean).join(" · ");
   if (addr) push(esc(addr), addr);
 
+  // Kontaktblock (Telefon/Mobil/Web) mit Leerzeile von Organisation/Adresse absetzen
+  if ((val("phone") || val("mobile") || val("web").trim()) && rows.some(r => !r.gap)) gap();
+
   // Kontakt: Telefonnummern als tel:-Link, aber Theme-Farbe (inherit) – dark-mode-fest
   if (val("phone")) push("<a href=\"" + telHref(val("phone")) + "\" style=\"color:inherit;text-decoration:none;\">" + esc(val("phone")) + "</a>", val("phone"));
   if (val("mobile")) push("<a href=\"" + telHref(val("mobile")) + "\" style=\"color:inherit;text-decoration:none;\">" + esc(val("mobile")) + "</a>", val("mobile"));
@@ -477,7 +480,7 @@ function buildSignature() {
   while (hl.length && hl[0] === "") { hl.shift(); tl.shift(); }
   while (hl.length && hl[hl.length - 1] === "") { hl.pop(); tl.pop(); }
 
-  const html = "<div style=\"font-family:" + CFONT + ";font-size:12px;line-height:1.5;\">" + (hl.join("<br>") || "&nbsp;") + "</div>";
+  const html = "<div style=\"font-family:" + CFONT + ";font-size:12px;line-height:1.3;\">" + (hl.join("<br>") || "&nbsp;") + "</div>";
   const text = tl.join("\n");
   return { html, text };
 }

--- a/apps/visitenkarten-generator/index.html
+++ b/apps/visitenkarten-generator/index.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
   <title>Goetheanum Visitenkarten One-Pager</title>
   <link rel="stylesheet" href="../../design-system/tokens.css" />
   <link rel="stylesheet" href="../../design-system/base.css" />

--- a/briefschaften.html
+++ b/briefschaften.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
   <title>Weiterleitung zu Briefschaften</title>
   <meta http-equiv="refresh" content="0; url=./apps/briefschaften/" />
   <script>

--- a/cover-generator.html
+++ b/cover-generator.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
   <title>Weiterleitung zum Cover-Generator</title>
   <meta http-equiv="refresh" content="0; url=./apps/cover-generator/" />
   <script>

--- a/design-system/starter-artikel.html
+++ b/design-system/starter-artikel.html
@@ -17,6 +17,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
 <title>Artikel-Titel · Goetheanum</title>
 <meta name="description" content="Vorspann des Artikels in einem Satz." />
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />

--- a/design-system/starter.html
+++ b/design-system/starter.html
@@ -26,6 +26,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
 <title>Neues Werkzeug · Goetheanum</title>
 <meta name="description" content="Kurzbeschreibung des Werkzeugs – ein Satz, was es tut." />
 <!-- Pfadtiefe an den Ort DEINER Datei anpassen:

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
 <title>Goetheanum Werkzeuge – Hausgrafik</title>
 <meta name="description" content="Werkzeuge für die Hausgrafik des Goetheanum: Logos, Schriften, E-Mail-Signatur, Visitenkarten und das Design-System." />
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />

--- a/ineinander.html
+++ b/ineinander.html
@@ -1,6 +1,7 @@
 <!doctype html><html lang="de"><head>
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" /><meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1"><title>Ligaturen ineinander</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="robots" content="noindex" /><title>Ligaturen ineinander</title>
 <link rel="stylesheet" href="design-system/tokens.css" />
 <link rel="stylesheet" href="design-system/base.css" />
 <link rel="stylesheet" href="design-system/nav.css" />

--- a/karten-generator.html
+++ b/karten-generator.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
   <title>Weiterleitung zum Karten-Generator</title>
   <meta http-equiv="refresh" content="0; url=./apps/karten-generator/" />
   <script>

--- a/karten.html
+++ b/karten.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
   <title>Weiterleitung zum Karten-Generator</title>
   <meta http-equiv="refresh" content="0; url=./karten-generator.html" />
   <script>

--- a/kerning.html
+++ b/kerning.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="de"><head>
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" /><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex" />
 <title>Ligatur-Spacing</title>
 <link rel="stylesheet" href="design-system/tokens.css" />
 <link rel="stylesheet" href="design-system/base.css" />

--- a/ligvorschau.html
+++ b/ligvorschau.html
@@ -1,6 +1,7 @@
 <!doctype html><html lang="de"><head>
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" /><meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1"><title>Ligaturen — Werkschau</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="robots" content="noindex" /><title>Ligaturen — Werkschau</title>
 <link rel="stylesheet" href="design-system/tokens.css" />
 <link rel="stylesheet" href="design-system/base.css" />
 <link rel="stylesheet" href="design-system/nav.css" />

--- a/logo-generator.html
+++ b/logo-generator.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
 <title>Logos – Goetheanum</title>
 <meta http-equiv="refresh" content="0; url=./apps/logos/" />
 <link rel="canonical" href="./apps/logos/" />

--- a/marketing-maschine.html
+++ b/marketing-maschine.html
@@ -10,6 +10,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
 <title>Marketing-Maschine · Goetheanum</title>
 <meta name="description" content="Jahreszyklus, Kampagnen, Leads: die weitgehend automatisierte Marketing-Maschine für die Wochenschrift und goetheanum.tv – auf einer Seite." />
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />

--- a/powerpoint.html
+++ b/powerpoint.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
 <title>Goetheanum – PowerPoint-Vorlagen</title>
 <meta name="description" content="Präsentationsvorlage im Hausbild des Goetheanum als PowerPoint (A4), mit eingebetteten Schriften – plus die TrueType-Schriften fürs Office zum Installieren." />
 <link rel="stylesheet" href="design-system/tokens.css" />

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,81 @@
+# werkzeuge.goetheanum.ch — interne Werkzeuge der Goetheanum-Hausgrafik.
+# Nicht für Suchtreffer und nicht als Material für KI-Crawler gedacht.
+#
+# Arbeitsteilung (bewusst so, nicht anders):
+#   1) Jede Seite trägt <meta name="robots" content="noindex">.
+#   2) Klassische Suchmaschinen DÜRFEN crawlen — nur so lesen sie das
+#      noindex überhaupt. Ein pauschales Disallow würde es unsichtbar
+#      machen und URL-only-Treffer erlauben.
+#   3) KI-/Daten-Crawler werden hier per Disallow ausgeschlossen.
+
+# --- KI- und Daten-Crawler: kein Zugriff -------------------------------
+User-agent: GPTBot
+Disallow: /
+
+User-agent: OAI-SearchBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Claude-User
+Disallow: /
+
+User-agent: Claude-SearchBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: Perplexity-User
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: meta-externalagent
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: omgili
+Disallow: /
+
+User-agent: Timpibot
+Disallow: /
+
+User-agent: AI2Bot
+Disallow: /
+
+User-agent: MistralAI-User
+Disallow: /
+
+# --- Klassische Suchmaschinen: crawlen erlaubt, indexieren verboten
+#     (das Verbot steht als noindex-Meta in jeder Seite) ----------------
+User-agent: *
+Disallow:

--- a/schrift-webfont.html
+++ b/schrift-webfont.html
@@ -2,6 +2,7 @@
 <html lang="de"><head>
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" /><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="robots" content="noindex" />
 <title>Goetheanum Schrift — als Webfont einbinden</title>
 <link rel="stylesheet" href="design-system/tokens.css" />
 <link rel="stylesheet" href="design-system/base.css" />

--- a/sektionsfarben.html
+++ b/sektionsfarben.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
 <title>Goetheanum – Sektionsfarben</title>
 <meta name="description" content="Die Identitätsfarben der Schul-Sektionen und der Bereiche mit Hex, RGB, HSB und CMYK (Richtwert) – klick-kopierbar. Marken- und Neutralfarben wohnen im Design-System." />
 <link rel="stylesheet" href="design-system/tokens.css" />

--- a/signatur-generator.html
+++ b/signatur-generator.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
   <title>Weiterleitung zum Signatur-Generator</title>
   <meta http-equiv="refresh" content="0; url=./apps/signatur-generator/" />
   <script>

--- a/tools/build_sections.py
+++ b/tools/build_sections.py
@@ -19,6 +19,7 @@ TEMPLATE = """<!doctype html>
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
   <title>Weiterleitung … {label}</title>
   <link rel="canonical" href="../{target}" />
   <meta http-equiv="refresh" content="0; url=../{target}" />

--- a/uebersetzungen.html
+++ b/uebersetzungen.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
 <title>Goetheanum – Übersetzungen</title>
 <meta name="description" content="Gängige Übersetzungen der Sektionen, Bereiche und institutionellen Begriffe (Freie Hochschule für Geisteswissenschaft, Allgemeine Anthroposophische Gesellschaft …) in Deutsch, Englisch, Französisch und Spanisch – für die Sekretariate." />
 <link rel="stylesheet" href="design-system/tokens.css" />

--- a/visitenkarten-generator.html
+++ b/visitenkarten-generator.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
   <title>Weiterleitung zum Visitenkarten-Generator</title>
   <meta http-equiv="refresh" content="0; url=./apps/visitenkarten-generator/" />
   <script>

--- a/visitenkarten.html
+++ b/visitenkarten.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
   <title>Weiterleitung zum Visitenkarten-Generator</title>
   <meta http-equiv="refresh" content="0; url=./visitenkarten-generator.html" />
   <script>

--- a/wallpaper.html
+++ b/wallpaper.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
 <title>Goetheanum – Wallpaper</title>
 <meta name="description" content="Desktop-Hintergründe des Goetheanum (2500 × 1406) zum Herunterladen – elf Motive." />
 <link rel="stylesheet" href="design-system/tokens.css" />

--- a/zeichen.html
+++ b/zeichen.html
@@ -4,6 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
 <title>Goetheanum – Zeichen</title>
 <meta name="description" content="Die Zeichen von Rudolf Steiner – Hochschulzeichen, Gesellschaftszeichen und das Zeichen der Bau-Administration. Mit Hinweisen zur Anwendung und Zugang zu den vollständigen Paketen." />
 <link rel="stylesheet" href="design-system/tokens.css" />


### PR DESCRIPTION
## Crawler-Schutz (Audit-Ergebnis: lückenhaft → jetzt komplett)

**Befund:** 16 von 46 veröffentlichten Seiten trugen ein `noindex`-Meta, eine `robots.txt` gab es nicht — KI-Crawler (GPTBot, ClaudeBot, CCBot …) waren gar nicht adressiert.

**Arbeitsteilung der Lösung** (bewusst so herum):
- **`robots.txt`** sperrt KI-/Daten-Crawler per `Disallow: /` (OpenAI, Anthropic, Google-Extended, Applebot-Extended, Perplexity, CCBot, Bytespider, Meta, Amazon u. a.).
- **Klassische Suchmaschinen dürfen crawlen** — nur so lesen sie das `noindex` überhaupt. Ein pauschales Disallow würde es unsichtbar machen und URL-only-Treffer erlauben.
- **`noindex`-Meta in 30 Seiten ergänzt** (Root-Werkzeuge, alle apps/, Hub, Starter) — jetzt 46/46. Abschnitts-Stubs (`build_sections.py`) erben es im Build.
- `deploy-pages.yml` kopiert die `robots.txt` ins Bundle.

## Fussnote ‹Was in der Schweiz gilt›

Unter den elf Empfehlungen liegt jetzt ein zuklappbares Merkblatt zu den Schweizer Rechtskonventionen (nur CH, kein DE): keine Pflichtangaben in Geschäftsmails, Firmengebrauchspflicht (Art. 954a OR), UID auf Rechnungen statt in Signaturen, wirkungslose Vertraulichkeitshinweise, UWG-Regeln nur für Massenwerbung, DSG, ZertES ≠ E-Mail-Signatur.

Nebenbei: Sinnsprüche-Pikto zitiert jetzt mit Hausanführung ‹…› statt „…" (G16, vom typo-check gefunden).

Regel-IDs: G16 (Hausanführung), G18 (Halbgeviert), B02 (Fussnote in `--ink`), DS-konform über bestehende `.code-details`-Rolle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_