### PR TITLE
Menü: Strukturtitel Deutlich statt Laut

### DIFF
--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -16,6 +16,16 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ---
 
+## [1.9.4] – 2026-07-11
+
+### Menü: Strukturtitel von Laut auf Deutlich
+- **Was:** Schubladen-Titel, Bereichs-Titel und aktiver Eintrag laufen jetzt in
+  **Deutlich (580)** statt Laut (680). Die Laute ist die Inline-Fettung —
+  Strukturtitel tragen laut Hausregel Deutlich; bei 15–17px rendert 680
+  zudem klumpig (Befund Auftraggeber, iPhone-Screenshot 11. Juli 2026).
+- **Wirkung:** nav.css (`.dhead .t`, `.dsnav-group>summary`,
+  `.dsnav-link.is-active .tt`); keine neue Regel — eine Regel angewandt.
+
 ## [1.9.3] – 2026-07-10
 
 ### Status-Marker in der Intern-Schublade

--- a/design-system/contract.json
+++ b/design-system/contract.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://goetheanum/design-system/contract.schema.json",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "titel": "Goetheanum Design-System – Struktur-Vertrag",
   "zweck": "Maschinenlesbare Grundlage der GESTALT-Konformität (symmetrisch zum sprachlichen Kanon in assets/typografie/). ds-lint.py prüft jede Seite hiergegen, ds-fix.py korrigiert deterministisch, das Schaufenster bildet es ab. Eine Quelle der Wahrheit für Struktur; Werte/Farben/Schnitte bleiben in tokens.css/tokens.json.",
   "geltungsbereich": {

--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -123,7 +123,7 @@ html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
 
 .dsnav-drawer .dhead{display:flex;align-items:center;justify-content:space-between;
   padding:0 22px;height:var(--header-h);border-bottom:1px solid var(--line);flex:0 0 auto}
-.dsnav-drawer .dhead .t{font-weight:var(--w-strong);font-size:15px}
+.dsnav-drawer .dhead .t{font-weight:var(--w-deutlich);font-size:15px}
 .dsnav-drawer .close{font:inherit;font-size:22px;line-height:1;color:var(--muted);background:none;border:0;cursor:pointer;padding:4px}
 .dsnav-drawer .close:hover{color:var(--ink)}
 
@@ -182,7 +182,7 @@ html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
 
 .dsnav-group{border-bottom:1px solid var(--line-soft)}
 .dsnav-group>summary{list-style:none;cursor:pointer;display:flex;align-items:center;justify-content:space-between;
-  padding:var(--s4) 22px;font-weight:var(--w-strong);font-size:16px}
+  padding:var(--s4) 22px;font-weight:var(--w-deutlich);font-size:16px}
 .dsnav-group>summary::-webkit-details-marker{display:none}
 .dsnav-group>summary .arr{color:var(--muted);font-weight:var(--w-text);transition:transform .15s}
 .dsnav-group[open]>summary .arr{transform:rotate(90deg)}
@@ -193,7 +193,7 @@ html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
 .dsnav-link .tt{font-size:17px}
 /* Aktuelle Seite im Menü hervorheben – ruhig, mit Gold-Kante. */
 .dsnav-link.is-active{background:var(--soft);box-shadow:inset 3px 0 0 var(--gold-deep)}
-.dsnav-link.is-active .tt{color:var(--gold-ink);font-weight:var(--w-strong)}
+.dsnav-link.is-active .tt{color:var(--gold-ink);font-weight:var(--w-deutlich)}
 /* Status-Marker (nur Intern-Schublade): leises Wort rechts – Meta-Rolle in der
    Lese-Grotesk (B03-Floor), Live bleibt unmarkiert (G03). */
 .dsnav-link .st{margin-left:auto;flex:0 0 auto;font-family:var(--font-text);


### PR DESCRIPTION
## Was

Schubladen-Titel («Alles · intern»/«Navigation»), Bereichs-Titel (Werkzeuge · Schrift · Elemente …) und der aktive Eintrag laufen jetzt in **Deutlich (580)** statt Laut (680).

## Warum

Befund Auftraggeber (iPhone-Screenshot): Bei 15–17px rendert die Laute klumpig. Die Hausregel sagt es selbst — Laut ist die Inline-Fettung, Strukturtitel tragen Deutlich. Keine neue Regel, eine bestehende angewandt.

## Verifikation

Playwright: alle drei Stellen rechnen auf 580, Sichtprüfung im Intern-Menü ruhig und sauber. `ds-lint` 100%. Ledger **1.9.4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpogNYjVveXAJv6x7aHj8)_