### PR TITLE
QR-Generator: offenes Kurzlink-Register mit Klickzahlen

### DIFF
--- a/apps/qr-generator/index.html
+++ b/apps/qr-generator/index.html
@@ -76,7 +76,7 @@
   .codes .act{text-align:right;white-space:nowrap}
   .codes .mini{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);background:none;border:0;cursor:pointer;padding:4px 6px;min-height:var(--tap)}
   .codes .mini:hover{color:var(--blue)}
-  .codes .mini.weg:hover{color:var(--bad)}
+  .codes td.dat{font-variant-numeric:tabular-nums;white-space:nowrap}
   .tablewrap{overflow-x:auto;margin-top:var(--s4)}
   .empty{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small)}
   .zwischen{margin-top:var(--s8)}
@@ -304,13 +304,13 @@
       </div>
 
       <div class="shead zwischen">
-        <h3>Meine Codes</h3>
-        <p>In diesem Browser angelegte Kurzlinks. <q>Vergessen</q> löscht nur den Eintrag hier – der Kurzlink selbst läuft weiter.</p>
+        <h3>Alle Kurzlinks</h3>
+        <p>Das offene Register: jeder hier angelegte Code mit Ziel und Zählung – <q>Verlauf</q> holt die Tageskurve nach oben.</p>
       </div>
       <div class="tablewrap">
         <table class="codes">
-          <thead><tr><th>Code</th><th>Ziel</th><th class="num">Scans</th><th>letzter Scan</th><th></th></tr></thead>
-          <tbody id="codesBody"><tr><td class="empty" colspan="5">Noch keine Codes angelegt.</td></tr></tbody>
+          <thead><tr><th>Code</th><th>Ziel</th><th>angelegt</th><th class="num">Scans</th><th>letzter Scan</th><th></th></tr></thead>
+          <tbody id="codesBody"><tr><td class="empty" colspan="6">lädt …</td></tr></tbody>
         </table>
       </div>
     </div>
@@ -330,7 +330,6 @@
   var SB  = 'https://dagcsnfrlbpxcmdimnrw.supabase.co';
   var KEY = 'sb_publishable_SXhY0mrhXjdTnjbJ5Uobtg_zAXW_xGY';
   var SHORTBASE = 'https://tools.goetheanum.ch/s/';
-  var STORE = 'qrgen.codes';
 
   function el(id){ return document.getElementById(id); }
 
@@ -496,19 +495,6 @@
       .replace(/[^a-z0-9-]+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'');
   }
 
-  function meineCodes(){
-    try { return JSON.parse(localStorage.getItem(STORE) || '[]'); } catch(e){ return []; }
-  }
-  function merkeCode(code, url){
-    var liste = meineCodes().filter(function(x){ return x.code !== code; });
-    liste.unshift({ code: code, url: url, created: new Date().toISOString() });
-    try { localStorage.setItem(STORE, JSON.stringify(liste.slice(0, 60))); } catch(e){}
-  }
-  function vergissCode(code){
-    try { localStorage.setItem(STORE, JSON.stringify(meineCodes().filter(function(x){ return x.code !== code; }))); } catch(e){}
-    zeigeMeine();
-  }
-
   function zeigeKurzlink(code){
     var kurz = SHORTBASE + code;
     el('shortbox').hidden = false;
@@ -542,9 +528,8 @@
       .then(function(ergebnis){
         if(ergebnis === 'ok'){
           registriert = { code: code, url: u };
-          merkeCode(code, u);
           say('Kurzlink angelegt – der QR zeigt jetzt auf ihn.');
-          zeigeKurzlink(code); zeigeMeine(); render();
+          zeigeKurzlink(code); ladeRegister(); render();
         }
         else if(ergebnis === 'vergeben'){ say('Code „' + code + '“ ist schon vergeben – bitte einen anderen wählen.', true); }
         else if(ergebnis === 'ungueltig'){ say('Code oder Adresse ungültig – Code: 3–32 Zeichen (a–z, 0–9, Bindestrich), Adresse mit https://.', true); }
@@ -651,38 +636,35 @@
   el('statBtn').addEventListener('click', function(){ zeigeStats(el('statCode').value); });
   el('statCode').addEventListener('keydown', function(ev){ if(ev.key === 'Enter') zeigeStats(this.value); });
 
-  function zeigeMeine(){
-    var body = el('codesBody'), liste = meineCodes();
-    body.innerHTML = '';
-    if(!liste.length){ body.innerHTML = '<tr><td class="empty" colspan="5">Noch keine Codes angelegt.</td></tr>'; return; }
-    liste.forEach(function(x){
-      var tr = document.createElement('tr');
-      tr.innerHTML = '<td class="cd"></td><td class="zi"></td><td class="num">–</td><td>–</td><td class="act"></td>';
-      var a = document.createElement('a');
-      a.href = SHORTBASE + x.code; a.target = '_blank'; a.rel = 'noopener'; a.textContent = x.code;
-      tr.children[0].appendChild(a);
-      tr.children[1].textContent = x.url;
-      var zeig = document.createElement('button');
-      zeig.type = 'button'; zeig.className = 'mini'; zeig.textContent = 'Verlauf';
-      zeig.addEventListener('click', function(){ zeigeStats(x.code); el('statDetail').scrollIntoView({ behavior: 'smooth', block: 'nearest' }); });
-      var weg = document.createElement('button');
-      weg.type = 'button'; weg.className = 'mini weg'; weg.textContent = 'Vergessen';
-      weg.setAttribute('aria-label', 'Code aus diesem Browser vergessen');
-      weg.addEventListener('click', function(){ vergissCode(x.code); });
-      tr.children[4].appendChild(zeig); tr.children[4].appendChild(weg);
-      body.appendChild(tr);
-      rpc('qr_stats_public', { p_code: x.code }).then(function(rows){
-        var z = (rows || [])[0]; if(!z) return;
-        tr.children[2].textContent = Number(z.scans).toLocaleString('de-CH');
-        tr.children[3].textContent = fmtZeit(z.letzter_scan);
-      }).catch(function(){});
-    });
+  // Das offene Register: alle angelegten Kurzlinks mit Zählung (eine RPC-Runde).
+  function ladeRegister(){
+    var body = el('codesBody');
+    rpc('qr_links_public').then(function(rows){
+      body.innerHTML = '';
+      if(!rows || !rows.length){ body.innerHTML = '<tr><td class="empty" colspan="6">Noch keine Codes angelegt.</td></tr>'; return; }
+      rows.forEach(function(x){
+        var tr = document.createElement('tr');
+        tr.innerHTML = '<td class="cd"></td><td class="zi"></td><td class="dat"></td><td class="num"></td><td class="dat"></td><td class="act"></td>';
+        var a = document.createElement('a');
+        a.href = SHORTBASE + x.code; a.target = '_blank'; a.rel = 'noopener'; a.textContent = x.code;
+        tr.children[0].appendChild(a);
+        tr.children[1].textContent = x.url;
+        tr.children[2].textContent = new Date(x.created_at).toLocaleDateString('de-CH');
+        tr.children[3].textContent = Number(x.scans).toLocaleString('de-CH');
+        tr.children[4].textContent = fmtZeit(x.letzter_scan);
+        var zeig = document.createElement('button');
+        zeig.type = 'button'; zeig.className = 'mini'; zeig.textContent = 'Verlauf';
+        zeig.addEventListener('click', function(){ zeigeStats(x.code); el('statDetail').scrollIntoView({ behavior: 'smooth', block: 'nearest' }); });
+        tr.children[5].appendChild(zeig);
+        body.appendChild(tr);
+      });
+    }).catch(function(){ body.innerHTML = '<tr><td class="empty" colspan="6">Register nicht ladbar.</td></tr>'; });
   }
 
   // --- Start ---------------------------------------------------------------------
   el('kurzCode').value = neuerCode();
   render();
-  zeigeMeine();
+  ladeRegister();
 </script>
 
 </body>

--- a/services/qr-generator/README.md
+++ b/services/qr-generator/README.md
@@ -28,14 +28,19 @@ Weil beide Register denselben Namensraum `/s/` teilen, prüft
 Wie überall im Werkzeug-Backend (Muster `statistik.html`): Rohtabellen sind
 versiegelt (RLS an, keine anon-Policy, Rechte entzogen), nur die RPCs sind
 offen. Je Scan werden **nur Zeitpunkt und Code** gespeichert – keine IP, kein
-User-Agent, keine Cookies, keine Personendaten. `qr_stats_public` liefert nur,
-was zum Code gehört; wer den Code nicht kennt, sieht nichts.
+User-Agent, keine Cookies, keine Personendaten.
+
+Das Register selbst ist **offen** (Beschluss 10.7.2026, wie UTM-Generator und
+Cockpit): `qr_links_public()` zeigt alle angelegten Kurzlinks mit Ziel und
+Zählung. Wer hier einen Kurzlink anlegt, veröffentlicht ihn – für nicht
+öffentliche Ziele ist das Werkzeug nicht gedacht.
 
 ## RPCs
 
 | RPC | Wer | Zweck |
 | --- | --- | --- |
 | `qr_link_anlegen(p_code, p_url, p_ersteller)` | anon | Code anlegen: `ok` · `vergeben` · `ungueltig` · `unvollstaendig` |
+| `qr_links_public()` | anon | Offenes Register: alle QR-Kurzlinks mit Ziel und Zählung |
 | `qr_stats_public(p_code)` | anon | Summe, letzter Scan, Ziel-URL (beide Register) |
 | `qr_stats_tage(p_code)` | anon | Scans je Tag, letzte 30 Tage |
 | `kurzlink_aufloesen(p_code)` | nur service_role | Auflösen + Zählen für die Function `go` |

--- a/services/qr-generator/schema.sql
+++ b/services/qr-generator/schema.sql
@@ -82,6 +82,20 @@ language sql security definer set search_path to 'public' as $$
 $$;
 grant execute on function public.qr_stats_public(text) to anon, authenticated;
 
+-- Offenes Register (Migration «qr_links_offenes_register», Beschluss 10.7.2026,
+-- wie UTM-Generator/Cockpit): alle angelegten Kurzlinks mit Ziel und Zählung
+-- sind einsehbar – Transparenz vor Verschluss. Personendaten entstehen keine.
+create or replace function public.qr_links_public()
+returns table(code text, url text, created_at timestamptz, scans bigint, letzter_scan timestamptz)
+language sql security definer set search_path to 'public' as $$
+  select l.code, l.url, l.created_at,
+         count(h.id)::bigint as scans, max(h.ts) as letzter_scan
+    from public.qr_links l left join public.link_hits h on h.code = l.code
+   group by l.id, l.code, l.url, l.created_at
+   order by l.created_at desc;
+$$;
+grant execute on function public.qr_links_public() to anon, authenticated;
+
 -- Scans je Tag (letzte 30 Tage) für die kleine Verlaufsgrafik.
 create or replace function public.qr_stats_tage(p_code text)
 returns table(tag date, n bigint)


### PR DESCRIPTION
## Was

Folge zu #359, auf Zuruf: Statt des browsergebundenen «Meine Codes» (localStorage – auf anderen Geräten leer) zeigt die Statistik-Sektion jetzt das **offene Register**: alle im Werkzeug angelegten Kurzlinks mit Ziel, Anlagedatum, Scans und letztem Scan. Das entspricht der Hauslinie (UTM-Generator, Cockpit: offene Register, Transparenz vor Verschluss). «Verlauf» je Zeile holt die Tageskurve nach oben.

## Backend

- Neue Aggregat-RPC `qr_links_public()` (Migration `qr_links_offenes_register`, **bereits deployt**): alle QR-Kurzlinks mit Zählung in einer Runde statt N Einzelabfragen. Rohtabellen bleiben versiegelt; es entstehen weiterhin keine Personendaten.
- README hält den Beschluss fest und zieht die Konsequenz klar: wer einen Kurzlink anlegt, veröffentlicht ihn – für nicht öffentliche Ziele ist das Werkzeug nicht gedacht.

## Verifiziert

- Playwright gegen das echte Backend: Register lädt (leer/gefüllt), Anlage aktualisiert die Liste, «Verlauf» öffnet die Detailansicht. Keine JS-Fehler. Testdaten entfernt.
- `typo-check` und `ds-lint` auf der Seite: 0 Fehler, 0 Hinweise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4)_