### PR TITLE
Mails S26: Haus-Paarung komplett — Body in Source Sans 3, Kicker normal

### DIFF
--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -90,7 +90,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 11.07.2026, 13.04 Uhr · <code>2610229</code></p>
+  <p class="subline">Stand dieses Builds: 11.07.2026, 14.21 Uhr · <code>b1484dc</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -116,7 +116,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="shared#wortmarke"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#wortmarke')">senden</button></div></div></div><div class="fld" data-key="shared#badge"><div class="fh" onclick="toggle(this)"><span class="lbl">Badge</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="shared#badge">0</span></button></div>
-<div class="val"><span style="color:#A95278;font-weight:700">3 Monate gratis</span> / <span style="color:#A95278;font-weight:700">3 months free</span> — HTML-Text in der Mail-Grundschrift <!-- # ds-ok Mail-DNA, kein Theme --></div>
+<div class="val"><span style="color:#A95278">3 Monate gratis</span> / <span style="color:#A95278">3 months free</span> — HTML-Text, normal statt fett (G05) <!-- # ds-ok Mail-DNA, kein Theme --></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="shared#badge"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#badge')">senden</button></div></div></div><div class="fld" data-key="shared#beweisband"><div class="fh" onclick="toggle(this)"><span class="lbl">Beweis-Band</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="shared#beweisband">0</span></button></div>
@@ -124,7 +124,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="shared#beweisband"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#beweisband')">senden</button></div></div></div><div class="fld" data-key="shared#button"><div class="fh" onclick="toggle(this)"><span class="lbl">Button-Stil</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="shared#button">0</span></button></div>
-<div class="val"><span style="background:#A95278;color:#fff;border-radius:999px;padding:8px 18px;font:600 14px -apple-system,'Segoe UI',Helvetica,Arial,sans-serif">Gratis testen →</span> <!-- # ds-ok Mail-DNA, kein Theme --></div>
+<div class="val"><span style="background:#A95278;color:#fff;border-radius:999px;padding:8px 18px;font:600 14px 'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif">Gratis testen →</span> <!-- # ds-ok Mail-DNA, kein Theme --></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="shared#button"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#button')">senden</button></div></div></div><div class="fld" data-key="shared#kleinzeile"><div class="fh" onclick="toggle(this)"><span class="lbl">Kleinzeile (je Motiv)</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="shared#kleinzeile">0</span></button></div>
@@ -228,6 +228,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -310,7 +324,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -322,7 +336,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter: Woche für Woche schreiben dort Menschen, die einer Frage ihr Leben gewidmet haben — nicht was sie wissen, sondern wie sie suchen. Wer mitliest, kommt mit anderen Augen in die eigene Woche zurück.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter: Woche für Woche schreiben dort Menschen, die einer Frage ihr Leben gewidmet haben — nicht was sie wissen, sondern wie sie suchen. Wer mitliest, kommt mit anderen Augen in die eigene Woche zurück.</div>
                       </td>
                     </tr>
                     <tr>
@@ -331,7 +345,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Drei Monate lesen → </a>
+                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Drei Monate lesen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -340,7 +354,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -364,7 +378,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -388,7 +402,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -533,6 +547,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -615,7 +643,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -627,7 +655,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you watch on goetheanum.tv you can read on in the weekly: week after week, people who have given their lives to a question write down not what they know but how they search. Read along, and you return to your own week with different eyes.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you watch on goetheanum.tv you can read on in the weekly: week after week, people who have given their lives to a question write down not what they know but how they search. Read along, and you return to your own week with different eyes.</div>
                       </td>
                     </tr>
                     <tr>
@@ -636,7 +664,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Start reading free → </a>
+                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Start reading free → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -645,7 +673,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -669,7 +697,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -693,7 +721,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -838,6 +866,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -920,7 +962,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -932,7 +974,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Noch bis 8. August lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — Lesestoff, der in Ihnen weiterarbeitet, wenn der Bildschirm dunkel ist.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Noch bis 8. August lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — Lesestoff, der in Ihnen weiterarbeitet, wenn der Bildschirm dunkel ist.</div>
                       </td>
                     </tr>
                     <tr>
@@ -941,7 +983,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Drei Monate lesen → </a>
+                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Drei Monate lesen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -950,7 +992,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -974,7 +1016,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -998,7 +1040,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -1143,6 +1185,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -1225,7 +1281,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -1237,7 +1293,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark.</div>
                       </td>
                     </tr>
                     <tr>
@@ -1246,7 +1302,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Start reading free → </a>
+                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Start reading free → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -1255,7 +1311,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1279,7 +1335,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1303,7 +1359,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -1448,6 +1504,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -1530,7 +1600,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -1542,7 +1612,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Noch ein paar Sommertage lang: die Wochenschrift, drei Monate gratis zu Ihrem Abo. Wenn sie Ihnen nicht ans Herz wächst, kündigen Sie einfach.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Noch ein paar Sommertage lang: die Wochenschrift, drei Monate gratis zu Ihrem Abo. Wenn sie Ihnen nicht ans Herz wächst, kündigen Sie einfach.</div>
                       </td>
                     </tr>
                     <tr>
@@ -1551,7 +1621,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Drei Monate lesen → </a>
+                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Drei Monate lesen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -1560,7 +1630,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1584,7 +1654,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1608,7 +1678,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -1753,6 +1823,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -1835,7 +1919,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -1847,7 +1931,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>A few summer days remain: the weekly, free for three months with your subscription. If it doesn’t grow on you, simply cancel.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>A few summer days remain: the weekly, free for three months with your subscription. If it doesn’t grow on you, simply cancel.</div>
                       </td>
                     </tr>
                     <tr>
@@ -1856,7 +1940,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Start reading free → </a>
+                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Start reading free → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -1865,7 +1949,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1889,7 +1973,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1913,7 +1997,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -2058,6 +2142,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -2140,7 +2238,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -2152,7 +2250,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: Auf goetheanum.tv denken Menschen laut, in über 800 Vorträgen und Gesprächen. Sie hören das Zögern und das Finden mit — alles, was auf der gedruckten Seite unsichtbar bleibt.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: Auf goetheanum.tv denken Menschen laut, in über 800 Vorträgen und Gesprächen. Sie hören das Zögern und das Finden mit — alles, was auf der gedruckten Seite unsichtbar bleibt.</div>
                       </td>
                     </tr>
                     <tr>
@@ -2161,7 +2259,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Drei Monate schauen → </a>
+                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Drei Monate schauen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -2170,7 +2268,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2194,7 +2292,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2218,7 +2316,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -2363,6 +2461,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -2445,7 +2557,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -2457,7 +2569,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you read each week you can now watch and hear: on goetheanum.tv, people think out loud, in over 800 lectures and conversations. You hear the hesitation and the finding — everything the printed page keeps invisible.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you read each week you can now watch and hear: on goetheanum.tv, people think out loud, in over 800 lectures and conversations. You hear the hesitation and the finding — everything the printed page keeps invisible.</div>
                       </td>
                     </tr>
                     <tr>
@@ -2466,7 +2578,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Start watching free → </a>
+                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Start watching free → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -2475,7 +2587,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2499,7 +2611,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2523,7 +2635,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -2668,6 +2780,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -2750,7 +2876,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -2762,7 +2888,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Ein Abend auf goetheanum.tv ist ein Abend in Gesellschaft von Menschen, die ihr Leben lang an einer Frage gearbeitet haben — und die laut denken, statt fertige Antworten vorzutragen. Noch bis 8. August drei Monate gratis zu Ihrem Abo.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Ein Abend auf goetheanum.tv ist ein Abend in Gesellschaft von Menschen, die ihr Leben lang an einer Frage gearbeitet haben — und die laut denken, statt fertige Antworten vorzutragen. Noch bis 8. August drei Monate gratis zu Ihrem Abo.</div>
                       </td>
                     </tr>
                     <tr>
@@ -2771,7 +2897,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Drei Monate schauen → </a>
+                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Drei Monate schauen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -2780,7 +2906,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2804,7 +2930,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2828,7 +2954,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -2973,6 +3099,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -3055,7 +3195,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -3067,7 +3207,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>An evening on goetheanum.tv is an evening in the company of people who have worked on a question all their lives — thinking out loud rather than reciting finished answers. Until 8 August: three months free with your subscription.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>An evening on goetheanum.tv is an evening in the company of people who have worked on a question all their lives — thinking out loud rather than reciting finished answers. Until 8 August: three months free with your subscription.</div>
                       </td>
                     </tr>
                     <tr>
@@ -3076,7 +3216,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Start watching free → </a>
+                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Start watching free → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -3085,7 +3225,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3109,7 +3249,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3133,7 +3273,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -3278,6 +3418,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -3360,7 +3514,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -3372,7 +3526,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Noch ein paar Sommertage: goetheanum.tv, die ersten drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es in Ihnen nachklingt.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Noch ein paar Sommertage: goetheanum.tv, die ersten drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es in Ihnen nachklingt.</div>
                       </td>
                     </tr>
                     <tr>
@@ -3381,7 +3535,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Drei Monate schauen → </a>
+                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Drei Monate schauen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -3390,7 +3544,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3414,7 +3568,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3438,7 +3592,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -3583,6 +3737,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -3665,7 +3833,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -3677,7 +3845,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>A few summer days left: goetheanum.tv, the first three months free with your subscription — stay only if it stays with you.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>A few summer days left: goetheanum.tv, the first three months free with your subscription — stay only if it stays with you.</div>
                       </td>
                     </tr>
                     <tr>
@@ -3686,7 +3854,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Start watching free → </a>
+                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Start watching free → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -3695,7 +3863,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3719,7 +3887,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3743,7 +3911,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -3888,6 +4056,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -3970,7 +4152,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -3982,7 +4164,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie in der Wochenschrift Menschen, die einer Frage ihr Leben gewidmet haben, und sehen Sie auf goetheanum.tv zu, wie sie laut denken — die ersten drei Monate kostenlos, jederzeit kündbar.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie in der Wochenschrift Menschen, die einer Frage ihr Leben gewidmet haben, und sehen Sie auf goetheanum.tv zu, wie sie laut denken — die ersten drei Monate kostenlos, jederzeit kündbar.</div>
                       </td>
                     </tr>
                     <tr>
@@ -3991,7 +4173,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Ihren Sommer wählen → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -4000,7 +4182,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4024,7 +4206,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4048,7 +4230,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -4193,6 +4375,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -4275,7 +4471,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -4287,7 +4483,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Get to know the Goetheanum from both sides this summer: in the weekly, read people who have given their lives to a question; on goetheanum.tv, watch them think out loud — the first three months free, cancel anytime.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Get to know the Goetheanum from both sides this summer: in the weekly, read people who have given their lives to a question; on goetheanum.tv, watch them think out loud — the first three months free, cancel anytime.</div>
                       </td>
                     </tr>
                     <tr>
@@ -4296,7 +4492,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your summer → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -4305,7 +4501,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4329,7 +4525,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4353,7 +4549,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -4498,6 +4694,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -4580,7 +4790,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -4592,7 +4802,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Ein Essay am Morgen, ein Vortrag am Abend — und dazwischen merken Sie, wie die eigenen Gedanken weiter reichen als sonst. Die ersten drei Monate geschenkt, anmelden bis 8. August.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Ein Essay am Morgen, ein Vortrag am Abend — und dazwischen merken Sie, wie die eigenen Gedanken weiter reichen als sonst. Die ersten drei Monate geschenkt, anmelden bis 8. August.</div>
                       </td>
                     </tr>
                     <tr>
@@ -4601,7 +4811,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Ihren Sommer wählen → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -4610,7 +4820,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4634,7 +4844,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4658,7 +4868,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -4803,6 +5013,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -4885,7 +5109,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -4897,7 +5121,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>An essay in the morning, a lecture in the evening — and in between you notice your own thoughts reaching further than usual. The first three months free, sign up by 8 August.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>An essay in the morning, a lecture in the evening — and in between you notice your own thoughts reaching further than usual. The first three months free, sign up by 8 August.</div>
                       </td>
                     </tr>
                     <tr>
@@ -4906,7 +5130,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your summer → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -4915,7 +5139,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4939,7 +5163,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4963,7 +5187,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -5108,6 +5332,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -5190,7 +5428,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -5202,7 +5440,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Noch bis Samstag: drei Monate kostenlos lesen oder sehen — danach entscheiden Sie, ob es weitergeht.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Noch bis Samstag: drei Monate kostenlos lesen oder sehen — danach entscheiden Sie, ob es weitergeht.</div>
                       </td>
                     </tr>
                     <tr>
@@ -5211,7 +5449,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Ihren Sommer wählen → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -5220,7 +5458,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5244,7 +5482,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5268,7 +5506,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -5413,6 +5651,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -5495,7 +5747,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -5507,7 +5759,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Until Saturday: three months free to read or watch — after that, you decide whether it continues.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Until Saturday: three months free to read or watch — after that, you decide whether it continues.</div>
                       </td>
                     </tr>
                     <tr>
@@ -5516,7 +5768,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your summer → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -5525,7 +5777,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5549,7 +5801,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5573,7 +5825,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -5718,6 +5970,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -5800,7 +6066,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -5812,7 +6078,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute, und Sie haben drei Monate Zeit, dem nachzugehen.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute, und Sie haben drei Monate Zeit, dem nachzugehen.</div>
                       </td>
                     </tr>
                     <tr>
@@ -5821,7 +6087,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Ihren Sommer wählen → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -5830,7 +6096,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5854,7 +6120,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5878,7 +6144,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -6023,6 +6289,20 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -6105,7 +6385,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -6117,7 +6397,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you looked at spoke to you for a reason — one minute, and you have three months to follow it.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you looked at spoke to you for a reason — one minute, and you have three months to follow it.</div>
                       </td>
                     </tr>
                     <tr>
@@ -6126,7 +6406,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
-                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your summer → </a>
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -6135,7 +6415,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -6159,7 +6439,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -6183,7 +6463,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w1_de.html
+++ b/apps/mail-editor/mails/mail_beides_w1_de.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie in der Wochenschrift Menschen, die einer Frage ihr Leben gewidmet haben, und sehen Sie auf goetheanum.tv zu, wie sie laut denken — die ersten drei Monate kostenlos, jederzeit kündbar.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie in der Wochenschrift Menschen, die einer Frage ihr Leben gewidmet haben, und sehen Sie auf goetheanum.tv zu, wie sie laut denken — die ersten drei Monate kostenlos, jederzeit kündbar.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Ihren Sommer wählen → </a>
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w1_en.html
+++ b/apps/mail-editor/mails/mail_beides_w1_en.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Get to know the Goetheanum from both sides this summer: in the weekly, read people who have given their lives to a question; on goetheanum.tv, watch them think out loud — the first three months free, cancel anytime.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Get to know the Goetheanum from both sides this summer: in the weekly, read people who have given their lives to a question; on goetheanum.tv, watch them think out loud — the first three months free, cancel anytime.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your summer → </a>
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_de.html
+++ b/apps/mail-editor/mails/mail_beides_w2_de.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Ein Essay am Morgen, ein Vortrag am Abend — und dazwischen merken Sie, wie die eigenen Gedanken weiter reichen als sonst. Die ersten drei Monate geschenkt, anmelden bis 8. August.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Ein Essay am Morgen, ein Vortrag am Abend — und dazwischen merken Sie, wie die eigenen Gedanken weiter reichen als sonst. Die ersten drei Monate geschenkt, anmelden bis 8. August.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Ihren Sommer wählen → </a>
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_en.html
+++ b/apps/mail-editor/mails/mail_beides_w2_en.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">An essay in the morning, a lecture in the evening — and in between you notice your own thoughts reaching further than usual. The first three months free, sign up by 8 August.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">An essay in the morning, a lecture in the evening — and in between you notice your own thoughts reaching further than usual. The first three months free, sign up by 8 August.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your summer → </a>
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3_de.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Noch bis Samstag: drei Monate kostenlos lesen oder sehen — danach entscheiden Sie, ob es weitergeht.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Noch bis Samstag: drei Monate kostenlos lesen oder sehen — danach entscheiden Sie, ob es weitergeht.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Ihren Sommer wählen → </a>
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3_en.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Until Saturday: three months free to read or watch — after that, you decide whether it continues.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Until Saturday: three months free to read or watch — after that, you decide whether it continues.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your summer → </a>
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_de.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute, und Sie haben drei Monate Zeit, dem nachzugehen.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute, und Sie haben drei Monate Zeit, dem nachzugehen.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Ihren Sommer wählen → </a>
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Ihren Sommer wählen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_en.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you looked at spoke to you for a reason — one minute, and you have three months to follow it.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you looked at spoke to you for a reason — one minute, and you have three months to follow it.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your summer → </a>
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Choose your summer → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w1_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_de.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter: Woche für Woche schreiben dort Menschen, die einer Frage ihr Leben gewidmet haben — nicht was sie wissen, sondern wie sie suchen. Wer mitliest, kommt mit anderen Augen in die eigene Woche zurück.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter: Woche für Woche schreiben dort Menschen, die einer Frage ihr Leben gewidmet haben — nicht was sie wissen, sondern wie sie suchen. Wer mitliest, kommt mit anderen Augen in die eigene Woche zurück.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Drei Monate lesen → </a>
+                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Drei Monate lesen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w1_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_en.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you watch on goetheanum.tv you can read on in the weekly: week after week, people who have given their lives to a question write down not what they know but how they search. Read along, and you return to your own week with different eyes.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you watch on goetheanum.tv you can read on in the weekly: week after week, people who have given their lives to a question write down not what they know but how they search. Read along, and you return to your own week with different eyes.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Start reading free → </a>
+                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Start reading free → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_de.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Noch bis 8. August lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — Lesestoff, der in Ihnen weiterarbeitet, wenn der Bildschirm dunkel ist.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Noch bis 8. August lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — Lesestoff, der in Ihnen weiterarbeitet, wenn der Bildschirm dunkel ist.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Drei Monate lesen → </a>
+                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Drei Monate lesen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_en.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Start reading free → </a>
+                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Start reading free → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_de.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Noch ein paar Sommertage lang: die Wochenschrift, drei Monate gratis zu Ihrem Abo. Wenn sie Ihnen nicht ans Herz wächst, kündigen Sie einfach.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Noch ein paar Sommertage lang: die Wochenschrift, drei Monate gratis zu Ihrem Abo. Wenn sie Ihnen nicht ans Herz wächst, kündigen Sie einfach.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Drei Monate lesen → </a>
+                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Drei Monate lesen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_en.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">A few summer days remain: the weekly, free for three months with your subscription. If it doesn’t grow on you, simply cancel.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">A few summer days remain: the weekly, free for three months with your subscription. If it doesn’t grow on you, simply cancel.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Start reading free → </a>
+                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Start reading free → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w1_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_de.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: Auf goetheanum.tv denken Menschen laut, in über 800 Vorträgen und Gesprächen. Sie hören das Zögern und das Finden mit — alles, was auf der gedruckten Seite unsichtbar bleibt.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: Auf goetheanum.tv denken Menschen laut, in über 800 Vorträgen und Gesprächen. Sie hören das Zögern und das Finden mit — alles, was auf der gedruckten Seite unsichtbar bleibt.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Drei Monate schauen → </a>
+                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Drei Monate schauen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w1_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_en.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you read each week you can now watch and hear: on goetheanum.tv, people think out loud, in over 800 lectures and conversations. You hear the hesitation and the finding — everything the printed page keeps invisible.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you read each week you can now watch and hear: on goetheanum.tv, people think out loud, in over 800 lectures and conversations. You hear the hesitation and the finding — everything the printed page keeps invisible.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Start watching free → </a>
+                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Start watching free → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_de.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Ein Abend auf goetheanum.tv ist ein Abend in Gesellschaft von Menschen, die ihr Leben lang an einer Frage gearbeitet haben — und die laut denken, statt fertige Antworten vorzutragen. Noch bis 8. August drei Monate gratis zu Ihrem Abo.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Ein Abend auf goetheanum.tv ist ein Abend in Gesellschaft von Menschen, die ihr Leben lang an einer Frage gearbeitet haben — und die laut denken, statt fertige Antworten vorzutragen. Noch bis 8. August drei Monate gratis zu Ihrem Abo.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Drei Monate schauen → </a>
+                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Drei Monate schauen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_en.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">An evening on goetheanum.tv is an evening in the company of people who have worked on a question all their lives — thinking out loud rather than reciting finished answers. Until 8 August: three months free with your subscription.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">An evening on goetheanum.tv is an evening in the company of people who have worked on a question all their lives — thinking out loud rather than reciting finished answers. Until 8 August: three months free with your subscription.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Start watching free → </a>
+                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Start watching free → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_de.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Noch ein paar Sommertage: goetheanum.tv, die ersten drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es in Ihnen nachklingt.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Noch ein paar Sommertage: goetheanum.tv, die ersten drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es in Ihnen nachklingt.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Drei Monate schauen → </a>
+                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Drei Monate schauen → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_en.html
@@ -89,6 +89,20 @@
       font-weight: 700;
       font-style: normal;
     }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
   </style>
 </head>
 
@@ -171,7 +185,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -183,7 +197,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">A few summer days left: goetheanum.tv, the first three months free with your subscription — stay only if it stays with you.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">A few summer days left: goetheanum.tv, the first three months free with your subscription — stay only if it stays with you.</div>
                       </td>
                     </tr>
                     <tr>
@@ -192,7 +206,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Start watching free → </a>
+                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Start watching free → </a>
                               </td>
                             </tr>
                           </tbody>
@@ -201,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -225,7 +239,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
                       </td>
                     </tr>
                   </tbody>
@@ -249,7 +263,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/services/mailing-sommer2026/build_editor.py
+++ b/services/mailing-sommer2026/build_editor.py
@@ -107,9 +107,9 @@ def render_mail(motiv, welle, lang, wm):
     mehrere = len(ctas) > 1
     cta_links = [(label, links.link_for(welle, seg, ziel, lang, mehrere)) for ziel, label in ctas]
     hero = src_for(compose(var, f"{motiv}_{vid}"))
-    wf = T.get("headline_webfont")
-    fontface = (f"<mj-style>@font-face{{font-family:'{wf['family']}';src:url('{wf['url']}') "
-                f"format('{wf['format']}');font-weight:{wf['weight']};font-style:normal;}}</mj-style>") if (BASE and wf) else ""
+    faces = "".join(f"@font-face{{font-family:'{w['family']}';src:url('{w['url']}') format('woff2');"
+                    f"font-weight:{w['weight']};font-style:normal;}}" for w in T.get("webfonts", []))
+    fontface = f"<mj-style>{faces}</mj-style>" if (BASE and faces) else ""
     btns = []
     for i, (label, l) in enumerate(cta_links):
         primaer = i == 0
@@ -126,7 +126,7 @@ def render_mail(motiv, welle, lang, wm):
 <mj-section background-color="#FFFFFF" padding="18px 28px 14px 28px"><mj-column><mj-image src="{src_for(wm[0])}" alt="Goetheanum" width="{wm[1]}px" align="left" padding="0"/></mj-column></mj-section>
 <mj-section background-color="#FFFFFF" padding="0"><mj-column><mj-image src="{hero}" alt="{xml(var.get('alt',''))}" padding="0" fluid-on-mobile="true"/></mj-column></mj-section>
 <mj-section background-color="#FFFFFF" padding="24px 28px 0 28px"><mj-column>
-  <mj-text font-size="14px" line-height="20px" font-weight="700" color="{AKZENT}" padding="0 0 10px 0">{xml(H['badge'][lang])}</mj-text>
+  <mj-text font-size="14px" line-height="20px" color="{AKZENT}" padding="0 0 10px 0">{xml(H['badge'][lang])}</mj-text>
   <mj-text font-family="{HL_STACK}" font-size="30px" line-height="35px" font-weight="700" color="{INK}" padding="0 0 14px 0">{titel(c['botschaft'])}</mj-text>
   <mj-text padding="0 0 22px 0">{xml(c['text'])}</mj-text>
   {btns}
@@ -224,7 +224,7 @@ def main():
     # Gemeinsame Elemente. Der Button-Stil zeigt die Mail-DNA — Artefakt, kein Theme.
     shared = [
         ("shared#wortmarke", "Wortmarke", f'<img src="{data_uri(wm[0])}" style="height:20px" alt="Goetheanum"> — offizielles Logo'),
-        ("shared#badge", "Badge", f'<span style="color:{AKZENT};font-weight:700">{esc(H["badge"]["de"])}</span> / <span style="color:{AKZENT};font-weight:700">{esc(H["badge"]["en"])}</span> — HTML-Text in der Mail-Grundschrift <!-- # ds-ok Mail-DNA, kein Theme -->'),
+        ("shared#badge", "Badge", f'<span style="color:{AKZENT}">{esc(H["badge"]["de"])}</span> / <span style="color:{AKZENT}">{esc(H["badge"]["en"])}</span> — HTML-Text, normal statt fett (G05) <!-- # ds-ok Mail-DNA, kein Theme -->'),
         ("shared#beweisband", "Beweis-Band", f'{esc(H["proof"]["de"])}<br>{esc(H["proof"]["en"])}'),
         ("shared#button", "Button-Stil", f'<span style="background:{AKZENT};color:#fff;border-radius:999px;padding:8px 18px;font:600 14px {FONT_STACK}">Gratis testen →</span> <!-- # ds-ok Mail-DNA, kein Theme -->'),
         ("shared#kleinzeile", "Kleinzeile (je Motiv)", "<br>".join(esc(H["kleinzeile"][m]["de"]) for m in H["motive"])),

--- a/services/mailing-sommer2026/config.json
+++ b/services/mailing-sommer2026/config.json
@@ -5,7 +5,7 @@
   "frist": "2026-08-08",
   "frist_hinweis": "Samstag — wirksamer Schluss-Druck liegt auf Do 6.8. / Fr 7.8.",
   "theme": {
-    "_hinweis": "Kampagnen-DNA der Mails: Rosé-Palette + Sommer-Motive. Schrift-Beschluss 11.7.26 (Ph, Vorschlag 1): Headline = Hausschrift ‹Goetheanum› Schnitt Deutlich (Absender ist das Haus; TV-Seite und Übersicht sprechen sie schon; eigene Lizenz OFL — löst den Zeitungs-Einwand vom 9.7. prinzipiell). Body = ehrlicher System-Stack (Inter war toter Eintrag). Fazeta bleibt der WS-Landingpage vorbehalten.",
+    "_hinweis": "Kampagnen-DNA der Mails: Rosé-Palette + Sommer-Motive. Schrift-Beschlüsse 11.7.26 (Ph): Headline = Hausschrift ‹Goetheanum› Deutlich, Body = ‹Source Sans 3› als Webfont (Vorschlag 1 — die Haus-Paarung des Design-Systems, beide OFL/selbst gehostet; dieselben Clients laden beide, kein Zustand mischt falsch), Fallback = System-Stack. Kicker/Badge normal statt fett (G05). Fazeta bleibt der WS-Landingpage vorbehalten.",
     "akzent": "#A95278",
     "akzent_tief": "#8E3F62",
     "wash": "#FFF4F8",
@@ -13,15 +13,27 @@
     "nebel": "#F6F4F2",
     "gedaempft": "#6E6E6E",
     "fuss": "#9A9AA6",
-    "font_stack": "-apple-system,'Segoe UI',Helvetica,Arial,sans-serif",
+    "font_stack": "'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif",
     "headline_stack": "Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif",
-    "headline_webfont": {
-      "family": "Goetheanum",
-      "url": "https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.7-Deutlich.woff2",
-      "format": "woff2",
-      "weight": "700",
-      "_hinweis": "Deutlich (580) = Titelschnitt der Hausregeln; als weight 700 deklariert, damit Apple Mail ihn für die 700er-Headline nimmt (kein synthetisches Fetten). Nur Apple-Clients laden ihn (@font-face), der Rest sieht den Fallback-Stack."
-    }
+    "webfonts": [
+      {
+        "family": "Goetheanum",
+        "weight": "700",
+        "url": "https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.7-Deutlich.woff2",
+        "_hinweis": "Deutlich (580) als 700 deklariert — Apple Mail nimmt ihn exakt für die Headline, kein synthetisches Fetten."
+      },
+      {
+        "family": "Source Sans 3",
+        "weight": "400",
+        "url": "https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2"
+      },
+      {
+        "family": "Source Sans 3",
+        "weight": "600",
+        "url": "https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2",
+        "_hinweis": "600 deckt die Button-Beschriftung."
+      }
+    ]
   },
   "utm_fix": {
     "utm_source": "mailing",


### PR DESCRIPTION
Schrift-Beschluss 11.7. (Vorschlag 1 der zweiten Typografie-Runde) plus Kicker-Reklamation:

- **Body = ‹Source Sans 3› als Webfont** (Regular 400 + SemiBold 600 für die Buttons; woff2 aus dem Schriften-Bestand des Repos, OFL, selbst gehostet) — die Lese-Grotesk, die das Design-System als Partnerin der Hausschrift definiert. Eleganter Nebeneffekt: **Dieselben Clients, die die Goetheanum-Headline laden, laden auch den Body** — die Apple-Hälfte sieht die vollständige Haus-Typografie, der Rest ein stimmig humanistisches System-Paar (`-apple-system`/Segoe-Fallback); kein Zustand mischt falsch.
- `@font-face` wird jetzt aus der Liste `theme.webfonts` generiert (drei Einträge statt Einzelfeld).
- **Kicker entfettet:** ‹3 Monate gratis› lief mit `font-weight:700` — Reklamation des Auftraggebers, und die Hausregel sagt es seit je: **Kicker normal (G05)**. Jetzt Normalschnitt in Akzentfarbe; die Editor-Anzeige des gemeinsamen Elements zieht mit.
- Beschluss in `config.json` (`theme._hinweis`) dokumentiert.

Build grün, 3 `@font-face`-Blöcke je Mail verifiziert, Mails weiterhin ~15 KB (Fonts laden per URL, nichts eingebettet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_