### PR TITLE
Mails S26: Gehalt statt Inventar — fünf Stimmen am Tisch, Beweis-Band neu

### DIFF
--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -90,7 +90,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 10.07.2026, 22.33 Uhr · <code>f71801f</code></p>
+  <p class="subline">Stand dieses Builds: 10.07.2026, 22.43 Uhr · <code>629555a</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -120,7 +120,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="shared#badge"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#badge')">senden</button></div></div></div><div class="fld" data-key="shared#beweisband"><div class="fh" onclick="toggle(this)"><span class="lbl">Beweis-Band</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="shared#beweisband">0</span></button></div>
-<div class="val">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit<br>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+<div class="val">Stimmen und Gesichter der Anthroposophie von heute — seit 1921<br>Voices and faces of anthroposophy today — since 1921</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="shared#beweisband"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#beweisband')">senden</button></div></div></div><div class="fld" data-key="shared#button"><div class="fh" onclick="toggle(this)"><span class="lbl">Button-Stil</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="shared#button">0</span></button></div>
@@ -322,7 +322,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter — und sehen beim nächsten Mal mehr: Essays, Blicke auf die Gegenwart und Stimmen aus der weltweiten Bewegung, jede Woche neu, gedruckt und digital.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter: Woche für Woche schreiben dort Menschen, die einer Frage ihr Leben gewidmet haben — nicht was sie wissen, sondern wie sie suchen. Wer mitliest, kommt mit anderen Augen in die eigene Woche zurück.</div>
                       </td>
                     </tr>
                     <tr>
@@ -364,7 +364,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -420,7 +420,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#Text">0</span></button></div>
-<div class="val">Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter — und sehen beim nächsten Mal mehr: Essays, Blicke auf die Gegenwart und Stimmen aus der weltweiten Bewegung, jede Woche neu, gedruckt und digital.</div>
+<div class="val">Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter: Woche für Woche schreiben dort Menschen, die einer Frage ihr Leben gewidmet haben — nicht was sie wissen, sondern wie sie suchen. Wer mitliest, kommt mit anderen Augen in die eigene Woche zurück.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#CTA">0</span></button></div>
@@ -627,7 +627,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you watch on goetheanum.tv you can read on in the weekly — and see more the next time you return: essays, reflections on our times and voices from the movement worldwide, new every week, in print and digital.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you watch on goetheanum.tv you can read on in the weekly: week after week, people who have given their lives to a question write down not what they know but how they search. Read along, and you return to your own week with different eyes.</div>
                       </td>
                     </tr>
                     <tr>
@@ -669,7 +669,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -725,7 +725,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#Text">0</span></button></div>
-<div class="val">What you watch on goetheanum.tv you can read on in the weekly — and see more the next time you return: essays, reflections on our times and voices from the movement worldwide, new every week, in print and digital.</div>
+<div class="val">What you watch on goetheanum.tv you can read on in the weekly: week after week, people who have given their lives to a question write down not what they know but how they search. Read along, and you return to your own week with different eyes.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#CTA">0</span></button></div>
@@ -926,13 +926,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>Lesen, wo der Abend am schönsten&#160;ist.</div>
+                          <div style=&quot;text-wrap:balance&quot;>Ein Sommer über den eigenen Rand&#160;hinaus.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Noch bis 8. August legen wir die Wochenschrift drei Monate gratis zu Ihrem Abo dazu — sie passt in jede Tasche und auf jeden Balkon.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Noch bis 8. August lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — Lesestoff, der in Ihnen weiterarbeitet, wenn der Bildschirm dunkel ist.</div>
                       </td>
                     </tr>
                     <tr>
@@ -974,7 +974,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1026,11 +1026,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#Botschaft">0</span></button></div>
-<div class="val">Lesen, wo der Abend am schönsten ist.</div>
+<div class="val">Ein Sommer über den eigenen Rand hinaus.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#Text">0</span></button></div>
-<div class="val">Noch bis 8. August legen wir die Wochenschrift drei Monate gratis zu Ihrem Abo dazu — sie passt in jede Tasche und auf jeden Balkon.</div>
+<div class="val">Noch bis 8. August lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — Lesestoff, der in Ihnen weiterarbeitet, wenn der Bildschirm dunkel ist.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#CTA">0</span></button></div>
@@ -1038,7 +1038,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#CTA')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Noch bis 8. August: die Wochenschrift gratis</div>
+<div class="val">Lesestoff, der den Sommer überdauert — gratis</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#Alt-Betreff (AC-Split)"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#Link">0</span></button></div>
@@ -1231,13 +1231,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>Read where the evening is at its&#160;best.</div>
+                          <div style=&quot;text-wrap:balance&quot;>A summer beyond your own&#160;horizon.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Until 8 August we’ll add the weekly to your subscription, free for three months — it fits in any bag and on any balcony.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark.</div>
                       </td>
                     </tr>
                     <tr>
@@ -1279,7 +1279,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1331,11 +1331,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#Botschaft">0</span></button></div>
-<div class="val">Read where the evening is at its best.</div>
+<div class="val">A summer beyond your own horizon.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#Text">0</span></button></div>
-<div class="val">Until 8 August we’ll add the weekly to your subscription, free for three months — it fits in any bag and on any balcony.</div>
+<div class="val">Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#CTA">0</span></button></div>
@@ -1343,7 +1343,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#CTA')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Until 8 August: the weekly, free</div>
+<div class="val">Reading that outlasts the summer — free</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#Alt-Betreff (AC-Split)"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#Link">0</span></button></div>
@@ -1584,7 +1584,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1889,7 +1889,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2062,7 +2062,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Vorträge, Gespräche, Bühne vom Goetheanum — über 800 Videos, die mit Ihnen reisen.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Über 800 Vorträge und Gespräche, die Ihrem Lesen Tiefe geben — wohin der Sommer Sie trägt.</div>
   <div aria-label=&quot;Was Sie lesen, jetzt auch sehen — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -2146,13 +2146,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>Die Bühne kommt in Ihren&#160;Garten.</div>
+                          <div style=&quot;text-wrap:balance&quot;>Zusehen, wie jemand&#160;denkt.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: goetheanum.tv bringt Vorträge, Gespräche und die Bühne des Goetheanum zu Ihnen — über 800 Videos, wohin Sie der Sommer auch führt.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: Auf goetheanum.tv denken Menschen laut, in über 800 Vorträgen und Gesprächen. Sie hören das Zögern und das Finden mit — alles, was auf der gedruckten Seite unsichtbar bleibt.</div>
                       </td>
                     </tr>
                     <tr>
@@ -2194,7 +2194,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2246,11 +2246,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#Botschaft">0</span></button></div>
-<div class="val">Die Bühne kommt in Ihren Garten.</div>
+<div class="val">Zusehen, wie jemand denkt.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#Text">0</span></button></div>
-<div class="val">Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: goetheanum.tv bringt Vorträge, Gespräche und die Bühne des Goetheanum zu Ihnen — über 800 Videos, wohin Sie der Sommer auch führt.</div>
+<div class="val">Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: Auf goetheanum.tv denken Menschen laut, in über 800 Vorträgen und Gesprächen. Sie hören das Zögern und das Finden mit — alles, was auf der gedruckten Seite unsichtbar bleibt.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#CTA">0</span></button></div>
@@ -2258,7 +2258,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#CTA')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Das Goetheanum im Garten — 3 Monate gratis</div>
+<div class="val">Dem Gelesenen zuhören — 3 Monate gratis</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#Alt-Betreff (AC-Split)"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#Link">0</span></button></div>
@@ -2367,7 +2367,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Lectures, conversations, the Goetheanum stage — over 800 videos that travel with you.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Over 800 lectures and conversations that deepen your reading — wherever summer takes you.</div>
   <div aria-label=&quot;What you read, now also watch — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -2451,13 +2451,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>The stage comes to your&#160;garden.</div>
+                          <div style=&quot;text-wrap:balance&quot;>Watch someone&#160;think.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you read each week you can now watch and hear: goetheanum.tv brings lectures, conversations and the Goetheanum stage to you — over 800 videos, wherever summer finds you.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you read each week you can now watch and hear: on goetheanum.tv, people think out loud, in over 800 lectures and conversations. You hear the hesitation and the finding — everything the printed page keeps invisible.</div>
                       </td>
                     </tr>
                     <tr>
@@ -2499,7 +2499,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2551,11 +2551,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#Botschaft">0</span></button></div>
-<div class="val">The stage comes to your garden.</div>
+<div class="val">Watch someone think.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#Text">0</span></button></div>
-<div class="val">What you read each week you can now watch and hear: goetheanum.tv brings lectures, conversations and the Goetheanum stage to you — over 800 videos, wherever summer finds you.</div>
+<div class="val">What you read each week you can now watch and hear: on goetheanum.tv, people think out loud, in over 800 lectures and conversations. You hear the hesitation and the finding — everything the printed page keeps invisible.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#CTA">0</span></button></div>
@@ -2563,7 +2563,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#CTA')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">The Goetheanum in your garden — 3 months free</div>
+<div class="val">Listen to what you read — 3 months free</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#Alt-Betreff (AC-Split)"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#Link">0</span></button></div>
@@ -2582,7 +2582,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Sehen Sie, was diesen Sommer läuft</title>
+  <title>Ihr Sommer hat noch Abende frei</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -2672,8 +2672,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>goetheanum.tv drei Monate gratis zu Ihrem Abo — hineinschauen können Sie noch bis 8. August.</div>
-  <div aria-label=&quot;Sehen Sie, was diesen Sommer läuft&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>goetheanum.tv drei Monate gratis zu Ihrem Abo — Abende, die nachwirken. Bis 8. August.</div>
+  <div aria-label=&quot;Ihr Sommer hat noch Abende frei&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -2762,7 +2762,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Über 800 Videos warten auf einen lauen Abend: goetheanum.tv, noch bis 8. August drei Monate gratis zu Ihrem Abo.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Ein Abend auf goetheanum.tv ist ein Abend in Gesellschaft von Menschen, die ihr Leben lang an einer Frage gearbeitet haben — und die laut denken, statt fertige Antworten vorzutragen. Noch bis 8. August drei Monate gratis zu Ihrem Abo.</div>
                       </td>
                     </tr>
                     <tr>
@@ -2804,7 +2804,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2852,7 +2852,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#Motiv"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#Motiv')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_de#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#Betreff">0</span></button></div>
-<div class="val">Sehen Sie, was diesen Sommer läuft</div>
+<div class="val">Ihr Sommer hat noch Abende frei</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#Botschaft">0</span></button></div>
@@ -2860,7 +2860,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#Text">0</span></button></div>
-<div class="val">Über 800 Videos warten auf einen lauen Abend: goetheanum.tv, noch bis 8. August drei Monate gratis zu Ihrem Abo.</div>
+<div class="val">Ein Abend auf goetheanum.tv ist ein Abend in Gesellschaft von Menschen, die ihr Leben lang an einer Frage gearbeitet haben — und die laut denken, statt fertige Antworten vorzutragen. Noch bis 8. August drei Monate gratis zu Ihrem Abo.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#CTA">0</span></button></div>
@@ -2868,7 +2868,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#CTA')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Noch bis 8. August: goetheanum.tv gratis</div>
+<div class="val">Drei Monate weiter sehen — gratis</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#Alt-Betreff (AC-Split)"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#Link">0</span></button></div>
@@ -2887,7 +2887,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>See what’s on this summer</title>
+  <title>Your summer still has evenings free</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -2977,8 +2977,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of goetheanum.tv free with your subscription — take a seat by 8 August.</div>
-  <div aria-label=&quot;See what’s on this summer&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>goetheanum.tv, three months free with your subscription — evenings that linger. By 8 August.</div>
+  <div aria-label=&quot;Your summer still has evenings free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -3067,7 +3067,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Over 800 videos are waiting for a mild summer evening: goetheanum.tv, three months free with your subscription — until 8 August.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>An evening on goetheanum.tv is an evening in the company of people who have worked on a question all their lives — thinking out loud rather than reciting finished answers. Until 8 August: three months free with your subscription.</div>
                       </td>
                     </tr>
                     <tr>
@@ -3109,7 +3109,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3157,7 +3157,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#Motiv"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#Motiv')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_en#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#Betreff">0</span></button></div>
-<div class="val">See what’s on this summer</div>
+<div class="val">Your summer still has evenings free</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#Botschaft">0</span></button></div>
@@ -3165,7 +3165,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#Text">0</span></button></div>
-<div class="val">Over 800 videos are waiting for a mild summer evening: goetheanum.tv, three months free with your subscription — until 8 August.</div>
+<div class="val">An evening on goetheanum.tv is an evening in the company of people who have worked on a question all their lives — thinking out loud rather than reciting finished answers. Until 8 August: three months free with your subscription.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#CTA">0</span></button></div>
@@ -3173,7 +3173,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#CTA')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Until 8 August: goetheanum.tv free</div>
+<div class="val">See further for three months — free</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#Alt-Betreff (AC-Split)"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#Link">0</span></button></div>
@@ -3366,13 +3366,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>Der Vorhang fällt am&#160;Samstag.</div>
+                          <div style=&quot;text-wrap:balance&quot;>Bis Samstag ist Ihr Platz&#160;frei.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Noch ein paar Sommertage: goetheanum.tv, die ersten drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es Ihnen gefällt.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Noch ein paar Sommertage: goetheanum.tv, die ersten drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es in Ihnen nachklingt.</div>
                       </td>
                     </tr>
                     <tr>
@@ -3414,7 +3414,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3466,11 +3466,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_de#Botschaft">0</span></button></div>
-<div class="val">Der Vorhang fällt am Samstag.</div>
+<div class="val">Bis Samstag ist Ihr Platz frei.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_de#Text">0</span></button></div>
-<div class="val">Noch ein paar Sommertage: goetheanum.tv, die ersten drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es Ihnen gefällt.</div>
+<div class="val">Noch ein paar Sommertage: goetheanum.tv, die ersten drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es in Ihnen nachklingt.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_de#CTA">0</span></button></div>
@@ -3671,13 +3671,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>The curtain falls on&#160;Saturday.</div>
+                          <div style=&quot;text-wrap:balance&quot;>Your seat stays free until&#160;Saturday.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>A few summer days left: goetheanum.tv, the first three months free with your subscription — stay only if you love it.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>A few summer days left: goetheanum.tv, the first three months free with your subscription — stay only if it stays with you.</div>
                       </td>
                     </tr>
                     <tr>
@@ -3719,7 +3719,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3771,11 +3771,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_en#Botschaft">0</span></button></div>
-<div class="val">The curtain falls on Saturday.</div>
+<div class="val">Your seat stays free until Saturday.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_en#Text">0</span></button></div>
-<div class="val">A few summer days left: goetheanum.tv, the first three months free with your subscription — stay only if you love it.</div>
+<div class="val">A few summer days left: goetheanum.tv, the first three months free with your subscription — stay only if it stays with you.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_en#CTA">0</span></button></div>
@@ -3982,7 +3982,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie die Wochenschrift, schauen Sie goetheanum.tv — die ersten drei Monate kostenlos, jederzeit kündbar.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie in der Wochenschrift Menschen, die einer Frage ihr Leben gewidmet haben, und sehen Sie auf goetheanum.tv zu, wie sie laut denken — die ersten drei Monate kostenlos, jederzeit kündbar.</div>
                       </td>
                     </tr>
                     <tr>
@@ -3991,7 +3991,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Geschenk aussuchen → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -4024,7 +4024,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4080,11 +4080,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#Text">0</span></button></div>
-<div class="val">Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie die Wochenschrift, schauen Sie goetheanum.tv — die ersten drei Monate kostenlos, jederzeit kündbar.</div>
+<div class="val">Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie in der Wochenschrift Menschen, die einer Frage ihr Leben gewidmet haben, und sehen Sie auf goetheanum.tv zu, wie sie laut denken — die ersten drei Monate kostenlos, jederzeit kündbar.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#CTA">0</span></button></div>
-<div class="val">Geschenk aussuchen →</div>
+<div class="val">Ihren Sommer wählen →</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#Alt-Betreff (AC-Split)">0</span></button></div>
@@ -4287,7 +4287,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Get to know the Goetheanum from both sides this summer: read the weekly, watch goetheanum.tv — the first three months free, cancel anytime.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Get to know the Goetheanum from both sides this summer: in the weekly, read people who have given their lives to a question; on goetheanum.tv, watch them think out loud — the first three months free, cancel anytime.</div>
                       </td>
                     </tr>
                     <tr>
@@ -4296,7 +4296,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your gift → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -4329,7 +4329,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4385,11 +4385,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#Text">0</span></button></div>
-<div class="val">Get to know the Goetheanum from both sides this summer: read the weekly, watch goetheanum.tv — the first three months free, cancel anytime.</div>
+<div class="val">Get to know the Goetheanum from both sides this summer: in the weekly, read people who have given their lives to a question; on goetheanum.tv, watch them think out loud — the first three months free, cancel anytime.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#CTA">0</span></button></div>
-<div class="val">Choose your gift →</div>
+<div class="val">Choose your summer →</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#Alt-Betreff (AC-Split)">0</span></button></div>
@@ -4502,7 +4502,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Die Wochenschrift und goetheanum.tv, drei Monate kostenlos — anmelden bis 8. August.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Wochenschrift und goetheanum.tv, drei Monate kostenlos — Stoff zum Weiterdenken. Bis 8. August.</div>
   <div aria-label=&quot;Lesen, sehen — oder gleich beides&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -4586,13 +4586,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>Wählen Sie, was Ihr Sommer&#160;braucht.</div>
+                          <div style=&quot;text-wrap:balance&quot;>Denken in guter&#160;Gesellschaft.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Lesen auf dem Balkon, schauen am Abend — oder beides: die ersten drei Monate geschenkt, noch bis 8. August.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Ein Essay am Morgen, ein Vortrag am Abend — und dazwischen merken Sie, wie die eigenen Gedanken weiter reichen als sonst. Die ersten drei Monate geschenkt, anmelden bis 8. August.</div>
                       </td>
                     </tr>
                     <tr>
@@ -4601,7 +4601,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Geschenk aussuchen → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -4634,7 +4634,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4686,15 +4686,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_de#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w2_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_de#Botschaft">0</span></button></div>
-<div class="val">Wählen Sie, was Ihr Sommer braucht.</div>
+<div class="val">Denken in guter Gesellschaft.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w2_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_de#Text">0</span></button></div>
-<div class="val">Lesen auf dem Balkon, schauen am Abend — oder beides: die ersten drei Monate geschenkt, noch bis 8. August.</div>
+<div class="val">Ein Essay am Morgen, ein Vortrag am Abend — und dazwischen merken Sie, wie die eigenen Gedanken weiter reichen als sonst. Die ersten drei Monate geschenkt, anmelden bis 8. August.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w2_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_de#CTA">0</span></button></div>
-<div class="val">Geschenk aussuchen →</div>
+<div class="val">Ihren Sommer wählen →</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_de#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w2_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_de#Alt-Betreff (AC-Split)">0</span></button></div>
@@ -4807,7 +4807,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>The weekly and goetheanum.tv, three months free — sign up by 8 August.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>The weekly and goetheanum.tv, three months free — food for thought all summer. By 8 August.</div>
   <div aria-label=&quot;Read, watch — or simply both&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -4891,13 +4891,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>Choose what your summer&#160;needs.</div>
+                          <div style=&quot;text-wrap:balance&quot;>Thinking in good&#160;company.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Reading on the balcony, watching in the evening — or both: the first three months free, until 8 August.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>An essay in the morning, a lecture in the evening — and in between you notice your own thoughts reaching further than usual. The first three months free, sign up by 8 August.</div>
                       </td>
                     </tr>
                     <tr>
@@ -4906,7 +4906,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your gift → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -4939,7 +4939,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4991,15 +4991,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_en#Betreff"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w2_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_en#Botschaft">0</span></button></div>
-<div class="val">Choose what your summer needs.</div>
+<div class="val">Thinking in good company.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w2_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_en#Text">0</span></button></div>
-<div class="val">Reading on the balcony, watching in the evening — or both: the first three months free, until 8 August.</div>
+<div class="val">An essay in the morning, a lecture in the evening — and in between you notice your own thoughts reaching further than usual. The first three months free, sign up by 8 August.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w2_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_en#CTA">0</span></button></div>
-<div class="val">Choose your gift →</div>
+<div class="val">Choose your summer →</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_en#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w2_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_en#Alt-Betreff (AC-Split)">0</span></button></div>
@@ -5211,7 +5211,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Geschenk aussuchen → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -5244,7 +5244,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5304,7 +5304,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w3_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#CTA">0</span></button></div>
-<div class="val">Geschenk aussuchen →</div>
+<div class="val">Ihren Sommer wählen →</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w3_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#Alt-Betreff (AC-Split)">0</span></button></div>
@@ -5516,7 +5516,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your gift → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -5549,7 +5549,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5609,7 +5609,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w3_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#CTA">0</span></button></div>
-<div class="val">Choose your gift →</div>
+<div class="val">Choose your summer →</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w3_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#Alt-Betreff (AC-Split)">0</span></button></div>
@@ -5812,7 +5812,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie sich angeschaut haben, liegt bereit — eine Minute, und Ihre drei kostenlosen Monate beginnen.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute, und Sie haben drei Monate Zeit, dem nachzugehen.</div>
                       </td>
                     </tr>
                     <tr>
@@ -5821,7 +5821,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Geschenk aussuchen → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -5854,7 +5854,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5910,11 +5910,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_de#Text">0</span></button></div>
-<div class="val">Was Sie sich angeschaut haben, liegt bereit — eine Minute, und Ihre drei kostenlosen Monate beginnen.</div>
+<div class="val">Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute, und Sie haben drei Monate Zeit, dem nachzugehen.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_de#CTA">0</span></button></div>
-<div class="val">Geschenk aussuchen →</div>
+<div class="val">Ihren Sommer wählen →</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_de#Alt-Betreff (AC-Split)">0</span></button></div>
@@ -6117,7 +6117,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you looked at is still there — one minute, and your three free months begin.</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you looked at spoke to you for a reason — one minute, and you have three months to follow it.</div>
                       </td>
                     </tr>
                     <tr>
@@ -6126,7 +6126,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your gift → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -6159,7 +6159,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style=&quot;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -6215,11 +6215,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#Botschaft"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_en#Text">0</span></button></div>
-<div class="val">What you looked at is still there — one minute, and your three free months begin.</div>
+<div class="val">What you looked at spoke to you for a reason — one minute, and you have three months to follow it.</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#Text"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_en#CTA">0</span></button></div>
-<div class="val">Choose your gift →</div>
+<div class="val">Choose your summer →</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#CTA"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_en#Alt-Betreff (AC-Split)">0</span></button></div>

--- a/apps/mail-editor/mails/mail_beides_w1_de.html
+++ b/apps/mail-editor/mails/mail_beides_w1_de.html
@@ -183,7 +183,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie die Wochenschrift, schauen Sie goetheanum.tv — die ersten drei Monate kostenlos, jederzeit kündbar.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie in der Wochenschrift Menschen, die einer Frage ihr Leben gewidmet haben, und sehen Sie auf goetheanum.tv zu, wie sie laut denken — die ersten drei Monate kostenlos, jederzeit kündbar.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +192,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Geschenk aussuchen → </a>
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w1_en.html
+++ b/apps/mail-editor/mails/mail_beides_w1_en.html
@@ -183,7 +183,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Get to know the Goetheanum from both sides this summer: read the weekly, watch goetheanum.tv — the first three months free, cancel anytime.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Get to know the Goetheanum from both sides this summer: in the weekly, read people who have given their lives to a question; on goetheanum.tv, watch them think out loud — the first three months free, cancel anytime.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +192,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your gift → </a>
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_de.html
+++ b/apps/mail-editor/mails/mail_beides_w2_de.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Die Wochenschrift und goetheanum.tv, drei Monate kostenlos — anmelden bis 8. August.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Wochenschrift und goetheanum.tv, drei Monate kostenlos — Stoff zum Weiterdenken. Bis 8. August.</div>
   <div aria-label="Lesen, sehen — oder gleich beides" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -177,13 +177,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">Wählen Sie, was Ihr Sommer&#160;braucht.</div>
+                          <div style="text-wrap:balance">Denken in guter&#160;Gesellschaft.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Lesen auf dem Balkon, schauen am Abend — oder beides: die ersten drei Monate geschenkt, noch bis 8. August.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Ein Essay am Morgen, ein Vortrag am Abend — und dazwischen merken Sie, wie die eigenen Gedanken weiter reichen als sonst. Die ersten drei Monate geschenkt, anmelden bis 8. August.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +192,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Geschenk aussuchen → </a>
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_en.html
+++ b/apps/mail-editor/mails/mail_beides_w2_en.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">The weekly and goetheanum.tv, three months free — sign up by 8 August.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">The weekly and goetheanum.tv, three months free — food for thought all summer. By 8 August.</div>
   <div aria-label="Read, watch — or simply both" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -177,13 +177,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">Choose what your summer&#160;needs.</div>
+                          <div style="text-wrap:balance">Thinking in good&#160;company.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Reading on the balcony, watching in the evening — or both: the first three months free, until 8 August.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">An essay in the morning, a lecture in the evening — and in between you notice your own thoughts reaching further than usual. The first three months free, sign up by 8 August.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +192,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your gift → </a>
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3_de.html
@@ -192,7 +192,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Geschenk aussuchen → </a>
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3_en.html
@@ -192,7 +192,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your gift → </a>
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_de.html
@@ -183,7 +183,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie sich angeschaut haben, liegt bereit — eine Minute, und Ihre drei kostenlosen Monate beginnen.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute, und Sie haben drei Monate Zeit, dem nachzugehen.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +192,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Geschenk aussuchen → </a>
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_en.html
@@ -183,7 +183,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you looked at is still there — one minute, and your three free months begin.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you looked at spoke to you for a reason — one minute, and you have three months to follow it.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +192,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your gift → </a>
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w1_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_de.html
@@ -183,7 +183,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter — und sehen beim nächsten Mal mehr: Essays, Blicke auf die Gegenwart und Stimmen aus der weltweiten Bewegung, jede Woche neu, gedruckt und digital.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter: Woche für Woche schreiben dort Menschen, die einer Frage ihr Leben gewidmet haben — nicht was sie wissen, sondern wie sie suchen. Wer mitliest, kommt mit anderen Augen in die eigene Woche zurück.</div>
                       </td>
                     </tr>
                     <tr>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w1_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_en.html
@@ -183,7 +183,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you watch on goetheanum.tv you can read on in the weekly — and see more the next time you return: essays, reflections on our times and voices from the movement worldwide, new every week, in print and digital.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you watch on goetheanum.tv you can read on in the weekly: week after week, people who have given their lives to a question write down not what they know but how they search. Read along, and you return to your own week with different eyes.</div>
                       </td>
                     </tr>
                     <tr>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_de.html
@@ -177,13 +177,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">Lesen, wo der Abend am schönsten&#160;ist.</div>
+                          <div style="text-wrap:balance">Ein Sommer über den eigenen Rand&#160;hinaus.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Noch bis 8. August legen wir die Wochenschrift drei Monate gratis zu Ihrem Abo dazu — sie passt in jede Tasche und auf jeden Balkon.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Noch bis 8. August lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — Lesestoff, der in Ihnen weiterarbeitet, wenn der Bildschirm dunkel ist.</div>
                       </td>
                     </tr>
                     <tr>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_en.html
@@ -177,13 +177,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">Read where the evening is at its&#160;best.</div>
+                          <div style="text-wrap:balance">A summer beyond your own&#160;horizon.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Until 8 August we’ll add the weekly to your subscription, free for three months — it fits in any bag and on any balcony.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark.</div>
                       </td>
                     </tr>
                     <tr>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_de.html
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_en.html
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w1_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_de.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Vorträge, Gespräche, Bühne vom Goetheanum — über 800 Videos, die mit Ihnen reisen.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Über 800 Vorträge und Gespräche, die Ihrem Lesen Tiefe geben — wohin der Sommer Sie trägt.</div>
   <div aria-label="Was Sie lesen, jetzt auch sehen — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -177,13 +177,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">Die Bühne kommt in Ihren&#160;Garten.</div>
+                          <div style="text-wrap:balance">Zusehen, wie jemand&#160;denkt.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: goetheanum.tv bringt Vorträge, Gespräche und die Bühne des Goetheanum zu Ihnen — über 800 Videos, wohin Sie der Sommer auch führt.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: Auf goetheanum.tv denken Menschen laut, in über 800 Vorträgen und Gesprächen. Sie hören das Zögern und das Finden mit — alles, was auf der gedruckten Seite unsichtbar bleibt.</div>
                       </td>
                     </tr>
                     <tr>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w1_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_en.html
@@ -93,7 +93,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Lectures, conversations, the Goetheanum stage — over 800 videos that travel with you.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Over 800 lectures and conversations that deepen your reading — wherever summer takes you.</div>
   <div aria-label="What you read, now also watch — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -177,13 +177,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">The stage comes to your&#160;garden.</div>
+                          <div style="text-wrap:balance">Watch someone&#160;think.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you read each week you can now watch and hear: goetheanum.tv brings lectures, conversations and the Goetheanum stage to you — over 800 videos, wherever summer finds you.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you read each week you can now watch and hear: on goetheanum.tv, people think out loud, in over 800 lectures and conversations. You hear the hesitation and the finding — everything the printed page keeps invisible.</div>
                       </td>
                     </tr>
                     <tr>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Sehen Sie, was diesen Sommer läuft</title>
+  <title>Ihr Sommer hat noch Abende frei</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -93,8 +93,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">goetheanum.tv drei Monate gratis zu Ihrem Abo — hineinschauen können Sie noch bis 8. August.</div>
-  <div aria-label="Sehen Sie, was diesen Sommer läuft" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">goetheanum.tv drei Monate gratis zu Ihrem Abo — Abende, die nachwirken. Bis 8. August.</div>
+  <div aria-label="Ihr Sommer hat noch Abende frei" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -183,7 +183,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Über 800 Videos warten auf einen lauen Abend: goetheanum.tv, noch bis 8. August drei Monate gratis zu Ihrem Abo.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Ein Abend auf goetheanum.tv ist ein Abend in Gesellschaft von Menschen, die ihr Leben lang an einer Frage gearbeitet haben — und die laut denken, statt fertige Antworten vorzutragen. Noch bis 8. August drei Monate gratis zu Ihrem Abo.</div>
                       </td>
                     </tr>
                     <tr>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>See what’s on this summer</title>
+  <title>Your summer still has evenings free</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -93,8 +93,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of goetheanum.tv free with your subscription — take a seat by 8 August.</div>
-  <div aria-label="See what’s on this summer" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">goetheanum.tv, three months free with your subscription — evenings that linger. By 8 August.</div>
+  <div aria-label="Your summer still has evenings free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -183,7 +183,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Over 800 videos are waiting for a mild summer evening: goetheanum.tv, three months free with your subscription — until 8 August.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">An evening on goetheanum.tv is an evening in the company of people who have worked on a question all their lives — thinking out loud rather than reciting finished answers. Until 8 August: three months free with your subscription.</div>
                       </td>
                     </tr>
                     <tr>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_de.html
@@ -177,13 +177,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">Der Vorhang fällt am&#160;Samstag.</div>
+                          <div style="text-wrap:balance">Bis Samstag ist Ihr Platz&#160;frei.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Noch ein paar Sommertage: goetheanum.tv, die ersten drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es Ihnen gefällt.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Noch ein paar Sommertage: goetheanum.tv, die ersten drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es in Ihnen nachklingt.</div>
                       </td>
                     </tr>
                     <tr>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_en.html
@@ -177,13 +177,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Fazeta Sans','Trebuchet MS','Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">The curtain falls on&#160;Saturday.</div>
+                          <div style="text-wrap:balance">Your seat stays free until&#160;Saturday.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">A few summer days left: goetheanum.tv, the first three months free with your subscription — stay only if you love it.</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">A few summer days left: goetheanum.tv, the first three months free with your subscription — stay only if it stays with you.</div>
                       </td>
                     </tr>
                     <tr>
@@ -225,7 +225,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">since 1921 · 800+ videos · 42 issues a year · worldwide</div>
+                        <div style="font-family:Inter,-apple-system,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>

--- a/services/mailing-sommer2026/heroes.json
+++ b/services/mailing-sommer2026/heroes.json
@@ -34,7 +34,8 @@
         },
         "alternativen": [
           "Lesen, wo der Sommer Sie hinträgt",
-          "Ihren Sommer mit nachhaltigen Gedanken verbringen"
+          "Ihren Sommer mit nachhaltigen Gedanken verbringen",
+          "Jede Woche denkt ein erfahrener Mensch vor Ihnen laut — und Sie sehen weiter als allein."
         ]
       },
       "en": {
@@ -43,7 +44,8 @@
         },
         "alternativen": [
           "Read wherever the summer takes you",
-          "Spend your summer with lasting thoughts"
+          "Spend your summer with lasting thoughts",
+          "Each week, someone thinks out loud for you — and you leave seeing more than you brought."
         ]
       }
     },
@@ -88,7 +90,8 @@
         },
         "alternativen": [
           "Wo immer Sie diesen Sommer verbringen",
-          "Über 800 Videos — einen Sommer lang gratis"
+          "Über 800 Videos — einen Sommer lang gratis",
+          "Über 800 Mal einem Menschen beim Denken zusehen — Saal und Bühne offen, wann Sie wollen."
         ]
       },
       "en": {
@@ -97,7 +100,8 @@
         },
         "alternativen": [
           "Wherever you spend this summer",
-          "Over 800 videos — one summer, free"
+          "Over 800 videos — one summer, free",
+          "Watch a person think, more than 800 times — the Goetheanum’s hall open whenever you are."
         ]
       }
     },
@@ -130,24 +134,26 @@
       ],
       "de": {
         "cta_labels": {
-          "uebersicht": "Geschenk aussuchen →",
+          "uebersicht": "Ihren Sommer wählen →",
           "wos": "Lesen wählen →",
           "gtv": "Sehen wählen →"
         },
         "alternativen": [
           "Wählen Sie Ihr Geschenk: lesen oder streamen",
-          "Zwei Angebote, ein Geschenk — bis 8. August"
+          "Zwei Angebote, ein Geschenk — bis 8. August",
+          "Zusehen, wie Menschen laut denken — und die eigenen Fragen bekommen Gesellschaft."
         ]
       },
       "en": {
         "cta_labels": {
-          "uebersicht": "Choose your gift →",
+          "uebersicht": "Choose your summer →",
           "wos": "Choose reading →",
           "gtv": "Choose watching →"
         },
         "alternativen": [
           "Choose your gift: read or stream",
-          "Two offers, one gift — until 8 August"
+          "Two offers, one gift — until 8 August",
+          "Watch people think out loud — and your own questions find company."
         ]
       }
     }
@@ -167,8 +173,8 @@
     }
   },
   "proof": {
-    "de": "seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit",
-    "en": "since 1921 · 800+ videos · 42 issues a year · worldwide"
+    "de": "Stimmen und Gesichter der Anthroposophie von heute — seit 1921",
+    "en": "Voices and faces of anthroposophy today — since 1921"
   },
   "badge": {
     "de": "3 Monate gratis",
@@ -203,14 +209,14 @@
         "de": {
           "betreff": "Was Sie sehen, jetzt auch lesen — 3 Monate gratis",
           "botschaft": "Jede Woche ein Stück weiter sehen.",
-          "text": "Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter — und sehen beim nächsten Mal mehr: Essays, Blicke auf die Gegenwart und Stimmen aus der weltweiten Bewegung, jede Woche neu, gedruckt und digital.",
+          "text": "Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter: Woche für Woche schreiben dort Menschen, die einer Frage ihr Leben gewidmet haben — nicht was sie wissen, sondern wie sie suchen. Wer mitliest, kommt mit anderen Augen in die eigene Woche zurück.",
           "alt": "Drei Monate im Freien lesen — gratis",
           "preheader": "Die ersten drei Monate geschenkt — lesen, wo der Sommer Sie hinträgt. Bis 8. August."
         },
         "en": {
           "betreff": "What you watch, now also read — 3 months free",
           "botschaft": "See a little further every week.",
-          "text": "What you watch on goetheanum.tv you can read on in the weekly — and see more the next time you return: essays, reflections on our times and voices from the movement worldwide, new every week, in print and digital.",
+          "text": "What you watch on goetheanum.tv you can read on in the weekly: week after week, people who have given their lives to a question write down not what they know but how they search. Read along, and you return to your own week with different eyes.",
           "alt": "Read in the open air — three months free",
           "preheader": "The first three months as a gift — read wherever summer takes you. Until 8 August."
         }
@@ -218,16 +224,16 @@
       "w2": {
         "de": {
           "betreff": "Ihr Sommer hat noch Seiten frei",
-          "botschaft": "Lesen, wo der Abend am schönsten ist.",
-          "text": "Noch bis 8. August legen wir die Wochenschrift drei Monate gratis zu Ihrem Abo dazu — sie passt in jede Tasche und auf jeden Balkon.",
-          "alt": "Noch bis 8. August: die Wochenschrift gratis",
+          "botschaft": "Ein Sommer über den eigenen Rand hinaus.",
+          "text": "Noch bis 8. August lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — Lesestoff, der in Ihnen weiterarbeitet, wenn der Bildschirm dunkel ist.",
+          "alt": "Lesestoff, der den Sommer überdauert — gratis",
           "preheader": "Bis 8. August: die Wochenschrift drei Monate gratis zu Ihrem Abo — sie liest sich überall."
         },
         "en": {
           "betreff": "Your summer still has pages to turn",
-          "botschaft": "Read where the evening is at its best.",
-          "text": "Until 8 August we’ll add the weekly to your subscription, free for three months — it fits in any bag and on any balcony.",
-          "alt": "Until 8 August: the weekly, free",
+          "botschaft": "A summer beyond your own horizon.",
+          "text": "Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark.",
+          "alt": "Reading that outlasts the summer — free",
           "preheader": "Until 8 August: three months of the weekly, free with your subscription — it goes where you go."
         }
       },
@@ -252,47 +258,47 @@
       "w1": {
         "de": {
           "betreff": "Was Sie lesen, jetzt auch sehen — 3 Monate gratis",
-          "botschaft": "Die Bühne kommt in Ihren Garten.",
-          "text": "Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: goetheanum.tv bringt Vorträge, Gespräche und die Bühne des Goetheanum zu Ihnen — über 800 Videos, wohin Sie der Sommer auch führt.",
-          "alt": "Das Goetheanum im Garten — 3 Monate gratis",
-          "preheader": "Vorträge, Gespräche, Bühne vom Goetheanum — über 800 Videos, die mit Ihnen reisen."
+          "botschaft": "Zusehen, wie jemand denkt.",
+          "text": "Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: Auf goetheanum.tv denken Menschen laut, in über 800 Vorträgen und Gesprächen. Sie hören das Zögern und das Finden mit — alles, was auf der gedruckten Seite unsichtbar bleibt.",
+          "alt": "Dem Gelesenen zuhören — 3 Monate gratis",
+          "preheader": "Über 800 Vorträge und Gespräche, die Ihrem Lesen Tiefe geben — wohin der Sommer Sie trägt."
         },
         "en": {
           "betreff": "What you read, now also watch — 3 months free",
-          "botschaft": "The stage comes to your garden.",
-          "text": "What you read each week you can now watch and hear: goetheanum.tv brings lectures, conversations and the Goetheanum stage to you — over 800 videos, wherever summer finds you.",
-          "alt": "The Goetheanum in your garden — 3 months free",
-          "preheader": "Lectures, conversations, the Goetheanum stage — over 800 videos that travel with you."
+          "botschaft": "Watch someone think.",
+          "text": "What you read each week you can now watch and hear: on goetheanum.tv, people think out loud, in over 800 lectures and conversations. You hear the hesitation and the finding — everything the printed page keeps invisible.",
+          "alt": "Listen to what you read — 3 months free",
+          "preheader": "Over 800 lectures and conversations that deepen your reading — wherever summer takes you."
         }
       },
       "w2": {
         "de": {
-          "betreff": "Sehen Sie, was diesen Sommer läuft",
+          "betreff": "Ihr Sommer hat noch Abende frei",
           "botschaft": "Setzen Sie sich dazu.",
-          "text": "Über 800 Videos warten auf einen lauen Abend: goetheanum.tv, noch bis 8. August drei Monate gratis zu Ihrem Abo.",
-          "alt": "Noch bis 8. August: goetheanum.tv gratis",
-          "preheader": "goetheanum.tv drei Monate gratis zu Ihrem Abo — hineinschauen können Sie noch bis 8. August."
+          "text": "Ein Abend auf goetheanum.tv ist ein Abend in Gesellschaft von Menschen, die ihr Leben lang an einer Frage gearbeitet haben — und die laut denken, statt fertige Antworten vorzutragen. Noch bis 8. August drei Monate gratis zu Ihrem Abo.",
+          "alt": "Drei Monate weiter sehen — gratis",
+          "preheader": "goetheanum.tv drei Monate gratis zu Ihrem Abo — Abende, die nachwirken. Bis 8. August."
         },
         "en": {
-          "betreff": "See what’s on this summer",
+          "betreff": "Your summer still has evenings free",
           "botschaft": "Pull up a chair.",
-          "text": "Over 800 videos are waiting for a mild summer evening: goetheanum.tv, three months free with your subscription — until 8 August.",
-          "alt": "Until 8 August: goetheanum.tv free",
-          "preheader": "Three months of goetheanum.tv free with your subscription — take a seat by 8 August."
+          "text": "An evening on goetheanum.tv is an evening in the company of people who have worked on a question all their lives — thinking out loud rather than reciting finished answers. Until 8 August: three months free with your subscription.",
+          "alt": "See further for three months — free",
+          "preheader": "goetheanum.tv, three months free with your subscription — evenings that linger. By 8 August."
         }
       },
       "w3": {
         "de": {
           "betreff": "Nur noch bis Samstag: drei Monate gratis",
-          "botschaft": "Der Vorhang fällt am Samstag.",
-          "text": "Noch ein paar Sommertage: goetheanum.tv, die ersten drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es Ihnen gefällt.",
+          "botschaft": "Bis Samstag ist Ihr Platz frei.",
+          "text": "Noch ein paar Sommertage: goetheanum.tv, die ersten drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es in Ihnen nachklingt.",
           "alt": "Was Sie lesen, jetzt auch sehen — bis Samstag",
           "preheader": "Eine Minute für drei Monate goetheanum.tv: gratis zu Ihrem Abo — bis Samstag, 8. August."
         },
         "en": {
           "betreff": "Only until Saturday: three months free",
-          "botschaft": "The curtain falls on Saturday.",
-          "text": "A few summer days left: goetheanum.tv, the first three months free with your subscription — stay only if you love it.",
+          "botschaft": "Your seat stays free until Saturday.",
+          "text": "A few summer days left: goetheanum.tv, the first three months free with your subscription — stay only if it stays with you.",
           "alt": "What you read, now also watch — until Saturday",
           "preheader": "One minute for three months of goetheanum.tv — free with your subscription, until Saturday."
         }
@@ -303,14 +309,14 @@
         "de": {
           "betreff": "Ein Sommer mit dem Goetheanum — 3 Monate gratis",
           "botschaft": "Zwei Fenster auf, den ganzen Sommer.",
-          "text": "Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie die Wochenschrift, schauen Sie goetheanum.tv — die ersten drei Monate kostenlos, jederzeit kündbar.",
+          "text": "Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie in der Wochenschrift Menschen, die einer Frage ihr Leben gewidmet haben, und sehen Sie auf goetheanum.tv zu, wie sie laut denken — die ersten drei Monate kostenlos, jederzeit kündbar.",
           "alt": "Drei Monate sind eine Jahreszeit — gratis",
           "preheader": "Lesen oder schauen — oder beides: die ersten drei Monate geschenkt, bis 8. August."
         },
         "en": {
           "betreff": "A summer with the Goetheanum — 3 months free",
           "botschaft": "Two windows open, all summer long.",
-          "text": "Get to know the Goetheanum from both sides this summer: read the weekly, watch goetheanum.tv — the first three months free, cancel anytime.",
+          "text": "Get to know the Goetheanum from both sides this summer: in the weekly, read people who have given their lives to a question; on goetheanum.tv, watch them think out loud — the first three months free, cancel anytime.",
           "alt": "Three months is a whole season — free",
           "preheader": "Read the weekly, watch goetheanum.tv — or both: the first three months free. Until 8 August."
         }
@@ -318,17 +324,17 @@
       "w2": {
         "de": {
           "betreff": "Lesen, sehen — oder gleich beides",
-          "botschaft": "Wählen Sie, was Ihr Sommer braucht.",
-          "text": "Lesen auf dem Balkon, schauen am Abend — oder beides: die ersten drei Monate geschenkt, noch bis 8. August.",
+          "botschaft": "Denken in guter Gesellschaft.",
+          "text": "Ein Essay am Morgen, ein Vortrag am Abend — und dazwischen merken Sie, wie die eigenen Gedanken weiter reichen als sonst. Die ersten drei Monate geschenkt, anmelden bis 8. August.",
           "alt": "Noch bis 8. August: Ihr Sommer-Geschenk",
-          "preheader": "Die Wochenschrift und goetheanum.tv, drei Monate kostenlos — anmelden bis 8. August."
+          "preheader": "Wochenschrift und goetheanum.tv, drei Monate kostenlos — Stoff zum Weiterdenken. Bis 8. August."
         },
         "en": {
           "betreff": "Read, watch — or simply both",
-          "botschaft": "Choose what your summer needs.",
-          "text": "Reading on the balcony, watching in the evening — or both: the first three months free, until 8 August.",
+          "botschaft": "Thinking in good company.",
+          "text": "An essay in the morning, a lecture in the evening — and in between you notice your own thoughts reaching further than usual. The first three months free, sign up by 8 August.",
           "alt": "Until 8 August: your summer gift",
-          "preheader": "The weekly and goetheanum.tv, three months free — sign up by 8 August."
+          "preheader": "The weekly and goetheanum.tv, three months free — food for thought all summer. By 8 August."
         }
       },
       "w3": {
@@ -351,14 +357,14 @@
         "de": {
           "betreff": "Morgen ist Schluss",
           "botschaft": "Sie waren schon da — ein Schritt fehlt noch.",
-          "text": "Was Sie sich angeschaut haben, liegt bereit — eine Minute, und Ihre drei kostenlosen Monate beginnen.",
+          "text": "Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute, und Sie haben drei Monate Zeit, dem nachzugehen.",
           "alt": "Bis morgen: drei Monate Goetheanum gratis",
           "preheader": "Drei Monate Goetheanum, gratis und jederzeit kündbar — anmelden bis morgen, Samstag, 8. August."
         },
         "en": {
           "betreff": "It ends tomorrow",
           "botschaft": "You’ve already had a look — one step to go.",
-          "text": "What you looked at is still there — one minute, and your three free months begin.",
+          "text": "What you looked at spoke to you for a reason — one minute, and you have three months to follow it.",
           "alt": "Until tomorrow: 3 months of Goetheanum free",
           "preheader": "Three months of the Goetheanum, free, cancel anytime — sign up by tomorrow, Saturday 8 August."
         }


### PR DESCRIPTION
Vierte Text-Runde nach zwei Reklamationen des Auftraggebers: die Wachstums-Linse über alle Mails («Wann geht es nur um uns?») und der fehlende **Gehalt** der zwei Medien («Es wird alles als bekannt vorausgesetzt»). Dafür sassen fünf Stimmen am Tisch — Autorin, Copywriter, Hüterin plus neu **Marty Neumeier** (Onlyness) und **Fabian Geyrhalter** (Empfänger-Essenz), mit dem Rohmaterial des Auftraggebers als Brief (Erkenntnisringen reifer Persönlichkeiten, laut denkende Menschen, Befreiung aus dem eigenen Gesichtskreis).

## Kern der Synthese

- **lesen w1:** «… Woche für Woche schreiben dort Menschen, die einer Frage ihr Leben gewidmet haben — **nicht was sie wissen, sondern wie sie suchen.** Wer mitliest, kommt mit anderen Augen in die eigene Woche zurück.»
- **sehen w1:** Botschaft **«Zusehen, wie jemand denkt.»** (Neumeier); Text: «Sie hören **das Zögern und das Finden** mit — alles, was auf der gedruckten Seite unsichtbar bleibt.»
- **sehen w2:** Betreff neu **«Ihr Sommer hat noch Abende frei»** (Zwilling zu ‹Seiten frei›); «800 Videos warten» → «ein Abend **in Gesellschaft von Menschen**, die ihr Leben lang an einer Frage gearbeitet haben — und die laut denken, statt fertige Antworten vorzutragen».
- **sehen w3:** «**Bis Samstag ist Ihr Platz frei.**» statt fallendem Vorhang; «bleiben Sie nur, wenn es **in Ihnen nachklingt**».
- **beides:** Botschaft **«Denken in guter Gesellschaft.»**; w2-Text «… und dazwischen merken Sie, wie die eigenen Gedanken weiter reichen als sonst»; w3b nimmt das Interesse ernst («**hat Sie aus einem Grund angesprochen** — drei Monate Zeit, dem nachzugehen»); CTA «**Ihren Sommer wählen →**».
- **Beweis-Band:** «seit 1921 · 800+ Videos · 42 Ausgaben im Jahr · weltweit» (drei abstrakte Zahlen) → **«Stimmen und Gesichter der Anthroposophie von heute — seit 1921»** (Slogan-Vorschlag des Auftraggebers, um den 1921-Bogen ergänzt).
- Die Onlyness-/Essenz-Zeilen von Neumeier und Geyrhalter sind als Munition im `alternativen`-Feld abgelegt (Landingpages, AC-Splits, Signaturen).

AC-seitig ändert sich der Betreff **sehen w2** (DE/EN) und das HTML aller Mails (bereits eingefüllte Schritte frisch laden). Build grün, alle Mails < 100 KB, Kontrollskript sauber (Längen, keine «wartet auf»-/«unverbindlich»-Muster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_