### PR TITLE
Mails S26: Review umgesetzt — Cross-sell vorn, ehrliche Frist, 20 Preheader

### DIFF
--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -86,7 +86,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 10.07.2026, 2.40 Uhr · <code>37bd2f7</code></p>
+  <p class="subline">Stand dieses Builds: 10.07.2026, 17.52 Uhr · <code>c33442f</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -116,7 +116,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="shared#badge"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#badge')">senden</button></div></div></div><div class="fld" data-key="shared#beweisband"><div class="fh" onclick="toggle(this)"><span class="lbl">Beweis-Band</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="shared#beweisband">0</span></button></div>
-<div class="val">seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit<br>since 1921 · 800+ films · 42 issues a year · worldwide</div>
+<div class="val">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit<br>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="shared#beweisband"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#beweisband')">senden</button></div></div></div><div class="fld" data-key="shared#button"><div class="fh" onclick="toggle(this)"><span class="lbl">Button-Stil</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="shared#button">0</span></button></div>
@@ -138,7 +138,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Drei Monate im Freien lesen — gratis</title>
+  <title>Was Sie sehen, jetzt auch lesen — 3 Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -228,8 +228,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Aufsätze, Zeitsymptome und Stimmen aus der anthroposophischen Bewegung — jede Woche neu, …</div>
-  <div aria-label=&quot;Drei Monate im Freien lesen — gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Die Wochenschrift drei Monate geschenkt — lesen, wo der Sommer Sie hinträgt. Bis 8. August.</div>
+  <div aria-label=&quot;Was Sie sehen, jetzt auch lesen — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -316,7 +316,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Aufsätze, Zeitsymptome und Stimmen aus der anthroposophischen Bewegung — jede Woche neu, gedruckt und digital.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Zu Ihrem goetheanum.tv-Zugang: die Wochenschrift — Aufsätze, Zeitsymptome und Stimmen aus der anthroposophischen Bewegung, jede Woche neu, gedruckt und digital.</div>
                       </td>
                     </tr>
                     <tr>
@@ -358,7 +358,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>
@@ -406,7 +406,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Motiv"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Motiv')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#Betreff">0</span></button></div>
-<div class="val">Drei Monate im Freien lesen — gratis</div>
+<div class="val">Was Sie sehen, jetzt auch lesen — 3 Monate gratis</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#Botschaft">0</span></button></div>
@@ -414,7 +414,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#Text">0</span></button></div>
-<div class="val">Aufsätze, Zeitsymptome und Stimmen aus der anthroposophischen Bewegung — jede Woche neu, gedruckt und digital.</div>
+<div class="val">Zu Ihrem goetheanum.tv-Zugang: die Wochenschrift — Aufsätze, Zeitsymptome und Stimmen aus der anthroposophischen Bewegung, jede Woche neu, gedruckt und digital.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#CTA">0</span></button></div>
@@ -422,7 +422,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#CTA')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Was Sie sehen, jetzt auch lesen — 3 Monate gratis</div>
+<div class="val">Drei Monate im Freien lesen — gratis</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Alt-Betreff (AC-Split)"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#Link">0</span></button></div>
@@ -441,7 +441,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Read in the open air — three months free</title>
+  <title>What you watch, now also read — 3 months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -531,8 +531,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Essays, signs of the times and voices from the anthroposophical movement — every week, in …</div>
-  <div aria-label=&quot;Read in the open air — three months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of the weekly as a gift — read wherever summer takes you. Until 8 August.</div>
+  <div aria-label=&quot;What you watch, now also read — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -619,7 +619,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Essays, signs of the times and voices from the anthroposophical movement — every week, in print and digital.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>To go with your goetheanum.tv access: the weekly — essays, signs of the times and voices from the anthroposophical movement, new every week, in print and digital.</div>
                       </td>
                     </tr>
                     <tr>
@@ -661,7 +661,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>
@@ -709,7 +709,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Motiv"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Motiv')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#Betreff">0</span></button></div>
-<div class="val">Read in the open air — three months free</div>
+<div class="val">What you watch, now also read — 3 months free</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#Botschaft">0</span></button></div>
@@ -717,7 +717,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#Text">0</span></button></div>
-<div class="val">Essays, signs of the times and voices from the anthroposophical movement — every week, in print and digital.</div>
+<div class="val">To go with your goetheanum.tv access: the weekly — essays, signs of the times and voices from the anthroposophical movement, new every week, in print and digital.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#CTA">0</span></button></div>
@@ -725,7 +725,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#CTA')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">What you watch, now also read — 3 months free</div>
+<div class="val">Read in the open air — three months free</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Alt-Betreff (AC-Split)"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#Link">0</span></button></div>
@@ -834,7 +834,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Die Aktion läuft: Sichern Sie sich die Wochenschrift drei Monate gratis — und lesen Sie, wo …</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Die Wochenschrift drei Monate gratis zu Ihrem Abo — Anmeldung bis 8. August.</div>
   <div aria-label=&quot;Ihr Sommer hat noch Seiten frei&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -917,12 +917,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Ihr Sommer hat noch Seiten frei.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Lesen, wo der Abend am schönsten ist.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Die Aktion läuft: Sichern Sie sich die Wochenschrift drei Monate gratis — und lesen Sie, wo der Abend am schönsten ist.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Die Aktion läuft noch bis 8. August: die Wochenschrift drei Monate gratis zu Ihrem Abo dazu.</div>
                       </td>
                     </tr>
                     <tr>
@@ -964,7 +964,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1016,11 +1016,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#Botschaft">0</span></button></div>
-<div class="val">Ihr Sommer hat noch Seiten frei.</div>
+<div class="val">Lesen, wo der Abend am schönsten ist.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#Text">0</span></button></div>
-<div class="val">Die Aktion läuft: Sichern Sie sich die Wochenschrift drei Monate gratis — und lesen Sie, wo der Abend am schönsten ist.</div>
+<div class="val">Die Aktion läuft noch bis 8. August: die Wochenschrift drei Monate gratis zu Ihrem Abo dazu.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#CTA">0</span></button></div>
@@ -1137,7 +1137,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>The offer is on: take the weekly free for three months — and read where the evening is most …</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of the weekly free with your subscription — sign up by 8 August.</div>
   <div aria-label=&quot;Your summer still has pages to fill&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -1220,12 +1220,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Your summer still has pages to fill.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Read where the evening is most beautiful.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>The offer is on: take the weekly free for three months — and read where the evening is most beautiful.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>The offer runs until 8 August: three months of the weekly, free, added to your subscription.</div>
                       </td>
                     </tr>
                     <tr>
@@ -1267,7 +1267,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1319,11 +1319,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#Botschaft">0</span></button></div>
-<div class="val">Your summer still has pages to fill.</div>
+<div class="val">Read where the evening is most beautiful.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#Text">0</span></button></div>
-<div class="val">The offer is on: take the weekly free for three months — and read where the evening is most beautiful.</div>
+<div class="val">The offer runs until 8 August: three months of the weekly, free, added to your subscription.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#CTA">0</span></button></div>
@@ -1350,7 +1350,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Am Samstag endet Ihr Gratis-Zugang</title>
+  <title>Nur noch bis Samstag: drei Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -1440,8 +1440,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Nur noch wenige Tage: Ergänzen Sie Ihr Abo drei Monate gratis um die Wochenschrift. Ohne …</div>
-  <div aria-label=&quot;Am Samstag endet Ihr Gratis-Zugang&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Die Wochenschrift drei Monate gratis zu Ihrem Abo dazu — die Anmeldung dauert eine Minute.</div>
+  <div aria-label=&quot;Nur noch bis Samstag: drei Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -1570,7 +1570,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1618,7 +1618,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#Motiv"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#Motiv')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_de#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_de#Betreff">0</span></button></div>
-<div class="val">Am Samstag endet Ihr Gratis-Zugang</div>
+<div class="val">Nur noch bis Samstag: drei Monate gratis</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_de#Botschaft">0</span></button></div>
@@ -1653,7 +1653,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Your free access ends on Saturday</title>
+  <title>Only until Saturday: three months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -1743,8 +1743,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Only a few days left: add the weekly to your subscription free for three months. No obligation.</div>
-  <div aria-label=&quot;Your free access ends on Saturday&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of the weekly with your subscription — signing up takes a minute.</div>
+  <div aria-label=&quot;Only until Saturday: three months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -1873,7 +1873,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1921,7 +1921,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#Motiv"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#Motiv')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_en#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_en#Betreff">0</span></button></div>
-<div class="val">Your free access ends on Saturday</div>
+<div class="val">Only until Saturday: three months free</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_en#Botschaft">0</span></button></div>
@@ -1956,7 +1956,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Ein Sommer voller Inspiration — 3 Monate gratis</title>
+  <title>Was Sie lesen, jetzt auch sehen — 3 Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -2046,8 +2046,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Vorträge, Gespräche und Begegnungen vom Goetheanum — über 800 Beiträge, wo immer Sie diesen …</div>
-  <div aria-label=&quot;Ein Sommer voller Inspiration — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>goetheanum.tv drei Monate geschenkt — über 800 Videos, wo immer Sie den Sommer verbringen.</div>
+  <div aria-label=&quot;Was Sie lesen, jetzt auch sehen — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -2134,7 +2134,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Vorträge, Gespräche und Begegnungen vom Goetheanum — über 800 Beiträge, wo immer Sie diesen Sommer verbringen.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Zu Ihrer Wochenschrift: goetheanum.tv — Vorträge, Gespräche und Begegnungen vom Goetheanum, über 800 Videos, wo immer Sie diesen Sommer verbringen.</div>
                       </td>
                     </tr>
                     <tr>
@@ -2176,7 +2176,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2224,7 +2224,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#Motiv"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#Motiv')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#Betreff">0</span></button></div>
-<div class="val">Ein Sommer voller Inspiration — 3 Monate gratis</div>
+<div class="val">Was Sie lesen, jetzt auch sehen — 3 Monate gratis</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#Botschaft">0</span></button></div>
@@ -2232,7 +2232,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#Text">0</span></button></div>
-<div class="val">Vorträge, Gespräche und Begegnungen vom Goetheanum — über 800 Beiträge, wo immer Sie diesen Sommer verbringen.</div>
+<div class="val">Zu Ihrer Wochenschrift: goetheanum.tv — Vorträge, Gespräche und Begegnungen vom Goetheanum, über 800 Videos, wo immer Sie diesen Sommer verbringen.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#CTA">0</span></button></div>
@@ -2240,7 +2240,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#CTA')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Was Sie lesen, jetzt auch sehen — 3 Monate gratis</div>
+<div class="val">Ein Sommer voller Inspiration — 3 Monate gratis</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#Alt-Betreff (AC-Split)"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#Link">0</span></button></div>
@@ -2259,7 +2259,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>A summer full of inspiration — 3 months free</title>
+  <title>What you read, now also watch — 3 months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -2349,8 +2349,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Lectures, conversations and encounters from the Goetheanum — over 800 films, wherever you …</div>
-  <div aria-label=&quot;A summer full of inspiration — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of goetheanum.tv as a gift — over 800 videos, wherever you spend the summer.</div>
+  <div aria-label=&quot;What you read, now also watch — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -2437,7 +2437,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Lectures, conversations and encounters from the Goetheanum — over 800 films, wherever you spend this summer.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>To go with your weekly: goetheanum.tv — lectures, conversations and encounters from the Goetheanum, over 800 videos, wherever you spend this summer.</div>
                       </td>
                     </tr>
                     <tr>
@@ -2479,7 +2479,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2527,7 +2527,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#Motiv"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#Motiv')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#Betreff">0</span></button></div>
-<div class="val">A summer full of inspiration — 3 months free</div>
+<div class="val">What you read, now also watch — 3 months free</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#Botschaft">0</span></button></div>
@@ -2535,7 +2535,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#Text">0</span></button></div>
-<div class="val">Lectures, conversations and encounters from the Goetheanum — over 800 films, wherever you spend this summer.</div>
+<div class="val">To go with your weekly: goetheanum.tv — lectures, conversations and encounters from the Goetheanum, over 800 videos, wherever you spend this summer.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#CTA">0</span></button></div>
@@ -2543,7 +2543,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#CTA')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">What you read, now also watch — 3 months free</div>
+<div class="val">A summer full of inspiration — 3 months free</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#Alt-Betreff (AC-Split)"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#Link">0</span></button></div>
@@ -2652,7 +2652,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Über 800 Beiträge warten — Vorträge, Gespräche, Bühne. Drei Monate gratis, unverbindlich.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>goetheanum.tv drei Monate gratis zu Ihrem Abo — Anmeldung bis 8. August.</div>
   <div aria-label=&quot;Sehen Sie, was diesen Sommer läuft&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -2735,12 +2735,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Was diesen Sommer läuft.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Vorträge, Gespräche, Bühne.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Über 800 Beiträge warten — Vorträge, Gespräche, Bühne. Drei Monate gratis, unverbindlich.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Über 800 Videos warten — noch bis 8. August drei Monate gratis zu Ihrem Abo dazu, unverbindlich.</div>
                       </td>
                     </tr>
                     <tr>
@@ -2782,7 +2782,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2834,11 +2834,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#Botschaft">0</span></button></div>
-<div class="val">Was diesen Sommer läuft.</div>
+<div class="val">Vorträge, Gespräche, Bühne.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#Text">0</span></button></div>
-<div class="val">Über 800 Beiträge warten — Vorträge, Gespräche, Bühne. Drei Monate gratis, unverbindlich.</div>
+<div class="val">Über 800 Videos warten — noch bis 8. August drei Monate gratis zu Ihrem Abo dazu, unverbindlich.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#CTA">0</span></button></div>
@@ -2955,7 +2955,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Over 800 films are waiting — lectures, conversations, the stage. Three months free, no …</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of goetheanum.tv free with your subscription — sign up by 8 August.</div>
   <div aria-label=&quot;See what’s on this summer&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -3038,12 +3038,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>What’s on this summer.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Lectures, conversations, the stage.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Over 800 films are waiting — lectures, conversations, the stage. Three months free, no obligation.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Over 800 videos are waiting — until 8 August, three months free with your subscription, no obligation.</div>
                       </td>
                     </tr>
                     <tr>
@@ -3085,7 +3085,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3137,11 +3137,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#Botschaft">0</span></button></div>
-<div class="val">What’s on this summer.</div>
+<div class="val">Lectures, conversations, the stage.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#Text">0</span></button></div>
-<div class="val">Over 800 films are waiting — lectures, conversations, the stage. Three months free, no obligation.</div>
+<div class="val">Over 800 videos are waiting — until 8 August, three months free with your subscription, no obligation.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#CTA">0</span></button></div>
@@ -3168,7 +3168,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Am Samstag endet Ihr Gratis-Zugang</title>
+  <title>Nur noch bis Samstag: drei Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -3258,8 +3258,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Letzte Tage: Ergänzen Sie Ihr Abo drei Monate gratis um goetheanum.tv. Ohne Bindung.</div>
-  <div aria-label=&quot;Am Samstag endet Ihr Gratis-Zugang&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>goetheanum.tv drei Monate gratis zu Ihrem Abo dazu — die Anmeldung dauert eine Minute.</div>
+  <div aria-label=&quot;Nur noch bis Samstag: drei Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -3388,7 +3388,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3436,7 +3436,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#Motiv"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#Motiv')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_de#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_de#Betreff">0</span></button></div>
-<div class="val">Am Samstag endet Ihr Gratis-Zugang</div>
+<div class="val">Nur noch bis Samstag: drei Monate gratis</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_de#Botschaft">0</span></button></div>
@@ -3471,7 +3471,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Your free access ends on Saturday</title>
+  <title>Only until Saturday: three months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -3561,8 +3561,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Last days: add goetheanum.tv to your subscription free for three months. No strings.</div>
-  <div aria-label=&quot;Your free access ends on Saturday&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of goetheanum.tv with your subscription — signing up takes a minute.</div>
+  <div aria-label=&quot;Only until Saturday: three months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -3691,7 +3691,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3739,7 +3739,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_en#Motiv"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#Motiv')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_en#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_en#Betreff">0</span></button></div>
-<div class="val">Your free access ends on Saturday</div>
+<div class="val">Only until Saturday: three months free</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_en#Botschaft">0</span></button></div>
@@ -3864,7 +3864,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Zum Lesen und zum Streamen: zwei Angebote, ein Geschenk — drei Monate kostenlos, jederzeit …</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Lesen oder streamen — oder beides: drei Monate kostenlos, bis 8. August.</div>
   <div aria-label=&quot;Ein Sommer mit dem Goetheanum — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -3947,7 +3947,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Ein Sommer mit dem Goetheanum.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Lesen und sehen — den ganzen Sommer.</div>
                       </td>
                     </tr>
                     <tr>
@@ -4007,7 +4007,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4059,7 +4059,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#Botschaft">0</span></button></div>
-<div class="val">Ein Sommer mit dem Goetheanum.</div>
+<div class="val">Lesen und sehen — den ganzen Sommer.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#Text">0</span></button></div>
@@ -4180,7 +4180,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>To read and to stream: two offers, one gift — three months free, cancel anytime.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Read or stream — or both: three months free, until 8 August.</div>
   <div aria-label=&quot;A summer with the Goetheanum — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -4263,7 +4263,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>A summer with the Goetheanum.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Reading and watching — all summer long.</div>
                       </td>
                     </tr>
                     <tr>
@@ -4323,7 +4323,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4375,7 +4375,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#Botschaft">0</span></button></div>
-<div class="val">A summer with the Goetheanum.</div>
+<div class="val">Reading and watching — all summer long.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#Text">0</span></button></div>
@@ -4496,7 +4496,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Lesen und sehen — drei Monate kostenlos. Wählen Sie, was Ihr Sommer braucht.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Die Wochenschrift lesen oder goetheanum.tv streamen — drei Monate kostenlos, bis 8. August.</div>
   <div aria-label=&quot;Zwei Angebote, ein Geschenk&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -4579,12 +4579,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Zwei Angebote, ein Geschenk.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Wählen Sie, was Ihr Sommer braucht.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Lesen und sehen — drei Monate kostenlos. Wählen Sie, was Ihr Sommer braucht.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Lesen oder sehen — oder beides: drei Monate kostenlos, noch bis 8. August.</div>
                       </td>
                     </tr>
                     <tr>
@@ -4626,7 +4626,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4678,11 +4678,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w2_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_de#Botschaft">0</span></button></div>
-<div class="val">Zwei Angebote, ein Geschenk.</div>
+<div class="val">Wählen Sie, was Ihr Sommer braucht.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w2_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_de#Text">0</span></button></div>
-<div class="val">Lesen und sehen — drei Monate kostenlos. Wählen Sie, was Ihr Sommer braucht.</div>
+<div class="val">Lesen oder sehen — oder beides: drei Monate kostenlos, noch bis 8. August.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w2_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_de#CTA">0</span></button></div>
@@ -4799,7 +4799,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Read and watch — three months free. Choose what your summer needs.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Read the weekly or stream goetheanum.tv — three months free, until 8 August.</div>
   <div aria-label=&quot;Two offers, one gift&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -4882,12 +4882,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Two offers, one gift.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Choose what your summer needs.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Read and watch — three months free. Choose what your summer needs.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Read or watch — or both: three months free, until 8 August.</div>
                       </td>
                     </tr>
                     <tr>
@@ -4929,7 +4929,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4981,11 +4981,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w2_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_en#Botschaft">0</span></button></div>
-<div class="val">Two offers, one gift.</div>
+<div class="val">Choose what your summer needs.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w2_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_en#Text">0</span></button></div>
-<div class="val">Read and watch — three months free. Choose what your summer needs.</div>
+<div class="val">Read or watch — or both: three months free, until 8 August.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w2_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_en#CTA">0</span></button></div>
@@ -5102,7 +5102,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Nur noch wenige Tage für drei Monate Goetheanum — gratis, ohne Verpflichtung.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Drei Monate lesen oder streamen, gratis — nur noch bis Samstag, 8. August.</div>
   <div aria-label=&quot;Am Samstag endet die Sommer-Aktion&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -5185,12 +5185,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Am Samstag ist Schluss.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Drei Monate Goetheanum, noch bis Samstag.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Nur noch wenige Tage für drei Monate Goetheanum — gratis, ohne Verpflichtung.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Gratis und ohne Verpflichtung — wählen Sie Lesen, Sehen oder beides.</div>
                       </td>
                     </tr>
                     <tr>
@@ -5245,7 +5245,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5297,11 +5297,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w3_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#Botschaft">0</span></button></div>
-<div class="val">Am Samstag ist Schluss.</div>
+<div class="val">Drei Monate Goetheanum, noch bis Samstag.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w3_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#Text">0</span></button></div>
-<div class="val">Nur noch wenige Tage für drei Monate Goetheanum — gratis, ohne Verpflichtung.</div>
+<div class="val">Gratis und ohne Verpflichtung — wählen Sie Lesen, Sehen oder beides.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w3_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#CTA">0</span></button></div>
@@ -5418,7 +5418,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Just a few days left for three months of Goetheanum — free, no obligation.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of reading or streaming, free — only until Saturday, 8 August.</div>
   <div aria-label=&quot;The summer offer ends on Saturday&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -5501,12 +5501,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Saturday is the deadline.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Three months of Goetheanum, until Saturday.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Just a few days left for three months of Goetheanum — free, no obligation.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Free and without obligation — choose reading, watching or both.</div>
                       </td>
                     </tr>
                     <tr>
@@ -5561,7 +5561,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5613,11 +5613,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w3_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#Botschaft">0</span></button></div>
-<div class="val">Saturday is the deadline.</div>
+<div class="val">Three months of Goetheanum, until Saturday.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w3_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#Text">0</span></button></div>
-<div class="val">Just a few days left for three months of Goetheanum — free, no obligation.</div>
+<div class="val">Free and without obligation — choose reading, watching or both.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w3_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#CTA">0</span></button></div>
@@ -5734,7 +5734,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Ein Klick — und der Sommer mit dem Goetheanum gehört Ihnen. Unverbindlich.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Drei Monate Goetheanum gratis — heute oder morgen anmelden, dann gehört der Sommer Ihnen.</div>
   <div aria-label=&quot;Morgen ist Schluss&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -5817,12 +5817,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Morgen ist Schluss.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Sie waren schon da — ein Schritt fehlt noch.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Ein Klick — und der Sommer mit dem Goetheanum gehört Ihnen. Unverbindlich.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Drei Monate Goetheanum, gratis und unverbindlich — die Anmeldung dauert eine Minute.</div>
                       </td>
                     </tr>
                     <tr>
@@ -5864,7 +5864,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5916,11 +5916,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_de#Botschaft">0</span></button></div>
-<div class="val">Morgen ist Schluss.</div>
+<div class="val">Sie waren schon da — ein Schritt fehlt noch.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_de#Text">0</span></button></div>
-<div class="val">Ein Klick — und der Sommer mit dem Goetheanum gehört Ihnen. Unverbindlich.</div>
+<div class="val">Drei Monate Goetheanum, gratis und unverbindlich — die Anmeldung dauert eine Minute.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_de#CTA">0</span></button></div>
@@ -6037,7 +6037,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>One click — and the summer with the Goetheanum is yours. No obligation.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of Goetheanum, free — sign up today or tomorrow and the summer is yours.</div>
   <div aria-label=&quot;Last chance — it ends tomorrow&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -6120,12 +6120,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Tomorrow it ends.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>You were already there — one step to go.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>One click — and the summer with the Goetheanum is yours. No obligation.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Three months of Goetheanum, free and without obligation — signing up takes a minute.</div>
                       </td>
                     </tr>
                     <tr>
@@ -6167,7 +6167,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>
@@ -6219,11 +6219,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_en#Botschaft">0</span></button></div>
-<div class="val">Tomorrow it ends.</div>
+<div class="val">You were already there — one step to go.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_en#Text">0</span></button></div>
-<div class="val">One click — and the summer with the Goetheanum is yours. No obligation.</div>
+<div class="val">Three months of Goetheanum, free and without obligation — signing up takes a minute.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_en#CTA">0</span></button></div>

--- a/apps/mail-editor/mails/mail_beides_w1_de.html
+++ b/apps/mail-editor/mails/mail_beides_w1_de.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Zum Lesen und zum Streamen: zwei Angebote, ein Geschenk — drei Monate kostenlos, jederzeit …</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Lesen oder streamen — oder beides: drei Monate kostenlos, bis 8. August.</div>
   <div aria-label="Ein Sommer mit dem Goetheanum — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -176,7 +176,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Ein Sommer mit dem Goetheanum.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Lesen und sehen — den ganzen Sommer.</div>
                       </td>
                     </tr>
                     <tr>
@@ -236,7 +236,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w1_en.html
+++ b/apps/mail-editor/mails/mail_beides_w1_en.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">To read and to stream: two offers, one gift — three months free, cancel anytime.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Read or stream — or both: three months free, until 8 August.</div>
   <div aria-label="A summer with the Goetheanum — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -176,7 +176,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">A summer with the Goetheanum.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Reading and watching — all summer long.</div>
                       </td>
                     </tr>
                     <tr>
@@ -236,7 +236,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_de.html
+++ b/apps/mail-editor/mails/mail_beides_w2_de.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Lesen und sehen — drei Monate kostenlos. Wählen Sie, was Ihr Sommer braucht.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Die Wochenschrift lesen oder goetheanum.tv streamen — drei Monate kostenlos, bis 8. August.</div>
   <div aria-label="Zwei Angebote, ein Geschenk" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -176,12 +176,12 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Zwei Angebote, ein Geschenk.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Wählen Sie, was Ihr Sommer braucht.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Lesen und sehen — drei Monate kostenlos. Wählen Sie, was Ihr Sommer braucht.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Lesen oder sehen — oder beides: drei Monate kostenlos, noch bis 8. August.</div>
                       </td>
                     </tr>
                     <tr>
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_en.html
+++ b/apps/mail-editor/mails/mail_beides_w2_en.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Read and watch — three months free. Choose what your summer needs.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Read the weekly or stream goetheanum.tv — three months free, until 8 August.</div>
   <div aria-label="Two offers, one gift" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -176,12 +176,12 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Two offers, one gift.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Choose what your summer needs.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Read and watch — three months free. Choose what your summer needs.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Read or watch — or both: three months free, until 8 August.</div>
                       </td>
                     </tr>
                     <tr>
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3_de.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Nur noch wenige Tage für drei Monate Goetheanum — gratis, ohne Verpflichtung.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Drei Monate lesen oder streamen, gratis — nur noch bis Samstag, 8. August.</div>
   <div aria-label="Am Samstag endet die Sommer-Aktion" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -176,12 +176,12 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Am Samstag ist Schluss.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Drei Monate Goetheanum, noch bis Samstag.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Nur noch wenige Tage für drei Monate Goetheanum — gratis, ohne Verpflichtung.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Gratis und ohne Verpflichtung — wählen Sie Lesen, Sehen oder beides.</div>
                       </td>
                     </tr>
                     <tr>
@@ -236,7 +236,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3_en.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Just a few days left for three months of Goetheanum — free, no obligation.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of reading or streaming, free — only until Saturday, 8 August.</div>
   <div aria-label="The summer offer ends on Saturday" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -176,12 +176,12 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Saturday is the deadline.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Three months of Goetheanum, until Saturday.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Just a few days left for three months of Goetheanum — free, no obligation.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Free and without obligation — choose reading, watching or both.</div>
                       </td>
                     </tr>
                     <tr>
@@ -236,7 +236,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_de.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Ein Klick — und der Sommer mit dem Goetheanum gehört Ihnen. Unverbindlich.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Drei Monate Goetheanum gratis — heute oder morgen anmelden, dann gehört der Sommer Ihnen.</div>
   <div aria-label="Morgen ist Schluss" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -176,12 +176,12 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Morgen ist Schluss.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Sie waren schon da — ein Schritt fehlt noch.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Ein Klick — und der Sommer mit dem Goetheanum gehört Ihnen. Unverbindlich.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Drei Monate Goetheanum, gratis und unverbindlich — die Anmeldung dauert eine Minute.</div>
                       </td>
                     </tr>
                     <tr>
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_en.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">One click — and the summer with the Goetheanum is yours. No obligation.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of Goetheanum, free — sign up today or tomorrow and the summer is yours.</div>
   <div aria-label="Last chance — it ends tomorrow" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -176,12 +176,12 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Tomorrow it ends.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">You were already there — one step to go.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">One click — and the summer with the Goetheanum is yours. No obligation.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Three months of Goetheanum, free and without obligation — signing up takes a minute.</div>
                       </td>
                     </tr>
                     <tr>
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w1_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Drei Monate im Freien lesen — gratis</title>
+  <title>Was Sie sehen, jetzt auch lesen — 3 Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -93,8 +93,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Aufsätze, Zeitsymptome und Stimmen aus der anthroposophischen Bewegung — jede Woche neu, …</div>
-  <div aria-label="Drei Monate im Freien lesen — gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Die Wochenschrift drei Monate geschenkt — lesen, wo der Sommer Sie hinträgt. Bis 8. August.</div>
+  <div aria-label="Was Sie sehen, jetzt auch lesen — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -181,7 +181,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Aufsätze, Zeitsymptome und Stimmen aus der anthroposophischen Bewegung — jede Woche neu, gedruckt und digital.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Zu Ihrem goetheanum.tv-Zugang: die Wochenschrift — Aufsätze, Zeitsymptome und Stimmen aus der anthroposophischen Bewegung, jede Woche neu, gedruckt und digital.</div>
                       </td>
                     </tr>
                     <tr>
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w1_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Read in the open air — three months free</title>
+  <title>What you watch, now also read — 3 months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -93,8 +93,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Essays, signs of the times and voices from the anthroposophical movement — every week, in …</div>
-  <div aria-label="Read in the open air — three months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of the weekly as a gift — read wherever summer takes you. Until 8 August.</div>
+  <div aria-label="What you watch, now also read — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -181,7 +181,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Essays, signs of the times and voices from the anthroposophical movement — every week, in print and digital.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">To go with your goetheanum.tv access: the weekly — essays, signs of the times and voices from the anthroposophical movement, new every week, in print and digital.</div>
                       </td>
                     </tr>
                     <tr>
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_de.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Die Aktion läuft: Sichern Sie sich die Wochenschrift drei Monate gratis — und lesen Sie, wo …</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Die Wochenschrift drei Monate gratis zu Ihrem Abo — Anmeldung bis 8. August.</div>
   <div aria-label="Ihr Sommer hat noch Seiten frei" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -176,12 +176,12 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Ihr Sommer hat noch Seiten frei.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Lesen, wo der Abend am schönsten ist.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Die Aktion läuft: Sichern Sie sich die Wochenschrift drei Monate gratis — und lesen Sie, wo der Abend am schönsten ist.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Die Aktion läuft noch bis 8. August: die Wochenschrift drei Monate gratis zu Ihrem Abo dazu.</div>
                       </td>
                     </tr>
                     <tr>
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_en.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">The offer is on: take the weekly free for three months — and read where the evening is most …</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of the weekly free with your subscription — sign up by 8 August.</div>
   <div aria-label="Your summer still has pages to fill" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -176,12 +176,12 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Your summer still has pages to fill.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Read where the evening is most beautiful.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">The offer is on: take the weekly free for three months — and read where the evening is most beautiful.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">The offer runs until 8 August: three months of the weekly, free, added to your subscription.</div>
                       </td>
                     </tr>
                     <tr>
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Am Samstag endet Ihr Gratis-Zugang</title>
+  <title>Nur noch bis Samstag: drei Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -93,8 +93,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Nur noch wenige Tage: Ergänzen Sie Ihr Abo drei Monate gratis um die Wochenschrift. Ohne …</div>
-  <div aria-label="Am Samstag endet Ihr Gratis-Zugang" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Die Wochenschrift drei Monate gratis zu Ihrem Abo dazu — die Anmeldung dauert eine Minute.</div>
+  <div aria-label="Nur noch bis Samstag: drei Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Your free access ends on Saturday</title>
+  <title>Only until Saturday: three months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -93,8 +93,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Only a few days left: add the weekly to your subscription free for three months. No obligation.</div>
-  <div aria-label="Your free access ends on Saturday" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of the weekly with your subscription — signing up takes a minute.</div>
+  <div aria-label="Only until Saturday: three months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w1_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Ein Sommer voller Inspiration — 3 Monate gratis</title>
+  <title>Was Sie lesen, jetzt auch sehen — 3 Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -93,8 +93,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Vorträge, Gespräche und Begegnungen vom Goetheanum — über 800 Beiträge, wo immer Sie diesen …</div>
-  <div aria-label="Ein Sommer voller Inspiration — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">goetheanum.tv drei Monate geschenkt — über 800 Videos, wo immer Sie den Sommer verbringen.</div>
+  <div aria-label="Was Sie lesen, jetzt auch sehen — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -181,7 +181,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Vorträge, Gespräche und Begegnungen vom Goetheanum — über 800 Beiträge, wo immer Sie diesen Sommer verbringen.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Zu Ihrer Wochenschrift: goetheanum.tv — Vorträge, Gespräche und Begegnungen vom Goetheanum, über 800 Videos, wo immer Sie diesen Sommer verbringen.</div>
                       </td>
                     </tr>
                     <tr>
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w1_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>A summer full of inspiration — 3 months free</title>
+  <title>What you read, now also watch — 3 months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -93,8 +93,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Lectures, conversations and encounters from the Goetheanum — over 800 films, wherever you …</div>
-  <div aria-label="A summer full of inspiration — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of goetheanum.tv as a gift — over 800 videos, wherever you spend the summer.</div>
+  <div aria-label="What you read, now also watch — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -181,7 +181,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Lectures, conversations and encounters from the Goetheanum — over 800 films, wherever you spend this summer.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">To go with your weekly: goetheanum.tv — lectures, conversations and encounters from the Goetheanum, over 800 videos, wherever you spend this summer.</div>
                       </td>
                     </tr>
                     <tr>
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_de.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Über 800 Beiträge warten — Vorträge, Gespräche, Bühne. Drei Monate gratis, unverbindlich.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">goetheanum.tv drei Monate gratis zu Ihrem Abo — Anmeldung bis 8. August.</div>
   <div aria-label="Sehen Sie, was diesen Sommer läuft" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -176,12 +176,12 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Was diesen Sommer läuft.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Vorträge, Gespräche, Bühne.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Über 800 Beiträge warten — Vorträge, Gespräche, Bühne. Drei Monate gratis, unverbindlich.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Über 800 Videos warten — noch bis 8. August drei Monate gratis zu Ihrem Abo dazu, unverbindlich.</div>
                       </td>
                     </tr>
                     <tr>
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_en.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Over 800 films are waiting — lectures, conversations, the stage. Three months free, no …</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of goetheanum.tv free with your subscription — sign up by 8 August.</div>
   <div aria-label="See what’s on this summer" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -176,12 +176,12 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">What’s on this summer.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Lectures, conversations, the stage.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Over 800 films are waiting — lectures, conversations, the stage. Three months free, no obligation.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Over 800 videos are waiting — until 8 August, three months free with your subscription, no obligation.</div>
                       </td>
                     </tr>
                     <tr>
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Am Samstag endet Ihr Gratis-Zugang</title>
+  <title>Nur noch bis Samstag: drei Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -93,8 +93,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Letzte Tage: Ergänzen Sie Ihr Abo drei Monate gratis um goetheanum.tv. Ohne Bindung.</div>
-  <div aria-label="Am Samstag endet Ihr Gratis-Zugang" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">goetheanum.tv drei Monate gratis zu Ihrem Abo dazu — die Anmeldung dauert eine Minute.</div>
+  <div aria-label="Nur noch bis Samstag: drei Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Your free access ends on Saturday</title>
+  <title>Only until Saturday: three months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -93,8 +93,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Last days: add goetheanum.tv to your subscription free for three months. No strings.</div>
-  <div aria-label="Your free access ends on Saturday" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of goetheanum.tv with your subscription — signing up takes a minute.</div>
+  <div aria-label="Only until Saturday: three months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -223,7 +223,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ films · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
                       </td>
                     </tr>
                   </tbody>

--- a/services/mailing-sommer2026/CLAUDE.md
+++ b/services/mailing-sommer2026/CLAUDE.md
@@ -76,6 +76,23 @@ Versand ab Engagement-Segment, gestaffelt; Nicht-Öffner >12 Mt. weglassen.
 Merge-Tags/Abmeldelink in AC ersetzen `%UNSUBSCRIBELINK%`.
 
 ## Offen
+- [ ] **Attribution NoAbo w2/w3b (make-or-break):** Die Übersichts-Landingpage
+      (global-sommer2026.goetheanum.online) reicht die utm_* NICHT an die verlinkten
+      Zielseiten weiter (nackte hrefs, kein Query-Forwarding; geprüft 10.7.) — Anmeldungen
+      aus w2/w3b sind so im Cockpit unsichtbar. Fix auf der Übersicht: `location.search`
+      an beide Ausgangs-Links anhängen. (WS-Seite selbst ist sauber: Paperform-Buttons
+      mit `prefill-inherit`.)
+- [ ] **Attribution GTV prüfen:** tv-sommer2026 hat kein Paperform; der Anmelde-Dialog
+      (uscreen/goetheanum.tv) ist clientseitig — ob utm_* den Abschluss erreichen, ist
+      unverifiziert. Ohne das bleiben alle gtv-Register-Zeilen ohne Abschlüsse.
+- [ ] **Kleinzeilen an echte Mechanik angleichen** (Entscheid Ph ausstehend): WS-Seite =
+      Kündigungsmodell («die ersten drei Monate in jedem Fall kostenlos, jederzeit kündbar»);
+      die Übersicht behauptet dagegen «enden ohne Verpflichtung» — Landingpage-Widerspruch
+      dort auflösen, Mails auf die eine wahre Formel ziehen.
+- [ ] **Onboarding-Strecke nach dem 8. August** (Trial→Paid, August–November): Willkommen
+      mit Inhalts-Empfehlungen → Mid-Trial-Impuls → Erinnerung vor Ablauf. Grösster
+      Conversion-Hebel laut INMA/NZZ-Learnings; als neue heroes.json/config.json auf
+      derselben Fabrik bauen.
 - [ ] Wellen-Copy w2/w3/w3b feinschleifen (Kolleg:innen via Editor).
 - [ ] Zwei-Button-Labels noabo w1/w3 gegenlesen («Lesen wählen →» / «Sehen wählen →»).
 - [ ] Segment `beides` = geparkte Empfehlungsmail für Doppelabonnenten (später).

--- a/services/mailing-sommer2026/heroes.json
+++ b/services/mailing-sommer2026/heroes.json
@@ -80,7 +80,7 @@
         },
         "alternativen": [
           "Wo immer Sie diesen Sommer verbringen",
-          "Über 800 Beiträge — einen Sommer lang gratis"
+          "Über 800 Videos — einen Sommer lang gratis"
         ]
       },
       "en": {
@@ -89,7 +89,7 @@
         },
         "alternativen": [
           "Wherever you spend this summer",
-          "Over 800 films — one summer, free"
+          "Over 800 videos — one summer, free"
         ]
       }
     },
@@ -159,8 +159,8 @@
     }
   },
   "proof": {
-    "de": "seit 1921 · 800+ Beiträge · 42 Ausgaben im Jahr · weltweit",
-    "en": "since 1921 · 800+ films · 42 issues a year · worldwide"
+    "de": "seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit",
+    "en": "since 1921 · 800+ videos · 42 issues a year · worldwide"
   },
   "badge": {
     "de": "3 Monate gratis",
@@ -193,88 +193,100 @@
     "lesen": {
       "w1": {
         "de": {
-          "betreff": "Drei Monate im Freien lesen — gratis",
+          "betreff": "Was Sie sehen, jetzt auch lesen — 3 Monate gratis",
           "botschaft": "Drei Monate im Freien lesen.",
-          "text": "Aufsätze, Zeitsymptome und Stimmen aus der anthroposophischen Bewegung — jede Woche neu, gedruckt und digital.",
-          "alt": "Was Sie sehen, jetzt auch lesen — 3 Monate gratis"
+          "text": "Zu Ihrem goetheanum.tv-Zugang: die Wochenschrift — Aufsätze, Zeitsymptome und Stimmen aus der anthroposophischen Bewegung, jede Woche neu, gedruckt und digital.",
+          "alt": "Drei Monate im Freien lesen — gratis",
+          "preheader": "Die Wochenschrift drei Monate geschenkt — lesen, wo der Sommer Sie hinträgt. Bis 8. August."
         },
         "en": {
-          "betreff": "Read in the open air — three months free",
+          "betreff": "What you watch, now also read — 3 months free",
           "botschaft": "Read in the open air, all summer.",
-          "text": "Essays, signs of the times and voices from the anthroposophical movement — every week, in print and digital.",
-          "alt": "What you watch, now also read — 3 months free"
+          "text": "To go with your goetheanum.tv access: the weekly — essays, signs of the times and voices from the anthroposophical movement, new every week, in print and digital.",
+          "alt": "Read in the open air — three months free",
+          "preheader": "Three months of the weekly as a gift — read wherever summer takes you. Until 8 August."
         }
       },
       "w2": {
         "de": {
           "betreff": "Ihr Sommer hat noch Seiten frei",
-          "botschaft": "Ihr Sommer hat noch Seiten frei.",
-          "text": "Die Aktion läuft: Sichern Sie sich die Wochenschrift drei Monate gratis — und lesen Sie, wo der Abend am schönsten ist.",
-          "alt": "Noch bis 8. August: die Wochenschrift gratis"
+          "botschaft": "Lesen, wo der Abend am schönsten ist.",
+          "text": "Die Aktion läuft noch bis 8. August: die Wochenschrift drei Monate gratis zu Ihrem Abo dazu.",
+          "alt": "Noch bis 8. August: die Wochenschrift gratis",
+          "preheader": "Die Wochenschrift drei Monate gratis zu Ihrem Abo — Anmeldung bis 8. August."
         },
         "en": {
           "betreff": "Your summer still has pages to fill",
-          "botschaft": "Your summer still has pages to fill.",
-          "text": "The offer is on: take the weekly free for three months — and read where the evening is most beautiful.",
-          "alt": "Until 8 August: the weekly, free"
+          "botschaft": "Read where the evening is most beautiful.",
+          "text": "The offer runs until 8 August: three months of the weekly, free, added to your subscription.",
+          "alt": "Until 8 August: the weekly, free",
+          "preheader": "Three months of the weekly free with your subscription — sign up by 8 August."
         }
       },
       "w3": {
         "de": {
-          "betreff": "Am Samstag endet Ihr Gratis-Zugang",
+          "betreff": "Nur noch bis Samstag: drei Monate gratis",
           "botschaft": "Am Samstag ist Schluss.",
           "text": "Nur noch wenige Tage: Ergänzen Sie Ihr Abo drei Monate gratis um die Wochenschrift. Ohne Verpflichtung.",
-          "alt": "Letzte Tage: Wochenschrift gratis lesen"
+          "alt": "Letzte Tage: Wochenschrift gratis lesen",
+          "preheader": "Die Wochenschrift drei Monate gratis zu Ihrem Abo dazu — die Anmeldung dauert eine Minute."
         },
         "en": {
-          "betreff": "Your free access ends on Saturday",
+          "betreff": "Only until Saturday: three months free",
           "botschaft": "Saturday is the deadline.",
           "text": "Only a few days left: add the weekly to your subscription free for three months. No obligation.",
-          "alt": "Last days: read the weekly free"
+          "alt": "Last days: read the weekly free",
+          "preheader": "Three months of the weekly with your subscription — signing up takes a minute."
         }
       }
     },
     "sehen": {
       "w1": {
         "de": {
-          "betreff": "Ein Sommer voller Inspiration — 3 Monate gratis",
+          "betreff": "Was Sie lesen, jetzt auch sehen — 3 Monate gratis",
           "botschaft": "Ein Sommer voller Inspiration.",
-          "text": "Vorträge, Gespräche und Begegnungen vom Goetheanum — über 800 Beiträge, wo immer Sie diesen Sommer verbringen.",
-          "alt": "Was Sie lesen, jetzt auch sehen — 3 Monate gratis"
+          "text": "Zu Ihrer Wochenschrift: goetheanum.tv — Vorträge, Gespräche und Begegnungen vom Goetheanum, über 800 Videos, wo immer Sie diesen Sommer verbringen.",
+          "alt": "Ein Sommer voller Inspiration — 3 Monate gratis",
+          "preheader": "goetheanum.tv drei Monate geschenkt — über 800 Videos, wo immer Sie den Sommer verbringen."
         },
         "en": {
-          "betreff": "A summer full of inspiration — 3 months free",
+          "betreff": "What you read, now also watch — 3 months free",
           "botschaft": "A summer full of inspiration.",
-          "text": "Lectures, conversations and encounters from the Goetheanum — over 800 films, wherever you spend this summer.",
-          "alt": "What you read, now also watch — 3 months free"
+          "text": "To go with your weekly: goetheanum.tv — lectures, conversations and encounters from the Goetheanum, over 800 videos, wherever you spend this summer.",
+          "alt": "A summer full of inspiration — 3 months free",
+          "preheader": "Three months of goetheanum.tv as a gift — over 800 videos, wherever you spend the summer."
         }
       },
       "w2": {
         "de": {
           "betreff": "Sehen Sie, was diesen Sommer läuft",
-          "botschaft": "Was diesen Sommer läuft.",
-          "text": "Über 800 Beiträge warten — Vorträge, Gespräche, Bühne. Drei Monate gratis, unverbindlich.",
-          "alt": "Noch bis 8. August: goetheanum.tv gratis"
+          "botschaft": "Vorträge, Gespräche, Bühne.",
+          "text": "Über 800 Videos warten — noch bis 8. August drei Monate gratis zu Ihrem Abo dazu, unverbindlich.",
+          "alt": "Noch bis 8. August: goetheanum.tv gratis",
+          "preheader": "goetheanum.tv drei Monate gratis zu Ihrem Abo — Anmeldung bis 8. August."
         },
         "en": {
           "betreff": "See what’s on this summer",
-          "botschaft": "What’s on this summer.",
-          "text": "Over 800 films are waiting — lectures, conversations, the stage. Three months free, no obligation.",
-          "alt": "Until 8 August: goetheanum.tv free"
+          "botschaft": "Lectures, conversations, the stage.",
+          "text": "Over 800 videos are waiting — until 8 August, three months free with your subscription, no obligation.",
+          "alt": "Until 8 August: goetheanum.tv free",
+          "preheader": "Three months of goetheanum.tv free with your subscription — sign up by 8 August."
         }
       },
       "w3": {
         "de": {
-          "betreff": "Am Samstag endet Ihr Gratis-Zugang",
+          "betreff": "Nur noch bis Samstag: drei Monate gratis",
           "botschaft": "Am Samstag ist Schluss.",
           "text": "Letzte Tage: Ergänzen Sie Ihr Abo drei Monate gratis um goetheanum.tv. Ohne Bindung.",
-          "alt": "Letzte Tage: goetheanum.tv gratis sehen"
+          "alt": "Letzte Tage: goetheanum.tv gratis sehen",
+          "preheader": "goetheanum.tv drei Monate gratis zu Ihrem Abo dazu — die Anmeldung dauert eine Minute."
         },
         "en": {
-          "betreff": "Your free access ends on Saturday",
+          "betreff": "Only until Saturday: three months free",
           "botschaft": "Saturday is the deadline.",
           "text": "Last days: add goetheanum.tv to your subscription free for three months. No strings.",
-          "alt": "Last days: watch goetheanum.tv free"
+          "alt": "Last days: watch goetheanum.tv free",
+          "preheader": "Three months of goetheanum.tv with your subscription — signing up takes a minute."
         }
       }
     },
@@ -282,57 +294,65 @@
       "w1": {
         "de": {
           "betreff": "Ein Sommer mit dem Goetheanum — 3 Monate gratis",
-          "botschaft": "Ein Sommer mit dem Goetheanum.",
+          "botschaft": "Lesen und sehen — den ganzen Sommer.",
           "text": "Zum Lesen und zum Streamen: zwei Angebote, ein Geschenk — drei Monate kostenlos, jederzeit kündbar.",
-          "alt": "Drei Monate sind eine Jahreszeit — gratis"
+          "alt": "Drei Monate sind eine Jahreszeit — gratis",
+          "preheader": "Lesen oder streamen — oder beides: drei Monate kostenlos, bis 8. August."
         },
         "en": {
           "betreff": "A summer with the Goetheanum — 3 months free",
-          "botschaft": "A summer with the Goetheanum.",
+          "botschaft": "Reading and watching — all summer long.",
           "text": "To read and to stream: two offers, one gift — three months free, cancel anytime.",
-          "alt": "Three months are a season — free"
+          "alt": "Three months are a season — free",
+          "preheader": "Read or stream — or both: three months free, until 8 August."
         }
       },
       "w2": {
         "de": {
           "betreff": "Zwei Angebote, ein Geschenk",
-          "botschaft": "Zwei Angebote, ein Geschenk.",
-          "text": "Lesen und sehen — drei Monate kostenlos. Wählen Sie, was Ihr Sommer braucht.",
-          "alt": "Noch bis 8. August: Ihr Sommer-Geschenk"
+          "botschaft": "Wählen Sie, was Ihr Sommer braucht.",
+          "text": "Lesen oder sehen — oder beides: drei Monate kostenlos, noch bis 8. August.",
+          "alt": "Noch bis 8. August: Ihr Sommer-Geschenk",
+          "preheader": "Die Wochenschrift lesen oder goetheanum.tv streamen — drei Monate kostenlos, bis 8. August."
         },
         "en": {
           "betreff": "Two offers, one gift",
-          "botschaft": "Two offers, one gift.",
-          "text": "Read and watch — three months free. Choose what your summer needs.",
-          "alt": "Until 8 August: your summer gift"
+          "botschaft": "Choose what your summer needs.",
+          "text": "Read or watch — or both: three months free, until 8 August.",
+          "alt": "Until 8 August: your summer gift",
+          "preheader": "Read the weekly or stream goetheanum.tv — three months free, until 8 August."
         }
       },
       "w3": {
         "de": {
           "betreff": "Am Samstag endet die Sommer-Aktion",
-          "botschaft": "Am Samstag ist Schluss.",
-          "text": "Nur noch wenige Tage für drei Monate Goetheanum — gratis, ohne Verpflichtung.",
-          "alt": "Letzte Tage: drei Monate gratis"
+          "botschaft": "Drei Monate Goetheanum, noch bis Samstag.",
+          "text": "Gratis und ohne Verpflichtung — wählen Sie Lesen, Sehen oder beides.",
+          "alt": "Letzte Tage: drei Monate gratis",
+          "preheader": "Drei Monate lesen oder streamen, gratis — nur noch bis Samstag, 8. August."
         },
         "en": {
           "betreff": "The summer offer ends on Saturday",
-          "botschaft": "Saturday is the deadline.",
-          "text": "Just a few days left for three months of Goetheanum — free, no obligation.",
-          "alt": "Last days: three months free"
+          "botschaft": "Three months of Goetheanum, until Saturday.",
+          "text": "Free and without obligation — choose reading, watching or both.",
+          "alt": "Last days: three months free",
+          "preheader": "Three months of reading or streaming, free — only until Saturday, 8 August."
         }
       },
       "w3b": {
         "de": {
           "betreff": "Morgen ist Schluss",
-          "botschaft": "Morgen ist Schluss.",
-          "text": "Ein Klick — und der Sommer mit dem Goetheanum gehört Ihnen. Unverbindlich.",
-          "alt": "Letzte Stunden: 3 Monate gratis"
+          "botschaft": "Sie waren schon da — ein Schritt fehlt noch.",
+          "text": "Drei Monate Goetheanum, gratis und unverbindlich — die Anmeldung dauert eine Minute.",
+          "alt": "Letzte Stunden: 3 Monate gratis",
+          "preheader": "Drei Monate Goetheanum gratis — heute oder morgen anmelden, dann gehört der Sommer Ihnen."
         },
         "en": {
           "betreff": "Last chance — it ends tomorrow",
-          "botschaft": "Tomorrow it ends.",
-          "text": "One click — and the summer with the Goetheanum is yours. No obligation.",
-          "alt": "Final hours: 3 months free"
+          "botschaft": "You were already there — one step to go.",
+          "text": "Three months of Goetheanum, free and without obligation — signing up takes a minute.",
+          "alt": "Final hours: 3 months free",
+          "preheader": "Three months of Goetheanum, free — sign up today or tomorrow and the summer is yours."
         }
       }
     }


### PR DESCRIPTION
Umsetzung der freigegebenen Punkte aus der Inhalts-Review (10.7.):

## Redaktionelle Änderungen (`heroes.json`, alle 20 Mails neu gebaut)

- **Cross-sell nach vorn (w1 nurtv/nurws):** Die Brücke «Was Sie sehen, jetzt auch lesen» / «Was Sie lesen, jetzt auch sehen» wird Haupt-Betreff (lag bisher ungenutzt im Alt-Feld); die Texte sprechen das bestehende Abo direkt an («Zu Ihrem goetheanum.tv-Zugang…» / «Zu Ihrer Wochenschrift…»).
- **Ehrliche Frist (w3 nurtv/nurws):** «Am Samstag endet Ihr Gratis-Zugang» behauptete einen Zugang, den die Empfänger noch nicht haben — neu «Nur noch bis Samstag: drei Monate gratis».
- **20 dedizierte Preheader** (60–91 Zeichen): ergänzen den Betreff (Szene ↔ Angebot + Frist) statt den Fliesstext zu doppeln.
- **Botschaft ≠ Betreff:** In w2 (alle Segmente) sowie beides w1/w3/w3b wiederholt die Kopfzeile nach dem Öffnen nicht mehr die Betreffzeile.
- **w3b:** spricht Klicker als solche an («Sie waren schon da — ein Schritt fehlt noch») statt «Ein Klick»-Überversprechen.
- **«Videos»** statt «Beiträge»/«films» in Beweis-Band und sehen-Texten (DE/EN-Parität).

## Befunde der Landingpage-Studie als To-dos (CLAUDE.md)

- Übersichts-Seite reicht `utm_*` nicht an die Zielseiten weiter → Attribution NoAbo w2/w3b bricht (make-or-break).
- GTV-Anmelde-Dialog: utm-Attribution unverifiziert (kein Paperform auf der Seite).
- Kleinzeilen-Angleichung an die echte Mechanik (Entscheid ausstehend).
- Onboarding-Strecke nach dem 8.8. (Trial→Paid).

## Vertrag 1.7.3

`apps/mail-editor/mails/` ist vom ds-lint ausgenommen (MJML-Artefakte, keine Theme-Flächen; Ledger-Eintrag im Design-System-CHANGELOG). Score Repo-weit wieder 98 %.

Build grün: alle 20 Mails 14,7–16,0 KB · typo-check 0 Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_