### PR TITLE
QR-Generator: Stil ‹Fliessend› und Löschtaste mit Team-Passwort

### DIFF
--- a/apps/qr-generator/index.html
+++ b/apps/qr-generator/index.html
@@ -79,6 +79,7 @@
   .codes .act{text-align:right;white-space:nowrap}
   .codes .mini{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);background:none;border:0;cursor:pointer;padding:4px 6px;min-height:var(--tap)}
   .codes .mini:hover{color:var(--blue)}
+  .codes .mini.weg:hover{color:var(--bad)}
   .codes td.dat{font-variant-numeric:tabular-nums;white-space:nowrap}
   .tablewrap{overflow-x:auto;margin-top:var(--s4)}
   .empty{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small)}
@@ -234,6 +235,7 @@
             <span class="lab">Modulstil</span>
             <div class="seg" id="stilSeg" role="group" aria-label="Modulstil">
               <button type="button" data-stil="punkte" aria-pressed="true">Punkte</button>
+              <button type="button" data-stil="fliessend" aria-pressed="false">Fliessend</button>
               <button type="button" data-stil="weich" aria-pressed="false">Weich</button>
               <button type="button" data-stil="kanten" aria-pressed="false">Kanten</button>
             </div>
@@ -410,18 +412,48 @@
 
   // --- Gestalt: QR als SVG ------------------------------------------------------
   // Fehlerkorrektur Q (robust für Druck). Punkte berühren sich (r=0.5) → scannbar;
+  // Fliessend verschmilzt Nachbarn zu runden Formen (aussen wie innen gerundet);
   // Weich lässt minimale Fugen (0.94er-Module), Kanten ist der klassische Vollblock.
   function qrSvg(text, stilWahl, fg){
     var q = qrcode(0, 'Q'); q.addData(text); q.make();
     var n = q.getModuleCount(), pad = 4, S = n + pad * 2, p = [];
     function inFinder(r, c){ return (r < 7 && c < 7) || (r < 7 && c >= n - 7) || (r >= n - 7 && c < 7); }
+    // Dunkel im Sinn der Modulfläche (Finder-Augen zählen nicht mit – die werden
+    // separat gesetzt und sollen nicht mit den Modulen verschmelzen).
+    function dunkel(r, c){ return r >= 0 && c >= 0 && r < n && c < n && q.isDark(r, c) && !inFinder(r, c); }
+    // Einheitszelle mit wählbaren Eckradien (im/gegen den Nachbarschaftsverbund).
+    function zelle(x, y, tl, tr, br, bl){
+      return 'M' + (x + tl) + ' ' + y +
+        'H' + (x + 1 - tr) + (tr ? 'A' + tr + ' ' + tr + ' 0 0 1 ' + (x + 1) + ' ' + (y + tr) : '') +
+        'V' + (y + 1 - br) + (br ? 'A' + br + ' ' + br + ' 0 0 1 ' + (x + 1 - br) + ' ' + (y + 1) : '') +
+        'H' + (x + bl)     + (bl ? 'A' + bl + ' ' + bl + ' 0 0 1 ' + x + ' ' + (y + 1 - bl) : '') +
+        'V' + (y + tl)     + (tl ? 'A' + tl + ' ' + tl + ' 0 0 1 ' + (x + tl) + ' ' + y : '') + 'Z';
+    }
     p.push('<rect width="' + S + '" height="' + S + '" fill="' + QR_BG + '"/>');
+    var teile = [], R = 0.5;
     for(var r = 0; r < n; r++){
       for(var c = 0; c < n; c++){
-        if(!q.isDark(r, c) || inFinder(r, c)) continue;
         var x = c + pad, y = r + pad;
+        if(stilWahl === 'fliessend' && !dunkel(r, c) && !inFinder(r, c)){
+          // Innenecken glätten: liegt eine helle Zelle im Winkel dreier dunkler
+          // Nachbarn, wird ihre Ecke konkav gefüllt – die Form fliesst.
+          if(dunkel(r - 1, c) && dunkel(r, c - 1) && dunkel(r - 1, c - 1))
+            teile.push('M' + x + ' ' + y + 'L' + (x + R) + ' ' + y + 'A' + R + ' ' + R + ' 0 0 0 ' + x + ' ' + (y + R) + 'Z');
+          if(dunkel(r - 1, c) && dunkel(r, c + 1) && dunkel(r - 1, c + 1))
+            teile.push('M' + (x + 1) + ' ' + y + 'L' + (x + 1) + ' ' + (y + R) + 'A' + R + ' ' + R + ' 0 0 0 ' + (x + 1 - R) + ' ' + y + 'Z');
+          if(dunkel(r + 1, c) && dunkel(r, c - 1) && dunkel(r + 1, c - 1))
+            teile.push('M' + x + ' ' + (y + 1) + 'L' + x + ' ' + (y + 1 - R) + 'A' + R + ' ' + R + ' 0 0 0 ' + (x + R) + ' ' + (y + 1) + 'Z');
+          if(dunkel(r + 1, c) && dunkel(r, c + 1) && dunkel(r + 1, c + 1))
+            teile.push('M' + (x + 1) + ' ' + (y + 1) + 'L' + (x + 1 - R) + ' ' + (y + 1) + 'A' + R + ' ' + R + ' 0 0 0 ' + (x + 1) + ' ' + (y + 1 - R) + 'Z');
+          continue;
+        }
+        if(!dunkel(r, c)) continue;
         if(stilWahl === 'punkte'){
           p.push('<circle cx="' + (x + 0.5) + '" cy="' + (y + 0.5) + '" r="0.5" fill="' + fg + '"/>');
+        } else if(stilWahl === 'fliessend'){
+          // Aussenecken nur runden, wo kein dunkler Nachbar anschliesst.
+          var o = dunkel(r - 1, c), u = dunkel(r + 1, c), li = dunkel(r, c - 1), re = dunkel(r, c + 1);
+          teile.push(zelle(x, y, (!o && !li) ? R : 0, (!o && !re) ? R : 0, (!u && !re) ? R : 0, (!u && !li) ? R : 0));
         } else if(stilWahl === 'weich'){
           p.push('<rect x="' + (x + 0.03) + '" y="' + (y + 0.03) + '" width="0.94" height="0.94" rx="0.28" fill="' + fg + '"/>');
         } else {
@@ -429,6 +461,7 @@
         }
       }
     }
+    if(teile.length) p.push('<path d="' + teile.join('') + '" fill="' + fg + '"/>');
     // Die drei Finder-Augen (dunkel · hell · dunkel); gerundet ausser bei Kanten.
     var rund = stilWahl === 'kanten' ? [0, 0, 0] : [2.3, 1.7, 1.0];
     [[0, 0], [0, n - 7], [n - 7, 0]].forEach(function(e){
@@ -661,12 +694,28 @@
   el('statBtn').addEventListener('click', function(){ zeigeStats(el('statCode').value); });
   el('statCode').addEventListener('keydown', function(ev){ if(ev.key === 'Enter') zeigeStats(this.value); });
 
+  // Löschen: Knopf nur im Backstage-Modus (Schalter aus nav.js), der echte
+  // Riegel ist das Team-Passwort in der RPC qr_link_loeschen.
+  function imBackstage(){ try { return localStorage.getItem('goeNavIntern') === '1'; } catch(e){ return false; } }
+  function loescheCode(code){
+    var pw = window.prompt('Team-Passwort, um „' + code + '“ endgültig zu löschen (Kurzlink und Zählung):');
+    if(pw === null || pw === '') return;
+    rpc('qr_link_loeschen', { p_code: code, p_passwort: pw })
+      .then(function(ergebnis){
+        if(ergebnis === 'ok'){ statSay('Code „' + code + '“ gelöscht.'); el('statDetail').hidden = true; ladeRegister(); }
+        else if(ergebnis === 'passwort'){ statSay('Falsches Passwort – nichts gelöscht.', true); }
+        else { statSay('Code „' + code + '“ nicht gefunden.', true); }
+      })
+      .catch(function(){ statSay('Löschen nicht erreichbar.', true); });
+  }
+
   // Das offene Register: alle angelegten Kurzlinks mit Zählung (eine RPC-Runde).
   function ladeRegister(){
     var body = el('codesBody');
     rpc('qr_links_public').then(function(rows){
       body.innerHTML = '';
       if(!rows || !rows.length){ body.innerHTML = '<tr><td class="empty" colspan="6">Noch keine Codes angelegt.</td></tr>'; return; }
+      var backstage = imBackstage();
       rows.forEach(function(x){
         var tr = document.createElement('tr');
         tr.innerHTML = '<td class="cd"></td><td class="zi"></td><td class="dat"></td><td class="num"></td><td class="dat"></td><td class="act"></td>';
@@ -681,6 +730,13 @@
         zeig.type = 'button'; zeig.className = 'mini'; zeig.textContent = 'Verlauf';
         zeig.addEventListener('click', function(){ zeigeStats(x.code); el('statDetail').scrollIntoView({ behavior: 'smooth', block: 'nearest' }); });
         tr.children[5].appendChild(zeig);
+        if(backstage){
+          var weg = document.createElement('button');
+          weg.type = 'button'; weg.className = 'mini weg'; weg.textContent = 'Löschen';
+          weg.setAttribute('aria-label', 'Kurzlink löschen (Team-Passwort nötig)');
+          weg.addEventListener('click', function(){ loescheCode(x.code); });
+          tr.children[5].appendChild(weg);
+        }
         body.appendChild(tr);
       });
     }).catch(function(){ body.innerHTML = '<tr><td class="empty" colspan="6">Register nicht ladbar.</td></tr>'; });

--- a/services/qr-generator/README.md
+++ b/services/qr-generator/README.md
@@ -43,16 +43,18 @@ Zählung. Wer hier einen Kurzlink anlegt, veröffentlicht ihn – für nicht
 | `qr_links_public()` | anon | Offenes Register: alle QR-Kurzlinks mit Ziel und Zählung |
 | `qr_stats_public(p_code)` | anon | Summe, letzter Scan, Ziel-URL (beide Register) |
 | `qr_stats_tage(p_code)` | anon | Scans je Tag, letzte 30 Tage |
+| `qr_link_loeschen(p_code, p_passwort)` | anon, Team-Passwort | Löschen: `ok` · `passwort` · `unbekannt` (Zählung geht mit) |
 | `kurzlink_aufloesen(p_code)` | nur service_role | Auflösen + Zählen für die Function `go` |
 
 ## Bewusste Entscheide (v1)
 
-- **Keine Lösch-RPC, Löschen auf Zuruf** (Beschluss 10.7.2026): ein offener
-  Löschweg würde gedruckte Codes gefährden. Codes werden bei Bedarf direkt im
-  Backend gelöscht (Supabase-SQL: `delete from qr_links where code = '…'`;
-  zugehörige Zählung in `link_hits` gleich mit). Falls später doch ein Knopf
-  gewünscht ist: geschützter Weg nach dem Muster Passwort-Hash der
-  Multiplikatoren.
+- **Löschen nur mit Team-Passwort** (Beschluss 10.7.2026, revidiert vom
+  Auftraggeber): der Lösch-Knopf im Register erscheint nur im Backstage-Modus,
+  der echte Riegel ist das Passwort in `qr_link_loeschen` (Hash in `qr_config`,
+  Muster Multiplikatoren, Präfix `goe-qr:`). Ein offener Löschweg würde
+  gedruckte Codes gefährden. Passwort ändern: neuen Hash in `qr_config`
+  setzen (`update qr_config set value = encode(extensions.digest('goe-qr:' ||
+  lower(trim('NEU')), 'sha256'), 'hex') where key = 'loeschen_pw_hash'`).
 - **Fallback unbekannter Codes:** bleibt vorerst die Sommer-Landingpage (in
   `go/index.ts`); nach der Kampagne auf eine neutrale Seite stellen.
 - **Geparkt für v2:** Logo in der QR-Mitte (erzwingt Fehlerkorrektur H und

--- a/services/qr-generator/schema.sql
+++ b/services/qr-generator/schema.sql
@@ -106,6 +106,37 @@ language sql security definer set search_path to 'public' as $$
 $$;
 grant execute on function public.qr_stats_tage(text) to anon, authenticated;
 
+-- Löschtaste (Migration «qr_link_loeschen_mit_passwort», Beschluss 10.7.2026,
+-- revidiert): Löschen im Werkzeug, aber nur mit Team-Passwort (Muster
+-- Multiplikatoren: Hash in versiegelter Config, Präfix 'goe-qr:', Vergleich
+-- gross/klein- und leerzeichen-unabhängig). Der Knopf erscheint nur im
+-- Backstage-Modus; der echte Riegel ist die RPC.
+create table if not exists public.qr_config (
+  key   text primary key,
+  value text not null
+);
+alter table public.qr_config enable row level security;
+revoke all on table public.qr_config from anon, authenticated;
+-- Schlüssel in qr_config:
+--   loeschen_pw_hash : sha256('goe-qr:' || lower(trim(passwort))), hex
+
+create or replace function public.qr_link_loeschen(p_code text, p_passwort text)
+returns text language plpgsql security definer set search_path to 'public' as $$
+declare v_code text := lower(trim(coalesce(p_code,''))); n int;
+begin
+  if not exists (
+    select 1 from public.qr_config c
+     where c.key = 'loeschen_pw_hash'
+       and c.value = encode(extensions.digest('goe-qr:' || lower(trim(coalesce(p_passwort,''))), 'sha256'), 'hex')
+  ) then return 'passwort'; end if;
+  delete from public.qr_links where code = v_code;
+  get diagnostics n = row_count;
+  if n = 0 then return 'unbekannt'; end if;
+  delete from public.link_hits where code = v_code;   -- Zählung geht mit dem Code
+  return 'ok';
+end; $$;
+grant execute on function public.qr_link_loeschen(text, text) to anon, authenticated;
+
 -- Auflösen + Zählen in EINEM Rundgang – nur für die Edge Function (service_role).
 create or replace function public.kurzlink_aufloesen(p_code text)
 returns text language plpgsql security definer set search_path to 'public' as $$


### PR DESCRIPTION
## Was

Zwei Wünsche aus dem Praxistest:

**Neuer Modulstil «Fliessend»** (nach hochgeladener Wunschvorlage): benachbarte Module verschmelzen zu runden, durchgehenden Formen — Aussenecken werden nur gerundet, wo kein dunkler Nachbar anschliesst; Innenwinkel heller Zellen werden konkav gefüllt, so fliesst die Form. Ein einziger SVG-Pfad je Code; die drei Augen bleiben die gerundeten Haus-Augen. Reihenfolge der Pillen: Punkte · Fliessend · Weich · Kanten.

**Löschtaste im Register**: erscheint nur im Backstage-Modus (`goeNavIntern`), der echte Riegel ist das Team-Passwort in der neuen RPC `qr_link_loeschen` (Hash in versiegelter `qr_config`, Muster Multiplikatoren, Präfix `goe-qr:`; Migration `qr_link_loeschen_mit_passwort` **bereits deployt**). Löschen entfernt den Kurzlink samt Zählung; falsches Passwort löscht nichts und sagt es. Passwort-Wechsel ist im Service-README dokumentiert.

## Verifiziert

- Fliessend-Stil in Exportgrösse (1024 px) maschinell dekodiert (jsQR) — ebenso Weich und Kanten; der Handytest bleibt der Massstab.
- Lösch-Flow per Playwright gegen das echte Backend: Knopf nur im Backstage sichtbar, falsches Passwort → «nichts gelöscht», richtiges Passwort → Code samt Zählung weg, Register aktualisiert. Keine JS-Fehler, Testdaten entfernt.
- `typo-check` und `ds-lint`: 0 Fehler, 0 Hinweise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4)_