### PR TITLE
NoAbo auf einen Button, Kleinzeilen auf eine Wahrheit

### DIFF
--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -86,7 +86,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 10.07.2026, 17.52 Uhr · <code>c33442f</code></p>
+  <p class="subline">Stand dieses Builds: 10.07.2026, 18.11 Uhr · <code>8ed3263</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -124,7 +124,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="shared#button"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#button')">senden</button></div></div></div><div class="fld" data-key="shared#kleinzeile"><div class="fh" onclick="toggle(this)"><span class="lbl">Kleinzeile (je Motiv)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="shared#kleinzeile">0</span></button></div>
-<div class="val">Drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.<br>Jederzeit kündbar · keine Verpflichtung · Aktion bis 8. August 2026.<br>Drei Monate kostenlos · endet ohne Verpflichtung · nur bis 8. August 2026.</div>
+<div class="val">Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.<br>Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.<br>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="shared#kleinzeile"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#kleinzeile')">senden</button></div></div></div><div class="fld" data-key="shared#footer"><div class="fh" onclick="toggle(this)"><span class="lbl">Footer</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="shared#footer">0</span></button></div>
@@ -334,7 +334,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -637,7 +637,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -940,7 +940,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1243,7 +1243,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1546,7 +1546,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1849,7 +1849,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2152,7 +2152,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Jederzeit kündbar · keine Verpflichtung · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2455,7 +2455,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Cancel anytime · no obligation · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2758,7 +2758,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Jederzeit kündbar · keine Verpflichtung · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3061,7 +3061,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Cancel anytime · no obligation · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3364,7 +3364,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Jederzeit kündbar · keine Verpflichtung · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3667,7 +3667,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Cancel anytime · no obligation · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3956,25 +3956,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:separate;line-height:100%;&quot;>
-                          <tbody>
-                            <tr>
-                              <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_ws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Lesen wählen → </a>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-                    <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:separate;line-height:100%;&quot;>
                           <tbody>
                             <tr>
-                              <td align=&quot;center&quot; bgcolor=&quot;#FFFFFF&quot; role=&quot;presentation&quot; style=&quot;border:2px solid #A95278;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#FFFFFF;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_tv&quot; style=&quot;display:inline-block;background:#FFFFFF;color:#A95278;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Sehen wählen → </a>
+                              <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Geschenk wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -3983,7 +3970,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Drei Monate kostenlos · endet ohne Verpflichtung · nur bis 8. August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4067,7 +4054,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#CTA">0</span></button></div>
-<div class="val">Lesen wählen → · Sehen wählen →</div>
+<div class="val">Geschenk wählen →</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#Alt-Betreff (AC-Split)">0</span></button></div>
@@ -4075,7 +4062,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#Alt-Betreff (AC-Split)"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#Link">0</span></button></div>
-<div class="val"><code>https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_ws · https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_tv</code></div>
+<div class="val"><code>https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo</code></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#Link"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#Link')">senden</button></div></div></div>
     <div class="fld" data-key="beides_w1_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
@@ -4272,25 +4259,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:separate;line-height:100%;&quot;>
-                          <tbody>
-                            <tr>
-                              <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_ws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose reading → </a>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-                    <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:separate;line-height:100%;&quot;>
                           <tbody>
                             <tr>
-                              <td align=&quot;center&quot; bgcolor=&quot;#FFFFFF&quot; role=&quot;presentation&quot; style=&quot;border:2px solid #A95278;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#FFFFFF;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_tv&quot; style=&quot;display:inline-block;background:#FFFFFF;color:#A95278;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose streaming → </a>
+                              <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your gift → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -4299,7 +4273,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Three months free · ends with no obligation · only until 8 August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4383,7 +4357,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#CTA">0</span></button></div>
-<div class="val">Choose reading → · Choose streaming →</div>
+<div class="val">Choose your gift →</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#Alt-Betreff (AC-Split)">0</span></button></div>
@@ -4391,7 +4365,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#Alt-Betreff (AC-Split)"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#Link">0</span></button></div>
-<div class="val"><code>https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_ws · https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_tv</code></div>
+<div class="val"><code>https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo</code></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#Link"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#Link')">senden</button></div></div></div>
     <div class="fld" data-key="beides_w1_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
@@ -4602,7 +4576,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Drei Monate kostenlos · endet ohne Verpflichtung · nur bis 8. August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4905,7 +4879,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Three months free · ends with no obligation · only until 8 August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5194,25 +5168,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:separate;line-height:100%;&quot;>
-                          <tbody>
-                            <tr>
-                              <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_ws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Lesen wählen → </a>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-                    <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:separate;line-height:100%;&quot;>
                           <tbody>
                             <tr>
-                              <td align=&quot;center&quot; bgcolor=&quot;#FFFFFF&quot; role=&quot;presentation&quot; style=&quot;border:2px solid #A95278;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#FFFFFF;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_tv&quot; style=&quot;display:inline-block;background:#FFFFFF;color:#A95278;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Sehen wählen → </a>
+                              <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Geschenk wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -5221,7 +5182,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Drei Monate kostenlos · endet ohne Verpflichtung · nur bis 8. August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5305,7 +5266,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w3_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#CTA">0</span></button></div>
-<div class="val">Lesen wählen → · Sehen wählen →</div>
+<div class="val">Geschenk wählen →</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w3_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#Alt-Betreff (AC-Split)">0</span></button></div>
@@ -5313,7 +5274,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#Alt-Betreff (AC-Split)"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="beides_w3_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#Link">0</span></button></div>
-<div class="val"><code>https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_ws · https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_tv</code></div>
+<div class="val"><code>https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo</code></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#Link"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#Link')">senden</button></div></div></div>
     <div class="fld" data-key="beides_w3_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
@@ -5510,25 +5471,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:separate;line-height:100%;&quot;>
-                          <tbody>
-                            <tr>
-                              <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_ws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose reading → </a>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-                    <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:separate;line-height:100%;&quot;>
                           <tbody>
                             <tr>
-                              <td align=&quot;center&quot; bgcolor=&quot;#FFFFFF&quot; role=&quot;presentation&quot; style=&quot;border:2px solid #A95278;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#FFFFFF;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_tv&quot; style=&quot;display:inline-block;background:#FFFFFF;color:#A95278;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose streaming → </a>
+                              <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your gift → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -5537,7 +5485,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Three months free · ends with no obligation · only until 8 August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5621,7 +5569,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w3_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#CTA">0</span></button></div>
-<div class="val">Choose reading → · Choose streaming →</div>
+<div class="val">Choose your gift →</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w3_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#Alt-Betreff (AC-Split)">0</span></button></div>
@@ -5629,7 +5577,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#Alt-Betreff (AC-Split)"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="beides_w3_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#Link">0</span></button></div>
-<div class="val"><code>https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_ws · https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_tv</code></div>
+<div class="val"><code>https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo</code></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#Link"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#Link')">senden</button></div></div></div>
     <div class="fld" data-key="beides_w3_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
@@ -5840,7 +5788,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Drei Monate kostenlos · endet ohne Verpflichtung · nur bis 8. August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -6143,7 +6091,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Three months free · ends with no obligation · only until 8 August 2026.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w1_de.html
+++ b/apps/mail-editor/mails/mail_beides_w1_de.html
@@ -185,25 +185,12 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                          <tbody>
-                            <tr>
-                              <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_ws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Lesen wählen → </a>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-                    <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
                           <tbody>
                             <tr>
-                              <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:2px solid #A95278;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#FFFFFF;" valign="middle">
-                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_tv" style="display:inline-block;background:#FFFFFF;color:#A95278;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Sehen wählen → </a>
+                              <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Geschenk wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -212,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Drei Monate kostenlos · endet ohne Verpflichtung · nur bis 8. August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w1_en.html
+++ b/apps/mail-editor/mails/mail_beides_w1_en.html
@@ -185,25 +185,12 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                          <tbody>
-                            <tr>
-                              <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_ws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose reading → </a>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-                    <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
                           <tbody>
                             <tr>
-                              <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:2px solid #A95278;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#FFFFFF;" valign="middle">
-                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_tv" style="display:inline-block;background:#FFFFFF;color:#A95278;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose streaming → </a>
+                              <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your gift → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -212,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Three months free · ends with no obligation · only until 8 August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_de.html
+++ b/apps/mail-editor/mails/mail_beides_w2_de.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Drei Monate kostenlos · endet ohne Verpflichtung · nur bis 8. August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_en.html
+++ b/apps/mail-editor/mails/mail_beides_w2_en.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Three months free · ends with no obligation · only until 8 August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3_de.html
@@ -185,25 +185,12 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                          <tbody>
-                            <tr>
-                              <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_ws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Lesen wählen → </a>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-                    <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
                           <tbody>
                             <tr>
-                              <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:2px solid #A95278;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#FFFFFF;" valign="middle">
-                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_tv" style="display:inline-block;background:#FFFFFF;color:#A95278;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Sehen wählen → </a>
+                              <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Geschenk wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -212,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Drei Monate kostenlos · endet ohne Verpflichtung · nur bis 8. August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3_en.html
@@ -185,25 +185,12 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                          <tbody>
-                            <tr>
-                              <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_ws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose reading → </a>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-                    <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
                           <tbody>
                             <tr>
-                              <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:2px solid #A95278;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#FFFFFF;" valign="middle">
-                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_tv" style="display:inline-block;background:#FFFFFF;color:#A95278;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose streaming → </a>
+                              <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your gift → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -212,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Three months free · ends with no obligation · only until 8 August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_de.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Drei Monate kostenlos · endet ohne Verpflichtung · nur bis 8. August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_en.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Three months free · ends with no obligation · only until 8 August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w1_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_de.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w1_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_en.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_de.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_en.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_de.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_en.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w1_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_de.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Jederzeit kündbar · keine Verpflichtung · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w1_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_en.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Cancel anytime · no obligation · offer ends 8 August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_de.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Jederzeit kündbar · keine Verpflichtung · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_en.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Cancel anytime · no obligation · offer ends 8 August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_de.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Jederzeit kündbar · keine Verpflichtung · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_en.html
@@ -199,7 +199,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Cancel anytime · no obligation · offer ends 8 August 2026.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/services/mailing-sommer2026/CLAUDE.md
+++ b/services/mailing-sommer2026/CLAUDE.md
@@ -48,11 +48,13 @@ Betreff-Alternativen (`wellen.*.alt`) = Munition für AC-Split (Nicht-Öffner).
 ## Attribution / Links (verifiziert 9.7. gegen das Live-Register)
 Cockpit `sommer2026_links_public()` matcht nur über utm_campaign+utm_source+utm_medium+utm_content.
 Fix: utm_source=mailing, utm_medium=email, utm_campaign=summer26_trial. `links.py` erzeugt sie aus
-(segment, welle, ziel, sprache); `python3 links.py` leitet die 24 Registerzeilen ab — deckungsgleich
-mit dem eingespielten Register. **noabo w1/w3 haben ZWEI Buttons** (`w{n}_noabo_ws` + `w{n}_noabo_tv`),
-w2/w3b einen (Übersicht) — das Register kennt kein `w1_noabo`/`w3_noabo`, also nie auf einen Button
-reduzieren, ohne das Register mitzuziehen. **make-or-break vor Versand:** Landingpage muss die vier
-utm_* an das Paperform weiterreichen (Hidden Fields), sonst 0 Abschlüsse trotz Anmeldungen.
+(segment, welle, ziel, sprache); `python3 links.py` leitet die 20 aktiven Registerzeilen ab.
+**Ein-Button-Entscheid (10.7.):** noabo führt in ALLEN Wellen genau einen Button zur Übersicht
+(`w{n}_noabo`); das Register wurde um `w1_noabo`/`w3_noabo` erweitert, die alten Zwei-Button-Zeilen
+(`w{n}_noabo_ws|tv`) bleiben als Altbestand stehen. **make-or-break vor Versand:** (1) Die WS-Seite
+reicht utm_* via Paperform `prefill-inherit` weiter (verifiziert 10.7.). (2) Die **Übersichts-Seite
+muss utm_* an ihre zwei Ausgangs-Links anhängen** — ohne diesen Fix ist die gesamte NoAbo-Attribution
+blind (Snippet siehe To-do). (3) GTV-Anmeldedialog: utm-Durchreichung unverifiziert.
 
 ## Der Editor (Gegenlesen)
 `apps/mail-editor/` (Hub-Kategorie «Kampagne», intern): DE/EN-Umschalter, oben **Sammelansicht
@@ -76,25 +78,24 @@ Versand ab Engagement-Segment, gestaffelt; Nicht-Öffner >12 Mt. weglassen.
 Merge-Tags/Abmeldelink in AC ersetzen `%UNSUBSCRIBELINK%`.
 
 ## Offen
-- [ ] **Attribution NoAbo w2/w3b (make-or-break):** Die Übersichts-Landingpage
+- [ ] **VORAUSSETZUNG NoAbo (make-or-break, vor 14.7.):** Die Übersichts-Landingpage
       (global-sommer2026.goetheanum.online) reicht die utm_* NICHT an die verlinkten
-      Zielseiten weiter (nackte hrefs, kein Query-Forwarding; geprüft 10.7.) — Anmeldungen
-      aus w2/w3b sind so im Cockpit unsichtbar. Fix auf der Übersicht: `location.search`
-      an beide Ausgangs-Links anhängen. (WS-Seite selbst ist sauber: Paperform-Buttons
-      mit `prefill-inherit`.)
+      Zielseiten weiter (nackte hrefs; geprüft 10.7.). Seit dem Ein-Button-Entscheid
+      hängt daran die GESAMTE NoAbo-Attribution. Fix dort (beide Sprachfassungen):
+      `location.search` an die zwei Ausgangs-Links anhängen — Snippet liegt im
+      Zusatz-Auftrag für Chrome-Claude. Danach Klickpfad einmal live testen.
 - [ ] **Attribution GTV prüfen:** tv-sommer2026 hat kein Paperform; der Anmelde-Dialog
       (uscreen/goetheanum.tv) ist clientseitig — ob utm_* den Abschluss erreichen, ist
       unverifiziert. Ohne das bleiben alle gtv-Register-Zeilen ohne Abschlüsse.
-- [ ] **Kleinzeilen an echte Mechanik angleichen** (Entscheid Ph ausstehend): WS-Seite =
-      Kündigungsmodell («die ersten drei Monate in jedem Fall kostenlos, jederzeit kündbar»);
-      die Übersicht behauptet dagegen «enden ohne Verpflichtung» — Landingpage-Widerspruch
-      dort auflösen, Mails auf die eine wahre Formel ziehen.
+- [ ] **Landingpage-Widerspruch Übersicht:** Dort steht «enden ohne Verpflichtung — oder
+      Sie bleiben dabei» neben «jederzeit kündbar»; die WS-Seite ist eindeutig
+      Kündigungsmodell. Die Mails folgen seit 10.7. der einen Formel («Die ersten drei
+      Monate kostenlos · jederzeit kündbar») — die Übersichts-Zeile entsprechend anpassen.
 - [ ] **Onboarding-Strecke nach dem 8. August** (Trial→Paid, August–November): Willkommen
       mit Inhalts-Empfehlungen → Mid-Trial-Impuls → Erinnerung vor Ablauf. Grösster
       Conversion-Hebel laut INMA/NZZ-Learnings; als neue heroes.json/config.json auf
       derselben Fabrik bauen.
 - [ ] Wellen-Copy w2/w3/w3b feinschleifen (Kolleg:innen via Editor).
-- [ ] Zwei-Button-Labels noabo w1/w3 gegenlesen («Lesen wählen →» / «Sehen wählen →»).
 - [ ] Segment `beides` = geparkte Empfehlungsmail für Doppelabonnenten (später).
 - [ ] Nach Merge: `python3 build_editor.py --verify` (prüft Editor + alle Bild-URLs live),
       dann AC bestücken.

--- a/services/mailing-sommer2026/config.json
+++ b/services/mailing-sommer2026/config.json
@@ -54,11 +54,19 @@
         "gtv"
       ],
       "wellen_ctas": {
-        "_hinweis": "CTA-Ziele je Welle — deckungsgleich mit dem eingespielten Register (w1/w3 zwei Buttons ws+tv, w2/w3b ein Button Übersicht). Nicht ändern, ohne das Register mitzuziehen.",
-        "w1": ["wos", "gtv"],
-        "w2": ["uebersicht"],
-        "w3": ["wos", "gtv"],
-        "w3b": ["uebersicht"]
+        "_hinweis": "EIN Button je Welle -> Übersicht (Entscheid 10.7.: die Wahl wandert aus der Mail in den Browser). Register um w1_noabo/w3_noabo erweitert; die alten Zwei-Button-Zeilen (w1/w3_noabo_ws|tv) bleiben als Altbestand stehen. VORAUSSETZUNG: die Übersichts-Seite muss utm_* an die Zielseiten weiterreichen, sonst ist die gesamte NoAbo-Attribution blind.",
+        "w1": [
+          "uebersicht"
+        ],
+        "w2": [
+          "uebersicht"
+        ],
+        "w3": [
+          "uebersicht"
+        ],
+        "w3b": [
+          "uebersicht"
+        ]
       }
     },
     "nurtv": {

--- a/services/mailing-sommer2026/heroes.json
+++ b/services/mailing-sommer2026/heroes.json
@@ -146,16 +146,16 @@
   },
   "kleinzeile": {
     "lesen": {
-      "de": "Drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.",
-      "en": "Three months free · cancel anytime, no reason needed · offer ends 8 August 2026."
+      "de": "Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.",
+      "en": "The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026."
     },
     "sehen": {
-      "de": "Jederzeit kündbar · keine Verpflichtung · Aktion bis 8. August 2026.",
-      "en": "Cancel anytime · no obligation · offer ends 8 August 2026."
+      "de": "Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.",
+      "en": "The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026."
     },
     "beides": {
-      "de": "Drei Monate kostenlos · endet ohne Verpflichtung · nur bis 8. August 2026.",
-      "en": "Three months free · ends with no obligation · only until 8 August 2026."
+      "de": "Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.",
+      "en": "Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026."
     }
   },
   "proof": {

--- a/services/mailing-sommer2026/links.py
+++ b/services/mailing-sommer2026/links.py
@@ -6,9 +6,11 @@ Link und Anmeldung AUSSCHLIESSLICH ueber vier Felder:
     utm_campaign + utm_source + utm_medium + utm_content
 landing/sprache/url sind reine Register-Etiketten und zaehlen NICHT mit.
 
-utm_content-Regel (deckungsgleich mit den bereits eingespielten 24 Zeilen):
-    "w{n}_{segment}"                      bei einem Button
-    "w{n}_{segment}_{ws|tv}"              bei zwei Buttons (nur noabo w1/w3)
+utm_content-Regel (deckungsgleich mit dem eingespielten Register):
+    "w{n}_{segment}"                      bei einem Button (Stand 10.7.: überall)
+    "w{n}_{segment}_{ws|tv}"              bei zwei Buttons (Altbestand noabo w1/w3;
+                                          Zeilen bleiben im Register, Mails nutzen
+                                          seit dem Ein-Button-Entscheid die Übersicht)
 
 `python3 links.py` leitet alle Register-Zeilen aus heroes.json/config.json ab
 (Wellenplan × CTA-Ziele je Welle × Sprachen) — zum Abgleich mit dem Register.


### PR DESCRIPTION
Umsetzung der zwei Entscheide vom 10.7.:

## Kleinzeilen: Variante A (eine Wahrheit für alle 20 Mails)

Die Landingpage-Studie zeigte: Die WS-Seite ist eindeutig Kündigungsmodell («Die ersten drei Monate sind in jedem Fall kostenlos und während dieser Zeit jederzeit ohne Begründung kündbar»). Alle drei Kleinzeilen sagen jetzt dieses eine Modell — «**Die ersten** drei Monate kostenlos · jederzeit kündbar · Aktion bis 8. August 2026» (sehen: «ein Klick im Konto»; beides: «Beide Angebote kombinierbar»). Der bisherige Widerspruch (kündbar vs. «endet ohne Verpflichtung», teils in derselben Mail) ist aufgelöst; der verbleibende Widerspruch liegt auf der Übersichts-Landingpage und steht als To-do.

## NoAbo: ein Button je Welle («Geschenk wählen →» → Übersicht)

Die Wahl Lesen/Sehen wandert aus der Mail in den Browser (Ein-CTA-Evidenz; die Übersicht trägt die Wahl besser). `wellen_ctas` aller Wellen → `uebersicht`; `utm_content` w1/w3 neu `w1_noabo`/`w3_noabo`. **Register mitgezogen:** die vier neuen Zeilen sind in `sommer2026_links` eingespielt (idempotent, verifiziert); die Zwei-Button-Zeilen bleiben als Altbestand stehen.

**Als make-or-break-To-do markiert:** Die Übersichts-Seite muss `utm_*` an ihre zwei Ausgangs-Links anhängen (heute nackte hrefs), sonst ist die gesamte NoAbo-Attribution blind — Fix-Snippet liegt im Zusatz-Auftrag für Chrome-Claude.

Build grün (20 Mails, 14,7–16 KB) · Register-Abgleich `python3 links.py` = 20 aktive Zeilen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_