### PR TITLE
Mails S26: w1 verspricht dem Leser etwas — kein «uns»-Klubton mehr

### DIFF
--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -90,7 +90,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 10.07.2026, 22.18 Uhr · <code>7fe243a</code></p>
+  <p class="subline">Stand dieses Builds: 10.07.2026, 22.28 Uhr · <code>a157c73</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -232,7 +232,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Die Wochenschrift drei Monate geschenkt — lesen, wo der Sommer Sie hinträgt. Bis 8. August.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Die ersten drei Monate geschenkt — lesen, wo der Sommer Sie hinträgt. Bis 8. August.</div>
   <div aria-label=&quot;Was Sie sehen, jetzt auch lesen — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -315,12 +315,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Lesen Sie uns unter freiem Himmel.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Jede Woche ein Stück weiter sehen.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie auf goetheanum.tv hören und sehen, denkt in der Wochenschrift weiter: Aufsätze, Blicke auf die Gegenwart und Stimmen aus der weltweiten Bewegung — jede Woche neu, gedruckt und digital.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter — und sehen beim nächsten Mal mehr: Essays, Blicke auf die Gegenwart und Stimmen aus der weltweiten Bewegung, jede Woche neu, gedruckt und digital.</div>
                       </td>
                     </tr>
                     <tr>
@@ -414,11 +414,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#Botschaft">0</span></button></div>
-<div class="val">Lesen Sie uns unter freiem Himmel.</div>
+<div class="val">Jede Woche ein Stück weiter sehen.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#Text">0</span></button></div>
-<div class="val">Was Sie auf goetheanum.tv hören und sehen, denkt in der Wochenschrift weiter: Aufsätze, Blicke auf die Gegenwart und Stimmen aus der weltweiten Bewegung — jede Woche neu, gedruckt und digital.</div>
+<div class="val">Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter — und sehen beim nächsten Mal mehr: Essays, Blicke auf die Gegenwart und Stimmen aus der weltweiten Bewegung, jede Woche neu, gedruckt und digital.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#CTA">0</span></button></div>
@@ -535,7 +535,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of the weekly as a gift — read wherever summer takes you. Until 8 August.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>The first three months as a gift — read wherever summer takes you. Until 8 August.</div>
   <div aria-label=&quot;What you watch, now also read — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -618,12 +618,12 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Read us under the open sky.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>See a little further every week.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you hear and see on goetheanum.tv keeps thinking in the weekly: essays, reflections on our times and voices from the movement worldwide — new every week, in print and digital.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you watch on goetheanum.tv you can read on in the weekly — and see more the next time you return: essays, reflections on our times and voices from the movement worldwide, new every week, in print and digital.</div>
                       </td>
                     </tr>
                     <tr>
@@ -717,11 +717,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#Botschaft">0</span></button></div>
-<div class="val">Read us under the open sky.</div>
+<div class="val">See a little further every week.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#Text">0</span></button></div>
-<div class="val">What you hear and see on goetheanum.tv keeps thinking in the weekly: essays, reflections on our times and voices from the movement worldwide — new every week, in print and digital.</div>
+<div class="val">What you watch on goetheanum.tv you can read on in the weekly — and see more the next time you return: essays, reflections on our times and voices from the movement worldwide, new every week, in print and digital.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#CTA">0</span></button></div>
@@ -3951,7 +3951,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Lesen und sehen — den ganzen Sommer.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Zwei Fenster auf, den ganzen Sommer.</div>
                       </td>
                     </tr>
                     <tr>
@@ -4050,7 +4050,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#Botschaft">0</span></button></div>
-<div class="val">Lesen und sehen — den ganzen Sommer.</div>
+<div class="val">Zwei Fenster auf, den ganzen Sommer.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#Text">0</span></button></div>
@@ -4254,7 +4254,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Reading and watching — all summer long.</div>
+                        <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>Two windows open, all summer long.</div>
                       </td>
                     </tr>
                     <tr>
@@ -4353,7 +4353,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#Botschaft">0</span></button></div>
-<div class="val">Reading and watching — all summer long.</div>
+<div class="val">Two windows open, all summer long.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#Text">0</span></button></div>

--- a/apps/mail-editor/mails/mail_beides_w1_de.html
+++ b/apps/mail-editor/mails/mail_beides_w1_de.html
@@ -176,7 +176,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Lesen und sehen — den ganzen Sommer.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Zwei Fenster auf, den ganzen Sommer.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_beides_w1_en.html
+++ b/apps/mail-editor/mails/mail_beides_w1_en.html
@@ -176,7 +176,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Reading and watching — all summer long.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Two windows open, all summer long.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_lesen_w1_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_de.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Die Wochenschrift drei Monate geschenkt — lesen, wo der Sommer Sie hinträgt. Bis 8. August.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Die ersten drei Monate geschenkt — lesen, wo der Sommer Sie hinträgt. Bis 8. August.</div>
   <div aria-label="Was Sie sehen, jetzt auch lesen — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -176,12 +176,12 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Lesen Sie uns unter freiem Himmel.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Jede Woche ein Stück weiter sehen.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie auf goetheanum.tv hören und sehen, denkt in der Wochenschrift weiter: Aufsätze, Blicke auf die Gegenwart und Stimmen aus der weltweiten Bewegung — jede Woche neu, gedruckt und digital.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter — und sehen beim nächsten Mal mehr: Essays, Blicke auf die Gegenwart und Stimmen aus der weltweiten Bewegung, jede Woche neu, gedruckt und digital.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_lesen_w1_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_en.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of the weekly as a gift — read wherever summer takes you. Until 8 August.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">The first three months as a gift — read wherever summer takes you. Until 8 August.</div>
   <div aria-label="What you watch, now also read — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -176,12 +176,12 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">Read us under the open sky.</div>
+                        <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">See a little further every week.</div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you hear and see on goetheanum.tv keeps thinking in the weekly: essays, reflections on our times and voices from the movement worldwide — new every week, in print and digital.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you watch on goetheanum.tv you can read on in the weekly — and see more the next time you return: essays, reflections on our times and voices from the movement worldwide, new every week, in print and digital.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/mailing-sommer2026/heroes.json
+++ b/services/mailing-sommer2026/heroes.json
@@ -202,17 +202,17 @@
       "w1": {
         "de": {
           "betreff": "Was Sie sehen, jetzt auch lesen — 3 Monate gratis",
-          "botschaft": "Lesen Sie uns unter freiem Himmel.",
-          "text": "Was Sie auf goetheanum.tv hören und sehen, denkt in der Wochenschrift weiter: Aufsätze, Blicke auf die Gegenwart und Stimmen aus der weltweiten Bewegung — jede Woche neu, gedruckt und digital.",
+          "botschaft": "Jede Woche ein Stück weiter sehen.",
+          "text": "Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter — und sehen beim nächsten Mal mehr: Essays, Blicke auf die Gegenwart und Stimmen aus der weltweiten Bewegung, jede Woche neu, gedruckt und digital.",
           "alt": "Drei Monate im Freien lesen — gratis",
-          "preheader": "Die Wochenschrift drei Monate geschenkt — lesen, wo der Sommer Sie hinträgt. Bis 8. August."
+          "preheader": "Die ersten drei Monate geschenkt — lesen, wo der Sommer Sie hinträgt. Bis 8. August."
         },
         "en": {
           "betreff": "What you watch, now also read — 3 months free",
-          "botschaft": "Read us under the open sky.",
-          "text": "What you hear and see on goetheanum.tv keeps thinking in the weekly: essays, reflections on our times and voices from the movement worldwide — new every week, in print and digital.",
+          "botschaft": "See a little further every week.",
+          "text": "What you watch on goetheanum.tv you can read on in the weekly — and see more the next time you return: essays, reflections on our times and voices from the movement worldwide, new every week, in print and digital.",
           "alt": "Read in the open air — three months free",
-          "preheader": "Three months of the weekly as a gift — read wherever summer takes you. Until 8 August."
+          "preheader": "The first three months as a gift — read wherever summer takes you. Until 8 August."
         }
       },
       "w2": {
@@ -302,14 +302,14 @@
       "w1": {
         "de": {
           "betreff": "Ein Sommer mit dem Goetheanum — 3 Monate gratis",
-          "botschaft": "Lesen und sehen — den ganzen Sommer.",
+          "botschaft": "Zwei Fenster auf, den ganzen Sommer.",
           "text": "Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie die Wochenschrift, schauen Sie goetheanum.tv — die ersten drei Monate kostenlos, jederzeit kündbar.",
           "alt": "Drei Monate sind eine Jahreszeit — gratis",
           "preheader": "Lesen oder schauen — oder beides: die ersten drei Monate geschenkt, bis 8. August."
         },
         "en": {
           "betreff": "A summer with the Goetheanum — 3 months free",
-          "botschaft": "Reading and watching — all summer long.",
+          "botschaft": "Two windows open, all summer long.",
           "text": "Get to know the Goetheanum from both sides this summer: read the weekly, watch goetheanum.tv — the first three months free, cancel anytime.",
           "alt": "Three months is a whole season — free",
           "preheader": "Read the weekly, watch goetheanum.tv — or both: the first three months free. Until 8 August."


### PR DESCRIPTION
Zweite Tischrunde (drei Stimmen) auf Reklamation des Auftraggebers: «‹Lesen Sie uns unter freiem Himmel› — dieses ‹uns› klingt nach eingebildetem Klub. Ich brauche ein Versprechen für mich: wachsen, mehr werden, mehr sehen.»

- **lesen_w1:** Botschaft neu **«Jede Woche ein Stück weiter sehen.»** / «See a little further every week.» — Autorin und Hüterin konvergierten unabhängig auf diese Zeile; sie löst alle drei Wünsche in einem Bild und knüpft ans Sehen der TV-Abonnenten an. Der Text nennt den Mechanismus: «Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter — **und sehen beim nächsten Mal mehr** …». Preheader ehrlich präzisiert: «**Die ersten** drei Monate geschenkt».
- **beides_w1:** «Lesen und sehen — den ganzen Sommer.» fiel bei allen drei Stimmen als Programmzettel ohne Gewinn durch → neu **«Zwei Fenster auf, den ganzen Sommer.»** / «Two windows open, all summer long.» (vermeidet zugleich das «Ein Sommer»-Echo des Betreffs).
- **sehen_w1:** «Die Bühne kommt in Ihren Garten.» besteht die Linse einstimmig (Bewegung zum Empfänger, konkretes Bild) — unverändert.

Betreffe unverändert; AC-seitig ändert sich nur das w1-HTML (Reload steht bereits im AC-Prompt). Build grün, alle Mails < 100 KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_