### PR TITLE
Konvention: Merkblatt (PDF) vs. Fussnote vs. eigene Seite

### DIFF
--- a/assets/merkblaetter/README.md
+++ b/assets/merkblaetter/README.md
@@ -1,0 +1,35 @@
+# Merkblätter — und wann etwas keines ist
+
+Vertiefungen zu den Werkzeugen gibt es in drei Formen. Die Form folgt dem
+**Gebrauch**, nicht der Gleichheit (Konvention, 11. Juli 2026):
+
+1. **Merkblatt (PDF, hier im Ordner)** — für alles, das die Seite *verlassen*
+   soll: ausdrucken, als Anhang verschicken, in der Sitzung herumreichen.
+   Beispiele: ‹Das Kürzel vor der Zahl› (Länderkürzel/PLZ),
+   ‹Warum unsere Mails ohne Bilder auskommen› (Argumentarium).
+   Ein Merkblatt als Anhang ist regelkonform: Die Büroklammer verspricht
+   ein Dokument — hier ist eines.
+
+2. **Fussnote (auf der Seite, zuklappbar)** — für Belege, die *an Ort und
+   Stelle* gelesen werden und sich ändern können. Beispiel: ‹Was in der
+   Schweiz gilt› (Rechtslage) unter den elf Empfehlungen. Recht ändert
+   sich; eine Fussnote ist morgen korrigiert, ein kursierendes PDF trägt
+   den alten Stand für immer.
+
+3. **Eigene Seite** — erst wenn beides zusammenkommt: Der Inhalt braucht
+   eine *teilbare URL* (wird in Mails weitergereicht) **und** wächst über
+   ein Blatt hinaus. Vorher nicht: Miniseiten fragmentieren die Werkzeuge
+   und machen der Bühne (den Empfehlungen) Konkurrenz.
+   Vorlage: `design-system/starter-artikel.html`.
+
+**Einheitlich ist die Oberfläche:** Jede Vertiefung hängt als goldener
+Pfeil-Link (oder Knopf am Feld) an ihrer Empfehlung bzw. ihrem Formularfeld
+— Hilfe am Ort der Handlung. Pfeile zu Merkblättern tragen den Zusatz
+‹(PDF)›, Pfeile zu Fussnoten nicht.
+
+## Reproduzierbarkeit
+
+Selbst erzeugte Merkblätter haben ihre Druckquelle unter `src/` (HTML in
+den Hausschriften; PDF via Chromium, A4, printBackground). Hochgeladene
+Fremd-Merkblätter (z. B. das PLZ-Blatt) bleiben unverändert — übersetzte
+Autorität ist keine.


### PR DESCRIPTION
`assets/merkblaetter/README.md` schreibt die Entscheidungsregel für Vertiefungen fest — die Form folgt dem Gebrauch, nicht der Gleichheit:

1. **Merkblatt (PDF)** = verlässt die Seite (drucken, anhängen, herumreichen) — PLZ-Blatt, Argumentarium.
2. **Fussnote (auf der Seite)** = Beleg, wird an Ort und Stelle gelesen und kann sich ändern — Rechtslage CH. Ein kursierendes PDF trüge den alten Rechtsstand für immer.
3. **Eigene Seite** = erst bei teilbarer URL **und** Wachstum über ein Blatt hinaus (Vorlage: starter-artikel).

Einheitlich ist die Oberfläche: goldener Pfeil/Knopf am Ort der Handlung; PDF-Ziele tragen ‹(PDF)›. Dazu die Reproduzierbarkeits-Regel (Druckquellen unter `src/`, Fremd-Merkblätter bleiben unverändert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_