### PR TITLE
PS-Korrekturen: Fold heisst ‹Meistgelesen›, Link faust.jetzt, Ablauf Ende Juli 2027

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -229,7 +229,7 @@
         </details>
 
         <details class="fold" id="psFold">
-          <summary>PS – meistgelesen <span class="sub">Platz für eine Veranstaltung</span></summary>
+          <summary>Meistgelesen <span class="sub">Platz für eine Veranstaltung</span></summary>
           <div class="fold-body">
             <label class="field"><span class="lab"><span>PS-Text</span> <span class="counter" id="psCount">0/120</span></span>
               <textarea id="ps" rows="2" maxlength="120" placeholder="Faust 1+2 · drei mal im Sommer 2027"></textarea>
@@ -459,10 +459,10 @@ const EXAMPLE = {
   street: "Rüttiweg 45",
   city: "4143 Dornach",
   country: "Switzerland",
-  // Haus-PS: gehört allen Abteilungen, hält bis zum Sommerfestival 2027.
+  // Haus-PS: gehört allen Abteilungen, hält bis Ende Juli 2027.
   ps: "Faust 1+2 · drei mal im Sommer 2027",
-  pslink: "goetheanum.ch/faust",
-  psuntil: "2027-08-31"
+  pslink: "faust.jetzt",
+  psuntil: "2027-07-31"
 };
 
 const state = { mode: "light", plain: "" };


### PR DESCRIPTION
Drei Korrekturen am Faust-Beispiel-PS:

- Fold-Titel nur noch **‹Meistgelesen›** — das ‹PS› war doppelt, es steht als Feldname direkt darunter.
- Link auf die echte Adresse **faust.jetzt** (beide Formen antworten 200; die Anzeige kürzt www ohnehin) — `goetheanum.ch/faust` war falsch.
- Ablaufdatum **31.7.2027** statt Ende August.

Headless geprüft: Fold offen, Werte im Formular und in der Vorschau korrekt. Prüfmaschinen grün (Typografie konform, ds-lint 0 Fehler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_