### PR TITLE
Signatur: PS erbt die Schrift des Anschreibens (Augenhöhe in jedem Client)

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -67,7 +67,7 @@
   .mail-stage{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);box-shadow:var(--shadow-card);overflow-x:auto}
   .mail-stage.light{background:#ffffff;color:#111111} /* ds-ok: Artefakt (Empfänger hell) */
   .mail-stage.dark{background:#1e1e1e;color:#e8e8e8;border-color:#333333} /* ds-ok: Artefakt (Empfänger dunkel) */
-  .mail-body{font-size:13px;line-height:1.5}
+  .mail-body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:1.5} /* Artefakt: simuliert den Mail-Client */
   .mail-greeting{opacity:.6;margin-bottom:14px}
   .scroll-hint{display:none}
 
@@ -480,8 +480,12 @@ function buildSignature() {
   const push = (html, text) => rows.push({ html, text });
   const gap = () => rows.push({ gap: true });
 
-  // PS zuoberst, danach ein Trennzeichen und eine Leerzeile zur Signatur
+  // PS zuoberst – es gehört zum Anschreiben, nicht zur Signatur. Deshalb OHNE
+  // eigene Schrift/Grösse: Es erbt den Mailtext des Clients und steht so in
+  // jedem Programm auf Augenhöhe (Apple Mail 16px, Outlook ~15px, Gmail 13px).
   const ps = val("ps"), pslink = val("pslink");
+  let psHtml = "";
+  const psText = [];
   if (ps) {
     let h = "PS: " + esc(ps), t = "PS: " + ps;
     if (pslink) {
@@ -489,7 +493,8 @@ function buildSignature() {
       h += " – <a href=\"" + esc(webHref(pslink)) + "\" style=\"color:" + MAIL_BLUE + ";text-decoration:none;\">" + esc(d) + "</a>";
       t += " – " + d;
     }
-    push(h, t); gap();
+    psHtml = "<div>" + h + "</div><div><br></div>";
+    psText.push(t, "");
   }
 
   // Abgrenzender Unterstrich – immer, auch ohne PS (trennt Mailtext und Signatur).
@@ -527,8 +532,8 @@ function buildSignature() {
   while (hl.length && hl[0] === "") { hl.shift(); tl.shift(); }
   while (hl.length && hl[hl.length - 1] === "") { hl.pop(); tl.pop(); }
 
-  const html = "<div style=\"font-family:" + CFONT + ";font-size:12px;line-height:1.3;\">" + (hl.join("<br>") || "&nbsp;") + "</div>";
-  const text = tl.join("\n");
+  const html = psHtml + "<div style=\"font-family:" + CFONT + ";font-size:12px;line-height:1.3;\">" + (hl.join("<br>") || "&nbsp;") + "</div>";
+  const text = psText.concat(tl).join("\n");
   return { html, text };
 }
 


### PR DESCRIPTION
Die Signatur bleibt bei 12 px — einzige Ausnahme ist jetzt das PS: Es gehört zum Anschreiben, nicht zur Signatur, und braucht kein Understatement.

**Mechanik:** Das PS steht als eigener Block *vor* dem 12-px-Wrapper und trägt **keine eigene Schrift und keine eigene Grösse** mehr. Dadurch erbt es in jedem Mailprogramm automatisch den Mailtext des Empfängers bzw. Verfassers — Apple Mail 16 px, Outlook ≈15 px, Gmail 13 px — und steht überall exakt auf Augenhöhe mit dem Anschreiben. Eine fest gesetzte Grösse (z. B. 16 px) hätte in Gmail/Outlook lauter als der Text gewirkt.

Die Vorschau simuliert den Client jetzt auch in der Schriftfamilie (System-Stack), nicht nur in der Grösse — vorher erbte der Stage die Seitenschrift.

Geprüft im Headless-Browser: PS rendert bei Client-Grösse (13 px im Vorschau-Stage), Signatur bei 12 px; Klartext-Ausgabe unverändert `PS: … / leer / _ / …`.

Regel-IDs: G01 (keine zusätzliche Auszeichnung — das PS wechselt nur die Hierarchie-Ebene, kein Merkmal im Fliesstext), B03 (PS folgt der Client-Grösse ≥13 px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_