### PR TITLE
Multiplikatoren: Kontakte auffindbar, Passwort autokorrektur-fest

### DIFF
--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -428,7 +428,7 @@
   </section>
 
   <section id="multis">
-    <div class="shead"><h2>Multiplikatoren</h2><p>Wer hat wen wann kontaktiert – und was kam heraus? Eine Liste zum Fortschreiben. Namen sind verdeckt (M-01 …); das kleine Passwort blendet sie ein.</p></div>
+    <div class="shead"><h2>Multiplikatoren</h2><p>Wer hat wen wann kontaktiert – und was kam heraus? Erst den Multiplikator anlegen, dann über <q>Verlauf &amp; Kontakt</q> je Zeile jede Kontaktaufnahme nachtragen. Namen sind verdeckt (M-01 …); das kleine Passwort blendet sie ein.</p></div>
     <div style="display:flex;gap:var(--s3);align-items:center;flex-wrap:wrap;margin-bottom:var(--s4)">
       <button class="btn" type="button" id="muNamenBtn">Namen einblenden</button>
       <span class="said" id="muSaid"></span>
@@ -916,7 +916,7 @@
       muSag('Namen ausgeblendet.');
       renderMultis(); return;
     }
-    var pw = (window.prompt('Passwort für die Klarnamen:') || '').trim();
+    var pw = (window.prompt('Passwort für die Klarnamen:') || '').trim().toLowerCase();
     if (pw) muNamenLaden(pw, false);
   });
 
@@ -942,7 +942,7 @@
       tr.children[4].textContent = m.kontakte_n || 0;
       var btn = document.createElement('button');
       btn.type = 'button'; btn.className = 'medit';
-      btn.textContent = (muOffen === m.id) ? 'Schliessen' : 'Verlauf';
+      btn.textContent = (muOffen === m.id) ? 'Schliessen' : 'Verlauf & Kontakt';
       btn.addEventListener('click', function(){ muOffen = (muOffen === m.id) ? null : m.id; renderMultis(); });
       tr.children[5].appendChild(btn);
       body.appendChild(tr);

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -266,6 +266,9 @@ create table if not exists public.sommer2026_multi_kontakte (
 alter table public.sommer2026_multi_kontakte enable row level security;
 revoke all on table public.sommer2026_multi_kontakte from anon, authenticated;
 
+-- Passwort-Prüfung ist gross/klein- und leerzeichen-unabhängig
+-- (Migration «sommer2026_multi_pw_case_insensitive»: lower(trim(...)) vor
+-- dem Hash-Vergleich – Handy-Autokorrektur macht sonst aus «pw» ein «Pw»).
 -- RPCs: multi_liste() (Alias statt Name), multi_protokoll() (alle Kontakte),
 -- multi_namen(p_passwort) (Klarnamen nur bei korrektem Hash),
 -- multi_anlegen(name, rolle, ersteller), multi_kontakt_anlegen(...).


### PR DESCRIPTION
Zwei gemeldete Stolpersteine:

- **«Passwort stimmt nicht»**: Ursache war die Handy-Autokorrektur (`sommerkreis26` → `Sommerkreis26`) gegen die zeichengenaue Prüfung. Jetzt **gross/klein- und leerzeichen-unabhängig** — Migration `sommer2026_multi_pw_case_insensitive` (`lower(trim(...))` im Hash-Vergleich, live verifiziert: `Sommerkreis26`, `  SOMMERKREIS26 ` → true, falsches → false) **plus** Normalisierung im Browser. Wirkt sofort, ohne Neuladen.
- **«Aktivitäten lassen sich nicht eintragen»**: Der Kontakt-Nachtrag lag unentdeckt hinter «Verlauf». Knopf heisst jetzt **«Verlauf & Kontakt»**, die Sektions-Einleitung nennt den Weg (erst Multiplikator anlegen, dann je Zeile Kontakt nachtragen).

`schema.sql` nachgezogen; ds-lint 100 %, typo-check konform. (Die Sprungleiste klebt im aktuellen Code korrekt — per Screenshot geprüft; was noch «wegscrollte», war eine gecachte Vorversion.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_