### PR TITLE
Mail-Editor: Posteingang-Blick statt Feld-Liste; Mails verlinken zum Ziel

### DIFF
--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -37,6 +37,12 @@ main{--mailw:clamp(340px,30vw,600px)} /* 600 = native Mail-Breite: Vorschau in O
 .mhd{display:flex;align-items:center;background:var(--ink);color:var(--paper);font-family:var(--font-text);font-size:var(--t-micro);font-weight:600;padding:6px 12px}
 .mhd a{margin-left:auto;color:inherit;text-decoration:none;border:1px solid var(--paper);border-radius:999px;padding:1px 9px;font-weight:400}
 .mhd a:hover{background:var(--paper);color:var(--ink)}
+/* Posteingang-Zeile: was Empfangende zuerst sehen — Betreff fett, Anriss gedämpft. */
+.inbox{padding:var(--s2) var(--s3);border-bottom:1px solid var(--line-soft);font-family:var(--font-text)}
+.ib-b{font-size:var(--t-small);font-weight:600;color:var(--ink)}
+.ib-a{font-size:var(--t-small);color:var(--muted);line-height:1.45;margin-top:2px}
+.ib-alt{font-size:var(--t-micro);color:var(--muted);line-height:1.45;margin-top:4px}
+.ib-alt span{color:var(--gold-ink);font-weight:600}
 .mail iframe{width:100%;height:calc(var(--mailw)*1.55);border:0;display:block;background:#F6F4F2} /* # ds-ok Mail-Grund (Artefakt) */
 .flds{padding:var(--s2) var(--s3)}
 .fld{border-top:1px solid var(--line-soft);padding:8px 4px} .fld:first-child{border-top:0}
@@ -90,7 +96,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 11.07.2026, 15.46 Uhr · <code>c32fb55</code></p>
+  <p class="subline">Stand dieses Builds: 11.07.2026, 16.38 Uhr · <code>63a14f1</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -116,11 +122,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="shared#wortmarke"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#wortmarke')">senden</button></div></div></div><div class="fld" data-key="shared#badge"><div class="fh" onclick="toggle(this)"><span class="lbl">Badge</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="shared#badge">0</span></button></div>
-<div class="val"><span style="color:#A95278">3 Monate gratis</span> / <span style="color:#A95278">3 months free</span> — HTML-Text, normal statt fett (G05) <!-- # ds-ok Mail-DNA, kein Theme --></div>
+<div class="val"><span style="color:#A95278">Sommerangebot 2026 · 3 Monate gratis</span> / <span style="color:#A95278">Summer offer 2026 · 3 months free</span> — HTML-Text, normal statt fett (G05) <!-- # ds-ok Mail-DNA, kein Theme --></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="shared#badge"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#badge')">senden</button></div></div></div><div class="fld" data-key="shared#beweisband"><div class="fh" onclick="toggle(this)"><span class="lbl">Beweis-Band</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="shared#beweisband">0</span></button></div>
-<div class="val">Stimmen und Gesichter der Anthroposophie von heute — seit 1921<br>Voices and faces of anthroposophy today — since 1921</div>
+<div class="val">Stimmen und Gesichter der Anthroposophie von heute<br>Voices and faces of anthroposophy today</div>
 <div class="cpanel" hidden><ul class="clist" data-cl="shared#beweisband"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#beweisband')">senden</button></div></div></div><div class="fld" data-key="shared#button"><div class="fh" onclick="toggle(this)"><span class="lbl">Button-Stil</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="shared#button">0</span></button></div>
@@ -137,6 +143,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#footer')">senden</button></div></div></div></div></section>
 <section class="segment"><h2>Lesen · Die Wochenschrift — nurtv</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W1 · DE<a href="mails/mail_lesen_w1_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Was Sie sehen, jetzt auch lesen — 3 Monate gratis</div><div class="ib-a">Die ersten drei Monate geschenkt — lesen, wo der Sommer Sie hinträgt. Bis 8. August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -264,7 +271,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -296,7 +305,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;Im Garten lesen&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_garten.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Im Garten lesen&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_garten.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -324,7 +335,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -378,7 +389,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -402,7 +413,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -420,42 +431,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau lesen_w1_de"></iframe>
-  <div class="flds"><div class="fld" data-key="lesen_w1_de#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#Motiv">0</span></button></div>
-<div class="val">lesen/garten — Im Garten lesen</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Motiv')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#Betreff">0</span></button></div>
-<div class="val">Was Sie sehen, jetzt auch lesen — 3 Monate gratis</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#Botschaft">0</span></button></div>
-<div class="val">Jede Woche ein Stück weiter sehen.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#Text">0</span></button></div>
-<div class="val">Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter: Woche für Woche schreiben dort Menschen, die einer Frage ihr Leben gewidmet haben — nicht was sie wissen, sondern wie sie suchen. Wer mitliest, kommt mit anderen Augen in die eigene Woche zurück.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#CTA">0</span></button></div>
-<div class="val">Drei Monate lesen →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#CTA')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Drei Monate im Freien lesen — gratis</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#Link">0</span></button></div>
-<div class="val"><code>https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="lesen_w1_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="lesen_w1_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_de#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#gesamt')">senden</button></div></div></div>
-  </div></div><div class="mail" data-lang="en">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W1 · EN<a href="mails/mail_lesen_w1_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">What you watch, now also read — 3 months free</div><div class="ib-a">The first three months as a gift — read wherever summer takes you. Until 8 August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -583,7 +565,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -615,7 +599,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;Im Garten lesen&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_garten.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Im Garten lesen&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_garten.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -643,7 +629,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -697,7 +683,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -721,7 +707,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -739,42 +725,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau lesen_w1_en"></iframe>
-  <div class="flds"><div class="fld" data-key="lesen_w1_en#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#Motiv">0</span></button></div>
-<div class="val">lesen/garten — Im Garten lesen</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Motiv')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#Betreff">0</span></button></div>
-<div class="val">What you watch, now also read — 3 months free</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#Botschaft">0</span></button></div>
-<div class="val">See a little further every week.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#Text">0</span></button></div>
-<div class="val">What you watch on goetheanum.tv you can read on in the weekly: week after week, people who have given their lives to a question write down not what they know but how they search. Read along, and you return to your own week with different eyes.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#CTA">0</span></button></div>
-<div class="val">Start reading free →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#CTA')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Read in the open air — three months free</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="lesen_w1_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#Link">0</span></button></div>
-<div class="val"><code>https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="lesen_w1_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="lesen_w1_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w1_en#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#gesamt')">senden</button></div></div></div>
-  </div></div></div><div class="wave"><div class="mail" data-lang="de">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#gesamt')">senden</button></div></div></div></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W2 · DE<a href="mails/mail_lesen_w2_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Ihr Sommer hat noch Seiten frei</div><div class="ib-a">Bis 8. August: die Wochenschrift drei Monate gratis zu Ihrem Abo — sie liest sich überall.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -902,7 +859,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -934,7 +893,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;Lesen im Abendlicht&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_abendlicht.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Lesen im Abendlicht&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_abendlicht.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -962,7 +923,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -1016,7 +977,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1040,7 +1001,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -1058,42 +1019,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau lesen_w2_de"></iframe>
-  <div class="flds"><div class="fld" data-key="lesen_w2_de#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#Motiv">0</span></button></div>
-<div class="val">lesen/abendlicht — Lesen im Abendlicht</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#Motiv')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_de#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#Betreff">0</span></button></div>
-<div class="val">Ihr Sommer hat noch Seiten frei</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#Botschaft">0</span></button></div>
-<div class="val">Ein Sommer über den eigenen Rand hinaus.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#Text">0</span></button></div>
-<div class="val">Noch bis 8. August lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — Lesestoff, der in Ihnen weiterarbeitet, wenn der Bildschirm dunkel ist.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#CTA">0</span></button></div>
-<div class="val">Drei Monate lesen →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#CTA')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Lesestoff, der den Sommer überdauert — gratis</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#Link">0</span></button></div>
-<div class="val"><code>https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="lesen_w2_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="lesen_w2_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_de#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#gesamt')">senden</button></div></div></div>
-  </div></div><div class="mail" data-lang="en">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W2 · EN<a href="mails/mail_lesen_w2_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Your summer still has pages to turn</div><div class="ib-a">Until 8 August: three months of the weekly, free with your subscription — it goes where you go.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -1221,7 +1153,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -1253,7 +1187,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;Lesen im Abendlicht&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_abendlicht.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Lesen im Abendlicht&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_abendlicht.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -1281,7 +1217,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -1335,7 +1271,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1359,7 +1295,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -1377,42 +1313,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau lesen_w2_en"></iframe>
-  <div class="flds"><div class="fld" data-key="lesen_w2_en#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#Motiv">0</span></button></div>
-<div class="val">lesen/abendlicht — Lesen im Abendlicht</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#Motiv')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_en#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#Betreff">0</span></button></div>
-<div class="val">Your summer still has pages to turn</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#Botschaft">0</span></button></div>
-<div class="val">A summer beyond your own horizon.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#Text">0</span></button></div>
-<div class="val">Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#CTA">0</span></button></div>
-<div class="val">Start reading free →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#CTA')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Reading that outlasts the summer — free</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="lesen_w2_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#Link">0</span></button></div>
-<div class="val"><code>https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="lesen_w2_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="lesen_w2_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w2_en#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#gesamt')">senden</button></div></div></div>
-  </div></div></div><div class="wave"><div class="mail" data-lang="de">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#gesamt')">senden</button></div></div></div></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3 · DE<a href="mails/mail_lesen_w3_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Nur noch bis Samstag: drei Monate gratis</div><div class="ib-a">Eine Minute für drei Monate Lesezeit: die Wochenschrift gratis zu Ihrem Abo — bis Samstag.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Was Sie sehen, jetzt auch lesen — bis Samstag</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -1540,7 +1447,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -1572,7 +1481,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;Am See lesen&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_see.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Am See lesen&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_see.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -1600,7 +1511,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -1654,7 +1565,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1678,7 +1589,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -1696,42 +1607,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau lesen_w3_de"></iframe>
-  <div class="flds"><div class="fld" data-key="lesen_w3_de#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_de#Motiv">0</span></button></div>
-<div class="val">lesen/see — Am See lesen</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#Motiv')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_de#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_de#Betreff">0</span></button></div>
-<div class="val">Nur noch bis Samstag: drei Monate gratis</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_de#Botschaft">0</span></button></div>
-<div class="val">Bis Samstag bleibt die Tür offen.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_de#Text">0</span></button></div>
-<div class="val">Noch ein paar Sommertage lang: die Wochenschrift, drei Monate gratis zu Ihrem Abo. Wenn sie Ihnen nicht ans Herz wächst, kündigen Sie einfach.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_de#CTA">0</span></button></div>
-<div class="val">Drei Monate lesen →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#CTA')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_de#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Was Sie sehen, jetzt auch lesen — bis Samstag</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_de#Link">0</span></button></div>
-<div class="val"><code>https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="lesen_w3_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="lesen_w3_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_de#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#gesamt')">senden</button></div></div></div>
-  </div></div><div class="mail" data-lang="en">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3 · EN<a href="mails/mail_lesen_w3_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Only until Saturday: three months free</div><div class="ib-a">One minute for three months: the weekly, free with your subscription — until Saturday.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> What you watch, now also read — until Saturday</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -1859,7 +1741,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -1891,7 +1775,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;Am See lesen&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_see.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Am See lesen&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_see.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -1919,7 +1805,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -1973,7 +1859,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1997,7 +1883,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -2015,42 +1901,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau lesen_w3_en"></iframe>
-  <div class="flds"><div class="fld" data-key="lesen_w3_en#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_en#Motiv">0</span></button></div>
-<div class="val">lesen/see — Am See lesen</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#Motiv')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_en#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_en#Betreff">0</span></button></div>
-<div class="val">Only until Saturday: three months free</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_en#Botschaft">0</span></button></div>
-<div class="val">The door stays open until Saturday.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_en#Text">0</span></button></div>
-<div class="val">A few summer days remain: the weekly, free for three months with your subscription. If it doesn’t grow on you, simply cancel.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#Text')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_en#CTA">0</span></button></div>
-<div class="val">Start reading free →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#CTA')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_en#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">What you watch, now also read — until Saturday</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="lesen_w3_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_en#Link">0</span></button></div>
-<div class="val"><code>https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="lesen_w3_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="lesen_w3_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3_en#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#gesamt')">senden</button></div></div></div>
-  </div></div></div></div></section><section class="segment"><h2>Sehen · goetheanum.tv — nurws</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#gesamt')">senden</button></div></div></div></div></div></div></div></section><section class="segment"><h2>Sehen · goetheanum.tv — nurws</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W1 · DE<a href="mails/mail_sehen_w1_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Was Sie lesen, jetzt auch sehen — 3 Monate gratis</div><div class="ib-a">Über 800 Vorträge und Gespräche, die Ihrem Lesen Tiefe geben — wohin der Sommer Sie trägt.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -2178,7 +2035,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -2210,7 +2069,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;goetheanum.tv unter der Pergola&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_pergola.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;goetheanum.tv unter der Pergola&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_pergola.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -2238,7 +2099,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -2292,7 +2153,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2316,7 +2177,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -2334,42 +2195,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau sehen_w1_de"></iframe>
-  <div class="flds"><div class="fld" data-key="sehen_w1_de#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#Motiv">0</span></button></div>
-<div class="val">sehen/pergola — goetheanum.tv unter der Pergola</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#Motiv')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#Betreff">0</span></button></div>
-<div class="val">Was Sie lesen, jetzt auch sehen — 3 Monate gratis</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#Botschaft">0</span></button></div>
-<div class="val">Zusehen, wie jemand denkt.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#Text">0</span></button></div>
-<div class="val">Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: Auf goetheanum.tv denken Menschen laut, in über 800 Vorträgen und Gesprächen. Sie hören das Zögern und das Finden mit — alles, was auf der gedruckten Seite unsichtbar bleibt.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#CTA">0</span></button></div>
-<div class="val">Drei Monate schauen →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#CTA')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Dem Gelesenen zuhören — 3 Monate gratis</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#Link">0</span></button></div>
-<div class="val"><code>https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="sehen_w1_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="sehen_w1_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_de#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#gesamt')">senden</button></div></div></div>
-  </div></div><div class="mail" data-lang="en">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W1 · EN<a href="mails/mail_sehen_w1_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">What you read, now also watch — 3 months free</div><div class="ib-a">Over 800 lectures and conversations that deepen your reading — wherever summer takes you.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -2497,7 +2329,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -2529,7 +2363,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;goetheanum.tv unter der Pergola&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_pergola.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;goetheanum.tv unter der Pergola&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_pergola.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -2557,7 +2393,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -2611,7 +2447,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2635,7 +2471,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -2653,42 +2489,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau sehen_w1_en"></iframe>
-  <div class="flds"><div class="fld" data-key="sehen_w1_en#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#Motiv">0</span></button></div>
-<div class="val">sehen/pergola — goetheanum.tv unter der Pergola</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#Motiv')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#Betreff">0</span></button></div>
-<div class="val">What you read, now also watch — 3 months free</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#Botschaft">0</span></button></div>
-<div class="val">Watch someone think.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#Text">0</span></button></div>
-<div class="val">What you read each week you can now watch and hear: on goetheanum.tv, people think out loud, in over 800 lectures and conversations. You hear the hesitation and the finding — everything the printed page keeps invisible.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#CTA">0</span></button></div>
-<div class="val">Start watching free →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#CTA')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Listen to what you read — 3 months free</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="sehen_w1_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#Link">0</span></button></div>
-<div class="val"><code>https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="sehen_w1_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="sehen_w1_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w1_en#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_en#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#gesamt')">senden</button></div></div></div>
-  </div></div></div><div class="wave"><div class="mail" data-lang="de">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_en#gesamt')">senden</button></div></div></div></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W2 · DE<a href="mails/mail_sehen_w2_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Ihr Sommer hat noch Abende frei</div><div class="ib-a">goetheanum.tv drei Monate gratis zu Ihrem Abo — Abende, die nachwirken. Bis 8. August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -2816,7 +2623,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -2848,7 +2657,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;goetheanum.tv auf der Sommerterrasse&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_terrasse.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;goetheanum.tv auf der Sommerterrasse&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_terrasse.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -2876,7 +2687,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -2930,7 +2741,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2954,7 +2765,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -2972,42 +2783,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau sehen_w2_de"></iframe>
-  <div class="flds"><div class="fld" data-key="sehen_w2_de#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#Motiv">0</span></button></div>
-<div class="val">sehen/terrasse — goetheanum.tv auf der Sommerterrasse</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#Motiv')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_de#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#Betreff">0</span></button></div>
-<div class="val">Ihr Sommer hat noch Abende frei</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#Botschaft">0</span></button></div>
-<div class="val">Setzen Sie sich dazu.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#Text">0</span></button></div>
-<div class="val">Ein Abend auf goetheanum.tv ist ein Abend in Gesellschaft von Menschen, die ihr Leben lang an einer Frage gearbeitet haben — und die laut denken, statt fertige Antworten vorzutragen. Noch bis 8. August drei Monate gratis zu Ihrem Abo.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#CTA">0</span></button></div>
-<div class="val">Drei Monate schauen →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#CTA')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Drei Monate weiter sehen — gratis</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#Link">0</span></button></div>
-<div class="val"><code>https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="sehen_w2_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="sehen_w2_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_de#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_de#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#gesamt')">senden</button></div></div></div>
-  </div></div><div class="mail" data-lang="en">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W2 · EN<a href="mails/mail_sehen_w2_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Your summer still has evenings free</div><div class="ib-a">goetheanum.tv, three months free with your subscription — evenings that linger. By 8 August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -3135,7 +2917,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -3167,7 +2951,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;goetheanum.tv auf der Sommerterrasse&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_terrasse.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;goetheanum.tv auf der Sommerterrasse&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_terrasse.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -3195,7 +2981,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -3249,7 +3035,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3273,7 +3059,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -3291,42 +3077,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau sehen_w2_en"></iframe>
-  <div class="flds"><div class="fld" data-key="sehen_w2_en#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#Motiv">0</span></button></div>
-<div class="val">sehen/terrasse — goetheanum.tv auf der Sommerterrasse</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#Motiv')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_en#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#Betreff">0</span></button></div>
-<div class="val">Your summer still has evenings free</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#Botschaft">0</span></button></div>
-<div class="val">Pull up a chair.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#Text">0</span></button></div>
-<div class="val">An evening on goetheanum.tv is an evening in the company of people who have worked on a question all their lives — thinking out loud rather than reciting finished answers. Until 8 August: three months free with your subscription.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#CTA">0</span></button></div>
-<div class="val">Start watching free →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#CTA')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">See further for three months — free</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="sehen_w2_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#Link">0</span></button></div>
-<div class="val"><code>https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="sehen_w2_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="sehen_w2_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w2_en#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#gesamt')">senden</button></div></div></div>
-  </div></div></div><div class="wave"><div class="mail" data-lang="de">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#gesamt')">senden</button></div></div></div></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3 · DE<a href="mails/mail_sehen_w3_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Nur noch bis Samstag: drei Monate gratis</div><div class="ib-a">Eine Minute für drei Monate goetheanum.tv: gratis zu Ihrem Abo — bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Was Sie lesen, jetzt auch sehen — bis Samstag</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -3454,7 +3211,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -3486,7 +3245,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;goetheanum.tv in der Hängematte am See&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_haengematte.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;goetheanum.tv in der Hängematte am See&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_haengematte.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -3514,7 +3275,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -3568,7 +3329,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3592,7 +3353,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -3610,42 +3371,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau sehen_w3_de"></iframe>
-  <div class="flds"><div class="fld" data-key="sehen_w3_de#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_de#Motiv">0</span></button></div>
-<div class="val">sehen/haengematte — goetheanum.tv in der Hängematte am See</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#Motiv')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_de#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_de#Betreff">0</span></button></div>
-<div class="val">Nur noch bis Samstag: drei Monate gratis</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_de#Botschaft">0</span></button></div>
-<div class="val">Bis Samstag ist Ihr Platz frei.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_de#Text">0</span></button></div>
-<div class="val">Noch ein paar Sommertage: goetheanum.tv, die ersten drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es in Ihnen nachklingt.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_de#CTA">0</span></button></div>
-<div class="val">Drei Monate schauen →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#CTA')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_de#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Was Sie lesen, jetzt auch sehen — bis Samstag</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_de#Link">0</span></button></div>
-<div class="val"><code>https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="sehen_w3_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="sehen_w3_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_de#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#gesamt')">senden</button></div></div></div>
-  </div></div><div class="mail" data-lang="en">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3 · EN<a href="mails/mail_sehen_w3_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Only until Saturday: three months free</div><div class="ib-a">One minute for three months of goetheanum.tv — free with your subscription, until Saturday.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> What you read, now also watch — until Saturday</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -3773,7 +3505,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -3805,7 +3539,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;goetheanum.tv in der Hängematte am See&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_haengematte.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;goetheanum.tv in der Hängematte am See&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_haengematte.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -3833,7 +3569,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -3887,7 +3623,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3911,7 +3647,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -3929,42 +3665,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau sehen_w3_en"></iframe>
-  <div class="flds"><div class="fld" data-key="sehen_w3_en#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_en#Motiv">0</span></button></div>
-<div class="val">sehen/haengematte — goetheanum.tv in der Hängematte am See</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_en#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#Motiv')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_en#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_en#Betreff">0</span></button></div>
-<div class="val">Only until Saturday: three months free</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_en#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_en#Botschaft">0</span></button></div>
-<div class="val">Your seat stays free until Saturday.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_en#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_en#Text">0</span></button></div>
-<div class="val">A few summer days left: goetheanum.tv, the first three months free with your subscription — stay only if it stays with you.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_en#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#Text')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_en#CTA">0</span></button></div>
-<div class="val">Start watching free →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_en#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#CTA')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_en#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">What you read, now also watch — until Saturday</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_en#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="sehen_w3_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_en#Link">0</span></button></div>
-<div class="val"><code>https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_en#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="sehen_w3_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="sehen_w3_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3_en#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_en#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#gesamt')">senden</button></div></div></div>
-  </div></div></div></div></section><section class="segment"><h2>Beides · Das ganze Goetheanum — noabo</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#gesamt')">senden</button></div></div></div></div></div></div></div></section><section class="segment"><h2>Beides · Das ganze Goetheanum — noabo</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W1 · DE<a href="mails/mail_beides_w1_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Ein Sommer mit dem Goetheanum — 3 Monate gratis</div><div class="ib-a">Lesen oder schauen — oder beides: die ersten drei Monate geschenkt, bis 8. August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -4092,7 +3799,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -4124,7 +3833,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;Das Goetheanum im Abendlicht&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_abendlicht.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Das Goetheanum im Abendlicht&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_abendlicht.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -4152,7 +3863,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -4206,7 +3917,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4230,7 +3941,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -4248,42 +3959,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau beides_w1_de"></iframe>
-  <div class="flds"><div class="fld" data-key="beides_w1_de#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#Motiv">0</span></button></div>
-<div class="val">beides/abendlicht — Das Goetheanum im Abendlicht</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#Motiv')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#Betreff">0</span></button></div>
-<div class="val">Ein Sommer mit dem Goetheanum — 3 Monate gratis</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#Botschaft">0</span></button></div>
-<div class="val">Zwei Fenster auf, den ganzen Sommer.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#Text">0</span></button></div>
-<div class="val">Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie in der Wochenschrift Menschen, die einer Frage ihr Leben gewidmet haben, und sehen Sie auf goetheanum.tv zu, wie sie laut denken — die ersten drei Monate kostenlos, jederzeit kündbar.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#CTA">0</span></button></div>
-<div class="val">Ihren Sommer wählen →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Drei Monate sind eine Jahreszeit — gratis</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="beides_w1_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#Link">0</span></button></div>
-<div class="val"><code>https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="beides_w1_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="beides_w1_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_de#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_de#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#gesamt')">senden</button></div></div></div>
-  </div></div><div class="mail" data-lang="en">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W1 · EN<a href="mails/mail_beides_w1_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">A summer with the Goetheanum — 3 months free</div><div class="ib-a">Read the weekly, watch goetheanum.tv — or both: the first three months free. Until 8 August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -4411,7 +4093,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -4443,7 +4127,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;Das Goetheanum im Abendlicht&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_abendlicht.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Das Goetheanum im Abendlicht&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_abendlicht.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -4471,7 +4157,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -4525,7 +4211,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4549,7 +4235,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -4567,42 +4253,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau beides_w1_en"></iframe>
-  <div class="flds"><div class="fld" data-key="beides_w1_en#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#Motiv">0</span></button></div>
-<div class="val">beides/abendlicht — Das Goetheanum im Abendlicht</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#Motiv')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#Betreff">0</span></button></div>
-<div class="val">A summer with the Goetheanum — 3 months free</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#Botschaft">0</span></button></div>
-<div class="val">Two windows open, all summer long.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#Text">0</span></button></div>
-<div class="val">Get to know the Goetheanum from both sides this summer: in the weekly, read people who have given their lives to a question; on goetheanum.tv, watch them think out loud — the first three months free, cancel anytime.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#CTA">0</span></button></div>
-<div class="val">Choose your summer →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Three months is a whole season — free</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="beides_w1_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#Link">0</span></button></div>
-<div class="val"><code>https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="beides_w1_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="beides_w1_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w1_en#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w1_en#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#gesamt')">senden</button></div></div></div>
-  </div></div></div><div class="wave"><div class="mail" data-lang="de">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w1_en#gesamt')">senden</button></div></div></div></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W2 · DE<a href="mails/mail_beides_w2_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Lesen, sehen — oder gleich beides</div><div class="ib-a">Wochenschrift und goetheanum.tv, drei Monate kostenlos — Stoff zum Weiterdenken. Bis 8. August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -4730,7 +4387,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -4762,7 +4421,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;Hefte vor dem Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_vor-dem-bau.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Hefte vor dem Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_vor-dem-bau.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -4790,7 +4451,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -4844,7 +4505,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4868,7 +4529,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -4886,42 +4547,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau beides_w2_de"></iframe>
-  <div class="flds"><div class="fld" data-key="beides_w2_de#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_de#Motiv">0</span></button></div>
-<div class="val">beides/vor-dem-bau — Hefte vor dem Goetheanum</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_de#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#Motiv')">senden</button></div></div></div><div class="fld" data-key="beides_w2_de#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_de#Betreff">0</span></button></div>
-<div class="val">Lesen, sehen — oder gleich beides</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_de#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w2_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_de#Botschaft">0</span></button></div>
-<div class="val">Denken in guter Gesellschaft.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_de#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w2_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_de#Text">0</span></button></div>
-<div class="val">Ein Essay am Morgen, ein Vortrag am Abend — und dazwischen merken Sie, wie die eigenen Gedanken weiter reichen als sonst. Die ersten drei Monate geschenkt, anmelden bis 8. August.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_de#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w2_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_de#CTA">0</span></button></div>
-<div class="val">Ihren Sommer wählen →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_de#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w2_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_de#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Noch bis 8. August: Ihr Sommer-Geschenk</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_de#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="beides_w2_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_de#Link">0</span></button></div>
-<div class="val"><code>https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_de#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="beides_w2_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="beides_w2_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_de#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_de#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#gesamt')">senden</button></div></div></div>
-  </div></div><div class="mail" data-lang="en">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W2 · EN<a href="mails/mail_beides_w2_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Read, watch — or simply both</div><div class="ib-a">The weekly and goetheanum.tv, three months free — food for thought all summer. By 8 August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -5049,7 +4681,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -5081,7 +4715,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;Hefte vor dem Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_vor-dem-bau.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Hefte vor dem Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_vor-dem-bau.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -5109,7 +4745,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -5163,7 +4799,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5187,7 +4823,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -5205,42 +4841,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau beides_w2_en"></iframe>
-  <div class="flds"><div class="fld" data-key="beides_w2_en#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_en#Motiv">0</span></button></div>
-<div class="val">beides/vor-dem-bau — Hefte vor dem Goetheanum</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_en#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#Motiv')">senden</button></div></div></div><div class="fld" data-key="beides_w2_en#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_en#Betreff">0</span></button></div>
-<div class="val">Read, watch — or simply both</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_en#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w2_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_en#Botschaft">0</span></button></div>
-<div class="val">Thinking in good company.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_en#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w2_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_en#Text">0</span></button></div>
-<div class="val">An essay in the morning, a lecture in the evening — and in between you notice your own thoughts reaching further than usual. The first three months free, sign up by 8 August.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_en#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w2_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_en#CTA">0</span></button></div>
-<div class="val">Choose your summer →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_en#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w2_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_en#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Until 8 August: your summer gift</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_en#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="beides_w2_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_en#Link">0</span></button></div>
-<div class="val"><code>https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_en#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="beides_w2_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="beides_w2_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w2_en#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w2_en#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#gesamt')">senden</button></div></div></div>
-  </div></div></div><div class="wave"><div class="mail" data-lang="de">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#gesamt')">senden</button></div></div></div></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3 · DE<a href="mails/mail_beides_w3_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Am Samstag endet die Sommer-Aktion</div><div class="ib-a">Drei Monate lesen oder schauen, gratis — nur noch bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Drei Monate Goetheanum — lesen, sehen oder beides</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -5368,7 +4975,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -5400,7 +5009,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;Sommer-Picknick mit dem Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Sommer-Picknick mit dem Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -5428,7 +5039,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -5482,7 +5093,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5506,7 +5117,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -5524,42 +5135,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau beides_w3_de"></iframe>
-  <div class="flds"><div class="fld" data-key="beides_w3_de#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#Motiv">0</span></button></div>
-<div class="val">beides/picknick — Sommer-Picknick mit dem Goetheanum</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#Motiv')">senden</button></div></div></div><div class="fld" data-key="beides_w3_de#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#Betreff">0</span></button></div>
-<div class="val">Am Samstag endet die Sommer-Aktion</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w3_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#Botschaft">0</span></button></div>
-<div class="val">Lesen, sehen oder beides — Ihre Wahl.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w3_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#Text">0</span></button></div>
-<div class="val">Noch bis Samstag: drei Monate kostenlos lesen oder sehen — danach entscheiden Sie, ob es weitergeht.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w3_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#CTA">0</span></button></div>
-<div class="val">Ihren Sommer wählen →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w3_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Drei Monate Goetheanum — lesen, sehen oder beides</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="beides_w3_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#Link">0</span></button></div>
-<div class="val"><code>https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="beides_w3_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="beides_w3_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_de#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#gesamt')">senden</button></div></div></div>
-  </div></div><div class="mail" data-lang="en">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3 · EN<a href="mails/mail_beides_w3_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">The summer offer ends on Saturday</div><div class="ib-a">Three months of reading or watching, free — only until Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Three months of Goetheanum — read, watch or both</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -5687,7 +5269,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -5719,7 +5303,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;Sommer-Picknick mit dem Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Sommer-Picknick mit dem Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -5747,7 +5333,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -5801,7 +5387,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5825,7 +5411,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -5843,42 +5429,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau beides_w3_en"></iframe>
-  <div class="flds"><div class="fld" data-key="beides_w3_en#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#Motiv">0</span></button></div>
-<div class="val">beides/picknick — Sommer-Picknick mit dem Goetheanum</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#Motiv')">senden</button></div></div></div><div class="fld" data-key="beides_w3_en#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#Betreff">0</span></button></div>
-<div class="val">The summer offer ends on Saturday</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w3_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#Botschaft">0</span></button></div>
-<div class="val">Reading, watching or both — your choice.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w3_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#Text">0</span></button></div>
-<div class="val">Until Saturday: three months free to read or watch — after that, you decide whether it continues.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w3_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#CTA">0</span></button></div>
-<div class="val">Choose your summer →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w3_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Three months of Goetheanum — read, watch or both</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="beides_w3_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#Link">0</span></button></div>
-<div class="val"><code>https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="beides_w3_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="beides_w3_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3_en#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#gesamt')">senden</button></div></div></div>
-  </div></div></div><div class="wave"><div class="mail" data-lang="de">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#gesamt')">senden</button></div></div></div></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3B · DE<a href="mails/mail_beides_w3b_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Morgen ist Schluss</div><div class="ib-a">Drei Monate Goetheanum, gratis und jederzeit kündbar — anmelden bis morgen, Samstag, 8. August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -6006,7 +5563,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -6038,7 +5597,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;Sommer-Picknick mit dem Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Sommer-Picknick mit dem Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -6066,7 +5627,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 Monate gratis</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -6120,7 +5681,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -6144,7 +5705,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -6162,42 +5723,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau beides_w3b_de"></iframe>
-  <div class="flds"><div class="fld" data-key="beides_w3b_de#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_de#Motiv">0</span></button></div>
-<div class="val">beides/picknick — Sommer-Picknick mit dem Goetheanum</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#Motiv')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_de#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_de#Betreff">0</span></button></div>
-<div class="val">Morgen ist Schluss</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_de#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_de#Botschaft">0</span></button></div>
-<div class="val">Sie waren schon da — ein Schritt fehlt noch.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_de#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_de#Text">0</span></button></div>
-<div class="val">Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute, und Sie haben drei Monate Zeit, dem nachzugehen.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_de#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_de#CTA">0</span></button></div>
-<div class="val">Ihren Sommer wählen →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_de#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_de#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Bis morgen: drei Monate Goetheanum gratis</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_de#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_de#Link">0</span></button></div>
-<div class="val"><code>https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="beides_w3b_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="beides_w3b_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_de#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#gesamt')">senden</button></div></div></div>
-  </div></div><div class="mail" data-lang="en">
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3B · EN<a href="mails/mail_beides_w3b_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">It ends tomorrow</div><div class="ib-a">Three months of the Goetheanum, free, cancel anytime — sign up by tomorrow, Saturday 8 August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -6325,7 +5857,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:119px;&quot;>
-                                <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -6357,7 +5891,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                           <tbody>
                             <tr>
                               <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
-                                <img alt=&quot;Sommer-Picknick mit dem Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Sommer-Picknick mit dem Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -6385,7 +5921,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>3 months free</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;>Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -6439,7 +5975,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today — since 1921</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;>Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -6463,7 +5999,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;&quot;>Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href=&quot;https://goetheanum.ch&quot; style=&quot;color:#9A9AA6;&quot;>goetheanum.ch</a> · <a href=&quot;%UNSUBSCRIBELINK%&quot; style=&quot;color:#9A9AA6;&quot;>Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -6481,41 +6017,11 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 </html>
 " loading="lazy" title="Vorschau beides_w3b_en"></iframe>
-  <div class="flds"><div class="fld" data-key="beides_w3b_en#Motiv"><div class="fh" onclick="toggle(this)"><span class="lbl">Motiv</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_en#Motiv">0</span></button></div>
-<div class="val">beides/picknick — Sommer-Picknick mit dem Goetheanum</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#Motiv"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#Motiv')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_en#Betreff"><div class="fh" onclick="toggle(this)"><span class="lbl">Betreff</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_en#Betreff">0</span></button></div>
-<div class="val">It ends tomorrow</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#Betreff"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#Betreff')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_en#Botschaft"><div class="fh" onclick="toggle(this)"><span class="lbl">Botschaft</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_en#Botschaft">0</span></button></div>
-<div class="val">You’ve already had a look — one step to go.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#Botschaft"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#Botschaft')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_en#Text"><div class="fh" onclick="toggle(this)"><span class="lbl">Text</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_en#Text">0</span></button></div>
-<div class="val">What you looked at spoke to you for a reason — one minute, and you have three months to follow it.</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#Text"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#Text')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_en#CTA"><div class="fh" onclick="toggle(this)"><span class="lbl">CTA</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_en#CTA">0</span></button></div>
-<div class="val">Choose your summer →</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#CTA"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#CTA')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_en#Alt-Betreff (AC-Split)"><div class="fh" onclick="toggle(this)"><span class="lbl">Alt-Betreff (AC-Split)</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_en#Alt-Betreff (AC-Split)">0</span></button></div>
-<div class="val">Until tomorrow: 3 months of Goetheanum free</div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#Alt-Betreff (AC-Split)"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#Alt-Betreff (AC-Split)')">senden</button></div></div></div><div class="fld" data-key="beides_w3b_en#Link"><div class="fh" onclick="toggle(this)"><span class="lbl">Link</span>
-<button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_en#Link">0</span></button></div>
-<div class="val"><code>https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo</code></div>
-<div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#Link"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#Link')">senden</button></div></div></div>
-    <div class="fld" data-key="beides_w3b_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Ganze Mail</span>
+  <div class="flds"><div class="fld" data-key="beides_w3b_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="beides_w3b_en#gesamt">0</span></button></div>
-<div class="val"><i>Anmerkung zur ganzen Mail</i></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#gesamt"></ul>
-<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#gesamt')">senden</button></div></div></div>
-  </div></div></div></div></section>
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#gesamt')">senden</button></div></div></div></div></div></div></div></section>
 </main>
 
 <footer class="ds-footer"><div class="wrap"><div class="frow">
@@ -6539,14 +6045,23 @@ function toggleNur(){const b=document.getElementById('b-nur'),an=document.body.c
 function toggle(el){const p=el.closest('.fld').querySelector('.cpanel');p.hidden=!p.hidden;}
 function esc(s){const d=document.createElement('div');d.textContent=s;return d.innerHTML;}
 function zeit(iso){try{return new Date(iso).toLocaleString('de-CH',{day:'2-digit',month:'2-digit',hour:'2-digit',minute:'2-digit'}).replace(', ',' ');}catch(e){return '';}}
+function sammel(key){
+ // Mail-Panels (…#gesamt) bündeln ALLE Kommentare ihrer Mail — auch den
+ // Altbestand aus der früheren Feld-Ansicht (…#Betreff usw.).
+ if(!key.endsWith('#gesamt')) return COMMENTS[key]||[];
+ const basis=key.slice(0,key.length-'gesamt'.length);
+ let alle=[];
+ Object.keys(COMMENTS).forEach(k=>{if(k.startsWith(basis))alle=alle.concat(COMMENTS[k]);});
+ return alle.sort((a,b)=>a.created_at<b.created_at?-1:1);
+}
 function render(){
  document.querySelectorAll('.clist').forEach(ul=>{
-   const items=(COMMENTS[ul.dataset.cl]||[]).filter(c=>SHOW_DONE||!c.erledigt);
+   const items=sammel(ul.dataset.cl).filter(c=>SHOW_DONE||!c.erledigt);
    ul.innerHTML=items.map(c=>'<li class="'+(c.erledigt?'done':'')+'">'
      +'<div class="khead"><b>'+esc(c.autor||'?')+'</b><span class="kzeit">'+zeit(c.created_at)+'</span>'
      +'<button class="kdone" onclick="erledigt('+c.id+','+(!c.erledigt)+')" title="'+(c.erledigt?'wieder öffnen':'erledigt')+'" aria-label="'+(c.erledigt?'wieder öffnen':'erledigt')+'">'+(c.erledigt?'↩':'✓')+'</button></div>'
      +'<span class="ktxt">'+esc(c.kommentar)+'</span></li>').join('');});
- document.querySelectorAll('.cc').forEach(s=>{const n=(COMMENTS[s.dataset.cc]||[]).filter(c=>!c.erledigt).length;
+ document.querySelectorAll('.cc').forEach(s=>{const n=sammel(s.dataset.cc).filter(c=>!c.erledigt).length;
    s.textContent=n;s.classList.toggle('has',n>0);});
  const off=[];Object.values(COMMENTS).forEach(l=>l.forEach(c=>{if(!c.erledigt)off.push(c);}));
  off.sort((a,b)=>a.created_at<b.created_at?-1:1);
@@ -6557,7 +6072,10 @@ function render(){
      +'<span class="otxt">'+esc(c.kommentar)+'</span></button></li>';}).join('');
 }
 function springe(key){
- const fld=document.querySelector('.fld[data-key="'+CSS.escape(key)+'"]'); if(!fld) return;
+ let fld=document.querySelector('.fld[data-key="'+CSS.escape(key)+'"]');
+ if(!fld){const basis=key.split('#')[0];
+   fld=document.querySelector('.fld[data-key="'+CSS.escape(basis+'#gesamt')+'"]');}
+ if(!fld) return;
  const m=key.match(/_(de|en)#/); if(m) setLang(m[1]);
  fld.querySelector('.cpanel').hidden=false;
  fld.scrollIntoView({behavior:'smooth',block:'center'});
@@ -6585,8 +6103,9 @@ async function erledigt(id,wert){
 function spracheAus(key){const m=key.match(/_(de|en)#/);return m?m[1]:null;}
 async function send(btn,key){
  const inp=btn.previousElementSibling, txt=inp.value.trim(); if(!txt) return;
- const autor=(document.getElementById('autor').value||'').trim()||'anon';
- try{localStorage.setItem('autor',autor);}catch(e){}
+ const eingabe=(document.getElementById('autor').value||'').trim();
+ try{if(eingabe)localStorage.setItem('autor',eingabe);}catch(e){}
+ const autor=eingabe||'anon';
  btn.disabled=true; st("sende …");
  try{
   const r=await fetch(REST,{method:"POST",headers:{...HDR,"Prefer":"return=minimal"},body:JSON.stringify({mail_key:key,autor,kommentar:txt,sprache:spracheAus(key)})});
@@ -6596,6 +6115,6 @@ async function send(btn,key){
  btn.disabled=false;
 }
 document.getElementById('offenliste').addEventListener('click',e=>{const b=e.target.closest('[data-go]');if(b)springe(b.dataset.go);});
-try{document.getElementById('autor').value=localStorage.getItem('autor')||'';}catch(e){}
+try{const a=localStorage.getItem('autor');if(a&&a!=='anon')document.getElementById('autor').value=a;}catch(e){}
 setLang('de');load();
 </script></body></html>

--- a/apps/mail-editor/mails/mail_beides_w1_de.html
+++ b/apps/mail-editor/mails/mail_beides_w1_de.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="Das Goetheanum im Abendlicht" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_abendlicht.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo" target="_blank">
+                                  <img alt="Das Goetheanum im Abendlicht" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_abendlicht.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w1_en.html
+++ b/apps/mail-editor/mails/mail_beides_w1_en.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="Das Goetheanum im Abendlicht" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_abendlicht.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo" target="_blank">
+                                  <img alt="Das Goetheanum im Abendlicht" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_abendlicht.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_de.html
+++ b/apps/mail-editor/mails/mail_beides_w2_de.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="Hefte vor dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_vor-dem-bau.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo" target="_blank">
+                                  <img alt="Hefte vor dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_vor-dem-bau.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_en.html
+++ b/apps/mail-editor/mails/mail_beides_w2_en.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="Hefte vor dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_vor-dem-bau.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo" target="_blank">
+                                  <img alt="Hefte vor dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_vor-dem-bau.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3_de.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="Sommer-Picknick mit dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo" target="_blank">
+                                  <img alt="Sommer-Picknick mit dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3_en.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="Sommer-Picknick mit dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo" target="_blank">
+                                  <img alt="Sommer-Picknick mit dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_de.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="Sommer-Picknick mit dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" target="_blank">
+                                  <img alt="Sommer-Picknick mit dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_en.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="Sommer-Picknick mit dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" target="_blank">
+                                  <img alt="Sommer-Picknick mit dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w1_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_de.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="Im Garten lesen" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_garten.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv" target="_blank">
+                                  <img alt="Im Garten lesen" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_garten.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w1_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_en.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="Im Garten lesen" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_garten.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv" target="_blank">
+                                  <img alt="Im Garten lesen" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_garten.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_de.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="Lesen im Abendlicht" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_abendlicht.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv" target="_blank">
+                                  <img alt="Lesen im Abendlicht" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_abendlicht.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_en.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="Lesen im Abendlicht" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_abendlicht.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv" target="_blank">
+                                  <img alt="Lesen im Abendlicht" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_abendlicht.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_de.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="Am See lesen" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_see.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv" target="_blank">
+                                  <img alt="Am See lesen" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_see.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_en.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="Am See lesen" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_see.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv" target="_blank">
+                                  <img alt="Am See lesen" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_see.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w1_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_de.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="goetheanum.tv unter der Pergola" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_pergola.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws" target="_blank">
+                                  <img alt="goetheanum.tv unter der Pergola" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_pergola.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w1_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_en.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="goetheanum.tv unter der Pergola" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_pergola.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws" target="_blank">
+                                  <img alt="goetheanum.tv unter der Pergola" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_pergola.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_de.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="goetheanum.tv auf der Sommerterrasse" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_terrasse.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws" target="_blank">
+                                  <img alt="goetheanum.tv auf der Sommerterrasse" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_terrasse.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_en.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="goetheanum.tv auf der Sommerterrasse" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_terrasse.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws" target="_blank">
+                                  <img alt="goetheanum.tv auf der Sommerterrasse" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_terrasse.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_de.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="goetheanum.tv in der Hängematte am See" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_haengematte.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws" target="_blank">
+                                  <img alt="goetheanum.tv in der Hängematte am See" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_haengematte.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 Monate gratis</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Sommerangebot 2026 · 3 Monate gratis</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute — seit 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Stimmen und Gesichter der Anthroposophie von heute</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_en.html
@@ -125,7 +125,9 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws" target="_blank">
+                                  <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -157,7 +159,9 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <img alt="goetheanum.tv in der Hängematte am See" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_haengematte.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws" target="_blank">
+                                  <img alt="goetheanum.tv in der Hängematte am See" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_haengematte.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -185,7 +189,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">3 months free</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;">Summer offer 2026 · 3 months free</div>
                       </td>
                     </tr>
                     <tr>
@@ -239,7 +243,7 @@
                   <tbody>
                     <tr>
                       <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today — since 1921</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;">Voices and faces of anthroposophy today</div>
                       </td>
                     </tr>
                   </tbody>
@@ -263,7 +267,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:19px;text-align:left;color:#9A9AA6;">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br /><a href="https://goetheanum.ch" style="color:#9A9AA6;">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:#9A9AA6;">Abmelden</a></div>
                       </td>
                     </tr>
                   </tbody>

--- a/services/mailing-sommer2026/build_editor.py
+++ b/services/mailing-sommer2026/build_editor.py
@@ -113,6 +113,7 @@ def render_mail(motiv, welle, lang, wm):
     mehrere = len(ctas) > 1
     cta_links = [(label, links.link_for(welle, seg, ziel, lang, mehrere)) for ziel, label in ctas]
     hero = src_for(compose(var, f"{motiv}_{vid}"))
+    haupt = cta_links[0][1]["url"]  # Logo und Hero verlinken zur Landing (Kommentar ph 11.7.) — utm bleibt dran
     faces = "".join(f"@font-face{{font-family:'{w['family']}';src:url('{w['url']}') format('woff2');"
                     f"font-weight:{w['weight']};font-style:normal;}}" for w in T.get("webfonts", []))
     fontface = f"<mj-style>{faces}</mj-style>" if (BASE and faces) else ""
@@ -129,8 +130,8 @@ def render_mail(motiv, welle, lang, wm):
     mjml = f"""<mjml><mj-head><mj-title>{xml(c['betreff'])}</mj-title><mj-preview>{xml(preheader(c))}</mj-preview>{fontface}
 <mj-attributes><mj-all font-family="{FONT_STACK}"/><mj-text font-size="16px" line-height="25px" color="{INK}"/></mj-attributes></mj-head>
 <mj-body background-color="{MIST}">
-<mj-section background-color="#FFFFFF" padding="18px 28px 14px 28px"><mj-column><mj-image src="{src_for(wm[0])}" alt="Goetheanum" width="{wm[1]}px" align="left" padding="0"/></mj-column></mj-section>
-<mj-section background-color="#FFFFFF" padding="0"><mj-column><mj-image src="{hero}" alt="{xml(var.get('alt',''))}" padding="0" fluid-on-mobile="true"/></mj-column></mj-section>
+<mj-section background-color="#FFFFFF" padding="18px 28px 14px 28px"><mj-column><mj-image src="{src_for(wm[0])}" href="{xml(haupt)}" alt="Goetheanum" width="{wm[1]}px" align="left" padding="0"/></mj-column></mj-section>
+<mj-section background-color="#FFFFFF" padding="0"><mj-column><mj-image src="{hero}" href="{xml(haupt)}" alt="{xml(var.get('alt',''))}" padding="0" fluid-on-mobile="true"/></mj-column></mj-section>
 <mj-section background-color="#FFFFFF" padding="24px 28px 0 28px"><mj-column>
   <mj-text font-size="14px" line-height="20px" color="{AKZENT}" padding="0 0 10px 0">{xml(H['badge'][lang])}</mj-text>
   <mj-text font-family="{HL_STACK}" font-size="30px" line-height="35px" font-weight="700" color="{INK}" padding="0 0 14px 0">{titel(c['botschaft'])}</mj-text>
@@ -139,16 +140,11 @@ def render_mail(motiv, welle, lang, wm):
   <mj-text font-size="13px" line-height="20px" color="{MUTED}" padding="0 0 26px 0">{kleinzeile(H['kleinzeile'][motiv][lang])}</mj-text>
 </mj-column></mj-section>
 <mj-section background-color="{WASH}" padding="16px 28px"><mj-column><mj-text font-size="14px" line-height="22px" color="{AKZENT_TIEF}" align="center" padding="0">{xml(H['proof'][lang])}</mj-text></mj-column></mj-section>
-<mj-section background-color="{MIST}" padding="20px 28px"><mj-column><mj-text font-size="12px" line-height="19px" color="{FUSS}" padding="0">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br/><a href="%UNSUBSCRIBELINK%" style="color:{FUSS};">Abmelden</a></mj-text></mj-column></mj-section>
+<mj-section background-color="{MIST}" padding="20px 28px"><mj-column><mj-text font-size="12px" line-height="19px" color="{FUSS}" padding="0">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br/><a href="https://goetheanum.ch" style="color:{FUSS};">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:{FUSS};">Abmelden</a></mj-text></mj-column></mj-section>
 </mj-body></mjml>"""
     p = subprocess.run(["mjml", "-i", "-s"], input=mjml, capture_output=True, text=True)
     if p.returncode: raise RuntimeError(p.stderr)
-    fields = {"Motiv": f"{motiv}/{vid} — {var.get('alt','')}", "Betreff": c["betreff"],
-              "Botschaft": c["botschaft"], "Text": c["text"],
-              "CTA": " · ".join(label for label, _ in cta_links),
-              "Alt-Betreff (AC-Split)": c["alt"],
-              "Link": " · ".join(l["url"] for _, l in cta_links)}
-    return p.stdout, fields
+    return p.stdout, c
 
 
 def esc(s): return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
@@ -209,21 +205,24 @@ def main():
         for welle in H["wellenplan"][seg]:
             lang_cards = []
             for lang in ("de", "en"):
-                versand, fields = render_mail(motiv, welle, lang, wm)
+                versand, c = render_mail(motiv, welle, lang, wm)
                 out = ROOT/"dist"/f"mail_{motiv}_{welle}_{lang}.html"
                 out.write_text(versand, encoding="utf-8")
                 sizes.append((out.name, len(versand.encode("utf-8"))))
                 # Editor-Vorschau = exakt die Versand-Mail (gehostete Bilder, kleine Seite).
                 html = versand
                 base = f"{motiv}_{welle}_{lang}"
-                frows = "".join(commentable(f"{base}#{k}", k, esc(v) if k != "Link" else f'<code>{esc(v)}</code>')
-                                for k, v in fields.items())
+                # Posteingang-Zeile: was Empfangende zuerst sehen (Betreff + Anriss);
+                # bei w3 zusätzlich die Zweitrahmung des AC-Splits für Nicht-Öffner.
+                alt_zeile = (f'<div class="ib-alt"><span>Nicht-Öffner erhalten:</span> {esc(c["alt"])}</div>'
+                             if welle == "w3" else "")
+                inbox = (f'<div class="inbox"><div class="ib-b">{esc(c["betreff"])}</div>'
+                         f'<div class="ib-a">{esc(preheader(c))}</div>{alt_zeile}</div>')
                 lang_cards.append(f"""<div class="mail" data-lang="{lang}">
   <div class="mhd">{welle.upper()} · {lang.upper()}<a href="mails/mail_{base}.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  {inbox}
   <iframe srcdoc="{html.replace('"','&quot;')}" loading="lazy" title="Vorschau {base}"></iframe>
-  <div class="flds">{frows}
-    {commentable(f"{base}#gesamt","Ganze Mail","<i>Anmerkung zur ganzen Mail</i>")}
-  </div></div>""")
+  <div class="flds">{commentable(f"{base}#gesamt","Anmerkung zur Mail","<i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i>")}</div></div>""")
             wave_cards.append(f'<div class="wave">{"".join(lang_cards)}</div>')
         seg_blocks.append(f'<section class="segment"><h2>{H["motive"][motiv]["label"]} — {seg}</h2><div class="waves">{"".join(wave_cards)}</div></section>')
 
@@ -279,6 +278,12 @@ main{{--mailw:clamp(340px,30vw,600px)}} /* 600 = native Mail-Breite: Vorschau in
 .mhd{{display:flex;align-items:center;background:var(--ink);color:var(--paper);font-family:var(--font-text);font-size:var(--t-micro);font-weight:600;padding:6px 12px}}
 .mhd a{{margin-left:auto;color:inherit;text-decoration:none;border:1px solid var(--paper);border-radius:999px;padding:1px 9px;font-weight:400}}
 .mhd a:hover{{background:var(--paper);color:var(--ink)}}
+/* Posteingang-Zeile: was Empfangende zuerst sehen — Betreff fett, Anriss gedämpft. */
+.inbox{{padding:var(--s2) var(--s3);border-bottom:1px solid var(--line-soft);font-family:var(--font-text)}}
+.ib-b{{font-size:var(--t-small);font-weight:600;color:var(--ink)}}
+.ib-a{{font-size:var(--t-small);color:var(--muted);line-height:1.45;margin-top:2px}}
+.ib-alt{{font-size:var(--t-micro);color:var(--muted);line-height:1.45;margin-top:4px}}
+.ib-alt span{{color:var(--gold-ink);font-weight:600}}
 .mail iframe{{width:100%;height:calc(var(--mailw)*1.55);border:0;display:block;background:#F6F4F2}} /* # ds-ok Mail-Grund (Artefakt) */
 .flds{{padding:var(--s2) var(--s3)}}
 .fld{{border-top:1px solid var(--line-soft);padding:8px 4px}} .fld:first-child{{border-top:0}}
@@ -377,14 +382,23 @@ function toggleNur(){{const b=document.getElementById('b-nur'),an=document.body.
 function toggle(el){{const p=el.closest('.fld').querySelector('.cpanel');p.hidden=!p.hidden;}}
 function esc(s){{const d=document.createElement('div');d.textContent=s;return d.innerHTML;}}
 function zeit(iso){{try{{return new Date(iso).toLocaleString('de-CH',{{day:'2-digit',month:'2-digit',hour:'2-digit',minute:'2-digit'}}).replace(', ',' ');}}catch(e){{return '';}}}}
+function sammel(key){{
+ // Mail-Panels (…#gesamt) bündeln ALLE Kommentare ihrer Mail — auch den
+ // Altbestand aus der früheren Feld-Ansicht (…#Betreff usw.).
+ if(!key.endsWith('#gesamt')) return COMMENTS[key]||[];
+ const basis=key.slice(0,key.length-'gesamt'.length);
+ let alle=[];
+ Object.keys(COMMENTS).forEach(k=>{{if(k.startsWith(basis))alle=alle.concat(COMMENTS[k]);}});
+ return alle.sort((a,b)=>a.created_at<b.created_at?-1:1);
+}}
 function render(){{
  document.querySelectorAll('.clist').forEach(ul=>{{
-   const items=(COMMENTS[ul.dataset.cl]||[]).filter(c=>SHOW_DONE||!c.erledigt);
+   const items=sammel(ul.dataset.cl).filter(c=>SHOW_DONE||!c.erledigt);
    ul.innerHTML=items.map(c=>'<li class="'+(c.erledigt?'done':'')+'">'
      +'<div class="khead"><b>'+esc(c.autor||'?')+'</b><span class="kzeit">'+zeit(c.created_at)+'</span>'
      +'<button class="kdone" onclick="erledigt('+c.id+','+(!c.erledigt)+')" title="'+(c.erledigt?'wieder öffnen':'erledigt')+'" aria-label="'+(c.erledigt?'wieder öffnen':'erledigt')+'">'+(c.erledigt?'↩':'✓')+'</button></div>'
      +'<span class="ktxt">'+esc(c.kommentar)+'</span></li>').join('');}});
- document.querySelectorAll('.cc').forEach(s=>{{const n=(COMMENTS[s.dataset.cc]||[]).filter(c=>!c.erledigt).length;
+ document.querySelectorAll('.cc').forEach(s=>{{const n=sammel(s.dataset.cc).filter(c=>!c.erledigt).length;
    s.textContent=n;s.classList.toggle('has',n>0);}});
  const off=[];Object.values(COMMENTS).forEach(l=>l.forEach(c=>{{if(!c.erledigt)off.push(c);}}));
  off.sort((a,b)=>a.created_at<b.created_at?-1:1);
@@ -395,7 +409,10 @@ function render(){{
      +'<span class="otxt">'+esc(c.kommentar)+'</span></button></li>';}}).join('');
 }}
 function springe(key){{
- const fld=document.querySelector('.fld[data-key="'+CSS.escape(key)+'"]'); if(!fld) return;
+ let fld=document.querySelector('.fld[data-key="'+CSS.escape(key)+'"]');
+ if(!fld){{const basis=key.split('#')[0];
+   fld=document.querySelector('.fld[data-key="'+CSS.escape(basis+'#gesamt')+'"]');}}
+ if(!fld) return;
  const m=key.match(/_(de|en)#/); if(m) setLang(m[1]);
  fld.querySelector('.cpanel').hidden=false;
  fld.scrollIntoView({{behavior:'smooth',block:'center'}});
@@ -423,8 +440,9 @@ async function erledigt(id,wert){{
 function spracheAus(key){{const m=key.match(/_(de|en)#/);return m?m[1]:null;}}
 async function send(btn,key){{
  const inp=btn.previousElementSibling, txt=inp.value.trim(); if(!txt) return;
- const autor=(document.getElementById('autor').value||'').trim()||'anon';
- try{{localStorage.setItem('autor',autor);}}catch(e){{}}
+ const eingabe=(document.getElementById('autor').value||'').trim();
+ try{{if(eingabe)localStorage.setItem('autor',eingabe);}}catch(e){{}}
+ const autor=eingabe||'anon';
  btn.disabled=true; st("sende …");
  try{{
   const r=await fetch(REST,{{method:"POST",headers:{{...HDR,"Prefer":"return=minimal"}},body:JSON.stringify({{mail_key:key,autor,kommentar:txt,sprache:spracheAus(key)}})}});
@@ -434,7 +452,7 @@ async function send(btn,key){{
  btn.disabled=false;
 }}
 document.getElementById('offenliste').addEventListener('click',e=>{{const b=e.target.closest('[data-go]');if(b)springe(b.dataset.go);}});
-try{{document.getElementById('autor').value=localStorage.getItem('autor')||'';}}catch(e){{}}
+try{{const a=localStorage.getItem('autor');if(a&&a!=='anon')document.getElementById('autor').value=a;}}catch(e){{}}
 setLang('de');load();
 </script></body></html>"""
     (ROOT/"dist/editor.html").write_text(page, encoding="utf-8")

--- a/services/mailing-sommer2026/heroes.json
+++ b/services/mailing-sommer2026/heroes.json
@@ -173,12 +173,12 @@
     }
   },
   "proof": {
-    "de": "Stimmen und Gesichter der Anthroposophie von heute — seit 1921",
-    "en": "Voices and faces of anthroposophy today — since 1921"
+    "de": "Stimmen und Gesichter der Anthroposophie von heute",
+    "en": "Voices and faces of anthroposophy today"
   },
   "badge": {
-    "de": "3 Monate gratis",
-    "en": "3 months free"
+    "de": "Sommerangebot 2026 · 3 Monate gratis",
+    "en": "Summer offer 2026 · 3 months free"
   },
   "auswahl": {
     "lesen": "garten",


### PR DESCRIPTION
Editor-Feedback des Auftraggebers (11.7.) plus Auswertung der frischen Gegenlese-Kommentare (8–12):

## Editor entladen

- **Ein Kommentarfeld je Mail** («Anmerkung zur Mail» — das Element benennt man selbst) statt acht Einzelfeldern. Das Panel **bündelt auch den Altbestand** der früheren Feld-Kommentare (Prefix-Sammlung über `{mail}#…`), die Sammelansicht «Offene Kommentare» springt bei alten Feld-Keys auf die Karte.
- **Posteingang-Zeile** über jeder Vorschau: Betreff (fett) + Anriss (gedämpft) — das, was Empfangende im Mailprogramm zuerst sehen. Bei w3 zusätzlich sichtbar: **«Nicht-Öffner erhalten: …»** — die Zweitrahmung des AC-Splits.
- **‹anon›-Verwirrung behoben:** Das Kürzel-Feld wird nie mehr mit dem Fallback vorbefüllt; gespeichert wird nur eine echte Eingabe.

## Mails (aus den Kommentaren)

- **Wortmarke und Hero-Bild verlinken zur Landingpage** (erster CTA-Link, utm bleibt dran — Kommentar 10); der **Footer führt zum Absender**: goetheanum.ch (Kommentar 9).
- **Badge:** «Sommerangebot 2026 · 3 Monate gratis» (Kommentare 8/11 — Mittepunkt statt Doppelpunkt hält die Zeile scanbar).
- **Beweis-Band ohne Jahreszahl** (Kommentar 12: «seit 1921» irritiert bei goetheanum.tv, Baugeschichte datiert anders — Faktentreue vor Schmuck): «Stimmen und Gesichter der Anthroposophie von heute».

Build grün (Mails 15,0–15,2 KB) · Logo/Hero-Links mit utm verifiziert · Layout per Screenshot geprüft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_