### PR TITLE
Intern-Schublade: Status-Marker je Eintrag

### DIFF
--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -16,6 +16,17 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ---
 
+## [1.9.3] – 2026-07-10
+
+### Status-Marker in der Intern-Schublade
+- **Was:** Im Intern-Modus zeigt jeder Menü-Eintrag rechts leise seinen
+  Manifest-Status (Beta · Entwurf · intern · geparkt) — Meta-Rolle in der
+  Lese-Grotesk, `--t-micro`, gedeckt. **Live bleibt unmarkiert** (G03: der
+  Normalfall trägt kein Zeichen — was live ist, erkennt man am reinen Titel).
+  Das öffentliche Menü bleibt wortlos («koordiniert, erklärt nicht»).
+- **Warum:** In der Pflege-Ansicht war nicht unterscheidbar, was draussen
+  sichtbar ist und was noch Werkstatt ist.
+
 ## [1.9.2] – 2026-07-10
 
 ### Engine geschärft: Vertrags-Ausnahmen greifen auch für Wurzel-Ordner

--- a/design-system/contract.json
+++ b/design-system/contract.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://goetheanum/design-system/contract.schema.json",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "titel": "Goetheanum Design-System – Struktur-Vertrag",
   "zweck": "Maschinenlesbare Grundlage der GESTALT-Konformität (symmetrisch zum sprachlichen Kanon in assets/typografie/). ds-lint.py prüft jede Seite hiergegen, ds-fix.py korrigiert deterministisch, das Schaufenster bildet es ab. Eine Quelle der Wahrheit für Struktur; Werte/Farben/Schnitte bleiben in tokens.css/tokens.json.",
   "geltungsbereich": {

--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -194,6 +194,10 @@ html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
 /* Aktuelle Seite im Menü hervorheben – ruhig, mit Gold-Kante. */
 .dsnav-link.is-active{background:var(--soft);box-shadow:inset 3px 0 0 var(--gold-deep)}
 .dsnav-link.is-active .tt{color:var(--gold-ink);font-weight:var(--w-strong)}
+/* Status-Marker (nur Intern-Schublade): leises Wort rechts – Meta-Rolle in der
+   Lese-Grotesk (B03-Floor), Live bleibt unmarkiert (G03). */
+.dsnav-link .st{margin-left:auto;flex:0 0 auto;font-family:var(--font-text);
+  font-size:var(--t-micro);color:var(--muted)}
 
 .dsnav-drawer .foot{padding:var(--s4) 22px;border-top:1px solid var(--line);color:var(--muted);font-size:12px;flex:0 0 auto}
 .dsnav-drawer .foot a{color:var(--gold-ink);text-decoration:none}

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -449,6 +449,12 @@
     // Suchbegriffe (Synonyme) fürs Filtern – „Farben" findet so auch das Design-System.
     if (t.such) a.dataset.such = t.such;
     a.innerHTML = '<span class="tt">' + t.title + '</span>';
+    // Status-Marker, nur in der Intern-Schublade: Live bleibt unmarkiert (G03 –
+    // der Normalfall trägt kein Zeichen), alles andere sagt leise, was es ist.
+    if (isIntern() && t.status && t.status !== "live") {
+      var wort = { beta: "Beta", entwurf: "Entwurf", intern: "intern", geparkt: "geparkt" }[t.status] || t.status;
+      a.insertAdjacentHTML("beforeend", '<span class="st">' + wort + '</span>');
+    }
     return a;
   }
 


### PR DESCRIPTION
## Was

Im Intern-Modus zeigt jeder Eintrag der Schublade rechts leise seinen Manifest-Status: **Beta · Entwurf · intern · geparkt** — Meta-Rolle in der Lese-Grotesk, `--t-micro` (B03-Floor), gedeckte Tinte. **Live bleibt unmarkiert** (G03: der Normalfall trägt kein Zeichen) — was live ist, erkennt man am reinen Titel. Das öffentliche Menü bleibt unverändert wortlos («koordiniert, erklärt nicht»).

## Warum

In der Pflege-Ansicht war nicht unterscheidbar, was draussen sichtbar ist und was noch Werkstatt ist.

## Verifikation

Playwright: Intern-Modus zeigt 28 von 37 Einträgen markiert (alle vier Statusworte), Live-Einträge ohne Marker; öffentliche Schublade gegengeprüft: 0 Marker. `ds-lint` 100%. Ledger **1.7.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_