### PR TITLE
Wirkungskette auf gemessene Zahlen: Reichweite → Klicks → Abschlüsse → Geblieben

### DIFF
--- a/apps/sommer-zaehler/aktivitaeten.html
+++ b/apps/sommer-zaehler/aktivitaeten.html
@@ -59,18 +59,19 @@
               <option value="andere">Anderes</option>
             </select>
           </label>
-          <label class="field">
-            <span class="lab">Aufgabe der Aktivität</span>
-            <select id="mfRolle">
-              <option value="sichtbarkeit">Sichtbarkeit (gesehen werden)</option>
-              <option value="aktivierung">Aktivierung (Klicks holen)</option>
-              <option value="wirkung" selected>Wirkung (Abos bringen)</option>
-              <option value="bindung">Bindung (halten)</option>
-            </select>
-          </label>
           <label class="field span3">
             <span class="lab">Aktivität</span>
             <input type="text" id="mfTitel" placeholder="z. B. Reel Ernst Zürcher · Instagram" />
+          </label>
+          <label class="field">
+            <span class="lab">Reichweite – Menschen erreicht</span>
+            <input type="number" id="mfReichweite" min="0" step="1" inputmode="numeric" placeholder="z. B. 4200" />
+            <span class="hint">Impressionen / Auflage / Empfänger. Später über Bearbeiten ergänzbar.</span>
+          </label>
+          <label class="field">
+            <span class="lab">Klicks</span>
+            <input type="number" id="mfKlicks" min="0" step="1" inputmode="numeric" placeholder="z. B. 130" />
+            <span class="hint">Wie viele haben den Link angeklickt.</span>
           </label>
           <label class="field">
             <span class="lab">Kürzel – wer steht dahinter?</span>
@@ -81,7 +82,7 @@
           <button class="btn primary" type="button" id="mfBtn">Eintragen</button>
           <span class="said" id="mfSaid"></span>
         </div>
-        <p class="provisorisch" style="margin-top:var(--s3)">Für alle Kampagnen-Beteiligten offen. Reichweite, Klicks und Kosten werden gesammelt nachgetragen (CSV an Philipp oder per Bearbeiten-Knopf im Protokoll unten). Ausgaben trägst Du unter <a href="kosten.html">Kosten</a> ein.</p>
+        <p class="provisorisch" style="margin-top:var(--s3)">Für alle Kampagnen-Beteiligten offen. Reichweite und Klicks fliessen direkt in die Wirkungskette im Cockpit – kennst Du sie noch nicht, trag sie später über den Bearbeiten-Knopf im Protokoll nach. Ausgaben trägst Du unter <a href="kosten.html">Kosten</a> ein.</p>
       </div>
     </details>
     <details class="zb-form">

--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -102,7 +102,7 @@
   .kampagne{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);margin-top:var(--s4)}
   .kampagne code{font-family:var(--font-mono,var(--font-text));color:var(--ink)}
 
-  /* Wirkungskette (Trichter): Sichtbarkeit → Aktivierung → Wirkung → Bindung. */
+  /* Wirkungskette: Reichweite → Klicks → Abschlüsse → Geblieben (alles gemessen). */
   .funnel .lvl{margin-bottom:var(--s5)} .funnel .lvl:last-child{margin-bottom:0}
   .funnel .l2{display:flex;justify-content:space-between;align-items:baseline;gap:10px;margin-bottom:7px}
   .funnel .fname{font-family:var(--font-text);font-size:var(--t-small);color:var(--ink)}
@@ -115,6 +115,9 @@
   .funnel .s3>span{background:linear-gradient(90deg,var(--gold),var(--gold-ink))}
   .funnel .s4>span{background:var(--ok)}
   .funnel .fnote{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);margin-top:var(--s5);line-height:1.5}
+  /* Reichweite je Kanal – Aufschlüsselung unter der Kette (nutzt die .stream-Balken). */
+  .funnel .reach-kanal{margin-top:var(--s6);padding-top:var(--s5);border-top:1px solid var(--line-soft)}
+  .funnel .reach-kanal .rk-h{font-family:var(--font-text);font-size:var(--t-small);color:var(--ink);font-weight:600;margin-bottom:var(--s4)}
 
   /* Attribution nach Motiv (utm_content) – feiner als der kanal-Bucket. */
   .motive{margin-top:var(--s6)}

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -145,19 +145,26 @@
     });
   }
 
-  // ── Wirkungskette (Trichter) ───────────────────────────────────────────────
+  // ── Wirkungskette: Reichweite → Klicks → Abschlüsse → Geblieben ─────────────
+  // Alle vier Stufen sind GEMESSENE Zahlen, nicht die im Eintrag gewählte Aufgabe:
+  // Reichweite/Klicks summiert aus den Aktivitäten, Abschlüsse/Geblieben live aus
+  // den Anmeldungen. Darum tragen Kanäle mit Reichweite direkt hier bei.
   var TRICHTER = {
-    sichtbarkeit: { name:'Sichtbarkeit', frage:'wahrgenommen',        cls:'s1' },
-    aktivierung:  { name:'Aktivierung',  frage:'Interesse, Klick',    cls:'s2' },
-    wirkung:      { name:'Wirkung',      frage:'Abschluss',           cls:'s3' },
-    bindung:      { name:'Bindung',      frage:'bleibt zahlend',      cls:'s4' }
+    sichtbarkeit: { name:'Reichweite', frage:'Menschen erreicht',   cls:'s1' },
+    aktivierung:  { name:'Klicks',     frage:'haben geklickt',       cls:'s2' },
+    wirkung:      { name:'Abschlüsse', frage:'Abo gestartet',        cls:'s3' },
+    bindung:      { name:'Geblieben',  frage:'nach 3 Monaten dabei', cls:'s4' }
   };
-  function renderFunnel(trichter){
+  function renderFunnel(trichter, massnahmen){
     if (!el('funnel')) return;
     var host = el('funnel'); host.innerHTML = '';
     var vals = {}; (trichter || []).forEach(function(r){ vals[r.stufe] = Number(r.wert) || 0; });
     var order = ['sichtbarkeit','aktivierung','wirkung','bindung'];
     var max = order.reduce(function(m, s){ return Math.max(m, vals[s] || 0); }, 0) || 1;
+    // Umwandlung je Stufe gegen die vorige gemessene Grösse (Klickrate, Abschlussrate, Bleibequote).
+    var rate = { aktivierung: vals.sichtbarkeit > 0 ? vals.aktivierung / vals.sichtbarkeit : null,
+                 wirkung:     vals.aktivierung  > 0 ? vals.wirkung / vals.aktivierung   : null,
+                 bindung:     vals.wirkung      > 0 ? vals.bindung / vals.wirkung       : null };
     order.forEach(function(s){
       var meta = TRICHTER[s]; var v = vals[s] || 0;
       var lvl = document.createElement('div'); lvl.className = 'lvl';
@@ -165,15 +172,42 @@
         '<div class="ftrack ' + meta.cls + '"><span></span></div>';
       var nm = lvl.querySelector('.fname'); nm.textContent = meta.name;
       var rr = document.createElement('span'); rr.className = 'r'; rr.textContent = meta.frage; nm.appendChild(rr);
-      lvl.querySelector('.fval').textContent = fmt(v);
+      var vtxt = fmt(v);
+      if (rate[s] != null) vtxt += '  ·  ' + Math.round(rate[s] * 100) + ' %';
+      lvl.querySelector('.fval').textContent = vtxt;
       lvl.querySelector('.ftrack > span').style.width = Math.max(3, Math.round(v / max * 100)) + '%';
       host.appendChild(lvl);
     });
-    if((vals.sichtbarkeit || 0) === 0 && (vals.aktivierung || 0) === 0){
-      var note = document.createElement('div'); note.className = 'fnote';
-      note.textContent = 'Sichtbarkeit und Aktivierung erscheinen, sobald Reichweite und Klicks im Aktivitäten-Protokoll erfasst sind. Wirkung und Bindung zählen bereits live aus den Anmeldungen.';
-      host.appendChild(note);
+    // Reichweite je Kanal – aus den Aktivitäten summiert (Social, Newsletter, …).
+    var reach = {}, klick = {};
+    (massnahmen || []).forEach(function(m){
+      var r = Number(m.reichweite) || 0, k = Number(m.klicks) || 0, kn = m.kanal || 'andere';
+      if (r) reach[kn] = (reach[kn] || 0) + r;
+      if (k) klick[kn] = (klick[kn] || 0) + k;
+    });
+    var kanalItems = Object.keys(reach).map(function(kn){ return { kanal:kn, reach:reach[kn], klick:klick[kn] || 0 }; })
+                                       .sort(function(a, b){ return b.reach - a.reach; });
+    if (kanalItems.length){
+      var kmax = kanalItems.reduce(function(m, x){ return Math.max(m, x.reach); }, 0) || 1;
+      var box = document.createElement('div'); box.className = 'reach-kanal';
+      var head = document.createElement('div'); head.className = 'rk-h'; head.textContent = 'Reichweite je Kanal';
+      box.appendChild(head);
+      kanalItems.forEach(function(x){
+        var row = document.createElement('div'); row.className = 'stream';
+        row.innerHTML = '<div class="top2"><span class="name"></span>' +
+          '<span class="val"><b></b> <span class="g"></span></span></div>' +
+          '<div class="track"><span></span></div>';
+        row.querySelector('.name').textContent = KANAL_LABEL[x.kanal] || x.kanal;
+        row.querySelector('.val b').textContent = fmt(x.reach);
+        row.querySelector('.val .g').textContent = x.klick ? (fmt(x.klick) + ' Klicks') : '';
+        row.querySelector('.track > span').style.width = Math.max(3, Math.round(x.reach / kmax * 100)) + '%';
+        box.appendChild(row);
+      });
+      host.appendChild(box);
     }
+    var note = document.createElement('div'); note.className = 'fnote';
+    note.textContent = 'Reichweite und Klicks kommen aus den Aktivitäten – je Eintrag erfassen (auch später über Bearbeiten). Abschlüsse und Geblieben zählt das Cockpit live aus den Anmeldungen.';
+    host.appendChild(note);
   }
 
   // ── Attribution nach Motiv (utm_content) ───────────────────────────────────
@@ -199,8 +233,7 @@
     });
   }
 
-  // ── Massnahmen-Protokoll ────────────────────────────────────────────────────
-  var ROLLE_LABEL = { sichtbarkeit:'Sichtbarkeit', aktivierung:'Aktivierung', wirkung:'Wirkung', bindung:'Bindung' };
+  // ── Aktivitäten-Protokoll ───────────────────────────────────────────────────
   var KANAL_LABEL = { newsletter:'Newsletter', mailer:'Mailing', flyer:'Flyer/Stand', social:'Social Media', popup:'Popup', website:'Website', empfehlung:'Empfehlung', andere:'Andere' };
   // ── Zeitband: Phasen × Wochen × Kanäle ─────────────────────────────────────
   // Phasen der Aktion (anpassbar): Auftakt → Verdichtung → Schlussspurt.
@@ -213,7 +246,6 @@
     ['social', 'Social'], ['newsletter', 'Newsletter'], ['mailer', 'Mailing/Post'], ['flyer', 'Flyer/Stand'],
     ['popup', 'Popup'], ['website', 'Website'], ['empfehlung', 'Empfehlung'], ['andere', 'Anderes']
   ];
-  var ROLLEN_LABEL = { sichtbarkeit:'Sichtbarkeit', aktivierung:'Aktivierung', wirkung:'Wirkung', bindung:'Bindung' };
 
   function zbWochen(){
     // Montagsraster über den Aktionszeitraum.
@@ -275,7 +307,7 @@
           if ((m.kanal || 'andere') !== k[0] || !m.tag) return;
           var d = new Date(m.tag + 'T00:00:00');
           if (d < von || d > bis) return;
-          var det = [ROLLEN_LABEL[m.rolle] || ''];
+          var det = [];
           if (m.ersteller) det.push('Kürzel ' + m.ersteller);
           if (m.reichweite) det.push('Reichweite ' + Number(m.reichweite).toLocaleString('de-CH'));
           if (m.klicks) det.push('Klicks ' + Number(m.klicks).toLocaleString('de-CH'));
@@ -283,7 +315,7 @@
           var span = document.createElement('span');
           span.className = 'zb-chip';
           span.title = m.massnahme + ' – ' + det.filter(Boolean).join(' · ');
-          span.innerHTML = '<span class="zr ' + (m.rolle || 'wirkung') + '"></span><span class="zt">' + zbTag(d) + '</span>';
+          span.innerHTML = '<span class="zr"></span><span class="zt">' + zbTag(d) + '</span>';
           span.appendChild(document.createTextNode(m.massnahme));
           chips += span.outerHTML;
         });
@@ -293,9 +325,7 @@
     });
 
     tbl.innerHTML = '<thead>' + h1 + h2 + '</thead><tbody>' + body + '</tbody>';
-    el('zbLegende').innerHTML = Object.keys(ROLLEN_LABEL).map(function(r){
-      return '<span><span class="zr ' + r + '" style="display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:5px"></span>' + ROLLEN_LABEL[r] + '</span>';
-    }).join('') + '<span>Jeder Punkt = eine Aktivität; Details beim Überfahren.</span>';
+    el('zbLegende').innerHTML = '<span>Zeilen = Kanal, Spalten = Woche. Jeder Punkt eine Aktivität; Reichweite, Klicks und Kosten beim Überfahren.</span>';
   }
 
   // Eintragen/Bearbeiten: offener Schreibweg (Muster Link-Register),
@@ -306,11 +336,13 @@
     var titel = (el('mfTitel').value || '').trim();
     var wer = (el('mfWer').value || '').trim();
     if (!el('mfTag').value || !titel || !wer){ sagen('Datum, Aktivität und Kürzel sind Pflicht.', true); return; }
+    var zahl = function(id){ var e = el(id); return (e && e.value !== '') ? Math.max(0, Math.round(Number(e.value) || 0)) : null; };
     var istEdit = mfEditId != null;
     var params = {
       p_tag: el('mfTag').value, p_massnahme: titel,
-      p_kanal: el('mfKanal').value, p_rolle: el('mfRolle').value,
-      p_ersteller: wer, p_kosten: null, p_reichweite: null, p_klicks: null
+      p_kanal: el('mfKanal').value, p_rolle: null,
+      p_ersteller: wer, p_kosten: null,
+      p_reichweite: zahl('mfReichweite'), p_klicks: zahl('mfKlicks')
     };
     if (istEdit) { params.p_id = mfEditId; } else { params.p_zielgruppe = null; }
     fetch(SB + '/rest/v1/rpc/' + (istEdit ? 'sommer2026_massnahme_aendern' : 'sommer2026_massnahme_eintragen'), {
@@ -320,9 +352,12 @@
     }).then(function(r){ if(!r.ok) throw new Error(r.status); return r.json(); })
       .then(function(ergebnis){
         if (ergebnis === 'ok'){
-          sagen(istEdit ? 'Geändert.' : 'Eingetragen – erscheint im Zeitband und im Protokoll.');
+          sagen(istEdit ? 'Geändert.' : 'Eingetragen – erscheint im Zeitband, im Protokoll und in der Reichweite.');
           mfZuruecksetzen();
-          rpc('sommer2026_massnahmen_public').then(function(rows){ renderZeitband(rows); renderMassnahmen(rows); }).catch(function(){});
+          // Reichweite/Klicks fliessen in die Wirkungskette – darum Zeitband, Protokoll UND Trichter neu laden.
+          Promise.all([rpc('sommer2026_massnahmen_public'), rpc('sommer2026_trichter')])
+            .then(function(res){ var rows = res[0] || []; renderZeitband(rows); renderMassnahmen(rows); renderFunnel(res[1] || [], rows); })
+            .catch(function(){});
         } else { sagen('Datum und Aktivität prüfen.', true); }
       })
       .catch(function(){ sagen(istEdit ? 'Ändern nicht erreichbar.' : 'Eintragen nicht erreichbar.', true); });
@@ -337,7 +372,7 @@
     }
     rows.forEach(function(r){
       var tag = r.tag ? new Date(r.tag + 'T00:00:00').toLocaleDateString('de-CH', { day:'numeric', month:'numeric' }) : '–';
-      var kanal = (KANAL_LABEL[r.kanal] || r.kanal || '') + (r.rolle && ROLLE_LABEL[r.rolle] ? ' · ' + ROLLE_LABEL[r.rolle] : '');
+      var kanal = KANAL_LABEL[r.kanal] || r.kanal || '';
       var tr = document.createElement('tr');
       tr.innerHTML = '<td></td><td></td><td></td><td class="num"></td><td class="num"></td><td class="num"></td><td class="act"></td>';
       tr.children[0].textContent = tag;
@@ -354,8 +389,8 @@
     });
   }
 
-  // Bearbeiten: Zeile in die Maske laden; Speichern ändert nur die Kernfelder,
-  // vorhandene Zahlen (Kosten/Reichweite/Klicks) bleiben unangetastet.
+  // Bearbeiten: Zeile in die Maske laden; Speichern übernimmt auch nachgetragene
+  // Reichweite und Klicks (Kosten bleiben dem Kosten-Modul vorbehalten).
   var mfEditId = null;
   function massnahmeBearbeiten(r){
     mfEditId = r.id;
@@ -363,7 +398,8 @@
     el('mfTag').value = r.tag || '';
     el('mfTitel').value = r.massnahme || '';
     el('mfKanal').value = r.kanal || 'andere';
-    el('mfRolle').value = r.rolle || 'wirkung';
+    if (el('mfReichweite')) el('mfReichweite').value = (r.reichweite != null) ? r.reichweite : '';
+    if (el('mfKlicks')) el('mfKlicks').value = (r.klicks != null) ? r.klicks : '';
     el('mfWer').value = r.ersteller || '';
     el('mfBtn').textContent = 'Änderung speichern';
     el('mfSaid').textContent = 'Bearbeitung von «' + (r.massnahme || '') + '» – Speichern übernimmt.';
@@ -373,6 +409,8 @@
   function mfZuruecksetzen(){
     mfEditId = null;
     el('mfTitel').value = ''; el('mfWer').value = '';
+    if (el('mfReichweite')) el('mfReichweite').value = '';
+    if (el('mfKlicks')) el('mfKlicks').value = '';
     el('mfTag').value = new Date().toISOString().slice(0, 10);
     el('mfBtn').textContent = 'Eintragen';
   }
@@ -743,7 +781,7 @@
         var mo = renderSpark(timeline);
         renderTiles(total, mo.avg, mo.days);
         renderStreams(stats);
-        renderFunnel(trichter);
+        renderFunnel(trichter, massnahmen);
         renderKanaele(kanaele, total);
         renderMotive(attribution);
         renderTarif(stats);

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -88,7 +88,7 @@
 
 
   <section id="wirkung">
-    <div class="shead"><h2>Wirkung</h2><p>Woher die Abos kommen (aus den UTM-Parametern am Link) – und darunter die Kette davor: Sichtbarkeit → Klicks → Abschluss. Reichweite und Klicks stammen aus dem Zeitband.</p></div>
+    <div class="shead"><h2>Wirkung</h2><p>Woher die Abos kommen (aus den UTM-Parametern am Link) – und darunter die ganze Kette: Reichweite → Klicks → Abschlüsse → Geblieben. Reichweite und Klicks kommen aus den Aktivitäten, Abschlüsse und Geblieben zählt das Cockpit live aus den Anmeldungen.</p></div>
     <div id="kanalBars"><div class="empty">lädt …</div></div>
     <div class="motive" id="motive" hidden>
       <div class="mh">Nach Motiv</div>

--- a/services/sommer-zaehler/README.md
+++ b/services/sommer-zaehler/README.md
@@ -46,13 +46,24 @@ welcher Kanal. Die Ingestion (Paperform / Uscreen) schreibt das mit; der
 Zielmarken) im `CONFIG`-Block der Seite; daraus rechnet das Cockpit Kosten je Abo
 (CPA) und den Rückfluss je € Kosten.
 
-## Wirkungskette und Massnahmen-Protokoll
+## Wirkungskette und Aktivitäten-Protokoll
 
-Das Cockpit liest die Aktion als **Kette**, nicht als Einzelzahlen:
-**Sichtbarkeit → Aktivierung → Wirkung → Bindung** (`sommer2026_trichter`).
-Sichtbarkeit (Reichweite) und Aktivierung (Klicks) kommen aus dem
-**Massnahmen-Protokoll** `sommer2026_massnahmen` – eine Zeile je Massnahme
-(Newsletter, Inserat, Post) mit Datum, `rolle` (Hauptaufgabe), Kosten, Reichweite,
+Das Cockpit liest die Aktion als **Kette gemessener Zahlen**, nicht als
+Einzelwerte: **Reichweite → Klicks → Abschlüsse → Geblieben**
+(`sommer2026_trichter`). Alle vier Stufen sind gemessen, **nicht** eine im
+Eintrag gewählte Kategorie: Reichweite = Summe der `reichweite`, Klicks = Summe
+der `klicks` (beide aus den Aktivitäten); Abschlüsse = Anzahl Anmeldungen,
+Geblieben = Anmeldungen mit Status `bleibt` (beide live aus `sommer2026_signups`).
+Darum zeigt der Trichter zusätzlich die **Reichweite je Kanal** (Social,
+Newsletter, Popup …), client-seitig aus den Aktivitäten summiert. Reichweite und
+Klicks werden direkt beim Eintrag der Aktivität erfasst (oder später über
+Bearbeiten). Das frühere Feld „Aufgabe der Aktivität" (`rolle`) ist aus der
+Oberfläche entfernt, weil es dieselben vier Wörter trug wie die Trichterstufen
+und so den Eindruck erweckte, es steuere die Zählung – die Spalte bleibt in der
+DB, wird aber nicht mehr gepflegt.
+
+Quelle ist das **Aktivitäten-Protokoll** `sommer2026_massnahmen` – eine Zeile je
+Aktivität (Newsletter, Inserat, Post) mit Datum, Kanal, Kosten, Reichweite,
 Klicks und **internen** Notizen (`beobachtung` / `entscheidung`). Die internen
 Freitext-Spalten verlassen die DB **nie**: der öffentliche RPC
 `sommer2026_massnahmen_public` gibt nur die kuratierten Zahlen zurück. So wird CPA


### PR DESCRIPTION
Rückmeldung vom Social-Media-Kollegen: Er hatte Aktivitäten als „Sichtbarkeit" eingetragen, die Abos erschienen aber unter „Wirkung" — „Wieso?".

## Diagnose

Eine **Namens-Kollision**, kein Zählfehler. Der Trichter rechnet aus **gemessenen** Zahlen (`sommer2026_trichter`): Sichtbarkeit = Σ Reichweite, Aktivierung = Σ Klicks, Wirkung = Anzahl Anmeldungen, Bindung = Anmeldungen mit Status „bleibt". Das Formularfeld **„Aufgabe der Aktivität"** trug dieselben vier Wörter und liess vermuten, die Wahl route die Zählung — tut sie nicht. Alle Abschlüsse landen immer bei „Wirkung"; Sichtbarkeit/Aktivierung blieben 0, weil nie Reichweite/Klicks erfasst wurden.

## Was sich ändert (Frontend-only, keine DB-Migration)

- **Trichter klar benannt** auf die gemessenen Grössen: **Reichweite** (Menschen erreicht) → **Klicks** (haben geklickt) → **Abschlüsse** (Abo gestartet) → **Geblieben** (nach 3 Monaten). Je Stufe die **Umwandlungsrate** (Klick-, Abschluss-, Bleibequote).
- **Neu: „Reichweite je Kanal"** (Social, Newsletter, Popup …) — aus den Aktivitäten summiert, damit sichtbar wird, wo Menschen erreicht werden.
- **Reichweite und Klicks werden jetzt direkt beim Eintrag** der Aktivität erfasst (oder später über Bearbeiten). Vorher lagen sie brach → die Stufen blieben 0.
- **Verwirrendes Feld „Aufgabe der Aktivität" (`rolle`) entfernt.** Zeitband ohne Rollen-Farbe; Tooltip zeigt Reichweite/Klicks/Kosten. Die DB-Spalte bleibt (harmlos).
- Cockpit-Wirkungstext und README nachgezogen.

## Geprüft

- `tools/ds-lint.py --staged`: 100 %, 0 Fehler · `tools/typo-check.py`: konform
- `node --check` auf `campaign.js`: OK
- Lokal (Playwright, Mock-Zahlen): Kette zeigt Reichweite 24'200 → Klicks 1'310 · 5 % → Abschlüsse 44 · 3 % → Geblieben 0 · 0 %, darunter Reichweite je Kanal (Social 12'000 / 800 Klicks, Newsletter 8'000 / 400, Popup 4'200 / 110); keine Konsolenfehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_