### PR TITLE
Rücklauf-Agent: Gegenlese-Schleife automatisieren

### DIFF
--- a/services/mailing-sommer2026/CLAUDE.md
+++ b/services/mailing-sommer2026/CLAUDE.md
@@ -93,6 +93,15 @@ Kommentare → Supabase `sommer2026_mail_comments`, key = element-id (`shared#x`
 angewendet). Rücklauf: offene Kommentare lesen → in heroes.json korrigieren → neu bauen
 (`--publish`) → nach dem Merge `--verify`.
 
+## Rücklauf-Agent (Gegenlese-Schleife automatisiert)
+`ruecklauf.py` ist das deterministische Herz: `python3 ruecklauf.py` holt die **offenen**
+Kommentare aus Supabase und macht daraus eine Arbeitsliste mit dem **exakten heroes.json-
+Pfad**, dem **aktuellen Text** und der **Kommentar-ID** je Kommentar (`--json` maschinen-
+lesbar, `--alle` inkl. erledigter). Nur Lesen. Der Ablauf der Schleife und die Leitplanken
+(klar → umsetzen + PR; mehrdeutig → Rückfrage zurückschreiben, nicht raten; nie senden/
+Frist/Zahlung; versendete Wellen in Ruhe lassen; erledigt erst nach Merge) stehen in
+**RUECKLAUF-AGENT.md**. Auslöser: manuell oder als geplante Routine.
+
 ## ActiveCampaign (via Cowork)
 Automation einmal im UI bauen: If/Else-Split auf Abo-Tags (nurtv/nurws/noabo; beides ausgeschlossen),
 Conversion-Goal, Verhaltens-Split vor w3 (Nicht-Öffner → Alt-Betreff). Generiertes HTML aus dist/ in die Schritte.

--- a/services/mailing-sommer2026/RUECKLAUF-AGENT.md
+++ b/services/mailing-sommer2026/RUECKLAUF-AGENT.md
@@ -1,0 +1,51 @@
+# Rücklauf-Agent — Vertrag
+
+Der Rücklauf-Agent schliesst die Gegenlese-Schleife: **offener Kommentar → Fassung
+in `heroes.json` → gebaut → PR → nach Merge erledigt.** Er *bereitet vor und schlägt
+vor*; den Versand löst weiterhin ein Mensch aus. Kleiner Blast-Radius, weil er nur
+an einer Stelle schreibt (`heroes.json`) und die Prüfmaschinen (typo-check, ds-lint)
+jede Regelverletzung abfangen.
+
+## Herz (deterministisch)
+`python3 ruecklauf.py` — holt die **offenen** Kommentare aus Supabase und macht daraus
+eine Arbeitsliste: je Kommentar der **exakte heroes.json-Pfad**, der **aktuelle Text**
+und die **Kommentar-ID**. `--json` maschinenlesbar, `--alle` inkl. erledigter (Rückschau).
+Nur Lesen. Das ist der Teil, den der Agent nicht neu erraten muss.
+
+## Die Schleife (der Agent)
+1. **Briefing holen:** `python3 ruecklauf.py`. Keine offenen → fertig, nichts tun.
+2. **Je Kommentar einordnen:**
+   - **Klar und umsetzbar** (konkrete Fassung, eindeutige Korrektur): umsetzen.
+   - **Mehrdeutig** (z. B. „macht vielleicht mehr Sinn" ohne Fassung, Geschmacksfrage,
+     Struktur-/Architekturfrage): **nicht raten.** Rückfrage als Kommentar zurück-
+     schreiben (siehe unten) oder Philipp direkt fragen. Kommentar bleibt offen.
+3. **Umsetzen — nur in `heroes.json`** am genannten Pfad. Betroffene Regel-IDs nennen
+   (G/B/DS). Die Fabrik (`build_editor.py`) bleibt unangetastet.
+4. **Bauen:** `python3 build_editor.py --publish`. Bricht der Build oder eine Prüfmaschine
+   (Hook) → Fehler zuerst lösen, nicht drumherum bauen.
+5. **PR** auf `main`, Titel wie üblich. Prüfmaschinen (CI-Job „pruefen") grün → **Squash-
+   Merge** (Haus-Regel: Claude-PRs werden gemergt, nicht als Draft geparkt). Danach den
+   Arbeits-Branch frisch von `main` ziehen.
+6. **Nach dem Merge** `python3 build_editor.py --verify` (alle URLs live).
+7. **Erledigt setzen** — für jeden umgesetzten Kommentar:
+   - Antwort einfügen (Insert in `sommer2026_mail_comments`): `autor='claude'`, gleicher
+     `mail_key`, kurze Notiz was geändert wurde (+ PR-Nummer).
+   - Original per RPC schliessen: `sommer2026_comment_erledigt(kommentar_id, true)`.
+
+## Grenzen (bewusst)
+- **Nie senden, nie Fristen im Fremdsystem setzen, nie Zahlungs-/Offer-Konfiguration.**
+  Das sind die Haus-Ausnahmen (fragen, nicht tun). Der Agent ändert nur Quelltext.
+- **Nach dem Versand einer Welle** ist ihr Text beim Empfänger — Korrekturen daran sind
+  wirkungslos; der Agent prüft `config.json → wellen.*.versand` und lässt bereits
+  versendete Wellen in Ruhe (nur noch Landingpages/Bilder wären änderbar).
+- **Mehrdeutiges eskaliert**, es wird nicht interpretiert. Lieber eine Rückfrage zu viel.
+
+## Rückfrage zurückschreiben (statt raten)
+Insert in `sommer2026_mail_comments` mit `autor='claude'`, gleichem `mail_key`, der
+konkreten Rückfrage — erscheint im Editor unter demselben Element, Philipp antwortet dort.
+Den auslösenden Kommentar **offen lassen**, bis die Fassung klar ist.
+
+## Auslöser
+Manuell (jederzeit `python3 ruecklauf.py`) oder als geplante Routine, die eine frische
+Session weckt, das Briefing liest und bei offenen Kommentaren die Schleife fährt. Bei
+0 offenen endet sie sofort — ein HTTP-Aufruf, kein Aufwand.

--- a/services/mailing-sommer2026/ruecklauf.py
+++ b/services/mailing-sommer2026/ruecklauf.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""ruecklauf.py — das deterministische Herz des Rücklauf-Agenten.
+
+Liest die OFFENEN Gegenlese-Kommentare aus Supabase (`sommer2026_mail_comments`)
+und macht daraus eine Arbeitsliste, die auf die EXAKTE Stelle in `heroes.json`
+zeigt — mit dem aktuellen Text als Kontext. Das ist der Teil, den ein Sprach-
+modell nicht jedes Mal neu erraten soll: welcher Kommentar noch offen ist, wo
+sein Feld in der Quelle wohnt, und wie der Text dort gerade lautet.
+
+    python3 ruecklauf.py            # Briefing (Markdown) auf stdout
+    python3 ruecklauf.py --json     # dieselbe Arbeitsliste maschinenlesbar
+    python3 ruecklauf.py --alle     # auch erledigte Kommentare (Rückschau)
+
+Nur Lesen. Korrigiert wird von Hand oder vom Agenten in heroes.json; das
+Erledigt-Setzen läuft über den Editor bzw. die RPC `sommer2026_comment_erledigt`.
+Der Schlüssel ist der browser-taugliche Publishable Key (RLS: anon darf nur
+select+insert) — kein Secret, dieselbe Leseberechtigung wie der Editor.
+"""
+import json, os, ssl, sys, urllib.request, urllib.parse
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+CFG = json.loads((ROOT / "config.json").read_text(encoding="utf-8"))
+H = json.loads((ROOT / "heroes.json").read_text(encoding="utf-8"))
+SB = CFG["supabase"]
+KEY = os.environ.get("SUPABASE_ANON_KEY") or SB.get("publishable_key", "")
+SEG_OF = {m: H["motive"][m]["segment"] for m in H["motive"]}
+
+# Feld im Kommentar-Key -> (heroes-Pfad-Vorlage, Beschriftung). {m}/{w}/{l} werden gefüllt.
+MAILFELD = {
+    "betreff":   ("wellen.{m}.{w}.{l}.betreff",   "Betreff"),
+    "botschaft": ("wellen.{m}.{w}.{l}.botschaft", "Botschaft (Headline)"),
+    "text":      ("wellen.{m}.{w}.{l}.text",      "Fliesstext"),
+    "alt":       ("wellen.{m}.{w}.{l}.alt",       "Alt-Betreff (AC-Split)"),
+    "preheader": ("wellen.{m}.{w}.{l}.preheader", "Preheader"),
+    "cta":       ("motive.{m}.{l}.cta_labels",    "CTA-Beschriftung"),
+}
+SHARED = {  # shared#<element> -> (heroes-Pfad je Sprache oder None, Beschriftung)
+    "badge":      ("badge.{l}",      "Badge"),
+    "beweisband": ("proof.{l}",      "Beweis-Band"),
+    "proof":      ("proof.{l}",      "Beweis-Band"),
+    "kleinzeile": ("kleinzeile.*.{l}", "Kleinzeile (je Motiv)"),
+    "footer":     (None,             "Footer — steht in build_editor.py, nicht in heroes.json"),
+    "wortmarke":  (None,             "Wortmarke — Logo-Asset, nicht in heroes.json"),
+    "button":     (None,             "Button-Stil — Theme in config.json"),
+}
+
+
+def hole(pfad, default=None):
+    """Punktpfad in heroes.json auflösen ('wellen.lesen.w1.de.betreff')."""
+    cur = H
+    for teil in pfad.split("."):
+        if isinstance(cur, dict) and teil in cur:
+            cur = cur[teil]
+        else:
+            return default
+    return cur
+
+
+def fetch(alle=False):
+    q = {"select": "id,created_at,mail_key,sprache,autor,kommentar,erledigt",
+         "order": "created_at.asc"}
+    if not alle:
+        q["erledigt"] = "not.eq.true"
+    url = f"{SB['url']}/rest/v1/{SB['kommentar_tabelle']}?" + urllib.parse.urlencode(q)
+    ctx = ssl.create_default_context()
+    caf = os.environ.get("SSL_CERT_FILE") or "/root/.ccr/ca-bundle.crt"
+    if os.path.exists(caf):
+        try: ctx.load_verify_locations(caf)
+        except Exception: pass
+    req = urllib.request.Request(url, headers={"apikey": KEY, "Authorization": f"Bearer {KEY}"})
+    with urllib.request.urlopen(req, timeout=30, context=ctx) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def zerlege(mail_key):
+    """mail_key -> strukturierte Verortung + heroes-Pfade + aktueller Text."""
+    wo, _, feld = mail_key.partition("#")
+    feld = feld or "gesamt"
+    if wo == "shared":
+        pfad, label = SHARED.get(feld, (None, feld))
+        aktuell = {}
+        if pfad and "*" in pfad:  # je Motiv
+            for m in H["motive"]:
+                aktuell[m] = {l: hole(pfad.replace("*", m).format(l=l)) for l in ("de", "en")}
+        elif pfad:
+            aktuell = {l: hole(pfad.format(l=l)) for l in ("de", "en")}
+        return {"art": "shared", "element": feld, "label": label,
+                "pfad": pfad, "aktuell": aktuell}
+    teile = wo.split("_")
+    if len(teile) < 3:
+        return {"art": "unbekannt", "roh": mail_key}
+    lang, welle, motiv = teile[-1], teile[-2], "_".join(teile[:-2])
+    seg = SEG_OF.get(motiv, "?")
+    mail = hole(f"wellen.{motiv}.{welle}.{lang}", {}) or {}
+    if feld == "gesamt":
+        pfad, label = f"wellen.{motiv}.{welle}.{lang}", "ganze Mail"
+        aktuell = {k: mail.get(k) for k in ("betreff", "botschaft", "text", "alt") if mail.get(k)}
+    else:
+        tmpl, label = MAILFELD.get(feld.lower(), (f"wellen.{motiv}.{welle}.{lang}.{feld}", feld))
+        pfad = tmpl.format(m=motiv, w=welle, l=lang)
+        aktuell = hole(pfad)
+    return {"art": "mail", "segment": seg, "motiv": motiv, "welle": welle,
+            "sprache": lang, "feld": feld, "label": label, "pfad": pfad, "aktuell": aktuell}
+
+
+def zeit(iso):
+    return (iso or "").replace("T", " ")[:16]
+
+
+def briefing(rows):
+    if not rows:
+        print("Keine offenen Kommentare — nichts zu tun.")
+        return
+    print(f"# Rücklauf-Briefing · {len(rows)} offene Kommentar(e)\n")
+    print("Korrigiert wird ausschliesslich in `heroes.json` an den genannten Pfaden. "
+          "Danach: `python3 build_editor.py --publish`, PR, nach Merge `--verify`, "
+          "erst dann die Kommentare erledigt setzen.\n")
+    for c in rows:
+        v = zerlege(c["mail_key"])
+        if v["art"] == "mail":
+            kopf = f"{v['segment']} · {v['motiv']} · {v['welle']} · {v['sprache'].upper()} — {v['label']}"
+        elif v["art"] == "shared":
+            kopf = f"Gemeinsam — {v['label']}"
+        else:
+            kopf = f"(unklar) {v['roh']}"
+        print(f"## {kopf}")
+        print(f"- **Kommentar** ({c['autor'] or '?'}, {zeit(c['created_at'])}): {c['kommentar']}")
+        if v.get("pfad"):
+            print(f"- **heroes.json-Pfad**: `{v['pfad']}`")
+        akt = v.get("aktuell")
+        if akt:
+            print(f"- **Aktueller Text**:\n```\n{json.dumps(akt, ensure_ascii=False, indent=2)}\n```")
+        print(f"- **Kommentar-ID** (zum Erledigen): `{c['id']}`  ·  Key: `{c['mail_key']}`\n")
+
+
+def main():
+    if not KEY:
+        sys.exit("Kein Supabase-Key: SUPABASE_ANON_KEY setzen oder publishable_key in config.json.")
+    alle = "--alle" in sys.argv
+    try:
+        rows = fetch(alle)
+    except Exception as e:
+        sys.exit(f"Kommentare nicht ladbar: {e}")
+    if "--json" in sys.argv:
+        out = [{"kommentar": c, "verortung": zerlege(c["mail_key"])} for c in rows]
+        print(json.dumps(out, ensure_ascii=False, indent=2))
+    else:
+        briefing(rows)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Was

Erster stehender Agent aus der Agenten-Landkarte: der **Rücklauf-Agent** schliesst die Gegenlese-Schleife — offener Kommentar → Fassung in `heroes.json` → gebaut → PR → nach Merge erledigt. Er formalisiert genau die Handarbeit, die wir diese Woche mehrfach von Hand gedreht haben.

## Herz (deterministisch) — `ruecklauf.py`

`python3 ruecklauf.py` holt die **offenen** Kommentare aus Supabase (`sommer2026_mail_comments`) und macht daraus eine Arbeitsliste. Je Kommentar:

- den **exakten `heroes.json`-Pfad** (z. B. `wellen.lesen.w1.de.betreff`),
- den **aktuellen Text** als Kontext,
- die **Kommentar-ID** zum Erledigen.

`--json` maschinenlesbar, `--alle` inkl. erledigter (Rückschau). Nur Lesen; Publishable Key wie der Editor (RLS: anon nur select+insert). Das ist der Teil, den ein Sprachmodell nicht jedes Mal neu erraten soll.

## Brain — `RUECKLAUF-AGENT.md`

Der Vertrag der Schleife samt Leitplanken:

- **Klar und umsetzbar** → in `heroes.json` ändern, Regel-IDs nennen, bauen, PR, bei grünen Maschinen Squash-Merge, dann erledigt setzen (claude-Antwort einfügen + RPC).
- **Mehrdeutig** → **nicht raten:** Rückfrage als Kommentar zurückschreiben, Original bleibt offen.
- **Grenzen:** nie senden, nie Fristen im Fremdsystem, nie Zahlungs-/Offer-Konfiguration; bereits versendete Wellen in Ruhe lassen.

In der Kampagnen-`CLAUDE.md` verankert, damit jede künftige Session die Schleife findet.

## Prüfung

- Live gegen die Registerdaten getestet: Key→Pfad-Mapping stimmt (Mail- und `shared#`-Kommentare), aktueller Text wird korrekt gezogen; „offen" ist derzeit leer.
- typo-check / ds-lint: 0 Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_