### PR TITLE
QR-Code-Generator: neues Werkzeug mit Kurzlink und Scan-Statistik

### DIFF
--- a/apps/qr-generator/index.html
+++ b/apps/qr-generator/index.html
@@ -1,0 +1,689 @@
+<!doctype html>
+<!-- =============================================================================
+     QR-Code-Generator · Werkzeuge Goetheanum
+     -----------------------------------------------------------------------------
+     QR-Codes im Hausstil für Link, WLAN, Kontakt, E-Mail und Text. Link-Codes
+     laufen auf Wunsch als Kurzlink (tools.goetheanum.ch/s/<code>) über die
+     Edge Function go und zählen ihre Scans anonym in link_hits – gespeichert
+     werden nur Zeitpunkt und Code, keine Personendaten. Statistik über die
+     Aggregat-RPCs qr_stats_public / qr_stats_tage (Schema:
+     services/qr-generator/schema.sql).
+
+     Regelkonform: Farben/Schnitte/Abstände aus tokens.css + base.css. Ziffern
+     tabellarisch (G25), Betonung nur über Gewicht (G05), Labels normal, nicht
+     versal (G05/G23). Die QR-Farben selbst sind Artefakt, nicht Theme (# ds-ok
+     an den Konstanten unten) – ein Code muss dunkel auf Weiss bleiben, sonst
+     liest ihn keine Kamera.
+     ============================================================================= -->
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>QR-Code-Generator · Goetheanum</title>
+<meta name="description" content="QR-Codes für Link, WLAN, Kontakt, E-Mail und Text – im Hausstil, mit Kurzlink und einfacher Scan-Statistik, ohne Fremddienst." />
+<link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
+
+<link rel="stylesheet" href="../../design-system/tokens.css" />
+<link rel="stylesheet" href="../../design-system/base.css" />
+<link rel="stylesheet" href="../../design-system/nav.css" />
+
+<style>
+  /* Nur werkzeug-eigene Gestalt – alles Gemeinsame kommt aus base.css, nur Tokens. */
+  .grid{display:grid;grid-template-columns:1fr 1fr;gap:var(--s4);margin-top:var(--s4)}
+  .grid .span2{grid-column:1 / -1}
+  .field .hint{margin-top:6px}
+  .pane[hidden]{display:none}
+  .kurzrow{display:flex;gap:var(--s2);align-items:stretch;flex-wrap:wrap} .kurzrow input{flex:1;min-width:140px}
+  .check{display:flex;align-items:center;gap:var(--s2);font-family:var(--font-text);font-size:var(--t-body);color:var(--ink);cursor:pointer;min-height:var(--tap)}
+  .check input{width:20px;height:20px;accent-color:var(--blue)}
+
+  /* Gestalt & Ausgabe: Regler links, Vorschau rechts. */
+  .out{display:grid;grid-template-columns:1fr auto;gap:var(--s6);align-items:start}
+  .gopt{margin-bottom:var(--s4)}
+  .gopt .lab{display:block;margin-bottom:var(--s2)}
+  .qrwrap{display:flex;flex-direction:column;align-items:center;gap:var(--s2)}
+  .qr{width:220px;height:220px;border-radius:var(--r-control);overflow:hidden;background:var(--paper);border:1px solid var(--line);display:grid;place-items:center}
+  .qr svg{display:block;width:100%;height:100%}
+  .payloadbox{width:220px;font-family:var(--font-mono,var(--font-text));font-size:var(--t-micro);color:var(--muted);
+    word-break:break-all;line-height:1.5;max-height:5.5em;overflow:hidden}
+  .actions{display:flex;gap:var(--s2);flex-wrap:wrap;margin-top:var(--s4)}
+  .said{font-family:var(--font-text);font-size:var(--t-small);color:var(--ok);min-height:1.5em;margin-top:var(--s2)}
+  .shortbox{display:flex;flex-wrap:wrap;align-items:baseline;gap:var(--s2) var(--s4);margin-top:var(--s4);
+    font-family:var(--font-text);font-size:var(--t-small)}
+  .shortbox[hidden]{display:none}
+  .shortbox .sl{color:var(--muted)}
+  .shortbox .su{font-family:var(--font-mono,var(--font-text));color:var(--blue);word-break:break-all}
+
+  /* Statistik: Kennzahlen, Tagesbalken (Muster Kampagnen-Cockpit), Code-Tabelle. */
+  .kpis{display:flex;gap:var(--s4);flex-wrap:wrap;margin-top:var(--s4)}
+  .kpi{background:var(--paper);border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s4) var(--s6);min-width:150px}
+  .kpi .kl{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)}
+  .kpi .kv{font-family:var(--font-display);font-weight:var(--w-strong);font-size:var(--t-h3);color:var(--ink);font-variant-numeric:tabular-nums;margin-top:4px}
+  .spark{display:flex;align-items:stretch;gap:clamp(4px,1vw,10px);height:140px;padding-top:8px;margin-top:var(--s4)}
+  .spark .d{flex:1;display:flex;flex-direction:column;align-items:center;gap:6px;min-width:0}
+  .spark .barcell{flex:1;width:100%;display:flex;align-items:flex-end;justify-content:center}
+  .spark .bar{width:100%;max-width:30px;border-radius:6px 6px 0 0;background:linear-gradient(180deg,var(--blue),color-mix(in srgb,var(--blue) 55%,transparent));min-height:3px}
+  .spark .bv{font-family:var(--font-text);font-variant-numeric:tabular-nums;font-size:var(--t-micro);color:var(--ink)}
+  .spark .dl{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted)}
+  .ziel{margin-top:var(--s4)}
+
+  .codes{width:100%;border-collapse:collapse;font-family:var(--font-text);font-size:var(--t-small);min-width:520px}
+  .codes th,.codes td{padding:10px 12px;border-bottom:1px solid var(--line-soft);text-align:left;vertical-align:top}
+  .codes thead th{color:var(--muted);font-weight:600;font-size:var(--t-micro)}
+  .codes td.num,.codes th.num{text-align:right;font-variant-numeric:tabular-nums lining-nums}
+  .codes .cd a{font-family:var(--font-mono,var(--font-text));color:var(--blue)}
+  .codes .zi{color:var(--muted);word-break:break-all}
+  .codes .act{text-align:right;white-space:nowrap}
+  .codes .mini{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);background:none;border:0;cursor:pointer;padding:4px 6px;min-height:var(--tap)}
+  .codes .mini:hover{color:var(--blue)}
+  .codes .mini.weg:hover{color:var(--bad)}
+  .tablewrap{overflow-x:auto;margin-top:var(--s4)}
+  .empty{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small)}
+  .zwischen{margin-top:var(--s8)}
+
+  @media (max-width:640px){
+    .grid{grid-template-columns:1fr}
+    .out{grid-template-columns:1fr}
+    .qrwrap{align-items:flex-start}
+    .spark{height:112px;gap:3px}
+    .spark .bv{display:none}
+  }
+</style>
+</head>
+<body>
+
+<script src="../../design-system/nav.js" data-root="../../" data-variant="werkzeug" data-active="qr-generator"></script>
+
+<main class="wrap">
+
+  <section class="hero">
+    <h1>QR-Code-Generator</h1>
+    <p class="lede">QR-Codes im Hausstil – für Links, WLAN-Zugänge, Kontakte, E-Mail und Text. Link-Codes laufen auf Wunsch als Kurzlink und zählen ihre Scans: anonym und ohne Fremddienst.</p>
+  </section>
+
+  <section>
+    <div class="shead">
+      <h2>Inhalt</h2>
+      <p>Was der Code beim Scannen auslösen soll. Nur Link-Codes können zählen – alles andere steht fest im Code selbst.</p>
+    </div>
+
+    <div class="card soft">
+      <div class="seg" id="typSeg" role="group" aria-label="Inhaltstyp">
+        <button type="button" data-typ="link" aria-pressed="true">Link</button>
+        <button type="button" data-typ="wlan" aria-pressed="false">WLAN</button>
+        <button type="button" data-typ="kontakt" aria-pressed="false">Kontakt</button>
+        <button type="button" data-typ="email" aria-pressed="false">E-Mail</button>
+        <button type="button" data-typ="text" aria-pressed="false">Text</button>
+      </div>
+
+      <div class="pane grid" id="pane-link">
+        <label class="field span2">
+          <span class="lab">Ziel-Adresse (URL)</span>
+          <input id="linkUrl" type="url" placeholder="https://goetheanum.ch/veranstaltungen" autocomplete="off" />
+        </label>
+        <label class="check span2">
+          <input type="checkbox" id="kurzToggle" checked />
+          <span>Kurzlink mit Scan-Statistik (empfohlen)</span>
+        </label>
+        <div class="field span2" id="kurzFeld">
+          <span class="lab">Kurzname · tools.goetheanum.ch/s/…</span>
+          <span class="kurzrow">
+            <input id="kurzCode" autocomplete="off" maxlength="32" />
+            <button class="btn ghost" type="button" id="kurzNeu">anderer Code</button>
+            <button class="btn" type="button" id="kurzAnlegen">Kurzlink anlegen</button>
+          </span>
+          <span class="hint">Erst <q>Kurzlink anlegen</q> verdrahtet den Code – dann zeigt der QR auf den Kurzlink und jeder Scan wird gezählt.</span>
+        </div>
+      </div>
+
+      <div class="pane grid" id="pane-wlan" hidden>
+        <label class="field">
+          <span class="lab">Netzname (SSID)</span>
+          <input id="wlanSsid" autocomplete="off" placeholder="Goetheanum-Gast" />
+        </label>
+        <label class="field">
+          <span class="lab">Passwort</span>
+          <input id="wlanPass" autocomplete="off" />
+        </label>
+        <label class="field">
+          <span class="lab">Verschlüsselung</span>
+          <select id="wlanTyp">
+            <option value="WPA" selected>WPA / WPA2 / WPA3</option>
+            <option value="WEP">WEP (alt)</option>
+            <option value="nopass">offen, ohne Passwort</option>
+          </select>
+        </label>
+        <label class="check">
+          <input type="checkbox" id="wlanHidden" />
+          <span>verstecktes Netz</span>
+        </label>
+      </div>
+
+      <div class="pane grid" id="pane-kontakt" hidden>
+        <label class="field">
+          <span class="lab">Vorname</span>
+          <input id="kVor" autocomplete="off" />
+        </label>
+        <label class="field">
+          <span class="lab">Nachname</span>
+          <input id="kNach" autocomplete="off" />
+        </label>
+        <label class="field">
+          <span class="lab">Organisation</span>
+          <input id="kOrg" autocomplete="off" placeholder="Goetheanum" />
+        </label>
+        <label class="field">
+          <span class="lab">Funktion</span>
+          <input id="kFunk" autocomplete="off" />
+        </label>
+        <label class="field">
+          <span class="lab">Telefon</span>
+          <input id="kTel" type="tel" autocomplete="off" placeholder="+41 61 706 42 42" />
+        </label>
+        <label class="field">
+          <span class="lab">E-Mail</span>
+          <input id="kMail" type="email" autocomplete="off" />
+        </label>
+        <label class="field">
+          <span class="lab">Website</span>
+          <input id="kWeb" type="url" autocomplete="off" placeholder="https://goetheanum.ch" />
+        </label>
+        <label class="field">
+          <span class="lab">Adresse</span>
+          <input id="kAdr" autocomplete="off" placeholder="Rüttiweg 45, 4143 Dornach" />
+        </label>
+      </div>
+
+      <div class="pane grid" id="pane-email" hidden>
+        <label class="field span2">
+          <span class="lab">An (E-Mail-Adresse)</span>
+          <input id="mAn" type="email" autocomplete="off" />
+        </label>
+        <label class="field span2">
+          <span class="lab">Betreff</span>
+          <input id="mBetreff" autocomplete="off" />
+        </label>
+        <label class="field span2">
+          <span class="lab">Nachricht (vorausgefüllt)</span>
+          <textarea id="mText" rows="3"></textarea>
+        </label>
+      </div>
+
+      <div class="pane grid" id="pane-text" hidden>
+        <label class="field span2">
+          <span class="lab">Text</span>
+          <textarea id="tText" rows="4" placeholder="Beliebiger Text – erscheint beim Scannen direkt auf dem Gerät."></textarea>
+        </label>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="shead">
+      <h2>Gestalt und Ausgabe</h2>
+      <p>Drei Stile, drei Farben – immer dunkel auf Weiss, damit jede Kamera den Code liest. SVG für Druck und Layout, PNG für Mail und Web.</p>
+    </div>
+
+    <div class="card soft">
+      <div class="out">
+        <div>
+          <div class="gopt">
+            <span class="lab">Modulstil</span>
+            <div class="seg" id="stilSeg" role="group" aria-label="Modulstil">
+              <button type="button" data-stil="punkte" aria-pressed="true">Punkte</button>
+              <button type="button" data-stil="weich" aria-pressed="false">Weich</button>
+              <button type="button" data-stil="kanten" aria-pressed="false">Kanten</button>
+            </div>
+          </div>
+          <div class="gopt">
+            <span class="lab">Farbe</span>
+            <div class="seg" id="farbSeg" role="group" aria-label="Farbe">
+              <button type="button" data-farbe="tinte" aria-pressed="true">Tinte</button>
+              <button type="button" data-farbe="blau" aria-pressed="false">Blau</button>
+              <button type="button" data-farbe="gold" aria-pressed="false">Gold</button>
+            </div>
+          </div>
+          <div class="gopt">
+            <span class="lab">Format</span>
+            <div class="seg" id="fmtSeg" role="group" aria-label="Dateiformat">
+              <button type="button" data-fmt="svg" aria-pressed="true">SVG</button>
+              <button type="button" data-fmt="png" aria-pressed="false">PNG</button>
+            </div>
+          </div>
+          <div class="gopt" id="sizeOpt" hidden>
+            <span class="lab">Grösse (Pixel)</span>
+            <div class="seg" id="sizeSeg" role="group" aria-label="PNG-Grösse">
+              <button type="button" data-size="512" aria-pressed="false">512</button>
+              <button type="button" data-size="1024" aria-pressed="true">1024</button>
+              <button type="button" data-size="2048" aria-pressed="false">2048</button>
+            </div>
+          </div>
+          <div class="actions">
+            <button class="btn primary" type="button" id="dlBtn">Herunterladen</button>
+            <button class="btn" type="button" id="copyBtn">Inhalt kopieren</button>
+          </div>
+          <div class="said" id="said"></div>
+          <div class="shortbox" id="shortbox" hidden>
+            <span class="sl">Kurzlink (leitet weiter und zählt):</span>
+            <a class="su" id="shortUrl" target="_blank" rel="noopener"></a>
+            <button class="btn ghost" type="button" id="shortCopy">Kopieren</button>
+          </div>
+        </div>
+        <div class="qrwrap">
+          <div class="qr" id="qr"><span class="empty">QR</span></div>
+          <div class="payloadbox" id="payloadBox"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="shead">
+      <h2>Statistik</h2>
+      <p>Jeder Kurzlink zählt seine Scans – anonym: gespeichert werden nur Zeitpunkt und Code, keine Personendaten, keine Cookies.</p>
+    </div>
+
+    <div class="card soft">
+      <div class="field" style="max-width:420px">
+        <span class="lab">Code prüfen</span>
+        <span class="kurzrow">
+          <input id="statCode" autocomplete="off" maxlength="32" placeholder="z. B. tagung-24" />
+          <button class="btn" type="button" id="statBtn">Anzeigen</button>
+        </span>
+      </div>
+      <div class="said" id="statSaid"></div>
+
+      <div id="statDetail" hidden>
+        <div class="kpis">
+          <div class="kpi"><div class="kl">Scans gesamt</div><div class="kv" id="kScans">–</div></div>
+          <div class="kpi"><div class="kl">letzter Scan</div><div class="kv" id="kLetzter">–</div></div>
+          <div class="kpi"><div class="kl">angelegt</div><div class="kv" id="kAngelegt">–</div></div>
+        </div>
+        <div class="spark" id="statSpark"></div>
+        <p class="note ziel" id="statZiel"></p>
+      </div>
+
+      <div class="shead zwischen">
+        <h3>Meine Codes</h3>
+        <p>In diesem Browser angelegte Kurzlinks. <q>Vergessen</q> löscht nur den Eintrag hier – der Kurzlink selbst läuft weiter.</p>
+      </div>
+      <div class="tablewrap">
+        <table class="codes">
+          <thead><tr><th>Code</th><th>Ziel</th><th class="num">Scans</th><th>letzter Scan</th><th></th></tr></thead>
+          <tbody id="codesBody"><tr><td class="empty" colspan="5">Noch keine Codes angelegt.</td></tr></tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<footer class="ds-footer">
+  <div class="wrap frow">
+    <span><strong>QR-Code-Generator</strong> · Kurzlinks über tools.goetheanum.ch/s/… · Zählung anonym</span>
+    <span><a href="../../start/">Werkzeuge</a> · <a href="../../design-system/">Design-System</a></span>
+  </div>
+</footer>
+
+<script src="./vendor/qrcode.js"></script>
+<script>
+  var SB  = 'https://dagcsnfrlbpxcmdimnrw.supabase.co';
+  var KEY = 'sb_publishable_SXhY0mrhXjdTnjbJ5Uobtg_zAXW_xGY';
+  var SHORTBASE = 'https://tools.goetheanum.ch/s/';
+  var STORE = 'qrgen.codes';
+
+  function el(id){ return document.getElementById(id); }
+
+  // --- Zustand ---------------------------------------------------------------
+  var typ = 'link', stil = 'punkte', farbe = 'tinte', fmt = 'svg', size = 1024;
+  var registriert = null;   // { code, url } nach erfolgreichem Anlegen
+
+  // QR-Farben sind Artefakt, nicht Theme: ein Code braucht festen dunklen
+  // Vordergrund auf weissem Grund, sonst liest ihn keine Kamera – theme-unabhängig.
+  var FARBEN = {
+    tinte: '#141414',   // nahschwarz, wie im Inserat  # ds-ok
+    blau:  '#0061a9',   // Hausblau, Kontrast 5.0:1 auf Weiss  # ds-ok
+    gold:  '#94702e'    // tiefes Gold, Kontrast 4.6:1 auf Weiss  # ds-ok
+  };
+  var QR_BG = '#ffffff';  // Ruhezone weiss, muss scannbar bleiben  # ds-ok
+
+  // --- Inhalt: Nutzlast je Typ -----------------------------------------------
+  function urlNormal(s){
+    s = (s || '').trim();
+    if(!s) return '';
+    if(!/^[a-z][a-z0-9+.-]*:/i.test(s)) s = 'https://' + s;
+    return s;
+  }
+  // Sonderzeichen in WIFI-/vCard-Feldern entschärfen (Syntaxzeichen der Formate).
+  function escWifi(s){ return (s || '').replace(/([\\;,:"])/g, '\\$1'); }
+  function escVcard(s){ return (s || '').replace(/\\/g, '\\\\').replace(/([;,])/g, '\\$1').replace(/\r?\n/g, '\\n'); }
+
+  function payload(){
+    if(typ === 'link'){
+      var u = urlNormal(el('linkUrl').value);
+      if(!u) return null;
+      if(el('kurzToggle').checked && registriert && registriert.url === u){
+        return { text: SHORTBASE + registriert.code, name: registriert.code };
+      }
+      var host = u.replace(/^https?:\/\//, '').split(/[/?#]/)[0].replace(/[^a-z0-9.-]+/gi, '') || 'link';
+      return { text: u, name: host };
+    }
+    if(typ === 'wlan'){
+      var ssid = el('wlanSsid').value.trim();
+      if(!ssid) return null;
+      var t = el('wlanTyp').value;
+      var teile = 'WIFI:T:' + t + ';S:' + escWifi(ssid) + ';';
+      if(t !== 'nopass') teile += 'P:' + escWifi(el('wlanPass').value) + ';';
+      if(el('wlanHidden').checked) teile += 'H:true;';
+      return { text: teile + ';', name: ssid.replace(/[^a-z0-9-]+/gi, '-').toLowerCase() || 'wlan' };
+    }
+    if(typ === 'kontakt'){
+      var vor = el('kVor').value.trim(), nach = el('kNach').value.trim();
+      if(!vor && !nach) return null;
+      var z = ['BEGIN:VCARD', 'VERSION:3.0',
+               'N:' + escVcard(nach) + ';' + escVcard(vor) + ';;;',
+               'FN:' + escVcard((vor + ' ' + nach).trim())];
+      if(el('kOrg').value.trim())  z.push('ORG:' + escVcard(el('kOrg').value.trim()));
+      if(el('kFunk').value.trim()) z.push('TITLE:' + escVcard(el('kFunk').value.trim()));
+      if(el('kTel').value.trim())  z.push('TEL;TYPE=CELL:' + escVcard(el('kTel').value.trim()));
+      if(el('kMail').value.trim()) z.push('EMAIL:' + escVcard(el('kMail').value.trim()));
+      if(el('kWeb').value.trim())  z.push('URL:' + escVcard(urlNormal(el('kWeb').value)));
+      if(el('kAdr').value.trim())  z.push('ADR;TYPE=WORK:;;' + escVcard(el('kAdr').value.trim()) + ';;;;');
+      z.push('END:VCARD');
+      return { text: z.join('\r\n'), name: ((vor + '-' + nach).replace(/[^a-z0-9-]+/gi, '-').replace(/^-|-$/g, '') || 'kontakt').toLowerCase() };
+    }
+    if(typ === 'email'){
+      var an = el('mAn').value.trim();
+      if(!an) return null;
+      var q = [];
+      if(el('mBetreff').value.trim()) q.push('subject=' + encodeURIComponent(el('mBetreff').value.trim()));
+      if(el('mText').value.trim())    q.push('body=' + encodeURIComponent(el('mText').value));
+      return { text: 'mailto:' + an + (q.length ? '?' + q.join('&') : ''), name: an.split('@')[0].replace(/[^a-z0-9-]+/gi, '-').toLowerCase() || 'mail' };
+    }
+    var tx = el('tText').value;
+    if(!tx.trim()) return null;
+    return { text: tx, name: 'text' };
+  }
+
+  // --- Gestalt: QR als SVG ------------------------------------------------------
+  // Fehlerkorrektur Q (robust für Druck). Punkte berühren sich (r=0.5) → scannbar;
+  // Weich lässt minimale Fugen (0.94er-Module), Kanten ist der klassische Vollblock.
+  function qrSvg(text, stilWahl, fg){
+    var q = qrcode(0, 'Q'); q.addData(text); q.make();
+    var n = q.getModuleCount(), pad = 4, S = n + pad * 2, p = [];
+    function inFinder(r, c){ return (r < 7 && c < 7) || (r < 7 && c >= n - 7) || (r >= n - 7 && c < 7); }
+    p.push('<rect width="' + S + '" height="' + S + '" fill="' + QR_BG + '"/>');
+    for(var r = 0; r < n; r++){
+      for(var c = 0; c < n; c++){
+        if(!q.isDark(r, c) || inFinder(r, c)) continue;
+        var x = c + pad, y = r + pad;
+        if(stilWahl === 'punkte'){
+          p.push('<circle cx="' + (x + 0.5) + '" cy="' + (y + 0.5) + '" r="0.5" fill="' + fg + '"/>');
+        } else if(stilWahl === 'weich'){
+          p.push('<rect x="' + (x + 0.03) + '" y="' + (y + 0.03) + '" width="0.94" height="0.94" rx="0.28" fill="' + fg + '"/>');
+        } else {
+          p.push('<rect x="' + x + '" y="' + y + '" width="1" height="1" fill="' + fg + '"/>');
+        }
+      }
+    }
+    // Die drei Finder-Augen (dunkel · hell · dunkel); gerundet ausser bei Kanten.
+    var rund = stilWahl === 'kanten' ? [0, 0, 0] : [2.3, 1.7, 1.0];
+    [[0, 0], [0, n - 7], [n - 7, 0]].forEach(function(e){
+      var y = e[0] + pad, x = e[1] + pad;
+      p.push('<rect x="' + x + '" y="' + y + '" width="7" height="7" rx="' + rund[0] + '" fill="' + fg + '"/>');
+      p.push('<rect x="' + (x + 1) + '" y="' + (y + 1) + '" width="5" height="5" rx="' + rund[1] + '" fill="' + QR_BG + '"/>');
+      p.push('<rect x="' + (x + 2) + '" y="' + (y + 2) + '" width="3" height="3" rx="' + rund[2] + '" fill="' + fg + '"/>');
+    });
+    return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' + S + ' ' + S + '" ' +
+           'preserveAspectRatio="xMidYMid meet" shape-rendering="geometricPrecision">' + p.join('') + '</svg>';
+  }
+
+  var current = null;
+  function render(){
+    current = payload();
+    var qr = el('qr'), box = el('payloadBox');
+    if(!current){
+      qr.innerHTML = '<span class="empty">QR</span>';
+      box.textContent = '';
+      return;
+    }
+    try {
+      qr.innerHTML = qrSvg(current.text, stil, FARBEN[farbe]);
+      box.textContent = current.text;
+    } catch(e){
+      qr.innerHTML = '<span class="empty">zu viel Inhalt</span>';
+      box.textContent = '';
+      say('Zu viel Inhalt für einen QR-Code – bitte kürzen.', true);
+    }
+  }
+
+  function say(msg, bad){ var s = el('said'); s.textContent = msg; s.style.color = bad ? 'var(--bad)' : 'var(--ok)'; }
+
+  // --- Segmente (Typ, Stil, Farbe, Format, Grösse) -----------------------------
+  function segWire(segId, attr, cb){
+    el(segId).addEventListener('click', function(ev){
+      var b = ev.target.closest('button'); if(!b) return;
+      el(segId).querySelectorAll('button').forEach(function(x){ x.setAttribute('aria-pressed', x === b ? 'true' : 'false'); });
+      cb(b.dataset[attr]);
+    });
+  }
+  segWire('typSeg', 'typ', function(v){
+    typ = v;
+    ['link','wlan','kontakt','email','text'].forEach(function(t){ el('pane-' + t).hidden = (t !== v); });
+    render();
+  });
+  segWire('stilSeg', 'stil', function(v){ stil = v; render(); });
+  segWire('farbSeg', 'farbe', function(v){ farbe = v; render(); });
+  segWire('fmtSeg', 'fmt', function(v){ fmt = v; el('sizeOpt').hidden = (v !== 'png'); });
+  segWire('sizeSeg', 'size', function(v){ size = Number(v); });
+
+  ['linkUrl','wlanSsid','wlanPass','wlanTyp','wlanHidden','kVor','kNach','kOrg','kFunk','kTel','kMail','kWeb','kAdr','mAn','mBetreff','mText','tText','kurzToggle'].forEach(function(id){
+    el(id).addEventListener('input', render);
+    el(id).addEventListener('change', render);
+  });
+
+  // --- Kurzlink (dynamischer QR): anlegen, merken, zeigen ----------------------
+  var CODEZEICHEN = 'abcdefghjkmnpqrstuvwxyz23456789';   // ohne verwechselbare Zeichen
+  function neuerCode(){
+    var c = '';
+    var rnd = new Uint32Array(6); crypto.getRandomValues(rnd);
+    for(var i = 0; i < 6; i++) c += CODEZEICHEN[rnd[i] % CODEZEICHEN.length];
+    return c;
+  }
+  function codeForm(s){
+    return (s || '').toLowerCase()
+      .replace(/ä/g,'ae').replace(/ö/g,'oe').replace(/ü/g,'ue').replace(/ß/g,'ss')
+      .replace(/[^a-z0-9-]+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'');
+  }
+
+  function meineCodes(){
+    try { return JSON.parse(localStorage.getItem(STORE) || '[]'); } catch(e){ return []; }
+  }
+  function merkeCode(code, url){
+    var liste = meineCodes().filter(function(x){ return x.code !== code; });
+    liste.unshift({ code: code, url: url, created: new Date().toISOString() });
+    try { localStorage.setItem(STORE, JSON.stringify(liste.slice(0, 60))); } catch(e){}
+  }
+  function vergissCode(code){
+    try { localStorage.setItem(STORE, JSON.stringify(meineCodes().filter(function(x){ return x.code !== code; }))); } catch(e){}
+    zeigeMeine();
+  }
+
+  function zeigeKurzlink(code){
+    var kurz = SHORTBASE + code;
+    el('shortbox').hidden = false;
+    el('shortUrl').textContent = kurz;
+    el('shortUrl').href = kurz;
+    el('shortCopy').onclick = function(){
+      navigator.clipboard.writeText(kurz).then(function(){ say('Kurzlink kopiert.'); }, function(){ say('Kopieren nicht möglich.', true); });
+    };
+  }
+
+  el('kurzToggle').addEventListener('change', function(){ el('kurzFeld').hidden = !this.checked; });
+  el('kurzNeu').addEventListener('click', function(){ el('kurzCode').value = neuerCode(); });
+  el('linkUrl').addEventListener('input', function(){
+    if(registriert && registriert.url !== urlNormal(this.value)){ registriert = null; el('shortbox').hidden = true; }
+  });
+
+  function rpc(name, body){
+    return fetch(SB + '/rest/v1/rpc/' + name, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'apikey': KEY, 'Authorization': 'Bearer ' + KEY },
+      body: JSON.stringify(body || {})
+    }).then(function(r){ if(!r.ok) throw new Error(r.status); return r.json(); });
+  }
+
+  el('kurzAnlegen').addEventListener('click', function(){
+    var u = urlNormal(el('linkUrl').value);
+    if(!u){ say('Erst eine Ziel-Adresse eingeben.', true); return; }
+    var code = codeForm(el('kurzCode').value) || neuerCode();
+    el('kurzCode').value = code;
+    rpc('qr_link_anlegen', { p_code: code, p_url: u })
+      .then(function(ergebnis){
+        if(ergebnis === 'ok'){
+          registriert = { code: code, url: u };
+          merkeCode(code, u);
+          say('Kurzlink angelegt – der QR zeigt jetzt auf ihn.');
+          zeigeKurzlink(code); zeigeMeine(); render();
+        }
+        else if(ergebnis === 'vergeben'){ say('Code „' + code + '“ ist schon vergeben – bitte einen anderen wählen.', true); }
+        else if(ergebnis === 'ungueltig'){ say('Code oder Adresse ungültig – Code: 3–32 Zeichen (a–z, 0–9, Bindestrich), Adresse mit https://.', true); }
+        else { say('Angaben unvollständig – Adresse und Code prüfen.', true); }
+      })
+      .catch(function(){ say('Kurzlink-Dienst nicht erreichbar.', true); });
+  });
+
+  // --- Ausgabe: SVG direkt, PNG über Canvas ------------------------------------
+  function dlBlob(blob, name){
+    var u = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = u; a.download = name;
+    document.body.appendChild(a); a.click();
+    setTimeout(function(){ document.body.removeChild(a); URL.revokeObjectURL(u); }, 100);
+  }
+
+  el('dlBtn').addEventListener('click', function(){
+    var svg = el('qr').querySelector('svg');
+    if(!svg || !current){ say('Erst Inhalt eingeben – dann erscheint der QR.', true); return; }
+    var base = 'qr_' + (current.name || 'code');
+    if(fmt === 'svg'){
+      dlBlob(new Blob([svg.outerHTML], { type: 'image/svg+xml' }), base + '.svg');
+      say('SVG geladen.');
+      if(window.goeStat) goeStat('download', base + '.svg');
+      return;
+    }
+    var img = new Image();
+    img.onload = function(){
+      var c = document.createElement('canvas'); c.width = size; c.height = size;
+      var ctx = c.getContext('2d');
+      ctx.fillStyle = QR_BG; ctx.fillRect(0, 0, size, size);
+      ctx.imageSmoothingEnabled = false;
+      ctx.drawImage(img, 0, 0, size, size);
+      c.toBlob(function(b){
+        if(!b){ say('PNG konnte nicht erzeugt werden.', true); return; }
+        dlBlob(b, base + '_' + size + '.png');
+        say('PNG (' + size + ' px) geladen.');
+        if(window.goeStat) goeStat('download', base + '_' + size + '.png');
+      }, 'image/png');
+    };
+    img.onerror = function(){ say('PNG konnte nicht erzeugt werden.', true); };
+    img.src = 'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(svg.outerHTML)));
+  });
+
+  el('copyBtn').addEventListener('click', function(){
+    if(!current){ say('Erst Inhalt eingeben.', true); return; }
+    navigator.clipboard.writeText(current.text).then(function(){ say('Inhalt kopiert.'); }, function(){ say('Kopieren nicht möglich.', true); });
+  });
+
+  // --- Statistik ----------------------------------------------------------------
+  function statSay(msg, bad){ var s = el('statSaid'); s.textContent = msg; s.style.color = bad ? 'var(--bad)' : 'var(--ok)'; }
+  function fmtZeit(iso){
+    if(!iso) return 'noch nie';
+    var d = new Date(iso);
+    return d.toLocaleDateString('de-CH', { day: 'numeric', month: 'numeric', year: 'numeric' }) +
+           ', ' + d.toLocaleTimeString('de-CH', { hour: '2-digit', minute: '2-digit' });
+  }
+
+  function renderSpark(tage){
+    var host = el('statSpark'); host.innerHTML = '';
+    var byDay = {};
+    (tage || []).forEach(function(r){ byDay[r.tag] = Number(r.n); });
+    // Die letzten 14 Tage als lückenloses Fenster (leere Tage = 0).
+    var fenster = [];
+    for(var i = 13; i >= 0; i--){
+      var d = new Date(); d.setDate(d.getDate() - i);
+      fenster.push(d.toISOString().slice(0, 10));
+    }
+    var max = fenster.reduce(function(m, t){ return Math.max(m, byDay[t] || 0); }, 0);
+    if(!max){ host.innerHTML = '<div class="empty">In den letzten 14 Tagen keine Scans.</div>'; return; }
+    fenster.forEach(function(t){
+      var v = byDay[t] || 0;
+      var date = new Date(t + 'T00:00:00');
+      var cell = document.createElement('div'); cell.className = 'd';
+      cell.innerHTML = '<div class="bv"></div><div class="barcell"><div class="bar"></div></div><div class="dl"></div>';
+      cell.querySelector('.bv').textContent = v ? v.toLocaleString('de-CH') : '';
+      cell.querySelector('.bar').style.height = Math.max(3, Math.round(v / max * 100)) + '%';
+      cell.querySelector('.dl').textContent = date.toLocaleDateString('de-CH', { day: 'numeric', month: 'numeric' });
+      host.appendChild(cell);
+    });
+  }
+
+  function zeigeStats(code){
+    code = codeForm(code);
+    if(!code){ statSay('Erst einen Code eingeben.', true); return; }
+    el('statCode').value = code;
+    statSay('lädt …');
+    Promise.all([ rpc('qr_stats_public', { p_code: code }), rpc('qr_stats_tage', { p_code: code }) ])
+      .then(function(res){
+        var zeile = (res[0] || [])[0];
+        if(!zeile){ el('statDetail').hidden = true; statSay('Code „' + code + '“ ist nicht angelegt.', true); return; }
+        statSay('');
+        el('statDetail').hidden = false;
+        el('kScans').textContent = Number(zeile.scans).toLocaleString('de-CH');
+        el('kLetzter').textContent = fmtZeit(zeile.letzter_scan);
+        el('kAngelegt').textContent = new Date(zeile.created_at).toLocaleDateString('de-CH');
+        el('statZiel').textContent = 'Ziel: ' + zeile.url;
+        renderSpark(res[1]);
+      })
+      .catch(function(){ statSay('Statistik nicht erreichbar.', true); });
+  }
+
+  el('statBtn').addEventListener('click', function(){ zeigeStats(el('statCode').value); });
+  el('statCode').addEventListener('keydown', function(ev){ if(ev.key === 'Enter') zeigeStats(this.value); });
+
+  function zeigeMeine(){
+    var body = el('codesBody'), liste = meineCodes();
+    body.innerHTML = '';
+    if(!liste.length){ body.innerHTML = '<tr><td class="empty" colspan="5">Noch keine Codes angelegt.</td></tr>'; return; }
+    liste.forEach(function(x){
+      var tr = document.createElement('tr');
+      tr.innerHTML = '<td class="cd"></td><td class="zi"></td><td class="num">–</td><td>–</td><td class="act"></td>';
+      var a = document.createElement('a');
+      a.href = SHORTBASE + x.code; a.target = '_blank'; a.rel = 'noopener'; a.textContent = x.code;
+      tr.children[0].appendChild(a);
+      tr.children[1].textContent = x.url;
+      var zeig = document.createElement('button');
+      zeig.type = 'button'; zeig.className = 'mini'; zeig.textContent = 'Verlauf';
+      zeig.addEventListener('click', function(){ zeigeStats(x.code); el('statDetail').scrollIntoView({ behavior: 'smooth', block: 'nearest' }); });
+      var weg = document.createElement('button');
+      weg.type = 'button'; weg.className = 'mini weg'; weg.textContent = 'Vergessen';
+      weg.setAttribute('aria-label', 'Code aus diesem Browser vergessen');
+      weg.addEventListener('click', function(){ vergissCode(x.code); });
+      tr.children[4].appendChild(zeig); tr.children[4].appendChild(weg);
+      body.appendChild(tr);
+      rpc('qr_stats_public', { p_code: x.code }).then(function(rows){
+        var z = (rows || [])[0]; if(!z) return;
+        tr.children[2].textContent = Number(z.scans).toLocaleString('de-CH');
+        tr.children[3].textContent = fmtZeit(z.letzter_scan);
+      }).catch(function(){});
+    });
+  }
+
+  // --- Start ---------------------------------------------------------------------
+  el('kurzCode').value = neuerCode();
+  render();
+  zeigeMeine();
+</script>
+
+</body>
+</html>

--- a/apps/qr-generator/vendor/qrcode.js
+++ b/apps/qr-generator/vendor/qrcode.js
@@ -1,0 +1,2297 @@
+//---------------------------------------------------------------------
+//
+// QR Code Generator for JavaScript
+//
+// Copyright (c) 2009 Kazuhiko Arase
+//
+// URL: http://www.d-project.com/
+//
+// Licensed under the MIT license:
+//  http://www.opensource.org/licenses/mit-license.php
+//
+// The word 'QR Code' is registered trademark of
+// DENSO WAVE INCORPORATED
+//  http://www.denso-wave.com/qrcode/faqpatent-e.html
+//
+//---------------------------------------------------------------------
+
+var qrcode = function() {
+
+  //---------------------------------------------------------------------
+  // qrcode
+  //---------------------------------------------------------------------
+
+  /**
+   * qrcode
+   * @param typeNumber 1 to 40
+   * @param errorCorrectionLevel 'L','M','Q','H'
+   */
+  var qrcode = function(typeNumber, errorCorrectionLevel) {
+
+    var PAD0 = 0xEC;
+    var PAD1 = 0x11;
+
+    var _typeNumber = typeNumber;
+    var _errorCorrectionLevel = QRErrorCorrectionLevel[errorCorrectionLevel];
+    var _modules = null;
+    var _moduleCount = 0;
+    var _dataCache = null;
+    var _dataList = [];
+
+    var _this = {};
+
+    var makeImpl = function(test, maskPattern) {
+
+      _moduleCount = _typeNumber * 4 + 17;
+      _modules = function(moduleCount) {
+        var modules = new Array(moduleCount);
+        for (var row = 0; row < moduleCount; row += 1) {
+          modules[row] = new Array(moduleCount);
+          for (var col = 0; col < moduleCount; col += 1) {
+            modules[row][col] = null;
+          }
+        }
+        return modules;
+      }(_moduleCount);
+
+      setupPositionProbePattern(0, 0);
+      setupPositionProbePattern(_moduleCount - 7, 0);
+      setupPositionProbePattern(0, _moduleCount - 7);
+      setupPositionAdjustPattern();
+      setupTimingPattern();
+      setupTypeInfo(test, maskPattern);
+
+      if (_typeNumber >= 7) {
+        setupTypeNumber(test);
+      }
+
+      if (_dataCache == null) {
+        _dataCache = createData(_typeNumber, _errorCorrectionLevel, _dataList);
+      }
+
+      mapData(_dataCache, maskPattern);
+    };
+
+    var setupPositionProbePattern = function(row, col) {
+
+      for (var r = -1; r <= 7; r += 1) {
+
+        if (row + r <= -1 || _moduleCount <= row + r) continue;
+
+        for (var c = -1; c <= 7; c += 1) {
+
+          if (col + c <= -1 || _moduleCount <= col + c) continue;
+
+          if ( (0 <= r && r <= 6 && (c == 0 || c == 6) )
+              || (0 <= c && c <= 6 && (r == 0 || r == 6) )
+              || (2 <= r && r <= 4 && 2 <= c && c <= 4) ) {
+            _modules[row + r][col + c] = true;
+          } else {
+            _modules[row + r][col + c] = false;
+          }
+        }
+      }
+    };
+
+    var getBestMaskPattern = function() {
+
+      var minLostPoint = 0;
+      var pattern = 0;
+
+      for (var i = 0; i < 8; i += 1) {
+
+        makeImpl(true, i);
+
+        var lostPoint = QRUtil.getLostPoint(_this);
+
+        if (i == 0 || minLostPoint > lostPoint) {
+          minLostPoint = lostPoint;
+          pattern = i;
+        }
+      }
+
+      return pattern;
+    };
+
+    var setupTimingPattern = function() {
+
+      for (var r = 8; r < _moduleCount - 8; r += 1) {
+        if (_modules[r][6] != null) {
+          continue;
+        }
+        _modules[r][6] = (r % 2 == 0);
+      }
+
+      for (var c = 8; c < _moduleCount - 8; c += 1) {
+        if (_modules[6][c] != null) {
+          continue;
+        }
+        _modules[6][c] = (c % 2 == 0);
+      }
+    };
+
+    var setupPositionAdjustPattern = function() {
+
+      var pos = QRUtil.getPatternPosition(_typeNumber);
+
+      for (var i = 0; i < pos.length; i += 1) {
+
+        for (var j = 0; j < pos.length; j += 1) {
+
+          var row = pos[i];
+          var col = pos[j];
+
+          if (_modules[row][col] != null) {
+            continue;
+          }
+
+          for (var r = -2; r <= 2; r += 1) {
+
+            for (var c = -2; c <= 2; c += 1) {
+
+              if (r == -2 || r == 2 || c == -2 || c == 2
+                  || (r == 0 && c == 0) ) {
+                _modules[row + r][col + c] = true;
+              } else {
+                _modules[row + r][col + c] = false;
+              }
+            }
+          }
+        }
+      }
+    };
+
+    var setupTypeNumber = function(test) {
+
+      var bits = QRUtil.getBCHTypeNumber(_typeNumber);
+
+      for (var i = 0; i < 18; i += 1) {
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+        _modules[Math.floor(i / 3)][i % 3 + _moduleCount - 8 - 3] = mod;
+      }
+
+      for (var i = 0; i < 18; i += 1) {
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+        _modules[i % 3 + _moduleCount - 8 - 3][Math.floor(i / 3)] = mod;
+      }
+    };
+
+    var setupTypeInfo = function(test, maskPattern) {
+
+      var data = (_errorCorrectionLevel << 3) | maskPattern;
+      var bits = QRUtil.getBCHTypeInfo(data);
+
+      // vertical
+      for (var i = 0; i < 15; i += 1) {
+
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+
+        if (i < 6) {
+          _modules[i][8] = mod;
+        } else if (i < 8) {
+          _modules[i + 1][8] = mod;
+        } else {
+          _modules[_moduleCount - 15 + i][8] = mod;
+        }
+      }
+
+      // horizontal
+      for (var i = 0; i < 15; i += 1) {
+
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+
+        if (i < 8) {
+          _modules[8][_moduleCount - i - 1] = mod;
+        } else if (i < 9) {
+          _modules[8][15 - i - 1 + 1] = mod;
+        } else {
+          _modules[8][15 - i - 1] = mod;
+        }
+      }
+
+      // fixed module
+      _modules[_moduleCount - 8][8] = (!test);
+    };
+
+    var mapData = function(data, maskPattern) {
+
+      var inc = -1;
+      var row = _moduleCount - 1;
+      var bitIndex = 7;
+      var byteIndex = 0;
+      var maskFunc = QRUtil.getMaskFunction(maskPattern);
+
+      for (var col = _moduleCount - 1; col > 0; col -= 2) {
+
+        if (col == 6) col -= 1;
+
+        while (true) {
+
+          for (var c = 0; c < 2; c += 1) {
+
+            if (_modules[row][col - c] == null) {
+
+              var dark = false;
+
+              if (byteIndex < data.length) {
+                dark = ( ( (data[byteIndex] >>> bitIndex) & 1) == 1);
+              }
+
+              var mask = maskFunc(row, col - c);
+
+              if (mask) {
+                dark = !dark;
+              }
+
+              _modules[row][col - c] = dark;
+              bitIndex -= 1;
+
+              if (bitIndex == -1) {
+                byteIndex += 1;
+                bitIndex = 7;
+              }
+            }
+          }
+
+          row += inc;
+
+          if (row < 0 || _moduleCount <= row) {
+            row -= inc;
+            inc = -inc;
+            break;
+          }
+        }
+      }
+    };
+
+    var createBytes = function(buffer, rsBlocks) {
+
+      var offset = 0;
+
+      var maxDcCount = 0;
+      var maxEcCount = 0;
+
+      var dcdata = new Array(rsBlocks.length);
+      var ecdata = new Array(rsBlocks.length);
+
+      for (var r = 0; r < rsBlocks.length; r += 1) {
+
+        var dcCount = rsBlocks[r].dataCount;
+        var ecCount = rsBlocks[r].totalCount - dcCount;
+
+        maxDcCount = Math.max(maxDcCount, dcCount);
+        maxEcCount = Math.max(maxEcCount, ecCount);
+
+        dcdata[r] = new Array(dcCount);
+
+        for (var i = 0; i < dcdata[r].length; i += 1) {
+          dcdata[r][i] = 0xff & buffer.getBuffer()[i + offset];
+        }
+        offset += dcCount;
+
+        var rsPoly = QRUtil.getErrorCorrectPolynomial(ecCount);
+        var rawPoly = qrPolynomial(dcdata[r], rsPoly.getLength() - 1);
+
+        var modPoly = rawPoly.mod(rsPoly);
+        ecdata[r] = new Array(rsPoly.getLength() - 1);
+        for (var i = 0; i < ecdata[r].length; i += 1) {
+          var modIndex = i + modPoly.getLength() - ecdata[r].length;
+          ecdata[r][i] = (modIndex >= 0)? modPoly.getAt(modIndex) : 0;
+        }
+      }
+
+      var totalCodeCount = 0;
+      for (var i = 0; i < rsBlocks.length; i += 1) {
+        totalCodeCount += rsBlocks[i].totalCount;
+      }
+
+      var data = new Array(totalCodeCount);
+      var index = 0;
+
+      for (var i = 0; i < maxDcCount; i += 1) {
+        for (var r = 0; r < rsBlocks.length; r += 1) {
+          if (i < dcdata[r].length) {
+            data[index] = dcdata[r][i];
+            index += 1;
+          }
+        }
+      }
+
+      for (var i = 0; i < maxEcCount; i += 1) {
+        for (var r = 0; r < rsBlocks.length; r += 1) {
+          if (i < ecdata[r].length) {
+            data[index] = ecdata[r][i];
+            index += 1;
+          }
+        }
+      }
+
+      return data;
+    };
+
+    var createData = function(typeNumber, errorCorrectionLevel, dataList) {
+
+      var rsBlocks = QRRSBlock.getRSBlocks(typeNumber, errorCorrectionLevel);
+
+      var buffer = qrBitBuffer();
+
+      for (var i = 0; i < dataList.length; i += 1) {
+        var data = dataList[i];
+        buffer.put(data.getMode(), 4);
+        buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+        data.write(buffer);
+      }
+
+      // calc num max data.
+      var totalDataCount = 0;
+      for (var i = 0; i < rsBlocks.length; i += 1) {
+        totalDataCount += rsBlocks[i].dataCount;
+      }
+
+      if (buffer.getLengthInBits() > totalDataCount * 8) {
+        throw 'code length overflow. ('
+          + buffer.getLengthInBits()
+          + '>'
+          + totalDataCount * 8
+          + ')';
+      }
+
+      // end code
+      if (buffer.getLengthInBits() + 4 <= totalDataCount * 8) {
+        buffer.put(0, 4);
+      }
+
+      // padding
+      while (buffer.getLengthInBits() % 8 != 0) {
+        buffer.putBit(false);
+      }
+
+      // padding
+      while (true) {
+
+        if (buffer.getLengthInBits() >= totalDataCount * 8) {
+          break;
+        }
+        buffer.put(PAD0, 8);
+
+        if (buffer.getLengthInBits() >= totalDataCount * 8) {
+          break;
+        }
+        buffer.put(PAD1, 8);
+      }
+
+      return createBytes(buffer, rsBlocks);
+    };
+
+    _this.addData = function(data, mode) {
+
+      mode = mode || 'Byte';
+
+      var newData = null;
+
+      switch(mode) {
+      case 'Numeric' :
+        newData = qrNumber(data);
+        break;
+      case 'Alphanumeric' :
+        newData = qrAlphaNum(data);
+        break;
+      case 'Byte' :
+        newData = qr8BitByte(data);
+        break;
+      case 'Kanji' :
+        newData = qrKanji(data);
+        break;
+      default :
+        throw 'mode:' + mode;
+      }
+
+      _dataList.push(newData);
+      _dataCache = null;
+    };
+
+    _this.isDark = function(row, col) {
+      if (row < 0 || _moduleCount <= row || col < 0 || _moduleCount <= col) {
+        throw row + ',' + col;
+      }
+      return _modules[row][col];
+    };
+
+    _this.getModuleCount = function() {
+      return _moduleCount;
+    };
+
+    _this.make = function() {
+      if (_typeNumber < 1) {
+        var typeNumber = 1;
+
+        for (; typeNumber < 40; typeNumber++) {
+          var rsBlocks = QRRSBlock.getRSBlocks(typeNumber, _errorCorrectionLevel);
+          var buffer = qrBitBuffer();
+
+          for (var i = 0; i < _dataList.length; i++) {
+            var data = _dataList[i];
+            buffer.put(data.getMode(), 4);
+            buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+            data.write(buffer);
+          }
+
+          var totalDataCount = 0;
+          for (var i = 0; i < rsBlocks.length; i++) {
+            totalDataCount += rsBlocks[i].dataCount;
+          }
+
+          if (buffer.getLengthInBits() <= totalDataCount * 8) {
+            break;
+          }
+        }
+
+        _typeNumber = typeNumber;
+      }
+
+      makeImpl(false, getBestMaskPattern() );
+    };
+
+    _this.createTableTag = function(cellSize, margin) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var qrHtml = '';
+
+      qrHtml += '<table style="';
+      qrHtml += ' border-width: 0px; border-style: none;';
+      qrHtml += ' border-collapse: collapse;';
+      qrHtml += ' padding: 0px; margin: ' + margin + 'px;';
+      qrHtml += '">';
+      qrHtml += '<tbody>';
+
+      for (var r = 0; r < _this.getModuleCount(); r += 1) {
+
+        qrHtml += '<tr>';
+
+        for (var c = 0; c < _this.getModuleCount(); c += 1) {
+          qrHtml += '<td style="';
+          qrHtml += ' border-width: 0px; border-style: none;';
+          qrHtml += ' border-collapse: collapse;';
+          qrHtml += ' padding: 0px; margin: 0px;';
+          qrHtml += ' width: ' + cellSize + 'px;';
+          qrHtml += ' height: ' + cellSize + 'px;';
+          qrHtml += ' background-color: ';
+          qrHtml += _this.isDark(r, c)? '#000000' : '#ffffff';
+          qrHtml += ';';
+          qrHtml += '"/>';
+        }
+
+        qrHtml += '</tr>';
+      }
+
+      qrHtml += '</tbody>';
+      qrHtml += '</table>';
+
+      return qrHtml;
+    };
+
+    _this.createSvgTag = function(cellSize, margin, alt, title) {
+
+      var opts = {};
+      if (typeof arguments[0] == 'object') {
+        // Called by options.
+        opts = arguments[0];
+        // overwrite cellSize and margin.
+        cellSize = opts.cellSize;
+        margin = opts.margin;
+        alt = opts.alt;
+        title = opts.title;
+      }
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      // Compose alt property surrogate
+      alt = (typeof alt === 'string') ? {text: alt} : alt || {};
+      alt.text = alt.text || null;
+      alt.id = (alt.text) ? alt.id || 'qrcode-description' : null;
+
+      // Compose title property surrogate
+      title = (typeof title === 'string') ? {text: title} : title || {};
+      title.text = title.text || null;
+      title.id = (title.text) ? title.id || 'qrcode-title' : null;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var c, mc, r, mr, qrSvg='', rect;
+
+      rect = 'l' + cellSize + ',0 0,' + cellSize +
+        ' -' + cellSize + ',0 0,-' + cellSize + 'z ';
+
+      qrSvg += '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"';
+      qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : '';
+      qrSvg += ' viewBox="0 0 ' + size + ' ' + size + '" ';
+      qrSvg += ' preserveAspectRatio="xMinYMin meet"';
+      qrSvg += (title.text || alt.text) ? ' role="img" aria-labelledby="' +
+          escapeXml([title.id, alt.id].join(' ').trim() ) + '"' : '';
+      qrSvg += '>';
+      qrSvg += (title.text) ? '<title id="' + escapeXml(title.id) + '">' +
+          escapeXml(title.text) + '</title>' : '';
+      qrSvg += (alt.text) ? '<description id="' + escapeXml(alt.id) + '">' +
+          escapeXml(alt.text) + '</description>' : '';
+      qrSvg += '<rect width="100%" height="100%" fill="white" cx="0" cy="0"/>';
+      qrSvg += '<path d="';
+
+      for (r = 0; r < _this.getModuleCount(); r += 1) {
+        mr = r * cellSize + margin;
+        for (c = 0; c < _this.getModuleCount(); c += 1) {
+          if (_this.isDark(r, c) ) {
+            mc = c*cellSize+margin;
+            qrSvg += 'M' + mc + ',' + mr + rect;
+          }
+        }
+      }
+
+      qrSvg += '" stroke="transparent" fill="black"/>';
+      qrSvg += '</svg>';
+
+      return qrSvg;
+    };
+
+    _this.createDataURL = function(cellSize, margin) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      return createDataURL(size, size, function(x, y) {
+        if (min <= x && x < max && min <= y && y < max) {
+          var c = Math.floor( (x - min) / cellSize);
+          var r = Math.floor( (y - min) / cellSize);
+          return _this.isDark(r, c)? 0 : 1;
+        } else {
+          return 1;
+        }
+      } );
+    };
+
+    _this.createImgTag = function(cellSize, margin, alt) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+
+      var img = '';
+      img += '<img';
+      img += '\u0020src="';
+      img += _this.createDataURL(cellSize, margin);
+      img += '"';
+      img += '\u0020width="';
+      img += size;
+      img += '"';
+      img += '\u0020height="';
+      img += size;
+      img += '"';
+      if (alt) {
+        img += '\u0020alt="';
+        img += escapeXml(alt);
+        img += '"';
+      }
+      img += '/>';
+
+      return img;
+    };
+
+    var escapeXml = function(s) {
+      var escaped = '';
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charAt(i);
+        switch(c) {
+        case '<': escaped += '&lt;'; break;
+        case '>': escaped += '&gt;'; break;
+        case '&': escaped += '&amp;'; break;
+        case '"': escaped += '&quot;'; break;
+        default : escaped += c; break;
+        }
+      }
+      return escaped;
+    };
+
+    var _createHalfASCII = function(margin) {
+      var cellSize = 1;
+      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      var y, x, r1, r2, p;
+
+      var blocks = {
+        '██': '█',
+        '█ ': '▀',
+        ' █': '▄',
+        '  ': ' '
+      };
+
+      var blocksLastLineNoMargin = {
+        '██': '▀',
+        '█ ': '▀',
+        ' █': ' ',
+        '  ': ' '
+      };
+
+      var ascii = '';
+      for (y = 0; y < size; y += 2) {
+        r1 = Math.floor((y - min) / cellSize);
+        r2 = Math.floor((y + 1 - min) / cellSize);
+        for (x = 0; x < size; x += 1) {
+          p = '█';
+
+          if (min <= x && x < max && min <= y && y < max && _this.isDark(r1, Math.floor((x - min) / cellSize))) {
+            p = ' ';
+          }
+
+          if (min <= x && x < max && min <= y+1 && y+1 < max && _this.isDark(r2, Math.floor((x - min) / cellSize))) {
+            p += ' ';
+          }
+          else {
+            p += '█';
+          }
+
+          // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+          ascii += (margin < 1 && y+1 >= max) ? blocksLastLineNoMargin[p] : blocks[p];
+        }
+
+        ascii += '\n';
+      }
+
+      if (size % 2 && margin > 0) {
+        return ascii.substring(0, ascii.length - size - 1) + Array(size+1).join('▀');
+      }
+
+      return ascii.substring(0, ascii.length-1);
+    };
+
+    _this.createASCII = function(cellSize, margin) {
+      cellSize = cellSize || 1;
+
+      if (cellSize < 2) {
+        return _createHalfASCII(margin);
+      }
+
+      cellSize -= 1;
+      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      var y, x, r, p;
+
+      var white = Array(cellSize+1).join('██');
+      var black = Array(cellSize+1).join('  ');
+
+      var ascii = '';
+      var line = '';
+      for (y = 0; y < size; y += 1) {
+        r = Math.floor( (y - min) / cellSize);
+        line = '';
+        for (x = 0; x < size; x += 1) {
+          p = 1;
+
+          if (min <= x && x < max && min <= y && y < max && _this.isDark(r, Math.floor((x - min) / cellSize))) {
+            p = 0;
+          }
+
+          // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+          line += p ? white : black;
+        }
+
+        for (r = 0; r < cellSize; r += 1) {
+          ascii += line + '\n';
+        }
+      }
+
+      return ascii.substring(0, ascii.length-1);
+    };
+
+    _this.renderTo2dContext = function(context, cellSize) {
+      cellSize = cellSize || 2;
+      var length = _this.getModuleCount();
+      for (var row = 0; row < length; row++) {
+        for (var col = 0; col < length; col++) {
+          context.fillStyle = _this.isDark(row, col) ? 'black' : 'white';
+          context.fillRect(row * cellSize, col * cellSize, cellSize, cellSize);
+        }
+      }
+    }
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrcode.stringToBytes
+  //---------------------------------------------------------------------
+
+  qrcode.stringToBytesFuncs = {
+    'default' : function(s) {
+      var bytes = [];
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charCodeAt(i);
+        bytes.push(c & 0xff);
+      }
+      return bytes;
+    }
+  };
+
+  qrcode.stringToBytes = qrcode.stringToBytesFuncs['default'];
+
+  //---------------------------------------------------------------------
+  // qrcode.createStringToBytes
+  //---------------------------------------------------------------------
+
+  /**
+   * @param unicodeData base64 string of byte array.
+   * [16bit Unicode],[16bit Bytes], ...
+   * @param numChars
+   */
+  qrcode.createStringToBytes = function(unicodeData, numChars) {
+
+    // create conversion map.
+
+    var unicodeMap = function() {
+
+      var bin = base64DecodeInputStream(unicodeData);
+      var read = function() {
+        var b = bin.read();
+        if (b == -1) throw 'eof';
+        return b;
+      };
+
+      var count = 0;
+      var unicodeMap = {};
+      while (true) {
+        var b0 = bin.read();
+        if (b0 == -1) break;
+        var b1 = read();
+        var b2 = read();
+        var b3 = read();
+        var k = String.fromCharCode( (b0 << 8) | b1);
+        var v = (b2 << 8) | b3;
+        unicodeMap[k] = v;
+        count += 1;
+      }
+      if (count != numChars) {
+        throw count + ' != ' + numChars;
+      }
+
+      return unicodeMap;
+    }();
+
+    var unknownChar = '?'.charCodeAt(0);
+
+    return function(s) {
+      var bytes = [];
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charCodeAt(i);
+        if (c < 128) {
+          bytes.push(c);
+        } else {
+          var b = unicodeMap[s.charAt(i)];
+          if (typeof b == 'number') {
+            if ( (b & 0xff) == b) {
+              // 1byte
+              bytes.push(b);
+            } else {
+              // 2bytes
+              bytes.push(b >>> 8);
+              bytes.push(b & 0xff);
+            }
+          } else {
+            bytes.push(unknownChar);
+          }
+        }
+      }
+      return bytes;
+    };
+  };
+
+  //---------------------------------------------------------------------
+  // QRMode
+  //---------------------------------------------------------------------
+
+  var QRMode = {
+    MODE_NUMBER :    1 << 0,
+    MODE_ALPHA_NUM : 1 << 1,
+    MODE_8BIT_BYTE : 1 << 2,
+    MODE_KANJI :     1 << 3
+  };
+
+  //---------------------------------------------------------------------
+  // QRErrorCorrectionLevel
+  //---------------------------------------------------------------------
+
+  var QRErrorCorrectionLevel = {
+    L : 1,
+    M : 0,
+    Q : 3,
+    H : 2
+  };
+
+  //---------------------------------------------------------------------
+  // QRMaskPattern
+  //---------------------------------------------------------------------
+
+  var QRMaskPattern = {
+    PATTERN000 : 0,
+    PATTERN001 : 1,
+    PATTERN010 : 2,
+    PATTERN011 : 3,
+    PATTERN100 : 4,
+    PATTERN101 : 5,
+    PATTERN110 : 6,
+    PATTERN111 : 7
+  };
+
+  //---------------------------------------------------------------------
+  // QRUtil
+  //---------------------------------------------------------------------
+
+  var QRUtil = function() {
+
+    var PATTERN_POSITION_TABLE = [
+      [],
+      [6, 18],
+      [6, 22],
+      [6, 26],
+      [6, 30],
+      [6, 34],
+      [6, 22, 38],
+      [6, 24, 42],
+      [6, 26, 46],
+      [6, 28, 50],
+      [6, 30, 54],
+      [6, 32, 58],
+      [6, 34, 62],
+      [6, 26, 46, 66],
+      [6, 26, 48, 70],
+      [6, 26, 50, 74],
+      [6, 30, 54, 78],
+      [6, 30, 56, 82],
+      [6, 30, 58, 86],
+      [6, 34, 62, 90],
+      [6, 28, 50, 72, 94],
+      [6, 26, 50, 74, 98],
+      [6, 30, 54, 78, 102],
+      [6, 28, 54, 80, 106],
+      [6, 32, 58, 84, 110],
+      [6, 30, 58, 86, 114],
+      [6, 34, 62, 90, 118],
+      [6, 26, 50, 74, 98, 122],
+      [6, 30, 54, 78, 102, 126],
+      [6, 26, 52, 78, 104, 130],
+      [6, 30, 56, 82, 108, 134],
+      [6, 34, 60, 86, 112, 138],
+      [6, 30, 58, 86, 114, 142],
+      [6, 34, 62, 90, 118, 146],
+      [6, 30, 54, 78, 102, 126, 150],
+      [6, 24, 50, 76, 102, 128, 154],
+      [6, 28, 54, 80, 106, 132, 158],
+      [6, 32, 58, 84, 110, 136, 162],
+      [6, 26, 54, 82, 110, 138, 166],
+      [6, 30, 58, 86, 114, 142, 170]
+    ];
+    var G15 = (1 << 10) | (1 << 8) | (1 << 5) | (1 << 4) | (1 << 2) | (1 << 1) | (1 << 0);
+    var G18 = (1 << 12) | (1 << 11) | (1 << 10) | (1 << 9) | (1 << 8) | (1 << 5) | (1 << 2) | (1 << 0);
+    var G15_MASK = (1 << 14) | (1 << 12) | (1 << 10) | (1 << 4) | (1 << 1);
+
+    var _this = {};
+
+    var getBCHDigit = function(data) {
+      var digit = 0;
+      while (data != 0) {
+        digit += 1;
+        data >>>= 1;
+      }
+      return digit;
+    };
+
+    _this.getBCHTypeInfo = function(data) {
+      var d = data << 10;
+      while (getBCHDigit(d) - getBCHDigit(G15) >= 0) {
+        d ^= (G15 << (getBCHDigit(d) - getBCHDigit(G15) ) );
+      }
+      return ( (data << 10) | d) ^ G15_MASK;
+    };
+
+    _this.getBCHTypeNumber = function(data) {
+      var d = data << 12;
+      while (getBCHDigit(d) - getBCHDigit(G18) >= 0) {
+        d ^= (G18 << (getBCHDigit(d) - getBCHDigit(G18) ) );
+      }
+      return (data << 12) | d;
+    };
+
+    _this.getPatternPosition = function(typeNumber) {
+      return PATTERN_POSITION_TABLE[typeNumber - 1];
+    };
+
+    _this.getMaskFunction = function(maskPattern) {
+
+      switch (maskPattern) {
+
+      case QRMaskPattern.PATTERN000 :
+        return function(i, j) { return (i + j) % 2 == 0; };
+      case QRMaskPattern.PATTERN001 :
+        return function(i, j) { return i % 2 == 0; };
+      case QRMaskPattern.PATTERN010 :
+        return function(i, j) { return j % 3 == 0; };
+      case QRMaskPattern.PATTERN011 :
+        return function(i, j) { return (i + j) % 3 == 0; };
+      case QRMaskPattern.PATTERN100 :
+        return function(i, j) { return (Math.floor(i / 2) + Math.floor(j / 3) ) % 2 == 0; };
+      case QRMaskPattern.PATTERN101 :
+        return function(i, j) { return (i * j) % 2 + (i * j) % 3 == 0; };
+      case QRMaskPattern.PATTERN110 :
+        return function(i, j) { return ( (i * j) % 2 + (i * j) % 3) % 2 == 0; };
+      case QRMaskPattern.PATTERN111 :
+        return function(i, j) { return ( (i * j) % 3 + (i + j) % 2) % 2 == 0; };
+
+      default :
+        throw 'bad maskPattern:' + maskPattern;
+      }
+    };
+
+    _this.getErrorCorrectPolynomial = function(errorCorrectLength) {
+      var a = qrPolynomial([1], 0);
+      for (var i = 0; i < errorCorrectLength; i += 1) {
+        a = a.multiply(qrPolynomial([1, QRMath.gexp(i)], 0) );
+      }
+      return a;
+    };
+
+    _this.getLengthInBits = function(mode, type) {
+
+      if (1 <= type && type < 10) {
+
+        // 1 - 9
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 10;
+        case QRMode.MODE_ALPHA_NUM : return 9;
+        case QRMode.MODE_8BIT_BYTE : return 8;
+        case QRMode.MODE_KANJI     : return 8;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else if (type < 27) {
+
+        // 10 - 26
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 12;
+        case QRMode.MODE_ALPHA_NUM : return 11;
+        case QRMode.MODE_8BIT_BYTE : return 16;
+        case QRMode.MODE_KANJI     : return 10;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else if (type < 41) {
+
+        // 27 - 40
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 14;
+        case QRMode.MODE_ALPHA_NUM : return 13;
+        case QRMode.MODE_8BIT_BYTE : return 16;
+        case QRMode.MODE_KANJI     : return 12;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else {
+        throw 'type:' + type;
+      }
+    };
+
+    _this.getLostPoint = function(qrcode) {
+
+      var moduleCount = qrcode.getModuleCount();
+
+      var lostPoint = 0;
+
+      // LEVEL1
+
+      for (var row = 0; row < moduleCount; row += 1) {
+        for (var col = 0; col < moduleCount; col += 1) {
+
+          var sameCount = 0;
+          var dark = qrcode.isDark(row, col);
+
+          for (var r = -1; r <= 1; r += 1) {
+
+            if (row + r < 0 || moduleCount <= row + r) {
+              continue;
+            }
+
+            for (var c = -1; c <= 1; c += 1) {
+
+              if (col + c < 0 || moduleCount <= col + c) {
+                continue;
+              }
+
+              if (r == 0 && c == 0) {
+                continue;
+              }
+
+              if (dark == qrcode.isDark(row + r, col + c) ) {
+                sameCount += 1;
+              }
+            }
+          }
+
+          if (sameCount > 5) {
+            lostPoint += (3 + sameCount - 5);
+          }
+        }
+      };
+
+      // LEVEL2
+
+      for (var row = 0; row < moduleCount - 1; row += 1) {
+        for (var col = 0; col < moduleCount - 1; col += 1) {
+          var count = 0;
+          if (qrcode.isDark(row, col) ) count += 1;
+          if (qrcode.isDark(row + 1, col) ) count += 1;
+          if (qrcode.isDark(row, col + 1) ) count += 1;
+          if (qrcode.isDark(row + 1, col + 1) ) count += 1;
+          if (count == 0 || count == 4) {
+            lostPoint += 3;
+          }
+        }
+      }
+
+      // LEVEL3
+
+      for (var row = 0; row < moduleCount; row += 1) {
+        for (var col = 0; col < moduleCount - 6; col += 1) {
+          if (qrcode.isDark(row, col)
+              && !qrcode.isDark(row, col + 1)
+              &&  qrcode.isDark(row, col + 2)
+              &&  qrcode.isDark(row, col + 3)
+              &&  qrcode.isDark(row, col + 4)
+              && !qrcode.isDark(row, col + 5)
+              &&  qrcode.isDark(row, col + 6) ) {
+            lostPoint += 40;
+          }
+        }
+      }
+
+      for (var col = 0; col < moduleCount; col += 1) {
+        for (var row = 0; row < moduleCount - 6; row += 1) {
+          if (qrcode.isDark(row, col)
+              && !qrcode.isDark(row + 1, col)
+              &&  qrcode.isDark(row + 2, col)
+              &&  qrcode.isDark(row + 3, col)
+              &&  qrcode.isDark(row + 4, col)
+              && !qrcode.isDark(row + 5, col)
+              &&  qrcode.isDark(row + 6, col) ) {
+            lostPoint += 40;
+          }
+        }
+      }
+
+      // LEVEL4
+
+      var darkCount = 0;
+
+      for (var col = 0; col < moduleCount; col += 1) {
+        for (var row = 0; row < moduleCount; row += 1) {
+          if (qrcode.isDark(row, col) ) {
+            darkCount += 1;
+          }
+        }
+      }
+
+      var ratio = Math.abs(100 * darkCount / moduleCount / moduleCount - 50) / 5;
+      lostPoint += ratio * 10;
+
+      return lostPoint;
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // QRMath
+  //---------------------------------------------------------------------
+
+  var QRMath = function() {
+
+    var EXP_TABLE = new Array(256);
+    var LOG_TABLE = new Array(256);
+
+    // initialize tables
+    for (var i = 0; i < 8; i += 1) {
+      EXP_TABLE[i] = 1 << i;
+    }
+    for (var i = 8; i < 256; i += 1) {
+      EXP_TABLE[i] = EXP_TABLE[i - 4]
+        ^ EXP_TABLE[i - 5]
+        ^ EXP_TABLE[i - 6]
+        ^ EXP_TABLE[i - 8];
+    }
+    for (var i = 0; i < 255; i += 1) {
+      LOG_TABLE[EXP_TABLE[i] ] = i;
+    }
+
+    var _this = {};
+
+    _this.glog = function(n) {
+
+      if (n < 1) {
+        throw 'glog(' + n + ')';
+      }
+
+      return LOG_TABLE[n];
+    };
+
+    _this.gexp = function(n) {
+
+      while (n < 0) {
+        n += 255;
+      }
+
+      while (n >= 256) {
+        n -= 255;
+      }
+
+      return EXP_TABLE[n];
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // qrPolynomial
+  //---------------------------------------------------------------------
+
+  function qrPolynomial(num, shift) {
+
+    if (typeof num.length == 'undefined') {
+      throw num.length + '/' + shift;
+    }
+
+    var _num = function() {
+      var offset = 0;
+      while (offset < num.length && num[offset] == 0) {
+        offset += 1;
+      }
+      var _num = new Array(num.length - offset + shift);
+      for (var i = 0; i < num.length - offset; i += 1) {
+        _num[i] = num[i + offset];
+      }
+      return _num;
+    }();
+
+    var _this = {};
+
+    _this.getAt = function(index) {
+      return _num[index];
+    };
+
+    _this.getLength = function() {
+      return _num.length;
+    };
+
+    _this.multiply = function(e) {
+
+      var num = new Array(_this.getLength() + e.getLength() - 1);
+
+      for (var i = 0; i < _this.getLength(); i += 1) {
+        for (var j = 0; j < e.getLength(); j += 1) {
+          num[i + j] ^= QRMath.gexp(QRMath.glog(_this.getAt(i) ) + QRMath.glog(e.getAt(j) ) );
+        }
+      }
+
+      return qrPolynomial(num, 0);
+    };
+
+    _this.mod = function(e) {
+
+      if (_this.getLength() - e.getLength() < 0) {
+        return _this;
+      }
+
+      var ratio = QRMath.glog(_this.getAt(0) ) - QRMath.glog(e.getAt(0) );
+
+      var num = new Array(_this.getLength() );
+      for (var i = 0; i < _this.getLength(); i += 1) {
+        num[i] = _this.getAt(i);
+      }
+
+      for (var i = 0; i < e.getLength(); i += 1) {
+        num[i] ^= QRMath.gexp(QRMath.glog(e.getAt(i) ) + ratio);
+      }
+
+      // recursive call
+      return qrPolynomial(num, 0).mod(e);
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // QRRSBlock
+  //---------------------------------------------------------------------
+
+  var QRRSBlock = function() {
+
+    var RS_BLOCK_TABLE = [
+
+      // L
+      // M
+      // Q
+      // H
+
+      // 1
+      [1, 26, 19],
+      [1, 26, 16],
+      [1, 26, 13],
+      [1, 26, 9],
+
+      // 2
+      [1, 44, 34],
+      [1, 44, 28],
+      [1, 44, 22],
+      [1, 44, 16],
+
+      // 3
+      [1, 70, 55],
+      [1, 70, 44],
+      [2, 35, 17],
+      [2, 35, 13],
+
+      // 4
+      [1, 100, 80],
+      [2, 50, 32],
+      [2, 50, 24],
+      [4, 25, 9],
+
+      // 5
+      [1, 134, 108],
+      [2, 67, 43],
+      [2, 33, 15, 2, 34, 16],
+      [2, 33, 11, 2, 34, 12],
+
+      // 6
+      [2, 86, 68],
+      [4, 43, 27],
+      [4, 43, 19],
+      [4, 43, 15],
+
+      // 7
+      [2, 98, 78],
+      [4, 49, 31],
+      [2, 32, 14, 4, 33, 15],
+      [4, 39, 13, 1, 40, 14],
+
+      // 8
+      [2, 121, 97],
+      [2, 60, 38, 2, 61, 39],
+      [4, 40, 18, 2, 41, 19],
+      [4, 40, 14, 2, 41, 15],
+
+      // 9
+      [2, 146, 116],
+      [3, 58, 36, 2, 59, 37],
+      [4, 36, 16, 4, 37, 17],
+      [4, 36, 12, 4, 37, 13],
+
+      // 10
+      [2, 86, 68, 2, 87, 69],
+      [4, 69, 43, 1, 70, 44],
+      [6, 43, 19, 2, 44, 20],
+      [6, 43, 15, 2, 44, 16],
+
+      // 11
+      [4, 101, 81],
+      [1, 80, 50, 4, 81, 51],
+      [4, 50, 22, 4, 51, 23],
+      [3, 36, 12, 8, 37, 13],
+
+      // 12
+      [2, 116, 92, 2, 117, 93],
+      [6, 58, 36, 2, 59, 37],
+      [4, 46, 20, 6, 47, 21],
+      [7, 42, 14, 4, 43, 15],
+
+      // 13
+      [4, 133, 107],
+      [8, 59, 37, 1, 60, 38],
+      [8, 44, 20, 4, 45, 21],
+      [12, 33, 11, 4, 34, 12],
+
+      // 14
+      [3, 145, 115, 1, 146, 116],
+      [4, 64, 40, 5, 65, 41],
+      [11, 36, 16, 5, 37, 17],
+      [11, 36, 12, 5, 37, 13],
+
+      // 15
+      [5, 109, 87, 1, 110, 88],
+      [5, 65, 41, 5, 66, 42],
+      [5, 54, 24, 7, 55, 25],
+      [11, 36, 12, 7, 37, 13],
+
+      // 16
+      [5, 122, 98, 1, 123, 99],
+      [7, 73, 45, 3, 74, 46],
+      [15, 43, 19, 2, 44, 20],
+      [3, 45, 15, 13, 46, 16],
+
+      // 17
+      [1, 135, 107, 5, 136, 108],
+      [10, 74, 46, 1, 75, 47],
+      [1, 50, 22, 15, 51, 23],
+      [2, 42, 14, 17, 43, 15],
+
+      // 18
+      [5, 150, 120, 1, 151, 121],
+      [9, 69, 43, 4, 70, 44],
+      [17, 50, 22, 1, 51, 23],
+      [2, 42, 14, 19, 43, 15],
+
+      // 19
+      [3, 141, 113, 4, 142, 114],
+      [3, 70, 44, 11, 71, 45],
+      [17, 47, 21, 4, 48, 22],
+      [9, 39, 13, 16, 40, 14],
+
+      // 20
+      [3, 135, 107, 5, 136, 108],
+      [3, 67, 41, 13, 68, 42],
+      [15, 54, 24, 5, 55, 25],
+      [15, 43, 15, 10, 44, 16],
+
+      // 21
+      [4, 144, 116, 4, 145, 117],
+      [17, 68, 42],
+      [17, 50, 22, 6, 51, 23],
+      [19, 46, 16, 6, 47, 17],
+
+      // 22
+      [2, 139, 111, 7, 140, 112],
+      [17, 74, 46],
+      [7, 54, 24, 16, 55, 25],
+      [34, 37, 13],
+
+      // 23
+      [4, 151, 121, 5, 152, 122],
+      [4, 75, 47, 14, 76, 48],
+      [11, 54, 24, 14, 55, 25],
+      [16, 45, 15, 14, 46, 16],
+
+      // 24
+      [6, 147, 117, 4, 148, 118],
+      [6, 73, 45, 14, 74, 46],
+      [11, 54, 24, 16, 55, 25],
+      [30, 46, 16, 2, 47, 17],
+
+      // 25
+      [8, 132, 106, 4, 133, 107],
+      [8, 75, 47, 13, 76, 48],
+      [7, 54, 24, 22, 55, 25],
+      [22, 45, 15, 13, 46, 16],
+
+      // 26
+      [10, 142, 114, 2, 143, 115],
+      [19, 74, 46, 4, 75, 47],
+      [28, 50, 22, 6, 51, 23],
+      [33, 46, 16, 4, 47, 17],
+
+      // 27
+      [8, 152, 122, 4, 153, 123],
+      [22, 73, 45, 3, 74, 46],
+      [8, 53, 23, 26, 54, 24],
+      [12, 45, 15, 28, 46, 16],
+
+      // 28
+      [3, 147, 117, 10, 148, 118],
+      [3, 73, 45, 23, 74, 46],
+      [4, 54, 24, 31, 55, 25],
+      [11, 45, 15, 31, 46, 16],
+
+      // 29
+      [7, 146, 116, 7, 147, 117],
+      [21, 73, 45, 7, 74, 46],
+      [1, 53, 23, 37, 54, 24],
+      [19, 45, 15, 26, 46, 16],
+
+      // 30
+      [5, 145, 115, 10, 146, 116],
+      [19, 75, 47, 10, 76, 48],
+      [15, 54, 24, 25, 55, 25],
+      [23, 45, 15, 25, 46, 16],
+
+      // 31
+      [13, 145, 115, 3, 146, 116],
+      [2, 74, 46, 29, 75, 47],
+      [42, 54, 24, 1, 55, 25],
+      [23, 45, 15, 28, 46, 16],
+
+      // 32
+      [17, 145, 115],
+      [10, 74, 46, 23, 75, 47],
+      [10, 54, 24, 35, 55, 25],
+      [19, 45, 15, 35, 46, 16],
+
+      // 33
+      [17, 145, 115, 1, 146, 116],
+      [14, 74, 46, 21, 75, 47],
+      [29, 54, 24, 19, 55, 25],
+      [11, 45, 15, 46, 46, 16],
+
+      // 34
+      [13, 145, 115, 6, 146, 116],
+      [14, 74, 46, 23, 75, 47],
+      [44, 54, 24, 7, 55, 25],
+      [59, 46, 16, 1, 47, 17],
+
+      // 35
+      [12, 151, 121, 7, 152, 122],
+      [12, 75, 47, 26, 76, 48],
+      [39, 54, 24, 14, 55, 25],
+      [22, 45, 15, 41, 46, 16],
+
+      // 36
+      [6, 151, 121, 14, 152, 122],
+      [6, 75, 47, 34, 76, 48],
+      [46, 54, 24, 10, 55, 25],
+      [2, 45, 15, 64, 46, 16],
+
+      // 37
+      [17, 152, 122, 4, 153, 123],
+      [29, 74, 46, 14, 75, 47],
+      [49, 54, 24, 10, 55, 25],
+      [24, 45, 15, 46, 46, 16],
+
+      // 38
+      [4, 152, 122, 18, 153, 123],
+      [13, 74, 46, 32, 75, 47],
+      [48, 54, 24, 14, 55, 25],
+      [42, 45, 15, 32, 46, 16],
+
+      // 39
+      [20, 147, 117, 4, 148, 118],
+      [40, 75, 47, 7, 76, 48],
+      [43, 54, 24, 22, 55, 25],
+      [10, 45, 15, 67, 46, 16],
+
+      // 40
+      [19, 148, 118, 6, 149, 119],
+      [18, 75, 47, 31, 76, 48],
+      [34, 54, 24, 34, 55, 25],
+      [20, 45, 15, 61, 46, 16]
+    ];
+
+    var qrRSBlock = function(totalCount, dataCount) {
+      var _this = {};
+      _this.totalCount = totalCount;
+      _this.dataCount = dataCount;
+      return _this;
+    };
+
+    var _this = {};
+
+    var getRsBlockTable = function(typeNumber, errorCorrectionLevel) {
+
+      switch(errorCorrectionLevel) {
+      case QRErrorCorrectionLevel.L :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 0];
+      case QRErrorCorrectionLevel.M :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 1];
+      case QRErrorCorrectionLevel.Q :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 2];
+      case QRErrorCorrectionLevel.H :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 3];
+      default :
+        return undefined;
+      }
+    };
+
+    _this.getRSBlocks = function(typeNumber, errorCorrectionLevel) {
+
+      var rsBlock = getRsBlockTable(typeNumber, errorCorrectionLevel);
+
+      if (typeof rsBlock == 'undefined') {
+        throw 'bad rs block @ typeNumber:' + typeNumber +
+            '/errorCorrectionLevel:' + errorCorrectionLevel;
+      }
+
+      var length = rsBlock.length / 3;
+
+      var list = [];
+
+      for (var i = 0; i < length; i += 1) {
+
+        var count = rsBlock[i * 3 + 0];
+        var totalCount = rsBlock[i * 3 + 1];
+        var dataCount = rsBlock[i * 3 + 2];
+
+        for (var j = 0; j < count; j += 1) {
+          list.push(qrRSBlock(totalCount, dataCount) );
+        }
+      }
+
+      return list;
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // qrBitBuffer
+  //---------------------------------------------------------------------
+
+  var qrBitBuffer = function() {
+
+    var _buffer = [];
+    var _length = 0;
+
+    var _this = {};
+
+    _this.getBuffer = function() {
+      return _buffer;
+    };
+
+    _this.getAt = function(index) {
+      var bufIndex = Math.floor(index / 8);
+      return ( (_buffer[bufIndex] >>> (7 - index % 8) ) & 1) == 1;
+    };
+
+    _this.put = function(num, length) {
+      for (var i = 0; i < length; i += 1) {
+        _this.putBit( ( (num >>> (length - i - 1) ) & 1) == 1);
+      }
+    };
+
+    _this.getLengthInBits = function() {
+      return _length;
+    };
+
+    _this.putBit = function(bit) {
+
+      var bufIndex = Math.floor(_length / 8);
+      if (_buffer.length <= bufIndex) {
+        _buffer.push(0);
+      }
+
+      if (bit) {
+        _buffer[bufIndex] |= (0x80 >>> (_length % 8) );
+      }
+
+      _length += 1;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrNumber
+  //---------------------------------------------------------------------
+
+  var qrNumber = function(data) {
+
+    var _mode = QRMode.MODE_NUMBER;
+    var _data = data;
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _data.length;
+    };
+
+    _this.write = function(buffer) {
+
+      var data = _data;
+
+      var i = 0;
+
+      while (i + 2 < data.length) {
+        buffer.put(strToNum(data.substring(i, i + 3) ), 10);
+        i += 3;
+      }
+
+      if (i < data.length) {
+        if (data.length - i == 1) {
+          buffer.put(strToNum(data.substring(i, i + 1) ), 4);
+        } else if (data.length - i == 2) {
+          buffer.put(strToNum(data.substring(i, i + 2) ), 7);
+        }
+      }
+    };
+
+    var strToNum = function(s) {
+      var num = 0;
+      for (var i = 0; i < s.length; i += 1) {
+        num = num * 10 + chatToNum(s.charAt(i) );
+      }
+      return num;
+    };
+
+    var chatToNum = function(c) {
+      if ('0' <= c && c <= '9') {
+        return c.charCodeAt(0) - '0'.charCodeAt(0);
+      }
+      throw 'illegal char :' + c;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrAlphaNum
+  //---------------------------------------------------------------------
+
+  var qrAlphaNum = function(data) {
+
+    var _mode = QRMode.MODE_ALPHA_NUM;
+    var _data = data;
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _data.length;
+    };
+
+    _this.write = function(buffer) {
+
+      var s = _data;
+
+      var i = 0;
+
+      while (i + 1 < s.length) {
+        buffer.put(
+          getCode(s.charAt(i) ) * 45 +
+          getCode(s.charAt(i + 1) ), 11);
+        i += 2;
+      }
+
+      if (i < s.length) {
+        buffer.put(getCode(s.charAt(i) ), 6);
+      }
+    };
+
+    var getCode = function(c) {
+
+      if ('0' <= c && c <= '9') {
+        return c.charCodeAt(0) - '0'.charCodeAt(0);
+      } else if ('A' <= c && c <= 'Z') {
+        return c.charCodeAt(0) - 'A'.charCodeAt(0) + 10;
+      } else {
+        switch (c) {
+        case ' ' : return 36;
+        case '$' : return 37;
+        case '%' : return 38;
+        case '*' : return 39;
+        case '+' : return 40;
+        case '-' : return 41;
+        case '.' : return 42;
+        case '/' : return 43;
+        case ':' : return 44;
+        default :
+          throw 'illegal char :' + c;
+        }
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qr8BitByte
+  //---------------------------------------------------------------------
+
+  var qr8BitByte = function(data) {
+
+    var _mode = QRMode.MODE_8BIT_BYTE;
+    var _data = data;
+    var _bytes = qrcode.stringToBytes(data);
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _bytes.length;
+    };
+
+    _this.write = function(buffer) {
+      for (var i = 0; i < _bytes.length; i += 1) {
+        buffer.put(_bytes[i], 8);
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrKanji
+  //---------------------------------------------------------------------
+
+  var qrKanji = function(data) {
+
+    var _mode = QRMode.MODE_KANJI;
+    var _data = data;
+
+    var stringToBytes = qrcode.stringToBytesFuncs['SJIS'];
+    if (!stringToBytes) {
+      throw 'sjis not supported.';
+    }
+    !function(c, code) {
+      // self test for sjis support.
+      var test = stringToBytes(c);
+      if (test.length != 2 || ( (test[0] << 8) | test[1]) != code) {
+        throw 'sjis not supported.';
+      }
+    }('\u53cb', 0x9746);
+
+    var _bytes = stringToBytes(data);
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return ~~(_bytes.length / 2);
+    };
+
+    _this.write = function(buffer) {
+
+      var data = _bytes;
+
+      var i = 0;
+
+      while (i + 1 < data.length) {
+
+        var c = ( (0xff & data[i]) << 8) | (0xff & data[i + 1]);
+
+        if (0x8140 <= c && c <= 0x9FFC) {
+          c -= 0x8140;
+        } else if (0xE040 <= c && c <= 0xEBBF) {
+          c -= 0xC140;
+        } else {
+          throw 'illegal char at ' + (i + 1) + '/' + c;
+        }
+
+        c = ( (c >>> 8) & 0xff) * 0xC0 + (c & 0xff);
+
+        buffer.put(c, 13);
+
+        i += 2;
+      }
+
+      if (i < data.length) {
+        throw 'illegal char at ' + (i + 1);
+      }
+    };
+
+    return _this;
+  };
+
+  //=====================================================================
+  // GIF Support etc.
+  //
+
+  //---------------------------------------------------------------------
+  // byteArrayOutputStream
+  //---------------------------------------------------------------------
+
+  var byteArrayOutputStream = function() {
+
+    var _bytes = [];
+
+    var _this = {};
+
+    _this.writeByte = function(b) {
+      _bytes.push(b & 0xff);
+    };
+
+    _this.writeShort = function(i) {
+      _this.writeByte(i);
+      _this.writeByte(i >>> 8);
+    };
+
+    _this.writeBytes = function(b, off, len) {
+      off = off || 0;
+      len = len || b.length;
+      for (var i = 0; i < len; i += 1) {
+        _this.writeByte(b[i + off]);
+      }
+    };
+
+    _this.writeString = function(s) {
+      for (var i = 0; i < s.length; i += 1) {
+        _this.writeByte(s.charCodeAt(i) );
+      }
+    };
+
+    _this.toByteArray = function() {
+      return _bytes;
+    };
+
+    _this.toString = function() {
+      var s = '';
+      s += '[';
+      for (var i = 0; i < _bytes.length; i += 1) {
+        if (i > 0) {
+          s += ',';
+        }
+        s += _bytes[i];
+      }
+      s += ']';
+      return s;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // base64EncodeOutputStream
+  //---------------------------------------------------------------------
+
+  var base64EncodeOutputStream = function() {
+
+    var _buffer = 0;
+    var _buflen = 0;
+    var _length = 0;
+    var _base64 = '';
+
+    var _this = {};
+
+    var writeEncoded = function(b) {
+      _base64 += String.fromCharCode(encode(b & 0x3f) );
+    };
+
+    var encode = function(n) {
+      if (n < 0) {
+        // error.
+      } else if (n < 26) {
+        return 0x41 + n;
+      } else if (n < 52) {
+        return 0x61 + (n - 26);
+      } else if (n < 62) {
+        return 0x30 + (n - 52);
+      } else if (n == 62) {
+        return 0x2b;
+      } else if (n == 63) {
+        return 0x2f;
+      }
+      throw 'n:' + n;
+    };
+
+    _this.writeByte = function(n) {
+
+      _buffer = (_buffer << 8) | (n & 0xff);
+      _buflen += 8;
+      _length += 1;
+
+      while (_buflen >= 6) {
+        writeEncoded(_buffer >>> (_buflen - 6) );
+        _buflen -= 6;
+      }
+    };
+
+    _this.flush = function() {
+
+      if (_buflen > 0) {
+        writeEncoded(_buffer << (6 - _buflen) );
+        _buffer = 0;
+        _buflen = 0;
+      }
+
+      if (_length % 3 != 0) {
+        // padding
+        var padlen = 3 - _length % 3;
+        for (var i = 0; i < padlen; i += 1) {
+          _base64 += '=';
+        }
+      }
+    };
+
+    _this.toString = function() {
+      return _base64;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // base64DecodeInputStream
+  //---------------------------------------------------------------------
+
+  var base64DecodeInputStream = function(str) {
+
+    var _str = str;
+    var _pos = 0;
+    var _buffer = 0;
+    var _buflen = 0;
+
+    var _this = {};
+
+    _this.read = function() {
+
+      while (_buflen < 8) {
+
+        if (_pos >= _str.length) {
+          if (_buflen == 0) {
+            return -1;
+          }
+          throw 'unexpected end of file./' + _buflen;
+        }
+
+        var c = _str.charAt(_pos);
+        _pos += 1;
+
+        if (c == '=') {
+          _buflen = 0;
+          return -1;
+        } else if (c.match(/^\s$/) ) {
+          // ignore if whitespace.
+          continue;
+        }
+
+        _buffer = (_buffer << 6) | decode(c.charCodeAt(0) );
+        _buflen += 6;
+      }
+
+      var n = (_buffer >>> (_buflen - 8) ) & 0xff;
+      _buflen -= 8;
+      return n;
+    };
+
+    var decode = function(c) {
+      if (0x41 <= c && c <= 0x5a) {
+        return c - 0x41;
+      } else if (0x61 <= c && c <= 0x7a) {
+        return c - 0x61 + 26;
+      } else if (0x30 <= c && c <= 0x39) {
+        return c - 0x30 + 52;
+      } else if (c == 0x2b) {
+        return 62;
+      } else if (c == 0x2f) {
+        return 63;
+      } else {
+        throw 'c:' + c;
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // gifImage (B/W)
+  //---------------------------------------------------------------------
+
+  var gifImage = function(width, height) {
+
+    var _width = width;
+    var _height = height;
+    var _data = new Array(width * height);
+
+    var _this = {};
+
+    _this.setPixel = function(x, y, pixel) {
+      _data[y * _width + x] = pixel;
+    };
+
+    _this.write = function(out) {
+
+      //---------------------------------
+      // GIF Signature
+
+      out.writeString('GIF87a');
+
+      //---------------------------------
+      // Screen Descriptor
+
+      out.writeShort(_width);
+      out.writeShort(_height);
+
+      out.writeByte(0x80); // 2bit
+      out.writeByte(0);
+      out.writeByte(0);
+
+      //---------------------------------
+      // Global Color Map
+
+      // black
+      out.writeByte(0x00);
+      out.writeByte(0x00);
+      out.writeByte(0x00);
+
+      // white
+      out.writeByte(0xff);
+      out.writeByte(0xff);
+      out.writeByte(0xff);
+
+      //---------------------------------
+      // Image Descriptor
+
+      out.writeString(',');
+      out.writeShort(0);
+      out.writeShort(0);
+      out.writeShort(_width);
+      out.writeShort(_height);
+      out.writeByte(0);
+
+      //---------------------------------
+      // Local Color Map
+
+      //---------------------------------
+      // Raster Data
+
+      var lzwMinCodeSize = 2;
+      var raster = getLZWRaster(lzwMinCodeSize);
+
+      out.writeByte(lzwMinCodeSize);
+
+      var offset = 0;
+
+      while (raster.length - offset > 255) {
+        out.writeByte(255);
+        out.writeBytes(raster, offset, 255);
+        offset += 255;
+      }
+
+      out.writeByte(raster.length - offset);
+      out.writeBytes(raster, offset, raster.length - offset);
+      out.writeByte(0x00);
+
+      //---------------------------------
+      // GIF Terminator
+      out.writeString(';');
+    };
+
+    var bitOutputStream = function(out) {
+
+      var _out = out;
+      var _bitLength = 0;
+      var _bitBuffer = 0;
+
+      var _this = {};
+
+      _this.write = function(data, length) {
+
+        if ( (data >>> length) != 0) {
+          throw 'length over';
+        }
+
+        while (_bitLength + length >= 8) {
+          _out.writeByte(0xff & ( (data << _bitLength) | _bitBuffer) );
+          length -= (8 - _bitLength);
+          data >>>= (8 - _bitLength);
+          _bitBuffer = 0;
+          _bitLength = 0;
+        }
+
+        _bitBuffer = (data << _bitLength) | _bitBuffer;
+        _bitLength = _bitLength + length;
+      };
+
+      _this.flush = function() {
+        if (_bitLength > 0) {
+          _out.writeByte(_bitBuffer);
+        }
+      };
+
+      return _this;
+    };
+
+    var getLZWRaster = function(lzwMinCodeSize) {
+
+      var clearCode = 1 << lzwMinCodeSize;
+      var endCode = (1 << lzwMinCodeSize) + 1;
+      var bitLength = lzwMinCodeSize + 1;
+
+      // Setup LZWTable
+      var table = lzwTable();
+
+      for (var i = 0; i < clearCode; i += 1) {
+        table.add(String.fromCharCode(i) );
+      }
+      table.add(String.fromCharCode(clearCode) );
+      table.add(String.fromCharCode(endCode) );
+
+      var byteOut = byteArrayOutputStream();
+      var bitOut = bitOutputStream(byteOut);
+
+      // clear code
+      bitOut.write(clearCode, bitLength);
+
+      var dataIndex = 0;
+
+      var s = String.fromCharCode(_data[dataIndex]);
+      dataIndex += 1;
+
+      while (dataIndex < _data.length) {
+
+        var c = String.fromCharCode(_data[dataIndex]);
+        dataIndex += 1;
+
+        if (table.contains(s + c) ) {
+
+          s = s + c;
+
+        } else {
+
+          bitOut.write(table.indexOf(s), bitLength);
+
+          if (table.size() < 0xfff) {
+
+            if (table.size() == (1 << bitLength) ) {
+              bitLength += 1;
+            }
+
+            table.add(s + c);
+          }
+
+          s = c;
+        }
+      }
+
+      bitOut.write(table.indexOf(s), bitLength);
+
+      // end code
+      bitOut.write(endCode, bitLength);
+
+      bitOut.flush();
+
+      return byteOut.toByteArray();
+    };
+
+    var lzwTable = function() {
+
+      var _map = {};
+      var _size = 0;
+
+      var _this = {};
+
+      _this.add = function(key) {
+        if (_this.contains(key) ) {
+          throw 'dup key:' + key;
+        }
+        _map[key] = _size;
+        _size += 1;
+      };
+
+      _this.size = function() {
+        return _size;
+      };
+
+      _this.indexOf = function(key) {
+        return _map[key];
+      };
+
+      _this.contains = function(key) {
+        return typeof _map[key] != 'undefined';
+      };
+
+      return _this;
+    };
+
+    return _this;
+  };
+
+  var createDataURL = function(width, height, getPixel) {
+    var gif = gifImage(width, height);
+    for (var y = 0; y < height; y += 1) {
+      for (var x = 0; x < width; x += 1) {
+        gif.setPixel(x, y, getPixel(x, y) );
+      }
+    }
+
+    var b = byteArrayOutputStream();
+    gif.write(b);
+
+    var base64 = base64EncodeOutputStream();
+    var bytes = b.toByteArray();
+    for (var i = 0; i < bytes.length; i += 1) {
+      base64.writeByte(bytes[i]);
+    }
+    base64.flush();
+
+    return 'data:image/gif;base64,' + base64;
+  };
+
+  //---------------------------------------------------------------------
+  // returns qrcode function.
+
+  return qrcode;
+}();
+
+// multibyte support
+!function() {
+
+  qrcode.stringToBytesFuncs['UTF-8'] = function(s) {
+    // http://stackoverflow.com/questions/18729405/how-to-convert-utf8-string-to-byte-array
+    function toUTF8Array(str) {
+      var utf8 = [];
+      for (var i=0; i < str.length; i++) {
+        var charcode = str.charCodeAt(i);
+        if (charcode < 0x80) utf8.push(charcode);
+        else if (charcode < 0x800) {
+          utf8.push(0xc0 | (charcode >> 6),
+              0x80 | (charcode & 0x3f));
+        }
+        else if (charcode < 0xd800 || charcode >= 0xe000) {
+          utf8.push(0xe0 | (charcode >> 12),
+              0x80 | ((charcode>>6) & 0x3f),
+              0x80 | (charcode & 0x3f));
+        }
+        // surrogate pair
+        else {
+          i++;
+          // UTF-16 encodes 0x10000-0x10FFFF by
+          // subtracting 0x10000 and splitting the
+          // 20 bits of 0x0-0xFFFFF into two halves
+          charcode = 0x10000 + (((charcode & 0x3ff)<<10)
+            | (str.charCodeAt(i) & 0x3ff));
+          utf8.push(0xf0 | (charcode >>18),
+              0x80 | ((charcode>>12) & 0x3f),
+              0x80 | ((charcode>>6) & 0x3f),
+              0x80 | (charcode & 0x3f));
+        }
+      }
+      return utf8;
+    }
+    return toUTF8Array(s);
+  };
+
+}();
+
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+      define([], factory);
+  } else if (typeof exports === 'object') {
+      module.exports = factory();
+  }
+}(function () {
+    return qrcode;
+}));

--- a/services/qr-generator/README.md
+++ b/services/qr-generator/README.md
@@ -1,0 +1,52 @@
+# QR-Generator · Backend
+
+Backend des Werkzeugs `apps/qr-generator/`: Kurzlinks mit anonymer
+Scan-Zählung. Läuft im bestehenden Werkzeug-Backend (Supabase
+`dagcsnfrlbpxcmdimnrw`), deployt am 10. Juli 2026 – dieser Ordner ist die
+**Referenzkopie**, nicht das Deployment.
+
+## Wie es zusammenhängt
+
+1. Das Werkzeug legt per RPC `qr_link_anlegen` einen Code an
+   (Tabelle `qr_links`: Code → Ziel-URL).
+2. Der QR-Code zeigt auf `https://tools.goetheanum.ch/s/<code>` – dieselbe
+   Kurzlink-Brücke wie die Sommer-Kampagne (separates Repo `phtok/goelinks`,
+   Referenz in `../sommer-zaehler/kurzlink-site/`; dort ist **nichts** zu
+   ändern, die 404-Brücke leitet jeden Code blind weiter).
+3. Die Edge Function `go` (`../sommer-zaehler/go/index.ts`) löst den Code über
+   die RPC `kurzlink_aufloesen` auf: sie liest **beide** Register –
+   `sommer2026_links` (Kampagne) und `qr_links` (QR-Generator) – und zählt den
+   Aufruf in `link_hits`. Ein Rundgang, der Redirect bleibt gleich schnell.
+4. Das Werkzeug liest die Zahlen über die Aggregat-RPCs `qr_stats_public`
+   (Summe, letzter Scan, Ziel) und `qr_stats_tage` (Scans je Tag, 30 Tage).
+
+Weil beide Register denselben Namensraum `/s/` teilen, prüft
+`qr_link_anlegen` die Eindeutigkeit über **beide** Tabellen.
+
+## Datenschutz
+
+Wie überall im Werkzeug-Backend (Muster `statistik.html`): Rohtabellen sind
+versiegelt (RLS an, keine anon-Policy, Rechte entzogen), nur die RPCs sind
+offen. Je Scan werden **nur Zeitpunkt und Code** gespeichert – keine IP, kein
+User-Agent, keine Cookies, keine Personendaten. `qr_stats_public` liefert nur,
+was zum Code gehört; wer den Code nicht kennt, sieht nichts.
+
+## RPCs
+
+| RPC | Wer | Zweck |
+| --- | --- | --- |
+| `qr_link_anlegen(p_code, p_url, p_ersteller)` | anon | Code anlegen: `ok` · `vergeben` · `ungueltig` · `unvollstaendig` |
+| `qr_stats_public(p_code)` | anon | Summe, letzter Scan, Ziel-URL (beide Register) |
+| `qr_stats_tage(p_code)` | anon | Scans je Tag, letzte 30 Tage |
+| `kurzlink_aufloesen(p_code)` | nur service_role | Auflösen + Zählen für die Function `go` |
+
+## Bewusste Entscheide (v1)
+
+- **Keine Lösch-RPC:** ein offener Löschweg würde gedruckte Codes gefährden.
+  Falls nötig, später als geschützter Weg (Muster Passwort-Hash wie bei den
+  Multiplikatoren).
+- **Fallback unbekannter Codes:** bleibt vorerst die Sommer-Landingpage (in
+  `go/index.ts`); nach der Kampagne auf eine neutrale Seite stellen.
+- **Geparkt für v2:** Logo in der QR-Mitte (erzwingt Fehlerkorrektur H und
+  echte Gerätetests) sowie der Umzug des generalisierten QR-Renderers nach
+  `design-system/qr.js`, sobald er sich bewährt.

--- a/services/qr-generator/schema.sql
+++ b/services/qr-generator/schema.sql
@@ -1,0 +1,106 @@
+-- =============================================================================
+-- QR-Generator · Backend-Schema
+-- Projekt: Supabase «Public Secrets App» (dagcsnfrlbpxcmdimnrw) – dasselbe
+-- Werkzeug-Backend wie sommer2026_* / goeloggen_stats. Angewendet als
+-- Migrationen «qr_links_und_scans» und «qr_stats_beide_register».
+--
+-- Prinzip wie statistik.html: Rohtabellen bleiben für anon geschlossen (RLS an,
+-- keine Policy, Rechte entzogen). Nur die RPCs sind für anon offen – es
+-- verlassen ausschliesslich Summen die Datenbank. Keine Personendaten: je Scan
+-- werden nur Zeitpunkt und Code gespeichert (keine IP, kein User-Agent).
+--
+-- Gemeinsamer Namensraum mit sommer2026_links unter tools.goetheanum.ch/s/ —
+-- Eindeutigkeit prüft qr_link_anlegen über BEIDE Register. Die Weiterleitung
+-- (Edge Function go, services/sommer-zaehler/go/index.ts) löst über
+-- kurzlink_aufloesen beide Register auf und zählt dabei in link_hits.
+--
+-- Bewusst KEINE Lösch-RPC in v1: ein offener Löschweg würde gedruckte Codes
+-- gefährden. Geparkt für v2: Logo in der QR-Mitte (erzwingt Fehlerkorrektur H
+-- + Gerätetests).
+-- =============================================================================
+
+create table if not exists public.qr_links (
+  id         bigint generated always as identity primary key,
+  created_at timestamptz not null default now(),
+  code       text not null,          -- Kurzname unter tools.goetheanum.ch/s/<code>
+  url        text not null,          -- Ziel der Weiterleitung
+  ersteller  text                    -- optionales Kürzel
+);
+create unique index if not exists qr_links_code_uk on public.qr_links (code);
+alter table public.qr_links enable row level security;
+revoke all on table public.qr_links from anon, authenticated;
+
+comment on table public.qr_links is
+  'QR-Generator: eine Zeile je angelegtem Kurzlink. Rohzeilen zu, Lesen nur über qr_stats_public (wer den Code kennt).';
+
+create table if not exists public.link_hits (
+  id   bigint generated always as identity primary key,
+  ts   timestamptz not null default now(),
+  code text not null                 -- zählt QR- UND Kampagnen-Kurzlinks
+);
+create index if not exists link_hits_code_ts_idx on public.link_hits (code, ts);
+alter table public.link_hits enable row level security;
+revoke all on table public.link_hits from anon, authenticated;
+
+comment on table public.link_hits is
+  'Scan-/Klick-Zählung der Kurzlinks (Function go): nur Zeitpunkt + Code, keine Personendaten.';
+
+-- Anlegen: 'ok' | 'vergeben' | 'ungueltig' | 'unvollstaendig'.
+-- Kollisionsprüfung über BEIDE Register (gemeinsamer Namensraum /s/).
+create or replace function public.qr_link_anlegen(p_code text, p_url text, p_ersteller text default null)
+returns text language plpgsql security definer set search_path to 'public' as $$
+declare v_code text := lower(trim(coalesce(p_code,'')));
+begin
+  if coalesce(trim(p_url),'') = '' or v_code = '' then return 'unvollstaendig'; end if;
+  if v_code !~ '^[a-z0-9][a-z0-9-]{2,31}$' or trim(p_url) !~ '^https?://' then return 'ungueltig'; end if;
+  if exists (select 1 from public.sommer2026_links where code = v_code)
+     or exists (select 1 from public.qr_links where code = v_code) then return 'vergeben'; end if;
+  insert into public.qr_links (code, url, ersteller)
+  values (v_code, trim(p_url), nullif(trim(coalesce(p_ersteller,'')),''));
+  return 'ok';
+exception when unique_violation then return 'vergeben';
+end; $$;
+grant execute on function public.qr_link_anlegen(text, text, text) to anon, authenticated;
+
+-- Statistik je Code: Summe, letzter Scan, Ziel-URL (nur wer den Code kennt).
+-- Liest BEIDE Register (Migration «qr_stats_beide_register»): auch
+-- Kampagnen-Kurzlinks haben eine Zählung in link_hits; kein neues Datenleck,
+-- die Kampagnen-URLs sind über sommer2026_links_public ohnehin öffentlich.
+create or replace function public.qr_stats_public(p_code text)
+returns table(code text, url text, created_at timestamptz, scans bigint, letzter_scan timestamptz)
+language sql security definer set search_path to 'public' as $$
+  with reg as (
+    select l.code, l.url, l.created_at from public.qr_links l where l.code = lower(trim(p_code))
+    union all
+    select s.code, s.url, s.created_at from public.sommer2026_links s where s.code = lower(trim(p_code))
+  )
+  select r.code, r.url, r.created_at,
+         count(h.id)::bigint as scans, max(h.ts) as letzter_scan
+    from reg r left join public.link_hits h on h.code = r.code
+   group by r.code, r.url, r.created_at
+   limit 1;
+$$;
+grant execute on function public.qr_stats_public(text) to anon, authenticated;
+
+-- Scans je Tag (letzte 30 Tage) für die kleine Verlaufsgrafik.
+create or replace function public.qr_stats_tage(p_code text)
+returns table(tag date, n bigint)
+language sql security definer set search_path to 'public' as $$
+  select ts::date as tag, count(*)::bigint as n from public.link_hits
+   where code = lower(trim(p_code)) and ts >= now() - interval '30 days'
+   group by ts::date order by tag;
+$$;
+grant execute on function public.qr_stats_tage(text) to anon, authenticated;
+
+-- Auflösen + Zählen in EINEM Rundgang – nur für die Edge Function (service_role).
+create or replace function public.kurzlink_aufloesen(p_code text)
+returns text language plpgsql security definer set search_path to 'public' as $$
+declare v_code text := lower(trim(coalesce(p_code,''))); v_url text;
+begin
+  if v_code = '' then return null; end if;
+  select url into v_url from public.sommer2026_links where code = v_code;
+  if v_url is null then select url into v_url from public.qr_links where code = v_code; end if;
+  if v_url is not null then insert into public.link_hits (code) values (v_code); end if;
+  return v_url;
+end; $$;
+revoke execute on function public.kurzlink_aufloesen(text) from public, anon, authenticated;

--- a/services/sommer-zaehler/go/index.ts
+++ b/services/sommer-zaehler/go/index.ts
@@ -1,11 +1,14 @@
 // =============================================================================
-// go · Supabase Edge Function — Kurzlink-Weiterleitung
-// Öffentlicher Redirect: /go/<code> (oder ?c=<code>) → 302 auf die volle UTM-URL
-// aus public.sommer2026_links. So bleiben veröffentlichte Links kurz und
-// aufgeräumt; die UTM-Parameter reisen erst beim Redirect mit (302 auf die
-// Landingpage inkl. ?utm_*). Kein API-Key nötig (öffentliche Weiterleitung).
+// go · Supabase Edge Function — Kurzlink-Weiterleitung mit Scan-Zählung
+// Öffentlicher Redirect: /go/<code> (oder ?c=<code>) → 302 auf die hinterlegte
+// URL. Aufgelöst wird über die RPC kurzlink_aufloesen (nur service_role): sie
+// liest BEIDE Register — public.sommer2026_links (Kampagne) und public.qr_links
+// (QR-Generator) — und zählt den Aufruf in public.link_hits (nur Zeitpunkt +
+// Code, keine Personendaten). Ein Rundgang, der Redirect bleibt gleich schnell.
+// Kein API-Key nötig (öffentliche Weiterleitung).
 //
 // Fällt ein Code ins Leere, geht es freundlich auf die Übersichts-Landingpage.
+// Schema: services/qr-generator/schema.sql (Migration «qr_links_und_scans»).
 // =============================================================================
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 
@@ -24,11 +27,11 @@ Deno.serve(async (req) => {
   const code = (u.searchParams.get("c") || (seg && seg !== "go" ? seg : "")).trim();
   if (!code) return redirect(FALLBACK);
 
-  const rows = await fetch(
-    `${SB}/rest/v1/sommer2026_links?code=eq.${encodeURIComponent(code)}&select=url&limit=1`,
-    { headers: { apikey: KEY, Authorization: `Bearer ${KEY}` } },
-  ).then((r) => r.json()).catch(() => []);
+  const target = await fetch(`${SB}/rest/v1/rpc/kurzlink_aufloesen`, {
+    method: "POST",
+    headers: { apikey: KEY, Authorization: `Bearer ${KEY}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ p_code: code }),
+  }).then((r) => r.json()).catch(() => null);
 
-  const target = Array.isArray(rows) && rows[0] && typeof rows[0].url === "string" ? rows[0].url : "";
-  return redirect(target || FALLBACK);
+  return redirect(typeof target === "string" && target ? target : FALLBACK);
 });

--- a/tools.json
+++ b/tools.json
@@ -159,6 +159,17 @@
       "such": "E-Mail Mail Outlook Signatur Fusszeile"
     },
     {
+      "slug": "qr-generator",
+      "cat": "generatoren",
+      "status": "live",
+      "tag": "QR",
+      "title": "QR-Code-Generator",
+      "short": "QR-Codes",
+      "href": "apps/qr-generator/",
+      "desc": "QR-Codes für Link, WLAN, Kontakt, E-Mail und Text – im Hausstil, mit Kurzlink und einfacher Scan-Statistik, ohne Fremddienst.",
+      "such": "QR Code Generator Kurzlink WLAN WiFi vCard Kontakt E-Mail Statistik Scans"
+    },
+    {
       "slug": "editor",
       "cat": "generatoren",
       "status": "intern",


### PR DESCRIPTION
## Was

Neues öffentliches Werkzeug **`apps/qr-generator/`** (im Hub unter «Werkzeuge», `status: live`): QR-Codes für **Link, WLAN, Kontakt (vCard), E-Mail und Text** – mit Gestaltungsoptionen im Hausstil und einfacher **Scan-Statistik**. Das liefert gratis und datensparsam, was qrcode-generator.de u. a. nur im Abo bieten (dynamische QR-Codes mit Zählung).

## Gestalt

- Modulstile **Punkte** (Haus-Default, wie im Inserat) · **Weich** · **Kanten**; Farben **Tinte / Blau / Gold** auf festem Weiss – Artefaktfarben mit `# ds-ok` (ein QR muss theme-unabhängig dunkel auf Weiss bleiben, sonst liest ihn keine Kamera).
- Export **SVG** (Druck/Layout) und **PNG** (512/1024/2048 px), Download zählt über `goeStat`.
- Regelkonform gebaut: Fundament per `<link>` (DS01), nur Token-Farben im CSS (DS02/DS07), Ziffern tabellarisch (G25), Betonung über Gewicht (G05), Fingerziele ≥ 44 px (B04). Prüfmaschinen: **0 Fehler, 0 Hinweise** auf der neuen Seite.

## Statistik (Backend, bereits deployt)

Link-Codes laufen auf Wunsch als Kurzlink über `tools.goetheanum.ch/s/<code>` und zählen ihre Scans anonym – gespeichert werden **nur Zeitpunkt + Code**, keine Personendaten, keine Cookies.

- Migrationen `qr_links_und_scans` + `qr_stats_beide_register` im Werkzeug-Backend: Tabellen `qr_links` und `link_hits` versiegelt (RLS an, keine anon-Policy), RPCs `qr_link_anlegen` / `qr_stats_public` / `qr_stats_tage` für anon, `kurzlink_aufloesen` nur service_role.
- Edge Function `go` (v2 deployt) löst jetzt **beide** Register (Kampagne + QR) in **einem** Rundgang auf und zählt dabei – Kampagnen-Kurzlinks zählen ab sofort mit (erster echter Scan von `delfin` bereits erfasst). Das goelinks-Repo braucht keine Änderung.
- `services/qr-generator/` ist die Referenzkopie (Schema + README mit Datenschutzmodell), `services/sommer-zaehler/go/index.ts` auf den deployten Stand gehoben.
- Bewusst **keine** Lösch-/Änder-RPC in v1 – ein offener Weg würde gedruckte Codes gefährden. Geparkt für v2: Logo in der QR-Mitte, Umzug des Renderers nach `design-system/qr.js`.

## Verifiziert

- Backend per curl: anlegen → 302-Redirect mit Zählung → Stats (scans 1) → Regression Sommer-Code → Kollision (`vergeben`) → Rechteschutz (anon darf `kurzlink_aufloesen` nicht). Testdaten entfernt.
- UI per Playwright gegen das echte Backend: alle fünf Inhaltstypen, Stil-/Farbwechsel, Kurzlink-Anlage, Kollisionsmeldung, Statistik-Ansicht mit Tagesbalken. Keine JS-Fehler.
- `typo-check --all` und `ds-lint`: 0 Fehler, Score 100 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4)_