### PR TITLE
Kampagnen-Drehbuch: die Lehren der Sommer-Aktion 2026, eingefroren

### DIFF
--- a/docs/kampagnen-drehbuch.md
+++ b/docs/kampagnen-drehbuch.md
@@ -1,0 +1,157 @@
+# Kampagnen-Drehbuch — Mailing-Kampagnen nach dem Muster Sommer 2026
+
+Destillat der Sommer-Aktion 2026 (Juli 2026): Was sich bewährt hat, in der
+Reihenfolge, in der es beim nächsten Mal geschehen soll. Die Fabrik
+(`services/mailing-sommer2026/build_editor.py` + Editor) ist wiederverwendbar —
+neue Kampagne = neue `heroes.json` + `config.json` + Motive; alle
+Typografie-, Umbruch- und Versand-Beschlüsse stecken im Generator und werden
+geerbt.
+
+## Die eine Lehre über allen
+
+**Es beginnt nicht mit Texten.** Es beginnt mit zwei Dingen, die wir 2026
+erst unterwegs nachziehen mussten: der **Wahrheit des Angebots** und der
+**Messkette**. Beides war teurer nachzurüsten als alles Redaktionelle.
+
+## Phase 0 — Angebots-Wahrheit (bevor irgendjemand gestaltet)
+
+1. **Mechanik schriftlich festzurren, in einem Satz:** Was genau bekommt man,
+   was kostet es danach, endet es automatisch oder muss gekündigt werden,
+   bis wann gilt es? 2026 sagten die Kleinzeilen dreierlei und die
+   Landingpages widersprachen sich — die eine wahre Formel («Die ersten drei
+   Monate kostenlos · jederzeit kündbar · Aktion bis …») muss VOR allem
+   anderen stehen. Sie ist der Vertrag; kein Text darf mehr versprechen.
+2. **Frist im System, nicht nur im Text:** Der Aktionsschluss existiert nur,
+   wenn ihn eine Maschine durchsetzt — uscreen-Trial-Werte zurückstellen
+   (Termin in den Kalender, Vor-Aktions-Wert notieren!), Paperform kennt
+   geplantes Formular-Schliessen. 2026-Befund: «nur bis 8. August» stand
+   ausschliesslich im Beschreibungstext der regulären Standard-Abos.
+3. **Segmente und ihre AC-Tags benennen** (2026: nurtv/nurws/noabo über
+   Abo-Tags; Doppel-Abonnenten ausgeschlossen) und die **Erfolgsdefinition**:
+   Was zählt als Conversion, wer liest sie wo ab, welche Zielzahl?
+
+## Phase 1 — Messkette (das Fundament, Ende-zu-Ende, VOR dem Inhalt)
+
+1. **utm-Schema aus `links.py`** übernehmen: fix `utm_source/medium/campaign`,
+   `utm_content = w{n}_{segment}` (ein Button je Mail — Entscheid 2026: die
+   Wahl wandert aus der Mail in den Browser). Register in Supabase einspielen
+   (`links.py` erzeugt die Zeilen; Cockpit matcht NUR über die vier Felder).
+2. **Jeden Hop prüfen:** Landingpages müssen die Query weiterreichen —
+   Zwischenseiten (Übersicht!) brauchen explizites Forwarding (Lovable:
+   `location.search` an alle Ausgangs-Links, sessionStorage-Fallback);
+   Paperform-Buttons `prefill-inherit` (leeres Attribut genügt); Formulare
+   brauchen die vier Hidden Fields MIT URL-Prefill; Webhook → Cockpit
+   (`sommer2026_signups`-Muster) muss die Felder speichern.
+3. **uscreen-Wissen (eingefroren):** utm wird beim Klick im Session-Cookie
+   gehalten und bei KONTOERSTELLUNG am Kunden gespeichert (first touch, nur
+   Web-Checkout, In-App nie) — Wellen-Zählung nach Kampagnenende per
+   People-CSV-Export. Der uscreen-Webhook trägt KEIN utm (wohl aber
+   `offer_id`); Standard-Abos taugen nicht als Kampagnen-Zähler.
+   Prüfen: Wie schnell setzt die Kette uscreen→(Make/Uncanny)→AC das
+   Abo-Tag? Die Conversion-Ausstiege der Automationen hängen daran.
+4. **Ende-zu-Ende-Beweis vor Inhalt:** Test-URL mit `utm_content=e2etest`
+   durch die ganze Kette; im Backend nachsehen. 2026-Trick: echte
+   Produktions-Anmeldungen mit utm sind der beste Beweis — kein Testeintrag
+   mit Nebenwirkungen nötig, erst in den Daten nachschauen.
+
+## Phase 2 — Gehalt und Inhalt (in DIESER Reihenfolge)
+
+1. **Rohmaterial des Auftraggebers zuerst.** Die wirksamste Textrunde 2026
+   war die letzte — sie hätte die erste sein sollen: Was ist der GEHALT, die
+   Onlyness, die Essenz aus Empfängersicht? («Teilhabe am Erkenntnisringen
+   reifer Persönlichkeiten», «laut denkende Menschen», «Befreiung aus dem
+   eigenen Gesichtskreis».) Erst wenn diese Sätze stehen, lohnt Dramaturgie.
+2. **Der Fünfer-Tisch** (wiederverwendbare Rollen-Prompts): lyrische Autorin
+   (Bild, Verb, Rhythmus) · Direct-Response-Copywriter (ein Gedanke pro
+   Zeile, Öffnungskraft, Mobile-35-Zeichen) · Hüterin der Haus-Stimme
+   (Würde, kein Jargon, EN eigenständig) · Neumeier (Onlyness) · Geyrhalter
+   (Empfänger-Essenz). Arbeitsweise: parallel, Durchfaller-Listen mit je
+   einem Kandidaten, Redaktor synthetisiert. Prüf-Linsen, die 2026 trafen:
+   «Wann geht es nur um uns?» · «Wo zählt Inventar statt Gewinn?» («800
+   Videos warten») · «Verspricht der Betreff etwas Falsches?» («Ihr
+   Gratis-Zugang endet» — es endete die Frist).
+3. **Dramaturgie-Muster (bewährt):** w1 Brücke/Ankündigung (Cross-sell-Brücke
+   in den Betreff: «Was Sie sehen, jetzt auch lesen»), w2 Erinnerung mit
+   Datum, w3 echte Frist (Alt-Betreff für Nicht-Öffner = ANDERE Rahmung, am
+   besten die Brücke — die haben sie nie gesehen), w3b Mini-Reminder nur an
+   Klicker («Sie waren schon da»). Botschaft wiederholt NIE den Betreff.
+   Preheader ergänzt den Betreff (Szene↔Angebot+Frist), 60–95 Zeichen,
+   IMMER als eigenes Feld pflegen.
+4. **Motive:** Geräte in Aktion im echten Set schlagen Cover/Titelkarten;
+   die Aktionsseiten sind eine gute Bildquelle (l5e-Assets).
+5. **Gegenlesen im Editor** (Kolleg:innen, Kommentar je Feld, ✎ liefert
+   konkrete Fassungen) → Rücklauf in heroes.json → neu bauen.
+
+## Phase 3 — Fabrik und Versandreife
+
+- `heroes.json`/`config.json` füllen, `--publish`, nach dem Merge `--verify`
+  (prüft Editor, Assets UND Mail-URLs live). Build bricht >100 KB ab
+  (Gmail clippt bei ~102 KB; Bilder immer gehostet, nie Data-URI).
+- **Typografie (beschlossen, im Generator eingefroren):** Headline =
+  Hausschrift ‹Goetheanum Deutlich›, Body = ‹Source Sans 3› (beide OFL,
+  selbst gehostete woff2 — nur Apple-Clients laden Webfonts, ~Hälfte der
+  Öffnungen; Fallback -apple-system/Segoe). Kicker normal (G05). Titel ohne
+  einzelnes Schlusswort (nbsp) + text-wrap:balance. Kleinzeile bricht an
+  den Mittepunkten, eine Aussage je Zeile. Echte Apostrophe (G16).
+- Testversand an echte Clients: iPhone/Apple Mail (Webfonts!), Gmail,
+  Outlook — Links auf utm_content kontrollieren (Tabelle im AC-Prompt).
+
+## Phase 4 — ActiveCampaign (Muster 2026)
+
+- **Drei Automationen, eine je Segment**, Sprach-Split innen (If/Else auf
+  Trigger-Liste DE/EN). **Eintritt über Bulk-Tag** («S26-Start») — die
+  Listen-Trigger feuern nur bei NEUanmeldungen, nie für den Bestand!
+- Je Automation: Hygiene-Filter (keine Öffnung >12 Monate → Ende) →
+  Segment-Weiche (Tags, überschneidungsfrei) → Wellen-Drip mit «Warten bis
+  Datum» → vor jeder Welle Conversion-Check (Ziel-Abo-Tag → Ende) → vor w3
+  Öffner-Split (ODER via «match any»; Plan B: verschachtelte If/Else —
+  UND und ODER nie in derselben Bedingungsgruppe!) → Goal am Ende.
+- **Predictive Sending nur für frühe Wellen** — es streut bis 24 h; Frist-
+  Mails (w3/w3b) fix senden. HTML als Custom-HTML von den Mail-URLs
+  einfügen; %UNSUBSCRIBELINK% ersetzt AC; AC-Klick-Tracking ummantelt die
+  URLs nur (utm bleibt intakt).
+- Reihenfolge: Automationen bauen → Testversände → AKTIV schalten → dann
+  erst Bulk-Tag setzen.
+
+## Phase 5 — Betrieb während der Wellen
+
+- **AC hält Kopien:** Text/Betreff-Änderung vor Versand der Welle = neu
+  bauen + HTML im Schritt frisch einfügen. Bilder/Schrift laden zur
+  Öffnungszeit von unseren URLs — Bildtausch wirkt ohne AC, auch
+  rückwirkend. **⚠ Ab dem ersten Versand sind Asset-Dateinamen append-only**
+  (`--publish` räumt das Verzeichnis — gelöschte Variationen reissen tote
+  Bilder in versendete Mails).
+- Cockpit beobachten (Reichweite → Klicks → Abschlüsse je utm_content).
+
+## Phase 6 — Nach der Frist (der grösste Hebel liegt HIER)
+
+1. Frist durchsetzen (Trial zurück, Formulare schliessen) — am Tag danach.
+2. Zählung: Paperform/Backend direkt; TV per uscreen-People-CSV
+   (`utm_campaign` × `utm_content`), App-Zugänge als bekannte Lücke.
+3. **Onboarding-Strecke für die Gratis-Monate** (Willkommen mit
+   Inhalts-Empfehlungen → Mid-Trial-Impuls → Erinnerung vor Ablauf): laut
+   INMA/NZZ der grösste Trial→Paid-Hebel — 2026 als To-do notiert, nächstes
+   Mal von Anfang an Teil des Plans (dieselbe Fabrik, eigene heroes.json).
+4. Retro in dieses Drehbuch zurückschreiben.
+
+## Eingefrorenes Detailwissen (Nachschlag)
+
+- **Gmail:** clippt ~102 KB, blockt Data-URIs, kein @font-face.
+- **Webfonts:** nur Apple-Clients (~50 % der Öffnungen, Litmus); dieselben
+  Clients laden Headline- UND Body-Font → Paarung mischt nie falsch.
+- **Resend an Nicht-Öffner:** andere RAHMUNG, nicht Variante; Konvertierte
+  ausschliessen; zweite Welle performt immer schwächer (Deliverability im
+  Blick behalten).
+- **AC:** If/Else & Goals nutzen den Segment-Builder; «match any» = ODER;
+  UND+ODER nur über getrennte Gruppen. Listen-Trigger ≠ Bestand.
+- **Paperform:** `prefill-inherit` (auch ohne data-, leer = aktiv);
+  Formulare je Währung/Sprache (Geo-Logik CH→chf, INTL→eur); Webhooks
+  tragen den vollen Payload inkl. Hidden Fields.
+- **Lovable-Seiten:** Query-Weitergabe gehört als Anforderung in jeden
+  Seiten-Auftrag (alle Ausgangs-Links, beide Sprachfassungen, /en-Ziele
+  auf -en-Domains prüfen).
+- **Sicherheit/Ordnung:** keine Test-Endpunkte (webhook.site!) an
+  Produktions-Webhooks; kommerzielle Fonts nie als offene Dateien hosten
+  (eigene OFL-Schriften schon).
+- **Sommer-Saisonalität:** Juli/August schwächste Öffnungsmonate — w2/w3
+  sind wichtiger, nicht optional; Predictive hilft früh.

--- a/services/mailing-sommer2026/CLAUDE.md
+++ b/services/mailing-sommer2026/CLAUDE.md
@@ -11,6 +11,10 @@ echte Sommer-Lifestyle-Motive. **Schrift-Beschluss 11.7. (Vorschlag 1):** Headli
 System-Stack; Fazeta bleibt der WS-Landingpage vorbehalten. Die Mail ist **Artefakt** (Kampagnen-DNA),
 das Editor-Chrome läuft auf dem Haus-Design-System.
 
+## Drehbuch für die nächste Kampagne
+Die übertragbaren Lehren (Reihenfolge, Messkette, Fünfer-Tisch, AC-Muster, eingefrorenes
+Detailwissen) stehen in **docs/kampagnen-drehbuch.md** — dort beginnt die nächste Kampagne.
+
 ## Eine Quelle
 `heroes.json` trägt alles Redaktionelle: die Wellen-Texte (`wellen`, je Welle × Sprache, optional
 `preheader`), die Motive mit CTA-Labels und Bildvariationen, den Wellenplan, Kleinzeile/Proof/Badge.


### PR DESCRIPTION
Retrospektive auf Wunsch des Auftraggebers (11.7.): **`docs/kampagnen-drehbuch.md`** destilliert die Kampagnen-Woche in einen wiederverwendbaren Ablauf für die nächste Kampagne — mit der Kernlehre «Es beginnt nicht mit Texten»:

- **Phase 0 Angebots-Wahrheit:** eine Mechanik-Formel vor allem anderen; Frist im System durchsetzen (Trial-Werte, Formular-Schliessdatum), nicht nur im Text.
- **Phase 1 Messkette Ende-zu-Ende VOR dem Inhalt:** utm-Schema/Register, jeder Hop (Zwischenseiten-Forwarding, prefill-inherit, Hidden Fields, Webhook→Cockpit), eingefrorenes uscreen-Wissen (utm am Kunden, People-CSV; Webhook ohne utm).
- **Phase 2 Gehalt zuerst:** Rohmaterial des Auftraggebers vor der Dramaturgie; der Fünfer-Tisch (Autorin · Copywriter · Hüterin · Neumeier · Geyrhalter) als wiederverwendbares Muster samt bewährter Prüf-Linsen.
- **Phase 3 Fabrik:** alle Typografie-/Umbruch-/Versand-Beschlüsse stecken im Generator und werden geerbt.
- **Phase 4 AC-Muster:** drei Automationen je Segment, Bulk-Tag-Eintritt (Listen-Trigger ≠ Bestand!), Conversion-Checks, Predictive nur früh.
- **Phase 5 Betrieb:** AC hält Kopien; Assets append-only nach Erstversand.
- **Phase 6 nach der Frist:** Frist durchsetzen, People-CSV-Zählung, Onboarding-Strecke als grösster Hebel, Retro ins Drehbuch.
- **Nachschlag:** eingefrorenes Detailwissen (Gmail-Clipping, Webfont-Hälfte, AC-Bedingungsgruppen, Paperform, Lovable-Anforderung, webhook.site-Warnung, Saisonalität).

Service-CLAUDE.md verweist auf das Drehbuch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_