### PR TITLE
Aktivitäten: direkt im Zeitband bearbeiten + klärende Notiz

### DIFF
--- a/apps/sommer-zaehler/aktivitaeten.html
+++ b/apps/sommer-zaehler/aktivitaeten.html
@@ -77,6 +77,11 @@
             <span class="lab">Kürzel – wer steht dahinter?</span>
             <input type="text" id="mfWer" placeholder="z. B. pt" autocomplete="off" />
           </label>
+          <label class="field span3">
+            <span class="lab">Notiz – klärende Präzisierung (optional)</span>
+            <input type="text" id="mfNotiz" placeholder="z. B. Reichweite = geöffnete Mails, nicht versendete" autocomplete="off" />
+            <span class="hint">Erscheint im Zeitband und im Protokoll, damit die Zahl richtig gelesen wird.</span>
+          </label>
         </div>
         <div style="display:flex;gap:var(--s3);align-items:center;flex-wrap:wrap;margin-top:var(--s4)">
           <button class="btn primary" type="button" id="mfBtn">Eintragen</button>

--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -137,10 +137,14 @@
   .zb td{min-width:104px}
   .zb-chip{display:block;margin:2px 0;padding:4px 8px;border:1px solid var(--line);border-radius:var(--r-control);
     background:var(--field-bg);color:var(--ink);font-size:var(--t-micro);line-height:1.35;overflow-wrap:anywhere}
+  .zb-chip.clickable{cursor:pointer}
+  .zb-chip.clickable:hover{border-color:var(--gold);background:var(--soft)}
+  .zb-chip.clickable:focus-visible{outline:2px solid var(--blue);outline-offset:1px}
+  .zb-chip.has-note{border-left:3px solid var(--gold)}
   .zb-chip .zt{color:var(--muted);font-variant-numeric:tabular-nums;margin-right:5px}
-  .zb-chip .zr{display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:5px;vertical-align:baseline}
-  .zr.sichtbarkeit{background:var(--gold)} .zr.aktivierung{background:var(--blue)}
-  .zr.wirkung{background:var(--ok)} .zr.bindung{background:var(--muted)}
+  .zb-chip .zr{display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:5px;vertical-align:baseline;background:var(--blue)}
+  .zb-chip .zn{display:block;margin-top:3px;color:var(--muted);font-style:normal}
+  .mnote{display:block;margin-top:2px;color:var(--muted);font-size:var(--t-micro);line-height:1.4}
   .zb-legende{display:flex;flex-wrap:wrap;gap:var(--s2) var(--s4);margin-top:var(--s3);font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted)}
   /* Multiplikatoren: Status-Wortlabel, Verlaufszeile, Mini-Maske (DS02, G25) */
   .mstat{font-family:var(--font-text);font-size:var(--t-small);white-space:nowrap;color:var(--muted)}

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -262,6 +262,10 @@
   }
   function zbTag(d){ return d.getDate() + '.' + (d.getMonth() + 1) + '.'; }
 
+  // Zeitband-Chips sind anklickbar → laden die Aktivität in die Bearbeiten-Maske.
+  // Delegation über die Tabelle; die Zeilen-Zuordnung liegt in zbById (je Render neu).
+  var zbById = {}, zbWired = false;
+
   function renderZeitband(rows){
     if (!el('zeitband')) return;
     var tbl = el('zeitband'); if(!tbl) return;
@@ -312,11 +316,17 @@
           if (m.reichweite) det.push('Reichweite ' + Number(m.reichweite).toLocaleString('de-CH'));
           if (m.klicks) det.push('Klicks ' + Number(m.klicks).toLocaleString('de-CH'));
           if (m.kosten) det.push('Kosten ' + Number(m.kosten).toLocaleString('de-CH'));
+          if (m.notiz) det.push('Notiz: ' + m.notiz);
+          zbById[m.id] = m;
           var span = document.createElement('span');
-          span.className = 'zb-chip';
-          span.title = m.massnahme + ' – ' + det.filter(Boolean).join(' · ');
+          span.className = 'zb-chip clickable' + (m.notiz ? ' has-note' : '');
+          span.setAttribute('data-mid', m.id);
+          span.setAttribute('role', 'button');
+          span.setAttribute('tabindex', '0');
+          span.title = m.massnahme + ' – ' + det.filter(Boolean).join(' · ') + ' · anklicken zum Bearbeiten';
           span.innerHTML = '<span class="zr"></span><span class="zt">' + zbTag(d) + '</span>';
           span.appendChild(document.createTextNode(m.massnahme));
+          if (m.notiz){ var zn = document.createElement('span'); zn.className = 'zn'; zn.textContent = m.notiz; span.appendChild(zn); }
           chips += span.outerHTML;
         });
         zeile += '<td>' + chips + '</td>';
@@ -325,7 +335,14 @@
     });
 
     tbl.innerHTML = '<thead>' + h1 + h2 + '</thead><tbody>' + body + '</tbody>';
-    el('zbLegende').innerHTML = '<span>Zeilen = Kanal, Spalten = Woche. Jeder Punkt eine Aktivität; Reichweite, Klicks und Kosten beim Überfahren.</span>';
+    // Delegierter Klick/Tastatur: Chip → Aktivität in die Bearbeiten-Maske laden.
+    if (!zbWired){
+      zbWired = true;
+      var oeffne = function(t){ var c = t && t.closest && t.closest('.zb-chip[data-mid]'); if (!c) return false; var m = zbById[c.getAttribute('data-mid')]; if (m) massnahmeBearbeiten(m); return !!m; };
+      tbl.addEventListener('click', function(e){ oeffne(e.target); });
+      tbl.addEventListener('keydown', function(e){ if (e.key === 'Enter' || e.key === ' '){ if (oeffne(e.target)) e.preventDefault(); } });
+    }
+    el('zbLegende').innerHTML = '<span>Zeilen = Kanal, Spalten = Woche. Jeder Punkt eine Aktivität – anklicken zum Bearbeiten; Reichweite, Klicks, Kosten und Notiz beim Überfahren.</span>';
   }
 
   // Eintragen/Bearbeiten: offener Schreibweg (Muster Link-Register),
@@ -338,11 +355,13 @@
     if (!el('mfTag').value || !titel || !wer){ sagen('Datum, Aktivität und Kürzel sind Pflicht.', true); return; }
     var zahl = function(id){ var e = el(id); return (e && e.value !== '') ? Math.max(0, Math.round(Number(e.value) || 0)) : null; };
     var istEdit = mfEditId != null;
+    var notiz = el('mfNotiz') ? (el('mfNotiz').value || '').trim() : '';
     var params = {
       p_tag: el('mfTag').value, p_massnahme: titel,
       p_kanal: el('mfKanal').value, p_rolle: null,
       p_ersteller: wer, p_kosten: null,
-      p_reichweite: zahl('mfReichweite'), p_klicks: zahl('mfKlicks')
+      p_reichweite: zahl('mfReichweite'), p_klicks: zahl('mfKlicks'),
+      p_notiz: notiz || null
     };
     if (istEdit) { params.p_id = mfEditId; } else { params.p_zielgruppe = null; }
     fetch(SB + '/rest/v1/rpc/' + (istEdit ? 'sommer2026_massnahme_aendern' : 'sommer2026_massnahme_eintragen'), {
@@ -377,6 +396,7 @@
       tr.innerHTML = '<td></td><td></td><td></td><td class="num"></td><td class="num"></td><td class="num"></td><td class="act"></td>';
       tr.children[0].textContent = tag;
       tr.children[1].textContent = (r.massnahme || '') + (r.ersteller ? ' · ' + r.ersteller : '');
+      if (r.notiz){ var nn = document.createElement('span'); nn.className = 'mnote'; nn.textContent = r.notiz; tr.children[1].appendChild(nn); }
       tr.children[2].textContent = kanal;
       tr.children[3].textContent = (r.kosten != null) ? eur(r.kosten) : '–';
       tr.children[4].textContent = (r.reichweite != null) ? fmt(r.reichweite) : '–';
@@ -400,6 +420,7 @@
     el('mfKanal').value = r.kanal || 'andere';
     if (el('mfReichweite')) el('mfReichweite').value = (r.reichweite != null) ? r.reichweite : '';
     if (el('mfKlicks')) el('mfKlicks').value = (r.klicks != null) ? r.klicks : '';
+    if (el('mfNotiz')) el('mfNotiz').value = r.notiz || '';
     el('mfWer').value = r.ersteller || '';
     el('mfBtn').textContent = 'Änderung speichern';
     el('mfSaid').textContent = 'Bearbeitung von «' + (r.massnahme || '') + '» – Speichern übernimmt.';
@@ -411,6 +432,7 @@
     el('mfTitel').value = ''; el('mfWer').value = '';
     if (el('mfReichweite')) el('mfReichweite').value = '';
     if (el('mfKlicks')) el('mfKlicks').value = '';
+    if (el('mfNotiz')) el('mfNotiz').value = '';
     el('mfTag').value = new Date().toISOString().slice(0, 10);
     el('mfBtn').textContent = 'Eintragen';
   }

--- a/services/sommer-zaehler/README.md
+++ b/services/sommer-zaehler/README.md
@@ -64,12 +64,18 @@ DB, wird aber nicht mehr gepflegt.
 
 Quelle ist das **Aktivitäten-Protokoll** `sommer2026_massnahmen` – eine Zeile je
 Aktivität (Newsletter, Inserat, Post) mit Datum, Kanal, Kosten, Reichweite,
-Klicks und **internen** Notizen (`beobachtung` / `entscheidung`). Die internen
-Freitext-Spalten verlassen die DB **nie**: der öffentliche RPC
-`sommer2026_massnahmen_public` gibt nur die kuratierten Zahlen zurück. So wird CPA
-je **Massnahme** rechenbar (nicht nur je Bucket), und aus der Aktion wird eine
-lesbare Geschichte statt eines Datenhaufens. Pflege per `insert`/`update` (Service-
-Role), kein Commit je Aktualisierung.
+Klicks, einer öffentlichen **`notiz`** (klärende Präzisierung, z. B. „Reichweite =
+geöffnete Mails, nicht versendete") und **internen** Notizen (`beobachtung` /
+`entscheidung`). Die internen Freitext-Spalten verlassen die DB **nie**: der
+öffentliche RPC `sommer2026_massnahmen_public` gibt nur die kuratierten Zahlen
+plus `notiz` zurück. So wird CPA je **Aktivität** rechenbar (nicht nur je Bucket),
+und aus der Aktion wird eine lesbare Geschichte statt eines Datenhaufens.
+
+**Eintragen und Bearbeiten** über die RPCs `sommer2026_massnahme_eintragen` und
+`…_aendern` (offener Schreibweg fürs Team, Muster Link-Register; `notiz` ist
+Bestandteil beider). Im Cockpit lässt sich jede Aktivität **direkt im Zeitband
+anklicken** – der Chip lädt die Zeile in die Bearbeiten-Maske. Chips mit Notiz
+tragen sie als Zeile im Chip und einen goldenen Rand.
 
 ## Ströme und Tarife
 

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -115,6 +115,7 @@ create table if not exists public.sommer2026_massnahmen (
   reichweite  bigint,                                     -- Sichtbarkeit (Impressionen)
   klicks      bigint,                                     -- Aktivierung
   ersteller   text,                                       -- Kürzel: wer steht dahinter
+  notiz       text,                                        -- ÖFFENTLICH: klärende Präzisierung (z. B. «nur geöffnete Mails»)
   beobachtung text,                                       -- INTERN (nicht im RPC)
   entscheidung text                                       -- INTERN (nicht im RPC)
 );
@@ -131,11 +132,13 @@ language sql security definer set search_path to 'public' as $$
    order by n desc;
 $$;
 
--- Massnahmen-Protokoll, kuratiert (ohne interne Freitext-Spalten)
+-- Massnahmen-Protokoll, kuratiert (ohne interne Freitext-Spalten; notiz ist die
+-- öffentliche, klärende Präzisierung und darf mit)
+drop function if exists public.sommer2026_massnahmen_public();
 create or replace function public.sommer2026_massnahmen_public()
-returns table(id bigint, tag date, massnahme text, kanal text, rolle text, ersteller text, kosten numeric, reichweite bigint, klicks bigint)
+returns table(id bigint, tag date, massnahme text, kanal text, rolle text, ersteller text, kosten numeric, reichweite bigint, klicks bigint, notiz text)
 language sql security definer set search_path to 'public' as $$
-  select id, tag, massnahme, kanal, rolle, ersteller, kosten, reichweite, klicks
+  select id, tag, massnahme, kanal, rolle, ersteller, kosten, reichweite, klicks, notiz
     from public.sommer2026_massnahmen
    order by tag, id;
 $$;
@@ -144,10 +147,11 @@ $$;
 -- Schreibweg fürs Team (Muster Link-Register) – nur kuratierte Felder, die
 -- internen Freitext-Spalten bleiben der Redaktion. Speist Zeitband, Protokoll
 -- und Wirkungskette im Cockpit.
+drop function if exists public.sommer2026_massnahme_eintragen(date, text, text, text, text, numeric, bigint, bigint, text);
 create or replace function public.sommer2026_massnahme_eintragen(
   p_tag date, p_massnahme text, p_kanal text, p_rolle text,
   p_zielgruppe text, p_kosten numeric, p_reichweite bigint, p_klicks bigint,
-  p_ersteller text default null)
+  p_ersteller text default null, p_notiz text default null)
 returns text language plpgsql security definer set search_path to 'public' as $$
 declare
   v_kanal text; v_rolle text;
@@ -159,19 +163,21 @@ begin
   if v_kanal not in ('newsletter','mailer','flyer','social','popup','website','empfehlung','andere') then v_kanal := 'andere'; end if;
   v_rolle := lower(coalesce(p_rolle, ''));
   if v_rolle not in ('sichtbarkeit','aktivierung','wirkung','bindung') then v_rolle := 'wirkung'; end if;
-  insert into public.sommer2026_massnahmen (tag, massnahme, kanal, rolle, zielgruppe, kosten, reichweite, klicks, ersteller)
+  insert into public.sommer2026_massnahmen (tag, massnahme, kanal, rolle, zielgruppe, kosten, reichweite, klicks, ersteller, notiz)
   values (p_tag, trim(p_massnahme), v_kanal, v_rolle, nullif(trim(coalesce(p_zielgruppe,'')), ''), p_kosten, p_reichweite, p_klicks,
-          nullif(trim(coalesce(p_ersteller,'')), ''));
+          nullif(trim(coalesce(p_ersteller,'')), ''), nullif(trim(coalesce(p_notiz,'')), ''));
   return 'ok';
 end;
 $$;
-grant execute on function public.sommer2026_massnahme_eintragen(date, text, text, text, text, numeric, bigint, bigint, text) to anon, authenticated;
+grant execute on function public.sommer2026_massnahme_eintragen(date, text, text, text, text, numeric, bigint, bigint, text, text) to anon, authenticated;
 
 -- Bearbeiten (Migration «sommer2026_massnahmen_kuerzel_flyer_bearbeiten»):
 -- nur übergebene Werte ändern, vorhandene Zahlen bleiben erhalten.
+drop function if exists public.sommer2026_massnahme_aendern(bigint, date, text, text, text, text, numeric, bigint, bigint);
 create or replace function public.sommer2026_massnahme_aendern(
   p_id bigint, p_tag date, p_massnahme text, p_kanal text, p_rolle text,
-  p_ersteller text, p_kosten numeric, p_reichweite bigint, p_klicks bigint)
+  p_ersteller text, p_kosten numeric, p_reichweite bigint, p_klicks bigint,
+  p_notiz text default null)
 returns text language plpgsql security definer set search_path to 'public' as $$
 declare
   v_kanal text; v_rolle text; n int;
@@ -188,13 +194,14 @@ begin
     ersteller  = coalesce(nullif(trim(coalesce(p_ersteller,'')), ''), ersteller),
     kosten     = coalesce(p_kosten, kosten),
     reichweite = coalesce(p_reichweite, reichweite),
-    klicks     = coalesce(p_klicks, klicks)
+    klicks     = coalesce(p_klicks, klicks),
+    notiz      = coalesce(nullif(trim(coalesce(p_notiz,'')), ''), notiz)
   where id = p_id;
   get diagnostics n = row_count;
   return case when n > 0 then 'ok' else 'unbekannt' end;
 end;
 $$;
-grant execute on function public.sommer2026_massnahme_aendern(bigint, date, text, text, text, text, numeric, bigint, bigint) to anon, authenticated;
+grant execute on function public.sommer2026_massnahme_aendern(bigint, date, text, text, text, text, numeric, bigint, bigint, text) to anon, authenticated;
 
 -- Kosten-Einzelposten (Migration «sommer2026_kosten_posten»): das Team traegt
 -- Posten mit Kuerzel ein, das Cockpit summiert je Kostenart (Uebersicht bleibt,


### PR DESCRIPTION
Zwei Rückmeldungen aus dem Team umgesetzt.

## 1. Direkt im Zeitband bearbeiten
Bisher ging Bearbeiten nur über den Knopf im Protokoll. Jetzt ist **jeder Zeitband-Chip anklickbar** (Maus, Enter/Space) und lädt die Aktivität direkt in die Bearbeiten-Maske — mit Datum, Kanal, Reichweite, Klicks und Notiz vorbefüllt. Umsetzung per delegiertem Handler auf der Tabelle, Zuordnung über `data-mid`.

## 2. Klärende Notiz je Aktivität
Neues öffentliches Feld **`notiz`** für Präzisierungen im konkreten Fall — z. B. „Reichweite = geöffnete Mails, nicht versendete". Die Notiz erscheint als Zeile direkt im Zeitband-Chip (goldener Rand als Marker), im Protokoll unter dem Aktivitätsnamen und im Tooltip.

## Backend
Migration **`sommer2026_massnahme_notiz`** ist **angewandt** (DB live):
- Spalte `notiz text` in `sommer2026_massnahmen`
- `sommer2026_massnahmen_public()` gibt `notiz` mit zurück
- `sommer2026_massnahme_eintragen` / `…_aendern` akzeptieren `p_notiz`

Keine Datenlöschung, keine Secrets. `schema.sql` nachgezogen.

## Geprüft
- `tools/ds-lint.py --staged`: 100 %, 0 Fehler · `tools/typo-check.py`: konform
- `node --check` auf `campaign.js`: OK
- Lokal (Playwright, Mock): Chip-Klick öffnet die Maske und füllt Titel/Reichweite/Klicks/Notiz; Chip mit Notiz zeigt die Zeile + goldenen Rand; keine Konsolenfehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2

---
_Generated by [Claude Code](https://claude.ai/code/session_011cMmkRTwmMsvVwdhZRxDm2)_