### PR TITLE
Schilder: Raumschild-Vorlage, zweisprachig, Format-Familie A5–A1

### DIFF
--- a/apps/schilder/index.html
+++ b/apps/schilder/index.html
@@ -2,136 +2,151 @@
 <!-- =============================================================================
      Goetheanum-Werkzeug · SCHILDER
      -----------------------------------------------------------------------------
-     Editor für Orientierungs- und Türschilder im Hausbild. Vom Fundament aus
+     Editor für Orientierungs- und Raumschilder im Hausbild. Vom Fundament aus
      gebaut: tokens.css + base.css + nav.css EINGEBUNDEN (nicht kopiert), Farben,
      Schnitte und Abstände ausschliesslich aus den Tokens.
 
-     Stand (Entwurf): der Editor ersetzt zunächst nur einzelne Zeilen und Zeichen.
-     Vorlagen (feste Türschilder für Namen und Funktionen) folgen, sobald die
-     genauen Masse vorliegen. Auf dem Schild kommt ausschliesslich die Hausschrift
-     zum Einsatz, dazu die Haus-Icons und -Pfeile (Webfont, per Zeichen gesetzt).
+     Vorlage «Raumschild» nach den bestehenden Hausschildern (Rollschild Grosser
+     Saal, Ausstellungsregeln, Öffnungszeiten). Die tragende Grammatik dieser
+     Schilder ist umgesetzt:
+       · Zweisprachig gepaart – Deutsch (Deutlich) über Englisch (Klar), gleicher
+         Grad. Das ist das Kennzeichen aller Haus-Schilder.
+       · Titelblock, Icon-Regelzeilen (Haus-Icons/-Pfeile), hinterlegte Wechsel-
+         Box für die wechselnde Info, Kicker (Datum) und Fusszeile – je zuschaltbar.
+       · Format-Familie A5–A1, hoch und quer; das Schild skaliert in echten mm und
+         druckt in Originalgrösse.
+
+     Auf dem Schild kommt ausschliesslich die Hausschrift zum Einsatz, dazu die
+     Haus-Icons und -Pfeile (Webfont, per Zeichen/Codepoint gesetzt).
 
      Regel-IDs, die hier tragen:
-       · G05  Betonung mit Laut, nie Versalien/Unterstreichen/Sperren.
-       · B01  auf Farbe steht Weiss – hier steht dunkle Schrift auf weissem Schild.
-       · B03/B04 Mindestgrössen und Fingerziele der BEDIENUNG (das Schild selbst
-             ist ein Druck-Artefakt in Millimetern, kein Bildschirm-Text).
-       · DS01/DS02/DS07 Pflicht-Includes, nur Token-Farben, Flächen tokenisiert.
-             Die weisse Schild-Fläche ist ein physisches Artefakt (# ds-ok).
+       · G05  Betonung mit Schnitt (Deutlich/Klar), nie Versal/Unterstrich/Sperren.
+       · B01/B02 dunkle Markenschrift auf weissem Schild (Blau auf Weiss ≥4.5:1),
+             nie Text auf Farbfläche.
+       · DS01/DS02/DS07 Pflicht-Includes, nur Token-Farben in der Bedienung. Die
+             Schild-Farben (Markenblau auf Weiss) sind ein physisches Druck-
+             Artefakt, theme-fest – als --sign-* definiert (# ds-ok).
      ============================================================================= -->
 <html lang="de-CH">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Schilder · Goetheanum</title>
-<meta name="description" content="Orientierungs- und Türschilder im Hausbild setzen – Zeilen und Zeichen einsetzen, mit Haus-Icons und -Pfeilen, A5 quer drucken." />
+<meta name="description" content="Orientierungs- und Raumschilder im Hausbild setzen – zweisprachige Zeilen und Haus-Icons einsetzen, Format A5 bis A1 drucken." />
 <meta name="robots" content="noindex" />
 <link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
 
-<!-- Das Fundament – eine Quelle der Wahrheit. NICHT kopieren, EINBINDEN. -->
 <link rel="stylesheet" href="../../design-system/tokens.css" />
 <link rel="stylesheet" href="../../design-system/base.css" />
 <link rel="stylesheet" href="../../design-system/nav.css" />
 
 <style>
-  /* Haus-Icons als Webfont – deckt Piktogramme UND Pfeile/Kompass ab (per
-     Codepoint gesetzt, currentColor → folgt der Schildfarbe). */
+  /* Haus-Icons als Webfont – deckt Piktogramme UND Pfeile/Kompass ab. */
   @font-face{font-family:"G Icons";src:url("../../assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Icons-v2.7.woff2") format("woff2");font-display:block}
 
-  /* Nur werkzeug-eigenes Layout. Farbe/Schnitt/Abstand kommen aus den Tokens. */
   .hero{padding-block:clamp(40px,7vw,64px) var(--s4)}
-  .hero .lede{margin-top:var(--s4);max-width:60ch}
+  .hero .lede{margin-top:var(--s4);max-width:62ch}
 
-  /* Format-Wahl (Pillen aus base.css .seg). Gesperrte Formate treten zurück. */
-  .fmt-note{margin-top:var(--s3)}
-  .seg button[disabled]{opacity:.5;cursor:not-allowed}
-  .seg button[disabled]:hover{border-color:var(--line)}
+  /* Zwei Spalten: links die Bedienung, rechts die Vorschau (klebt mit). */
+  .work{display:grid;grid-template-columns:minmax(320px,1fr) minmax(360px,1.05fr);gap:var(--s8);align-items:start}
+  @media(max-width:960px){.work{grid-template-columns:1fr}.preview{order:-1;position:static}}
 
-  /* Zwei Spalten: links die Bedienung, rechts die Vorschau. Mobil gestapelt,
-     Vorschau zuerst (WYSIWYG). Container in %/ch, keine festen px-Höhen (B04). */
-  .work{display:grid;grid-template-columns:minmax(320px,1fr) minmax(340px,1.15fr);
-    gap:var(--s8);align-items:start}
-  @media(max-width:900px){.work{grid-template-columns:1fr}.preview{order:-1}}
+  .editor{display:grid;gap:var(--s6)}
+  .grp{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);background:var(--soft)}
+  .grp>h3{font-size:var(--t-h3);margin-bottom:var(--s2)}
+  .grp>.note{margin-bottom:var(--s4)}
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:var(--s3)}
+  @media(max-width:520px){.grid2{grid-template-columns:1fr}}
+  .stack{display:grid;gap:var(--s3)}
 
-  /* --- Zeilen-Editor -------------------------------------------------------- */
-  .rows{display:grid;gap:var(--s3)}
-  .row{display:grid;grid-template-columns:auto auto 1fr auto;gap:var(--s2);align-items:center;
-    padding:var(--s2);border:1px solid var(--line);border-radius:var(--r-card);background:var(--soft)}
-  .row .drag{color:var(--muted);font-size:var(--t-small);cursor:default;user-select:none;padding:0 2px}
-  /* Symbol-Knopf: zeigt das gewählte Zeichen (Icon-Font) oder ein Leerzeichen. */
-  .symbtn{display:inline-flex;align-items:center;justify-content:center;width:var(--tap);height:var(--tap);
-    flex:none;border:1px solid var(--line);border-radius:var(--r-control);background:var(--field-bg);
-    color:var(--ink);cursor:pointer;font-family:"G Icons";font-size:24px;line-height:1;transition:border-color .15s}
+  /* Feld: Label + Eingabe (Lese-Grotesk, 16px → kein iOS-Zoom). */
+  .f{display:grid;gap:var(--s1)}
+  .f>.lab{font-size:var(--t-small);color:var(--muted);letter-spacing:.01em}
+  .f input{width:100%;font-family:var(--font-text);font-size:16px;font-weight:400;line-height:1.3;color:var(--ink);
+    background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);padding:10px 12px;outline:none;transition:border-color .15s,box-shadow .15s}
+  .f input:focus{border-color:var(--blue);box-shadow:0 0 0 3px color-mix(in srgb,var(--blue) 22%,transparent)}
+
+  .optline{display:flex;align-items:center;gap:var(--s4);flex-wrap:wrap;justify-content:space-between;margin-top:var(--s2)}
+  .optline .lab{flex:0 0 auto;font-size:var(--t-small);color:var(--muted)}
+
+  /* --- Regel-Zeilen --------------------------------------------------------- */
+  .rules{display:grid;gap:var(--s3)}
+  .rule{display:grid;grid-template-columns:auto 1fr auto;gap:var(--s3);align-items:start;
+    padding:var(--s3);border:1px solid var(--line);border-radius:var(--r-card);background:var(--field-bg)}
+  .symbtn{display:inline-flex;align-items:center;justify-content:center;width:var(--tap);height:var(--tap);flex:none;
+    border:1px solid var(--line);border-radius:var(--r-control);background:var(--field-bg);color:var(--ink);cursor:pointer;
+    font-family:"G Icons";font-size:24px;line-height:1;transition:border-color .15s;margin-top:2px}
   .symbtn:hover{border-color:var(--gold-ink)}
-  .symbtn.empty{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted)}
-  .row input.linetext{width:100%;font-family:var(--font-text);font-size:16px;font-weight:400;line-height:1.3;
-    color:var(--ink);background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);padding:10px 12px;outline:none;transition:border-color .15s,box-shadow .15s}
-  .row input.linetext:focus{border-color:var(--blue);box-shadow:0 0 0 3px color-mix(in srgb,var(--blue) 22%,transparent)}
-  .rowtools{display:flex;gap:2px;align-items:center}
-  .iconbtn{display:inline-flex;align-items:center;justify-content:center;width:34px;height:34px;flex:none;
-    border:1px solid transparent;border-radius:8px;background:none;color:var(--muted);cursor:pointer;font-size:16px;line-height:1;transition:.15s}
+  .symbtn.empty{font-family:var(--font-text);font-size:22px;color:var(--muted)}
+  .ruletools{display:flex;flex-direction:column;gap:2px}
+  .iconbtn{display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;flex:none;
+    border:1px solid transparent;border-radius:8px;background:none;color:var(--muted);cursor:pointer;font-size:15px;line-height:1;transition:.15s}
   .iconbtn:hover{color:var(--ink);border-color:var(--line)}
-  .iconbtn:disabled{opacity:.35;cursor:not-allowed}
-  .iconbtn:disabled:hover{color:var(--muted);border-color:transparent}
-  /* Symbol-Seite (links/rechts) je Zeile – kleine Pillen. */
-  .sidewrap{display:flex;gap:6px;align-items:center;flex-wrap:wrap;margin-top:var(--s2)}
+  .iconbtn:disabled{opacity:.3;cursor:not-allowed}.iconbtn:disabled:hover{color:var(--muted);border-color:transparent}
+  .addrow{margin-top:var(--s1)}
 
-  .addrow{margin-top:var(--s3)}
-
-  /* Feld-Gruppe für Schild-Optionen. */
-  .opts{display:grid;gap:var(--s4);margin-top:var(--s6)}
-  .optline{display:flex;align-items:center;gap:var(--s4);flex-wrap:wrap;justify-content:space-between}
-  .optline .lab{flex:0 0 auto}
-
-  /* --- Vorschau: das Schild in echten Millimetern, für die Anzeige skaliert --- */
-  .preview .frame{border:1px solid var(--line);border-radius:var(--r-card);background:var(--soft);
-    padding:var(--s6);overflow:hidden}
+  /* --- Vorschau ------------------------------------------------------------- */
+  .preview{position:sticky;top:calc(var(--header-h) + 8px)}
+  .frame{border:1px solid var(--line);border-radius:var(--r-card);background:var(--soft);padding:var(--s6);overflow:hidden}
   .stage{display:flex;justify-content:center}
   .sheetscale{transform-origin:top center}
-  /* Das physische Schild: fixe Artefakt-Farben (weisses Papier), unabhängig vom
-     App-Theme – WYSIWYG für den Druck. Masse in mm → druckt in Originalgrösse. */
-  .sheet{--sheet-bg:#ffffff;      /* # ds-ok: weisses Schild (Druck-Artefakt) */
-    --sheet-ink:#23272b;          /* # ds-ok: dunkle Schrift auf weissem Schild */
-    width:var(--sheet-w,210mm);height:var(--sheet-h,148mm);background:var(--sheet-bg);color:var(--sheet-ink);
-    box-shadow:0 6px 24px rgba(20,24,28,.14);position:relative;overflow:hidden}
-  .sheet .pad{position:absolute;inset:12mm;display:flex;flex-direction:column;justify-content:center;gap:0}
-  .sheet.align-center .pad{align-items:stretch}
-  .sline{display:flex;align-items:center;gap:.5em;min-height:1em;padding:.18em 0}
-  .sline.pos-right{flex-direction:row-reverse;justify-content:flex-start}
-  .sheet.align-center .sline{justify-content:center}
-  .sheet.align-center .sline.pos-right{justify-content:center}
-  .sline .sym{font-family:"G Icons";line-height:1;flex:none;font-size:1.25em}
-  /* Schild-Text: Hausschrift, Schnitt Deutlich (Wegweisung = geschaute Hierarchie,
-     kein Fliesstext). Betonung nie über Versalien (G05). */
-  .sline .txt{font-family:var(--font-display);font-weight:var(--w-deutlich);line-height:1.1;letter-spacing:-.005em;
-    white-space:pre-wrap;word-break:break-word}
-  .sline .txt:empty::after{content:"\00a0"}
 
-  .size-s .pad{font-size:9mm}
-  .size-m .pad{font-size:13mm}
-  .size-l .pad{font-size:18mm}
+  /* Das physische Schild: Markenblau auf Weiss, theme-fest (WYSIWYG für den Druck).
+     Als --sign-* definiert – DS02 erlaubt Literale in Custom-Property-Definitionen;
+     Weiss ist als Papier ratifiziert (# ds-ok). Masse in mm → Originalgrösse. */
+  .sheet{
+    --sign-bg:#ffffff;      /* # ds-ok — weisses Schild (Druck-Artefakt) */
+    --sign-ink:#0061a9;     /* # ds-ok — Markenblau als Schild-Schrift auf Weiss */
+    --sign-soft:#5c7fa6;    /* # ds-ok — gedämpftes Blaugrau, Kicker und Fussnote */
+    --sign-box:#eef2f7;     /* # ds-ok — zarte Blau-Tönung der Wechsel-Box */
+    --sign-line:#cdd8e6;    /* # ds-ok — feine Trennlinie */
+    width:var(--sheet-w,297mm);height:var(--sheet-h,420mm);background:var(--sign-bg);color:var(--sign-ink);
+    box-shadow:0 6px 24px rgba(20,24,28,.14);position:relative;overflow:hidden;font-family:var(--font-display)}
+  .pad{position:absolute;inset:0;padding:8% 9%;display:flex;flex-direction:column;gap:.55em;font-size:var(--u,13mm)}
+
+  .s-kicker{font-family:var(--font-text);font-weight:600;color:var(--sign-soft);font-size:.5em;line-height:1.2;letter-spacing:.01em}
+
+  .s-title{display:grid;gap:.02em}
+  .s-title .de{font-weight:var(--w-deutlich);font-size:1.95em;line-height:1.02;letter-spacing:-.01em}
+  .s-title .en{font-weight:var(--w-text);font-size:1.95em;line-height:1.02;letter-spacing:-.01em}
+
+  .s-divider{border:0;border-top:.03em solid var(--sign-line);margin:.15em 0 .1em}
+
+  .s-rules{display:grid;grid-template-columns:1fr;gap:.55em .9em;align-items:start}
+  .s-rules.cols-2{grid-template-columns:1fr 1fr}
+  .s-rule{display:flex;gap:.45em;align-items:flex-start}
+  .s-rule .sym{font-family:"G Icons";font-size:1.5em;line-height:1;flex:none}
+  .s-rule .lab{display:grid;gap:.02em;font-size:.7em;line-height:1.08}
+  .s-rule .lab .de{font-weight:var(--w-deutlich)}
+  .s-rule .lab .en{font-weight:var(--w-text)}
+
+  .s-box{background:var(--sign-box);border-radius:.12em;padding:.7em .8em;display:flex;flex-direction:column;gap:.5em;margin-top:.2em}
+  .s-box .big{display:grid;gap:.02em}
+  .s-box .big .de{font-weight:var(--w-deutlich);font-size:.9em;line-height:1.08}
+  .s-box .big .en{font-weight:var(--w-text);font-size:.9em;line-height:1.08}
+  .s-box .note{display:grid;gap:.02em;margin-top:.6em;font-size:.5em;line-height:1.15;color:var(--sign-soft)}
+  .s-box .note .de{font-weight:var(--w-deutlich)}
+  .s-box .note .en{font-weight:var(--w-text)}
+
+  .s-foot{margin-top:auto;display:flex;align-items:center;gap:.4em;font-family:var(--font-text);color:var(--sign-ink);font-weight:600;font-size:.5em;line-height:1;padding-top:.5em}
+  .s-foot img{width:1.5em;height:1.5em;flex:none}
 
   .prevfoot{display:flex;justify-content:space-between;align-items:baseline;gap:var(--s4);flex-wrap:wrap;margin-top:var(--s4)}
   .dims{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small)}
   .actions{display:flex;gap:var(--s2);flex-wrap:wrap;margin-top:var(--s4)}
 
-  /* --- Zeichen-Wähler (Icons & Pfeile) -------------------------------------- */
-  dialog.picker{border:1px solid var(--line);border-radius:var(--r-card);background:var(--paper);color:var(--ink);
-    padding:0;width:min(640px,92vw);max-height:86vh;box-shadow:var(--shadow-card)}
+  /* --- Zeichen-Wähler ------------------------------------------------------- */
+  dialog.picker{border:1px solid var(--line);border-radius:var(--r-card);background:var(--paper);color:var(--ink);padding:0;width:min(640px,92vw);max-height:86vh;box-shadow:var(--shadow-card)}
   dialog.picker::backdrop{background:color-mix(in srgb,var(--ink) 45%,transparent)}
-  .picker .phead{position:sticky;top:0;background:var(--bar-bg);backdrop-filter:blur(6px);
-    border-bottom:1px solid var(--line);padding:var(--s4) var(--s6);display:flex;gap:var(--s4);align-items:center;justify-content:space-between}
+  .picker .phead{position:sticky;top:0;background:var(--bar-bg);backdrop-filter:blur(6px);border-bottom:1px solid var(--line);padding:var(--s4) var(--s6);display:flex;gap:var(--s4);align-items:center;justify-content:space-between}
   .picker .phead h3{font-size:var(--t-h3)}
   .picker .pbody{padding:var(--s4) var(--s6) var(--s6);overflow:auto}
   .picker .psearch{margin:var(--s4) 0}
-  .picker .psearch input{width:100%;font-family:var(--font-text);font-size:16px;color:var(--ink);background:var(--field-bg);
-    border:1px solid var(--line);border-radius:var(--r-control);padding:11px 12px;outline:none}
+  .picker .psearch input{width:100%;font-family:var(--font-text);font-size:16px;color:var(--ink);background:var(--field-bg);border:1px solid var(--line);border-radius:var(--r-control);padding:11px 12px;outline:none}
   .picker .psearch input:focus{border-color:var(--blue);box-shadow:0 0 0 3px color-mix(in srgb,var(--blue) 22%,transparent)}
-  .picker h4{font-family:var(--font-text);font-weight:600;font-size:var(--t-small);color:var(--muted);
-    margin:var(--s4) 0 var(--s2);letter-spacing:.01em}
+  .picker h4{font-family:var(--font-text);font-weight:600;font-size:var(--t-small);color:var(--muted);margin:var(--s4) 0 var(--s2)}
   .glyphgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(74px,1fr));gap:8px}
-  .glyphcell{display:flex;flex-direction:column;align-items:center;gap:6px;padding:12px 6px 8px;
-    border:1px solid var(--line-soft);border-radius:12px;background:var(--soft);cursor:pointer;transition:border-color .15s,background .15s}
+  .glyphcell{display:flex;flex-direction:column;align-items:center;gap:6px;padding:12px 6px 8px;border:1px solid var(--line-soft);border-radius:12px;background:var(--soft);cursor:pointer;transition:border-color .15s,background .15s}
   .glyphcell:hover,.glyphcell:focus-visible{border-color:var(--gold-ink);background:var(--paper);outline:none}
   .glyphcell .g{font-family:"G Icons";font-size:38px;line-height:1;color:var(--ink);height:40px}
   .glyphcell .n{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);text-align:center;line-height:1.2;min-height:2.4em}
@@ -141,7 +156,6 @@
 </head>
 <body>
 
-<!-- Globale Navigation aus tools.json. -->
 <script src="../../design-system/nav.js" data-root="../../" data-section="vorbereitung" data-active="schilder"></script>
 
 <main class="wrap">
@@ -149,24 +163,8 @@
   <section class="hero">
     <span class="kicker">Goetheanum · Orientierung</span>
     <h1>Schilder</h1>
-    <p class="lede">Orientierungs- und Türschilder im Hausbild setzen: Zeilen und Zeichen einsetzen,
-      mit den Haus-Icons und -Pfeilen, in der Hausschrift – und A5 quer ausdrucken.</p>
-  </section>
-
-  <section>
-    <div class="shead">
-      <h2>Format</h2>
-      <p>Zurzeit steht das Orientierungsschild A5 quer bereit. Feste Türschilder für Namen und
-        Funktionen kommen als Vorlagen, sobald die genauen Masse vorliegen.</p>
-    </div>
-
-    <div class="seg" id="formats" role="group" aria-label="Format wählen">
-      <button type="button" data-fmt="a5q" aria-pressed="true">Orientierung · A5 quer</button>
-      <button type="button" data-fmt="tuer-name" disabled aria-disabled="true">Türschild · Name — bald</button>
-      <button type="button" data-fmt="tuer-funktion" disabled aria-disabled="true">Türschild · Funktion — bald</button>
-    </div>
-    <p class="note fmt-note">Der Editor ersetzt zunächst nur einzelne Zeilen und Zeichen. Vorlagen mit
-      fest gesetzten Feldern folgen.</p>
+    <p class="lede">Orientierungs- und Raumschilder im Hausbild setzen: zweisprachige Zeilen und Haus-Icons
+      einsetzen, den Titel und die wechselnde Info bestimmen – von A5 bis A1, hoch oder quer, druckfertig.</p>
   </section>
 
   <section>
@@ -174,64 +172,117 @@
 
       <!-- ============================ BEDIENUNG ============================= -->
       <div class="editor">
-        <div class="shead">
-          <h2>Zeilen</h2>
-          <p>Je Zeile ein Ziel: Text eintragen, Symbol wählen und seine Seite bestimmen. Ein Symbol
-            ist ein Zeichen aus dem Haus-Icon- oder -Pfeil-Satz.</p>
-        </div>
 
-        <div class="rows" id="rows"></div>
-
-        <div class="addrow">
-          <button type="button" class="btn" id="addRow">Zeile hinzufügen</button>
-        </div>
-
-        <div class="opts">
+        <div class="grp">
+          <h3>Kopf</h3>
+          <p class="note">Titel zweisprachig – Deutsch (Deutlich) über Englisch (Klar). Die Datum-Zeile ist optional.</p>
           <div class="optline">
-            <span class="lab" id="lab-align">Ausrichtung</span>
-            <div class="seg" role="group" aria-labelledby="lab-align" id="align">
-              <button type="button" data-align="left" aria-pressed="true">Links</button>
-              <button type="button" data-align="center" aria-pressed="false">Mittig</button>
+            <span class="lab">Datum-Zeile</span>
+            <div class="seg" role="group" aria-label="Datum-Zeile" id="tg-kicker">
+              <button type="button" data-v="0" aria-pressed="true">Aus</button>
+              <button type="button" data-v="1" aria-pressed="false">Ein</button>
             </div>
           </div>
-          <div class="optline">
-            <span class="lab" id="lab-size">Schriftgrösse</span>
-            <div class="seg" role="group" aria-labelledby="lab-size" id="size">
-              <button type="button" data-size="s" aria-pressed="false">Klein</button>
-              <button type="button" data-size="m" aria-pressed="true">Mittel</button>
-              <button type="button" data-size="l" aria-pressed="false">Gross</button>
+          <div class="stack" style="margin-top:var(--s3)">
+            <label class="f" id="kicker-wrap" hidden><span class="lab">Datum / Überzeile</span><input type="text" id="kicker" placeholder="z. B. Juli 2026" /></label>
+            <div class="grid2">
+              <label class="f"><span class="lab">Titel · Deutsch</span><input type="text" id="title-de" placeholder="Grosser Saal" /></label>
+              <label class="f"><span class="lab">Titel · English</span><input type="text" id="title-en" placeholder="Main Auditorium" /></label>
             </div>
           </div>
         </div>
+
+        <div class="grp">
+          <h3>Regeln &amp; Wege</h3>
+          <p class="note">Je Zeile ein Icon oder Pfeil aus dem Haus-Satz, dazu das zweisprachige Label. Für Wegweiser genügen Pfeil und Zielname.</p>
+          <div class="rules" id="rules"></div>
+          <div class="addrow"><button type="button" class="btn" id="addRule">Zeile hinzufügen</button></div>
+          <div class="optline">
+            <span class="lab">Spalten</span>
+            <div class="seg" role="group" aria-label="Spalten" id="sg-cols">
+              <button type="button" data-v="1" aria-pressed="true">1</button>
+              <button type="button" data-v="2" aria-pressed="false">2</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="grp">
+          <h3>Wechsel-Box</h3>
+          <p class="note">Das hinterlegte Feld für die wechselnde Info (z. B. Besichtigungszeiten) mit optionaler Fussnote.</p>
+          <div class="optline">
+            <span class="lab">Wechsel-Box</span>
+            <div class="seg" role="group" aria-label="Wechsel-Box" id="tg-box">
+              <button type="button" data-v="0" aria-pressed="false">Aus</button>
+              <button type="button" data-v="1" aria-pressed="true">Ein</button>
+            </div>
+          </div>
+          <div class="stack" id="box-fields" style="margin-top:var(--s3)">
+            <div class="grid2">
+              <label class="f"><span class="lab">Info · Deutsch</span><input type="text" id="box-de" placeholder="Besichtigung 13.30–14.30" /></label>
+              <label class="f"><span class="lab">Info · English</span><input type="text" id="box-en" placeholder="Viewing 1.30–2.30 pm" /></label>
+            </div>
+            <div class="grid2">
+              <label class="f"><span class="lab">Fussnote · Deutsch</span><input type="text" id="note-de" placeholder="Mitunter geschlossen für Proben und Aufführungen" /></label>
+              <label class="f"><span class="lab">Fussnote · English</span><input type="text" id="note-en" placeholder="Sometimes closed for rehearsals and performances" /></label>
+            </div>
+          </div>
+        </div>
+
+        <div class="grp">
+          <h3>Format &amp; Gestalt</h3>
+          <div class="optline">
+            <span class="lab">Grösse</span>
+            <div class="seg" role="group" aria-label="Grösse" id="sg-size">
+              <button type="button" data-v="a5" aria-pressed="false">A5</button>
+              <button type="button" data-v="a4" aria-pressed="false">A4</button>
+              <button type="button" data-v="a3" aria-pressed="true">A3</button>
+              <button type="button" data-v="a2" aria-pressed="false">A2</button>
+              <button type="button" data-v="a1" aria-pressed="false">A1</button>
+            </div>
+          </div>
+          <div class="optline">
+            <span class="lab">Ausrichtung</span>
+            <div class="seg" role="group" aria-label="Ausrichtung" id="sg-orient">
+              <button type="button" data-v="hoch" aria-pressed="true">Hoch</button>
+              <button type="button" data-v="quer" aria-pressed="false">Quer</button>
+            </div>
+          </div>
+          <div class="optline">
+            <span class="lab">Schriftgrösse</span>
+            <div class="seg" role="group" aria-label="Schriftgrösse" id="sg-scale">
+              <button type="button" data-v="s" aria-pressed="false">Klein</button>
+              <button type="button" data-v="m" aria-pressed="true">Mittel</button>
+              <button type="button" data-v="l" aria-pressed="false">Gross</button>
+            </div>
+          </div>
+          <div class="optline">
+            <span class="lab">Fusszeile</span>
+            <div class="seg" role="group" aria-label="Fusszeile" id="tg-foot">
+              <button type="button" data-v="0" aria-pressed="false">Aus</button>
+              <button type="button" data-v="1" aria-pressed="true">Ein</button>
+            </div>
+          </div>
+        </div>
+
       </div>
 
       <!-- ============================ VORSCHAU ============================== -->
       <div class="preview">
-        <div class="shead">
-          <h2>Vorschau</h2>
-          <p>So wird gedruckt – in Originalgrösse.</p>
-        </div>
-
+        <div class="shead"><h2>Vorschau</h2><p>So wird gedruckt – in Originalgrösse.</p></div>
         <div class="frame">
           <div class="stage" id="stage">
             <div class="sheetscale" id="sheetscale">
-              <div class="sheet size-m align-left" id="sheet">
-                <div class="pad" id="pad"></div>
-              </div>
+              <div class="sheet" id="sheet"><div class="pad" id="pad"></div></div>
             </div>
           </div>
         </div>
-
-        <div class="prevfoot">
-          <span class="dims" id="dims">A5 quer · 210&#8239;×&#8239;148&#8239;mm</span>
-        </div>
-
+        <div class="prevfoot"><span class="dims" id="dims"></span></div>
         <div class="actions">
           <button type="button" class="btn primary" id="print">Drucken / als PDF</button>
           <button type="button" class="btn" id="reset">Zurücksetzen</button>
         </div>
-        <p class="note" style="margin-top:var(--s3)">Im Druckdialog Format A5, Ausrichtung Querformat und
-          Ränder ‹keine› wählen; als PDF sichern über ‹Als PDF speichern›.</p>
+        <p class="note" style="margin-top:var(--s3)">Im Druckdialog dasselbe Format wählen (A5–A1), Ausrichtung passend
+          und Ränder ‹keine›; als PDF sichern über ‹Als PDF speichern›.</p>
       </div>
 
     </div>
@@ -239,19 +290,11 @@
 
 </main>
 
-<!-- Zeichen-Wähler: Haus-Icons und -Pfeile. -->
 <dialog class="picker" id="picker" aria-label="Zeichen wählen">
-  <div class="phead">
-    <h3>Zeichen wählen</h3>
-    <button type="button" class="btn ghost" id="pickerClose" aria-label="Schliessen">Schliessen</button>
-  </div>
+  <div class="phead"><h3>Zeichen wählen</h3><button type="button" class="btn ghost" id="pickerClose" aria-label="Schliessen">Schliessen</button></div>
   <div class="pbody">
-    <div class="psearch">
-      <input type="search" id="pickerSearch" placeholder="Suchen – z. B. Pfeil, WC, WLAN" aria-label="Zeichen suchen" />
-    </div>
-    <div class="pnone">
-      <button type="button" class="btn" id="pickNone">Kein Symbol</button>
-    </div>
+    <div class="psearch"><input type="search" id="pickerSearch" placeholder="Suchen – z. B. Pfeil, WC, Kamera" aria-label="Zeichen suchen" /></div>
+    <div class="pnone"><button type="button" class="btn" id="pickNone">Kein Symbol</button></div>
     <div id="pickerBody"></div>
   </div>
 </dialog>
@@ -268,14 +311,17 @@
   "use strict";
 
   var ICONS_URL = "../../assets/fonts/goetheanum/Icons-Einzeldateien/icons.json";
+  var MARK_URL  = "../../assets/logos/goetheanum-mark-blue.svg";
 
-  // Fallback-Auswahl, falls die icons.json nicht geladen werden kann (offline):
-  // die gebräuchlichsten Wegweiser-Zeichen. group = Anzeige-Rubrik.
   var FALLBACK = [
     {slug:"pfeil-links",  label:"Pfeil links",  codepoint:"U+E267", group:"pfeil-kompass"},
     {slug:"pfeil-rechts", label:"Pfeil rechts", codepoint:"U+E265", group:"pfeil-kompass"},
     {slug:"pfeil-hoch",   label:"Pfeil hoch",   codepoint:"U+E264", group:"pfeil-kompass"},
     {slug:"pfeil-runter", label:"Pfeil runter", codepoint:"U+E266", group:"pfeil-kompass"},
+    {slug:"nur-mit-augen",label:"Nur mit den Augen", codepoint:"U+0077", group:"piktogramm"},
+    {slug:"keine-fotos",  label:"Keine Fotos",  codepoint:"U+007A", group:"piktogramm"},
+    {slug:"draussen-essen",label:"Draussen essen",codepoint:"U+0075",group:"piktogramm"},
+    {slug:"geraete-abschalten",label:"Geräte abschalten",codepoint:"U+006F",group:"piktogramm"},
     {slug:"eintritt",     label:"Eintritt",     codepoint:"U+0065", group:"piktogramm"},
     {slug:"garderobe",    label:"Garderobe",    codepoint:"U+0066", group:"piktogramm"},
     {slug:"fahrstuhl",    label:"Fahrstuhl",    codepoint:"U+0061", group:"piktogramm"},
@@ -285,260 +331,248 @@
     {slug:"wc-rollstuhl", label:"WC Rollstuhl", codepoint:"U+0078", group:"piktogramm"},
     {slug:"wlan",         label:"WLAN",         codepoint:"U+0067", group:"piktogramm"}
   ];
-
   var GROUP_TITLE = {"pfeil-kompass":"Pfeile & Kompass","piktogramm":"Piktogramme"};
   var GROUP_ORDER = ["pfeil-kompass","piktogramm"];
 
-  function cpChar(cp){
-    try{ return String.fromCodePoint(parseInt(String(cp).replace(/^U\+/i,""),16)); }
-    catch(e){ return ""; }
-  }
+  // A-Reihe (Hochformat, mm). Quer = getauscht.
+  var SIZES = {a5:[148,210], a4:[210,297], a3:[297,420], a2:[420,594], a1:[594,841]};
+  var SIZE_LABEL = {a5:"A5",a4:"A4",a3:"A3",a2:"A2",a1:"A1"};
+  var SCALE_MULT = {s:0.85, m:1, l:1.18};
 
-  // Zustand des Schildes. Symbol = {char, label} oder null.
-  function defaultLines(){
-    return [
-      {sym:{char:cpChar("U+E265"),label:"Pfeil rechts"}, pos:"left", text:"Grosser Saal"},
-      {sym:{char:cpChar("U+E267"),label:"Pfeil links"},  pos:"left", text:"Garderobe"},
-      {sym:{char:cpChar("U+0079"),label:"WC Damen"},     pos:"left", text:"WC"}
-    ];
+  function cpChar(cp){ try{ return String.fromCodePoint(parseInt(String(cp).replace(/^U\+/i,""),16)); }catch(e){ return ""; } }
+
+  function defaults(){
+    return {
+      kickerOn:false, kicker:"Juli 2026",
+      title:{de:"Grosser Saal", en:"Main Auditorium"},
+      rules:[
+        {sym:{char:cpChar("U+0077"),label:"Nur mit den Augen"}, de:"Bitte nur mit den Augen berühren", en:"Please touch with your eyes only"},
+        {sym:{char:cpChar("U+007A"),label:"Keine Fotos"}, de:"Keine Aufnahmen", en:"No records"},
+        {sym:{char:cpChar("U+0075"),label:"Draussen essen"}, de:"Draussen essen", en:"Eat outside"}
+      ],
+      cols:1,
+      boxOn:true, box:{de:"Besichtigung 13.30–14.30", en:"Viewing 1.30–2.30 pm"},
+      note:{de:"Mitunter geschlossen für Proben und Aufführungen", en:"Sometimes closed for rehearsals and performances"},
+      size:"a3", orient:"hoch", scale:"m", footOn:true
+    };
   }
-  var state = {lines:defaultLines(), align:"left", size:"m"};
+  var state = defaults();
   var symbols = FALLBACK.slice();
 
-  // --- Rendering ------------------------------------------------------------
-  var rowsEl   = document.getElementById("rows");
-  var padEl    = document.getElementById("pad");
-  var sheetEl  = document.getElementById("sheet");
+  var $ = function(id){ return document.getElementById(id); };
+  var pad = $("pad"), sheet = $("sheet"), dims = $("dims");
 
-  function renderRows(){
-    rowsEl.innerHTML = "";
-    state.lines.forEach(function(line, i){
-      var row = document.createElement("div");
-      row.className = "row";
+  function esc(t){ return (t==null?"":String(t)); }
 
-      var grip = document.createElement("span");
-      grip.className = "drag"; grip.setAttribute("aria-hidden","true"); grip.textContent = (i+1)+".";
+  // --- Regel-Bedienung ------------------------------------------------------
+  var rulesEl = $("rules");
+  function renderRules(){
+    rulesEl.innerHTML = "";
+    state.rules.forEach(function(r, i){
+      var row = document.createElement("div"); row.className = "rule";
 
       var sym = document.createElement("button");
-      sym.type = "button";
-      sym.className = "symbtn" + (line.sym ? "" : " empty");
-      sym.textContent = line.sym ? line.sym.char : "Symbol";
-      sym.setAttribute("aria-label", "Symbol für Zeile "+(i+1)+ (line.sym ? " – "+line.sym.label : " wählen"));
+      sym.type="button"; sym.className = "symbtn" + (r.sym ? "" : " empty");
+      sym.textContent = r.sym ? r.sym.char : "＋";
+      sym.setAttribute("aria-label","Symbol Zeile "+(i+1)+(r.sym?" – "+r.sym.label:" wählen"));
       sym.addEventListener("click", function(){ openPicker(i); });
 
-      var input = document.createElement("input");
-      input.type = "text"; input.className = "linetext"; input.value = line.text;
-      input.placeholder = "Beschriftung"; input.setAttribute("aria-label","Text Zeile "+(i+1));
-      input.addEventListener("input", function(){ state.lines[i].text = input.value; renderSheet(); });
+      var fields = document.createElement("div"); fields.className = "stack";
+      fields.appendChild(mkField("Deutsch", r.de, function(v){ state.rules[i].de=v; renderSheet(); }));
+      fields.appendChild(mkField("English", r.en, function(v){ state.rules[i].en=v; renderSheet(); }));
 
-      var tools = document.createElement("div");
-      tools.className = "rowtools";
+      var tools = document.createElement("div"); tools.className = "ruletools";
+      tools.appendChild(mkIcon("↑","nach oben", i===0, function(){ moveRule(i,-1); }));
+      tools.appendChild(mkIcon("↓","nach unten", i===state.rules.length-1, function(){ moveRule(i,1); }));
+      tools.appendChild(mkIcon("✕","entfernen", false, function(){ state.rules.splice(i,1); render(); }));
 
-      var up = mkIconBtn("↑","Zeile nach oben", i===0, function(){ move(i,-1); });
-      var dn = mkIconBtn("↓","Zeile nach unten", i===state.lines.length-1, function(){ move(i,1); });
-      var side = mkIconBtn(line.pos==="right" ? "⇥" : "⇤",
-        "Symbol-Seite: "+(line.pos==="right"?"rechts":"links"), false, function(){
-          state.lines[i].pos = line.pos==="right" ? "left" : "right"; render();
-        });
-      var del = mkIconBtn("✕","Zeile entfernen", state.lines.length<=1, function(){ removeLine(i); });
-
-      tools.appendChild(up); tools.appendChild(dn); tools.appendChild(side); tools.appendChild(del);
-
-      row.appendChild(grip); row.appendChild(sym); row.appendChild(input); row.appendChild(tools);
-      rowsEl.appendChild(row);
+      row.appendChild(sym); row.appendChild(fields); row.appendChild(tools);
+      rulesEl.appendChild(row);
     });
   }
-
-  function mkIconBtn(glyph, label, disabled, fn){
-    var b = document.createElement("button");
-    b.type = "button"; b.className = "iconbtn"; b.textContent = glyph;
-    b.title = label; b.setAttribute("aria-label", label);
-    if(disabled){ b.disabled = true; } else { b.addEventListener("click", fn); }
+  function mkField(lab, val, fn){
+    var l = document.createElement("label"); l.className="f";
+    var s = document.createElement("span"); s.className="lab"; s.textContent=lab;
+    var inp = document.createElement("input"); inp.type="text"; inp.value=val||""; inp.placeholder=lab;
+    inp.addEventListener("input", function(){ fn(inp.value); });
+    l.appendChild(s); l.appendChild(inp); return l;
+  }
+  function mkIcon(glyph, label, disabled, fn){
+    var b=document.createElement("button"); b.type="button"; b.className="iconbtn";
+    b.textContent=glyph; b.title=label; b.setAttribute("aria-label",label);
+    if(disabled) b.disabled=true; else b.addEventListener("click", fn);
     return b;
   }
+  function moveRule(i,d){ var j=i+d; if(j<0||j>=state.rules.length) return; var t=state.rules[i]; state.rules[i]=state.rules[j]; state.rules[j]=t; render(); }
+  $("addRule").addEventListener("click", function(){ state.rules.push({sym:null, de:"", en:""}); render(); });
 
+  // --- Schild zeichnen ------------------------------------------------------
+  function pair(de, en, cls){
+    var wrap = document.createElement("div"); wrap.className = cls;
+    if(esc(de)!==""){ var d=document.createElement("div"); d.className="de"; d.textContent=de; wrap.appendChild(d); }
+    if(esc(en)!==""){ var e=document.createElement("div"); e.className="en"; e.textContent=en; wrap.appendChild(e); }
+    return wrap;
+  }
   function renderSheet(){
-    padEl.innerHTML = "";
-    state.lines.forEach(function(line){
-      var l = document.createElement("div");
-      l.className = "sline pos-" + (line.pos==="right" ? "right":"left");
-      if(line.sym){
-        var s = document.createElement("span");
-        s.className = "sym"; s.setAttribute("aria-hidden","true"); s.textContent = line.sym.char;
-        l.appendChild(s);
-      }
-      var t = document.createElement("span");
-      t.className = "txt"; t.textContent = line.text || "";
-      l.appendChild(t);
-      padEl.appendChild(l);
-    });
-    sheetEl.className = "sheet size-"+state.size+" align-"+state.align;
+    // Format & Einheit
+    var base = SIZES[state.size]; var w=base[0], h=base[1];
+    if(state.orient==="quer"){ var t=w; w=h; h=t; }
+    sheet.style.setProperty("--sheet-w", w+"mm");
+    sheet.style.setProperty("--sheet-h", h+"mm");
+    var u = Math.min(w,h) * 0.045 * (SCALE_MULT[state.scale]||1);
+    pad.style.setProperty("--u", u.toFixed(3)+"mm");
+    dims.textContent = SIZE_LABEL[state.size] + " " + (state.orient==="quer"?"quer":"hoch") + " · " +
+      w + " × " + h + " mm";
+
+    pad.innerHTML = "";
+    if(state.kickerOn && esc(state.kicker)!==""){
+      var k=document.createElement("div"); k.className="s-kicker"; k.textContent=state.kicker; pad.appendChild(k);
+    }
+    if(esc(state.title.de)!=="" || esc(state.title.en)!==""){
+      pad.appendChild(pair(state.title.de, state.title.en, "s-title"));
+    }
+    var hasRules = state.rules.some(function(r){ return esc(r.de)!=="" || esc(r.en)!=="" || r.sym; });
+    if(hasRules){
+      var hr=document.createElement("hr"); hr.className="s-divider"; pad.appendChild(hr);
+      var box=document.createElement("div"); box.className="s-rules"+(state.cols===2?" cols-2":"");
+      state.rules.forEach(function(r){
+        if(esc(r.de)==="" && esc(r.en)==="" && !r.sym) return;
+        var row=document.createElement("div"); row.className="s-rule";
+        if(r.sym){ var s=document.createElement("span"); s.className="sym"; s.textContent=r.sym.char; row.appendChild(s); }
+        row.appendChild(pair(r.de, r.en, "lab"));
+        box.appendChild(row);
+      });
+      pad.appendChild(box);
+    }
+    if(state.boxOn && (esc(state.box.de)!=="" || esc(state.box.en)!=="" || esc(state.note.de)!=="" || esc(state.note.en)!=="")){
+      var b=document.createElement("div"); b.className="s-box";
+      b.appendChild(pair(state.box.de, state.box.en, "big"));
+      if(esc(state.note.de)!=="" || esc(state.note.en)!==""){ b.appendChild(pair(state.note.de, state.note.en, "note")); }
+      pad.appendChild(b);
+    }
+    if(state.footOn){
+      var f=document.createElement("div"); f.className="s-foot";
+      var img=document.createElement("img"); img.src=MARK_URL; img.alt=""; img.setAttribute("aria-hidden","true");
+      var sp=document.createElement("span"); sp.textContent="www.goetheanum.ch/campus";
+      f.appendChild(sp); f.appendChild(img); pad.appendChild(f);
+    }
     fit();
   }
+  function render(){ renderRules(); syncInputs(); renderSheet(); }
 
-  function render(){ renderRows(); renderSheet(); }
-
-  function move(i, d){
-    var j = i + d;
-    if(j < 0 || j >= state.lines.length) return;
-    var t = state.lines[i]; state.lines[i] = state.lines[j]; state.lines[j] = t;
-    render();
+  // --- Kopf-/Box-Felder an den Zustand binden -------------------------------
+  function bindInput(id, get, set){ var el=$(id); el.value=get()||""; el.addEventListener("input", function(){ set(el.value); renderSheet(); }); }
+  bindInput("kicker", function(){return state.kicker;}, function(v){state.kicker=v;});
+  bindInput("title-de", function(){return state.title.de;}, function(v){state.title.de=v;});
+  bindInput("title-en", function(){return state.title.en;}, function(v){state.title.en=v;});
+  bindInput("box-de", function(){return state.box.de;}, function(v){state.box.de=v;});
+  bindInput("box-en", function(){return state.box.en;}, function(v){state.box.en=v;});
+  bindInput("note-de", function(){return state.note.de;}, function(v){state.note.de=v;});
+  bindInput("note-en", function(){return state.note.en;}, function(v){state.note.en=v;});
+  function syncInputs(){
+    $("kicker").value=state.kicker||""; $("title-de").value=state.title.de||""; $("title-en").value=state.title.en||"";
+    $("box-de").value=state.box.de||""; $("box-en").value=state.box.en||""; $("note-de").value=state.note.de||""; $("note-en").value=state.note.en||"";
+    $("kicker-wrap").hidden = !state.kickerOn;
+    $("box-fields").style.display = state.boxOn ? "" : "none";
   }
-  function removeLine(i){
-    if(state.lines.length<=1) return;
-    state.lines.splice(i,1); render();
-  }
 
-  document.getElementById("addRow").addEventListener("click", function(){
-    state.lines.push({sym:null, pos:"left", text:""});
-    render();
-    var inputs = rowsEl.querySelectorAll("input.linetext");
-    if(inputs.length) inputs[inputs.length-1].focus();
-  });
-
-  // --- Seg-Umschalter (Ausrichtung, Grösse) ---------------------------------
-  function wireSeg(id, key, apply){
-    var group = document.getElementById(id);
-    group.addEventListener("click", function(e){
-      var btn = e.target.closest("button"); if(!btn) return;
-      Array.prototype.forEach.call(group.querySelectorAll("button"), function(b){
-        b.setAttribute("aria-pressed", String(b===btn));
-      });
-      state[key] = btn.getAttribute(apply);
-      renderSheet();
+  // --- Seg-/Toggle-Umschalter ----------------------------------------------
+  function wireSeg(id, apply){
+    var g=$(id);
+    g.addEventListener("click", function(e){
+      var b=e.target.closest("button"); if(!b) return;
+      Array.prototype.forEach.call(g.querySelectorAll("button"), function(x){ x.setAttribute("aria-pressed", String(x===b)); });
+      apply(b.getAttribute("data-v"));
     });
   }
-  wireSeg("align","align","data-align");
-  wireSeg("size","size","data-size");
+  wireSeg("tg-kicker", function(v){ state.kickerOn = v==="1"; $("kicker-wrap").hidden=!state.kickerOn; renderSheet(); });
+  wireSeg("sg-cols",   function(v){ state.cols = parseInt(v,10); renderSheet(); });
+  wireSeg("tg-box",    function(v){ state.boxOn = v==="1"; $("box-fields").style.display=state.boxOn?"":"none"; renderSheet(); });
+  wireSeg("sg-size",   function(v){ state.size=v; renderSheet(); });
+  wireSeg("sg-orient", function(v){ state.orient=v; renderSheet(); });
+  wireSeg("sg-scale",  function(v){ state.scale=v; renderSheet(); });
+  wireSeg("tg-foot",   function(v){ state.footOn = v==="1"; renderSheet(); });
 
-  // --- Skalierung der Vorschau ----------------------------------------------
-  var stageEl = document.getElementById("stage");
-  var scaleEl = document.getElementById("sheetscale");
+  // --- Vorschau skalieren ---------------------------------------------------
+  var stage=$("stage"), scaleEl=$("sheetscale"), currentScale=1;
   function fit(){
-    // reale Pixelbreite des Schildes (mm → px) an die Bühne anpassen.
-    var natural = sheetEl.getBoundingClientRect().width / (currentScale || 1);
-    var avail = stageEl.clientWidth;
-    var s = avail > 0 ? Math.min(1, avail / natural) : 1;
-    currentScale = s;
-    scaleEl.style.transform = "scale("+s+")";
-    // Höhe der skalierten Bühne mitführen, damit der Rahmen nicht überläuft.
-    scaleEl.style.height = (sheetEl.offsetHeight * s) + "px";
+    var natural = sheet.getBoundingClientRect().width / (currentScale||1);
+    var avail = stage.clientWidth;
+    var s = avail>0 ? Math.min(1, avail/natural) : 1;
+    currentScale=s; scaleEl.style.transform="scale("+s+")";
+    scaleEl.style.height=(sheet.offsetHeight*s)+"px";
   }
-  var currentScale = 1;
-  if(window.ResizeObserver){ new ResizeObserver(fit).observe(stageEl); }
-  window.addEventListener("resize", fit);
-  window.addEventListener("load", fit);
+  if(window.ResizeObserver){ new ResizeObserver(fit).observe(stage); }
+  window.addEventListener("resize", fit); window.addEventListener("load", fit);
 
   // --- Zeichen-Wähler -------------------------------------------------------
-  var picker = document.getElementById("picker");
-  var pickerBody = document.getElementById("pickerBody");
-  var pickerSearch = document.getElementById("pickerSearch");
-  var activeLine = -1;
-
+  var picker=$("picker"), pickerBody=$("pickerBody"), pickerSearch=$("pickerSearch"), activeRule=-1;
   function buildPicker(filter){
-    pickerBody.innerHTML = "";
-    var q = (filter||"").trim().toLowerCase();
-    var any = false;
+    pickerBody.innerHTML=""; var q=(filter||"").trim().toLowerCase(), any=false;
     GROUP_ORDER.forEach(function(g){
-      var items = symbols.filter(function(it){
-        if(it.group !== g) return false;
-        if(!q) return true;
-        return it.label.toLowerCase().indexOf(q) >= 0 || it.slug.toLowerCase().indexOf(q) >= 0;
-      });
-      if(!items.length) return;
-      any = true;
-      var h = document.createElement("h4"); h.textContent = GROUP_TITLE[g] || g;
-      pickerBody.appendChild(h);
-      var grid = document.createElement("div"); grid.className = "glyphgrid";
+      var items=symbols.filter(function(it){ if(it.group!==g) return false; if(!q) return true; return it.label.toLowerCase().indexOf(q)>=0||it.slug.toLowerCase().indexOf(q)>=0; });
+      if(!items.length) return; any=true;
+      var h=document.createElement("h4"); h.textContent=GROUP_TITLE[g]||g; pickerBody.appendChild(h);
+      var grid=document.createElement("div"); grid.className="glyphgrid";
       items.forEach(function(it){
-        var ch = cpChar(it.codepoint);
-        var cell = document.createElement("button");
-        cell.type = "button"; cell.className = "glyphcell";
-        cell.setAttribute("aria-label", it.label);
-        var g1 = document.createElement("span"); g1.className = "g"; g1.setAttribute("aria-hidden","true"); g1.textContent = ch;
-        var n1 = document.createElement("span"); n1.className = "n"; n1.textContent = it.label;
+        var ch=cpChar(it.codepoint);
+        var cell=document.createElement("button"); cell.type="button"; cell.className="glyphcell"; cell.setAttribute("aria-label",it.label);
+        var g1=document.createElement("span"); g1.className="g"; g1.setAttribute("aria-hidden","true"); g1.textContent=ch;
+        var n1=document.createElement("span"); n1.className="n"; n1.textContent=it.label;
         cell.appendChild(g1); cell.appendChild(n1);
-        cell.addEventListener("click", function(){ chooseSymbol({char:ch, label:it.label}); });
+        cell.addEventListener("click", function(){ chooseSymbol({char:ch,label:it.label}); });
         grid.appendChild(cell);
       });
       pickerBody.appendChild(grid);
     });
-    if(!any){
-      var e = document.createElement("p"); e.className = "empty"; e.textContent = "Kein Zeichen gefunden.";
-      pickerBody.appendChild(e);
-    }
+    if(!any){ var e=document.createElement("p"); e.className="empty"; e.textContent="Kein Zeichen gefunden."; pickerBody.appendChild(e); }
   }
-
-  function openPicker(i){
-    activeLine = i;
-    pickerSearch.value = "";
-    buildPicker("");
-    if(typeof picker.showModal === "function"){ picker.showModal(); }
-    else { picker.setAttribute("open",""); }
-    setTimeout(function(){ pickerSearch.focus(); }, 30);
-  }
-  function closePicker(){
-    if(typeof picker.close === "function" && picker.open){ picker.close(); }
-    else { picker.removeAttribute("open"); }
-  }
-  function chooseSymbol(sym){
-    if(activeLine>=0 && activeLine<state.lines.length){ state.lines[activeLine].sym = sym; render(); }
-    closePicker();
-  }
-  document.getElementById("pickerClose").addEventListener("click", closePicker);
-  document.getElementById("pickNone").addEventListener("click", function(){
-    if(activeLine>=0 && activeLine<state.lines.length){ state.lines[activeLine].sym = null; render(); }
-    closePicker();
-  });
+  function openPicker(i){ activeRule=i; pickerSearch.value=""; buildPicker(""); if(picker.showModal) picker.showModal(); else picker.setAttribute("open",""); setTimeout(function(){pickerSearch.focus();},30); }
+  function closePicker(){ if(picker.close && picker.open) picker.close(); else picker.removeAttribute("open"); }
+  function chooseSymbol(sym){ if(activeRule>=0&&activeRule<state.rules.length){ state.rules[activeRule].sym=sym; render(); } closePicker(); }
+  $("pickerClose").addEventListener("click", closePicker);
+  $("pickNone").addEventListener("click", function(){ if(activeRule>=0&&activeRule<state.rules.length){ state.rules[activeRule].sym=null; render(); } closePicker(); });
   pickerSearch.addEventListener("input", function(){ buildPicker(pickerSearch.value); });
   picker.addEventListener("click", function(e){ if(e.target===picker) closePicker(); });
   picker.addEventListener("cancel", function(){ closePicker(); });
 
   // --- Aktionen -------------------------------------------------------------
-  document.getElementById("print").addEventListener("click", function(){ window.print(); });
-  document.getElementById("reset").addEventListener("click", function(){
-    state.lines = defaultLines(); state.align = "left"; state.size = "m";
-    resetSeg("align","left"); resetSeg("size","m");
+  $("print").addEventListener("click", function(){
+    // Druckseite auf das gewählte Format setzen.
+    var base=SIZES[state.size], w=base[0], h=base[1]; if(state.orient==="quer"){ var t=w; w=h; h=t; }
+    ensurePageStyle(w, h);
+    window.print();
+  });
+  var pageStyle=null;
+  function ensurePageStyle(w,h){
+    if(!pageStyle){ pageStyle=document.createElement("style"); document.head.appendChild(pageStyle); }
+    pageStyle.textContent = "@page{size:"+w+"mm "+h+"mm;margin:0}";
+  }
+  $("reset").addEventListener("click", function(){
+    state=defaults();
+    setSeg("tg-kicker", state.kickerOn?"1":"0"); setSeg("sg-cols", String(state.cols));
+    setSeg("tg-box", state.boxOn?"1":"0"); setSeg("sg-size", state.size);
+    setSeg("sg-orient", state.orient); setSeg("sg-scale", state.scale); setSeg("tg-foot", state.footOn?"1":"0");
     render();
   });
-  function resetSeg(id, val){
-    var group = document.getElementById(id);
-    Array.prototype.forEach.call(group.querySelectorAll("button"), function(b){
-      var k = id==="align" ? "data-align" : "data-size";
-      b.setAttribute("aria-pressed", String(b.getAttribute(k)===val));
-    });
-  }
+  function setSeg(id,val){ var g=$(id); Array.prototype.forEach.call(g.querySelectorAll("button"), function(b){ b.setAttribute("aria-pressed", String(b.getAttribute("data-v")===val)); }); }
 
-  // Türschild-Formate sind noch gesperrt – Klick meldet den Stand.
-  document.getElementById("formats").addEventListener("click", function(e){
-    var btn = e.target.closest("button"); if(!btn || !btn.disabled) return;
-  });
+  // --- Icon-Daten laden -----------------------------------------------------
+  fetch(ICONS_URL).then(function(r){ return r.ok?r.json():null; }).then(function(data){
+    if(Array.isArray(data)&&data.length){ symbols=data.filter(function(it){ return it.group==="piktogramm"||it.group==="pfeil-kompass"; }); }
+  }).catch(function(){});
 
-  // --- Icon-Daten laden (mit Fallback) --------------------------------------
-  fetch(ICONS_URL).then(function(r){ return r.ok ? r.json() : null; }).then(function(data){
-    if(Array.isArray(data) && data.length){
-      // Nur benannte Wegweiser-Zeichen: Piktogramme und Pfeile/Kompass. Die
-      // Platzhalter-Gruppe ‹weitere› (unbenannte Slots) bleibt aussen vor.
-      symbols = data.filter(function(it){ return it.group==="piktogramm" || it.group==="pfeil-kompass"; });
-    }
-  }).catch(function(){ /* Fallback bleibt bestehen */ });
-
-  // Start
   render();
 })();
 </script>
 
-<!-- Druck: nur das Schild, in Originalgrösse. A5 quer, ohne Ränder. -->
+<!-- Druck: nur das Schild, in Originalgrösse (Format wird beim Klick per @page gesetzt). -->
 <style>
-  @page{ size:A5 landscape; margin:0; }
   @media print{
     .ds-header,.dsnav,.dsnav-drawer,.dsnav-backdrop,.ds-footer,
-    .hero,.editor,.prevfoot,.actions,.shead,.fmt-note,.seg,
-    section > .shead, #formats, .note, dialog.picker{ display:none !important; }
-    body{ background:#ffffff; }        /* # ds-ok: Druck auf weissem Papier */
-    main.wrap, section, .work, .preview, .frame, .stage{
-      max-width:none;margin:0;padding:0;border:0;background:none;display:block;overflow:visible;
-    }
+    .hero,.editor,.prevfoot,.actions,.shead,.note,dialog.picker{ display:none !important; }
+    body{ background:#ffffff; }   /* # ds-ok: Druck auf weissem Papier */
+    main.wrap, section, .work, .preview, .frame, .stage{ max-width:none;margin:0;padding:0;border:0;background:none;display:block;overflow:visible;position:static }
     .frame{box-shadow:none}
     .sheetscale{ transform:none !important; height:auto !important; }
     .sheet{ box-shadow:none !important; }

--- a/tools.json
+++ b/tools.json
@@ -261,7 +261,7 @@
       "title": "Schilder",
       "short": "Schilder",
       "href": "apps/schilder/",
-      "desc": "Orientierungs- und Türschilder im Hausbild – Zeilen und Zeichen einsetzen, mit Haus-Icons und -Pfeilen, A5 quer drucken. Feste Vorlagen folgen.",
+      "desc": "Orientierungs- und Raumschilder im Hausbild – zweisprachige Zeilen (Deutsch über Englisch) und Haus-Icons einsetzen, Titel und wechselnde Info bestimmen, A5 bis A1 hoch oder quer drucken.",
       "such": "Schild Schilder Orientierung Türschild Wegweiser Wegweisung Piktogramm Pfeil A5 Namensschild"
     },
     {


### PR DESCRIPTION
## Was

Das Werkzeug **Schilder** nach den vorgelegten echten Hausschildern ausgebaut (Rollschild Grosser Saal, Ausstellungsregeln, Öffnungszeiten). Die tragende Grammatik dieser Schilder ist jetzt umgesetzt:

- **Zweisprachig gepaart** – Deutsch (Deutlich) über Englisch (Klar), gleicher Grad. Titel, Regelzeilen, Wechsel-Info und Fussnote je als DE/EN-Paar. Das ist das Kennzeichen aller Haus-Schilder.
- **Raumschild-Aufbau:** Kicker (Datum) · Titelblock · Trennlinie · **Icon-Regelzeilen** aus dem Haus-Icon-/Pfeil-Satz (1 oder 2 Spalten) · hinterlegte **Wechsel-Box** für die wechselnde Info mit Fussnote · Fusszeile mit Marke – jedes Element zuschaltbar.
- **Format-Familie A5/A4/A3/A2/A1, hoch und quer.** Das Schild rechnet in echten mm, skaliert die Vorschau und druckt über ein zur Wahl passendes `@page` in Originalgrösse.
- Auf dem Schild ausschliesslich die **Hausschrift** plus **Haus-Icons/-Pfeile** (Webfont, per Codepoint gesetzt). Zeichen-Wähler mit Suche, `icons.json` mit Offline-Fallback.

## Wie (vom Fundament aus)

- `tokens.css` + `base.css` + `nav.css` eingebunden, `nav.js` mit `data-section="vorbereitung"`. Bedienung ganz aus den Tokens, kanonische Textrollen aus `base.css`.
- Schild-Farben (Markenblau auf Weiss) als **theme-festes Druck-Artefakt** definiert (`--sign-*`, `# ds-ok`) – Hell/Dunkel lassen das Schild blau-auf-weiss.
- `tools.json`-Beschreibung nachgezogen (bleibt unter **In Vorbereitung**, `entwurf`).

## Betroffene Regeln

- **G05** – Betonung über Schnitt (Deutlich/Klar), nie Versal/Unterstrich/Sperren.
- **B01/B02** – Markenblau auf Weiss (≥ 4.5:1), nie Text auf Farbfläche.
- **DS01/DS02/DS07** – Pflicht-Includes, nur Token-Farben in der Bedienung; das Artefakt-Blau/-Weiss ist ratifiziert (`# ds-ok`).

## Prüfung

- `tools/ds-lint.py apps/schilder/index.html` → **Score 100 %**, 0 Fehler.
- `tools/typo-check.py apps/schilder/index.html` → **konform**.
- Im Browser gefahren (Chromium): Kopf/Regeln/Box editieren, Zeichen-Wähler, Spalten 1/2, Format A5–A1 hoch/quer mit korrekter mm-Geometrie, Vorschau skaliert, Dark-Mode hält das Schild blau-auf-weiss, `@page` wird beim Druck aufs gewählte Format gesetzt (z. B. A2 quer → 594×420 mm), Druckmedium isoliert das Schild. Layout gegen die Referenz-PDFs abgeglichen (Raumschild Grosser Saal).

## Offen / später

- Die Referenz-Schilder sind im **alten Hausbild** (Titillium, altes Blau); dieses Werkzeug setzt korrekt in der v2.7-Hausschrift – Vorbild ist Layout und Grammatik, nicht die Schrift.
- Denkbar als Nächstes: fertige Start-Vorlagen zum Anklicken (Regelschild, Öffnungszeiten-Liste), optionale vertikale Zentrierung, Export als PDF/SVG statt Druckdialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013whsL6oA2sRXKnC2wtJXGd

---
_Generated by [Claude Code](https://claude.ai/code/session_013whsL6oA2sRXKnC2wtJXGd)_