### PR TITLE
Mails S26: Kleinzeile mit definiertem Umbruch — eine Aussage je Zeile

### DIFF
--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -90,7 +90,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 11.07.2026, 14.21 Uhr · <code>b1484dc</code></p>
+  <p class="subline">Stand dieses Builds: 11.07.2026, 14.54 Uhr · <code>99c5810</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -354,7 +354,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -673,7 +673,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -992,7 +992,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1311,7 +1311,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1630,7 +1630,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1949,7 +1949,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2268,7 +2268,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2587,7 +2587,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2906,7 +2906,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3225,7 +3225,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3544,7 +3544,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3863,7 +3863,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4182,7 +4182,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4501,7 +4501,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4820,7 +4820,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5139,7 +5139,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5458,7 +5458,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5777,7 +5777,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -6096,7 +6096,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -6415,7 +6415,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w1_de.html
+++ b/apps/mail-editor/mails/mail_beides_w1_de.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w1_en.html
+++ b/apps/mail-editor/mails/mail_beides_w1_en.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_de.html
+++ b/apps/mail-editor/mails/mail_beides_w2_de.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_en.html
+++ b/apps/mail-editor/mails/mail_beides_w2_en.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3_de.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3_en.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_de.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar · die ersten drei Monate kostenlos, jederzeit kündbar · nur bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_en.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined · the first three months free, cancel anytime · only until 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w1_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_de.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w1_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_en.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_de.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_en.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_de.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit ohne Begründung kündbar · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_en.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime, no reason needed · offer ends 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w1_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_de.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w1_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_en.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_de.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_en.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_de.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos · jederzeit kündbar, ein Klick im Konto · Aktion bis 8. August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_en.html
@@ -215,7 +215,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free · cancel anytime with one click in your account · offer ends 8 August 2026.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/services/mailing-sommer2026/build_editor.py
+++ b/services/mailing-sommer2026/build_editor.py
@@ -38,6 +38,12 @@ def xml(s):
     return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
 
 
+def kleinzeile(s):
+    """Definierter Umbruch statt Zufallsfluss: jede Aussage eine Zeile, der Mittepunkt
+    schliesst die Zeile (geschütztes Spatium davor, damit er nie allein rutscht)."""
+    return "&#160;·<br />".join(xml(t.strip()) for t in s.split("·"))
+
+
 def titel(s):
     """Titelzeile ohne einzelnes Schlusswort: letztes Wortpaar unzertrennlich (trägt in
     jedem Client); text-wrap:balance gleicht die Zeilen aus, wo Clients es können."""
@@ -130,7 +136,7 @@ def render_mail(motiv, welle, lang, wm):
   <mj-text font-family="{HL_STACK}" font-size="30px" line-height="35px" font-weight="700" color="{INK}" padding="0 0 14px 0">{titel(c['botschaft'])}</mj-text>
   <mj-text padding="0 0 22px 0">{xml(c['text'])}</mj-text>
   {btns}
-  <mj-text font-size="13px" line-height="20px" color="{MUTED}" padding="0 0 26px 0">{xml(H['kleinzeile'][motiv][lang])}</mj-text>
+  <mj-text font-size="13px" line-height="20px" color="{MUTED}" padding="0 0 26px 0">{kleinzeile(H['kleinzeile'][motiv][lang])}</mj-text>
 </mj-column></mj-section>
 <mj-section background-color="{WASH}" padding="16px 28px"><mj-column><mj-text font-size="14px" line-height="22px" color="{AKZENT_TIEF}" align="center" padding="0">{xml(H['proof'][lang])}</mj-text></mj-column></mj-section>
 <mj-section background-color="{MIST}" padding="20px 28px"><mj-column><mj-text font-size="12px" line-height="19px" color="{FUSS}" padding="0">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br/><a href="%UNSUBSCRIBELINK%" style="color:{FUSS};">Abmelden</a></mj-text></mj-column></mj-section>


### PR DESCRIPTION
Wunsch des Auftraggebers (11.7.): Die Kleinzeile bricht jetzt definiert an den Mittepunkten statt im Zufallsfluss —

```
Die ersten drei Monate kostenlos ·
jederzeit ohne Begründung kündbar ·
Aktion bis 8. August 2026.
```

Der Mittepunkt schliesst die Zeile; ein geschütztes Spatium davor verhindert, dass er allein rutscht. Umsetzung als `kleinzeile()`-Helper im Generator (split an «·», join mit `&#160;·<br />`) — gilt automatisch für alle drei Segment-Varianten und beide Sprachen. Build grün, Markup in lesen/beides verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_