### PR TITLE
Grenzgänger: Trigger-ID der scharfgestellten Routine in der Charta nachtragen

### DIFF
--- a/docs/grenzgaenger/charta.md
+++ b/docs/grenzgaenger/charta.md
@@ -100,7 +100,8 @@ Die Routine feuert **wöchentlich, Dienstag 06:00 UTC** (nach dem
 Seelenkalender-Montagsversand liegen frische Wochenzahlen vor), jede
 Feuerung in einer frischen Session, Benachrichtigung per Push und E-Mail.
 
-Trigger-ID: _wird nach dem Scharfstellen hier nachgetragen._
+Trigger-ID: `trig_015FNRshk7nikmbZUTd5YYqv` (scharfgestellt 11. Juli 2026;
+erste Feuerung Dienstag, 14. Juli 2026, 06.00 UTC).
 
 **Der Prompt der Routine (versioniert, Quelle der Wahrheit):**
 


### PR DESCRIPTION
Folge-Commit zu #396: Die Grenzgänger-Routine ist scharfgestellt (wöchentlich Di 06:00 UTC, frische Session je Feuerung, Push- und E-Mail-Benachrichtigung). Die Charta trägt jetzt die Trigger-ID `trig_015FNRshk7nikmbZUTd5YYqv` und den Termin der ersten Feuerung (14.7.2026) — der Routine-Vertrag in §5 ist damit vollständig.

Ausserdem seit #396 erledigt (ausserhalb des Repos, dokumentiert in `services/lead-agent/README.md`): Migration `marketing_*` angewendet, Edge Function `lead-fang` deployed, pg-cron `marketing-wellen` (täglich 06:11 UTC) läuft, Fang-Strecke Ende-zu-Ende getestet (anmelden → bestätigen → ende, Honigtopf still, Wellen-Route 403 bei falschem Schlüssel, `marketing_stats()` liefert nur Summen, anon liest keine Zeilen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TCu7RxrXRsZjgNaEjjdSa

---
_Generated by [Claude Code](https://claude.ai/code/session_018TCu7RxrXRsZjgNaEjjdSa)_