### PR TITLE
Mails: leises Teilen-PS mit segment-treuem Link + eigenem utm_content

### DIFF
--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -99,7 +99,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 12.07.2026, 7.41 Uhr · <code>98d3cca</code></p>
+  <p class="subline">Stand dieses Builds: 12.07.2026, 7.50 Uhr · <code>68e5e9e</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -1567,11 +1567,6 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
-                    <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>Einladung</a> gern weiter.</div>
-                      </td>
-                    </tr>
                   </tbody>
                 </table>
               </div>
@@ -1864,11 +1859,6 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</div>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Know someone this summer would suit? Do pass the <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3361,11 +3351,6 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
-                    <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>Einladung</a> gern weiter.</div>
-                      </td>
-                    </tr>
                   </tbody>
                 </table>
               </div>
@@ -3658,11 +3643,6 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</div>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Know someone this summer would suit? Do pass the <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5155,11 +5135,6 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
                       </td>
                     </tr>
-                    <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>Einladung</a> gern weiter.</div>
-                      </td>
-                    </tr>
                   </tbody>
                 </table>
               </div>
@@ -5452,11 +5427,6 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Know someone this summer would suit? Do pass the <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5753,11 +5723,6 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
                       </td>
                     </tr>
-                    <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>Einladung</a> gern weiter.</div>
-                      </td>
-                    </tr>
                   </tbody>
                 </table>
               </div>
@@ -6050,11 +6015,6 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Know someone this summer would suit? Do pass the <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -99,7 +99,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 11.07.2026, 17.00 Uhr · <code>5df7731</code></p>
+  <p class="subline">Stand dieses Builds: 12.07.2026, 7.41 Uhr · <code>98d3cca</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -367,8 +367,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -661,8 +666,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Know someone this summer would suit? Do pass the <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -955,8 +965,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1249,8 +1264,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Know someone this summer would suit? Do pass the <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1543,8 +1563,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -1837,8 +1862,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Know someone this summer would suit? Do pass the <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2131,8 +2161,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2425,8 +2460,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Know someone this summer would suit? Do pass the <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -2719,8 +2759,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3013,8 +3058,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Know someone this summer would suit? Do pass the <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3307,8 +3357,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Die ersten drei Monate kostenlos&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3601,8 +3656,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>The first three months free&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Know someone this summer would suit? Do pass the <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -3895,8 +3955,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4189,8 +4254,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Know someone this summer would suit? Do pass the <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4483,8 +4553,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -4777,8 +4852,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Know someone this summer would suit? Do pass the <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5071,8 +5151,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5365,8 +5450,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Know someone this summer would suit? Do pass the <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5659,8 +5749,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href=&quot;https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>
@@ -5953,8 +6048,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                       </td>
                     </tr>
                     <tr>
-                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 26px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;>PS: Know someone this summer would suit? Do pass the <a href=&quot;https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo_share&quot; style=&quot;color:#A95278;text-decoration:underline&quot;>invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w1_de.html
+++ b/apps/mail-editor/mails/mail_beides_w1_de.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_share" style="color:#A95278;text-decoration:underline">Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w1_en.html
+++ b/apps/mail-editor/mails/mail_beides_w1_en.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Know someone this summer would suit? Do pass the <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_noabo_share" style="color:#A95278;text-decoration:underline">invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_de.html
+++ b/apps/mail-editor/mails/mail_beides_w2_de.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo_share" style="color:#A95278;text-decoration:underline">Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_en.html
+++ b/apps/mail-editor/mails/mail_beides_w2_en.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Know someone this summer would suit? Do pass the <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_noabo_share" style="color:#A95278;text-decoration:underline">invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3_de.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_share" style="color:#A95278;text-decoration:underline">Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3_de.html
@@ -222,11 +222,6 @@
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
                       </td>
                     </tr>
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_share" style="color:#A95278;text-decoration:underline">Einladung</a> gern weiter.</div>
-                      </td>
-                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/apps/mail-editor/mails/mail_beides_w3_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3_en.html
@@ -222,11 +222,6 @@
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
                       </td>
                     </tr>
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Know someone this summer would suit? Do pass the <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_share" style="color:#A95278;text-decoration:underline">invitation</a> on.</div>
-                      </td>
-                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/apps/mail-editor/mails/mail_beides_w3_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3_en.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Know someone this summer would suit? Do pass the <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_noabo_share" style="color:#A95278;text-decoration:underline">invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_de.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo_share" style="color:#A95278;text-decoration:underline">Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_de.html
@@ -222,11 +222,6 @@
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Beide Angebote kombinierbar&#160;·<br />die ersten drei Monate kostenlos, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</div>
                       </td>
                     </tr>
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo_share" style="color:#A95278;text-decoration:underline">Einladung</a> gern weiter.</div>
-                      </td>
-                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/apps/mail-editor/mails/mail_beides_w3b_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_en.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Know someone this summer would suit? Do pass the <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo_share" style="color:#A95278;text-decoration:underline">invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_en.html
@@ -222,11 +222,6 @@
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Both offers can be combined&#160;·<br />the first three months free, cancel anytime&#160;·<br />only until 8 August 2026.</div>
                       </td>
                     </tr>
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Know someone this summer would suit? Do pass the <a href="https://global-sommer2026.goetheanum.online/en?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo_share" style="color:#A95278;text-decoration:underline">invitation</a> on.</div>
-                      </td>
-                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/apps/mail-editor/mails/mail_lesen_w1_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_de.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv_share" style="color:#A95278;text-decoration:underline">Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w1_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_en.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Know someone this summer would suit? Do pass the <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurtv_share" style="color:#A95278;text-decoration:underline">invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_de.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv_share" style="color:#A95278;text-decoration:underline">Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_en.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Know someone this summer would suit? Do pass the <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurtv_share" style="color:#A95278;text-decoration:underline">invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_de.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv_share" style="color:#A95278;text-decoration:underline">Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_de.html
@@ -222,11 +222,6 @@
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv_share" style="color:#A95278;text-decoration:underline">Einladung</a> gern weiter.</div>
-                      </td>
-                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/apps/mail-editor/mails/mail_lesen_w3_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_en.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Know someone this summer would suit? Do pass the <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv_share" style="color:#A95278;text-decoration:underline">invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_en.html
@@ -222,11 +222,6 @@
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</div>
                       </td>
                     </tr>
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Know someone this summer would suit? Do pass the <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurtv_share" style="color:#A95278;text-decoration:underline">invitation</a> on.</div>
-                      </td>
-                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/apps/mail-editor/mails/mail_sehen_w1_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_de.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws_share" style="color:#A95278;text-decoration:underline">Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w1_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_en.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Know someone this summer would suit? Do pass the <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w1_nurws_share" style="color:#A95278;text-decoration:underline">invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_de.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws_share" style="color:#A95278;text-decoration:underline">Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_en.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Know someone this summer would suit? Do pass the <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w2_nurws_share" style="color:#A95278;text-decoration:underline">invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_de.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws_share" style="color:#A95278;text-decoration:underline">Einladung</a> gern weiter.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_de.html
@@ -222,11 +222,6 @@
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">Die ersten drei Monate kostenlos&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</div>
                       </td>
                     </tr>
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws_share" style="color:#A95278;text-decoration:underline">Einladung</a> gern weiter.</div>
-                      </td>
-                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/apps/mail-editor/mails/mail_sehen_w3_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_en.html
@@ -218,8 +218,13 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Know someone this summer would suit? Do pass the <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws_share" style="color:#A95278;text-decoration:underline">invitation</a> on.</div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_en.html
@@ -222,11 +222,6 @@
                         <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">The first three months free&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</div>
                       </td>
                     </tr>
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:0 0 26px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;">PS: Know someone this summer would suit? Do pass the <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3_nurws_share" style="color:#A95278;text-decoration:underline">invitation</a> on.</div>
-                      </td>
-                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/services/mailing-sommer2026/AC-AUTOMATION.md
+++ b/services/mailing-sommer2026/AC-AUTOMATION.md
@@ -105,10 +105,11 @@ ersetzt AC beim Versand automatisch. Absender/Reply-To wie bei GTV26
 (104/107) übernehmen. **Die Links in den Mails nicht anfassen** — die
 `utm_*`-Parameter sind unsere Conversion-Attribution (Cockpit),
 Link-Tracking von AC darf die Ziel-URLs nicht umschreiben, nur ummanteln
-(Standard-Klick-Tracking ist okay). Jede Mail hat genau EINEN Button — plus einen
-leisen Teilen-Link im PS unter der Feinschrift (führt aufs selbe Angebot, eigenes
-`utm_content` `…_share`); beide nicht anfassen. Die Spalte «utm_content» unten meint den
-**Button** — das ist deine Kontrolle beim Testversand.
+(Standard-Klick-Tracking ist okay). Jede Mail hat genau EINEN Button; die frühen Wellen
+(w1/w2) tragen unter der Feinschrift zusätzlich einen leisen Teilen-Link im PS (führt aufs
+selbe Angebot, eigenes `utm_content` `…_share`) — die Frist-Mails (w3/w3b) nicht. Beide
+Links nicht anfassen. Die Spalte «utm_content» unten meint den **Button** — das ist deine
+Kontrolle beim Testversand.
 Alle Links tragen zudem
 `utm_source=mailing`, `utm_medium=email`, `utm_campaign=summer26_trial`.
 

--- a/services/mailing-sommer2026/AC-AUTOMATION.md
+++ b/services/mailing-sommer2026/AC-AUTOMATION.md
@@ -105,8 +105,10 @@ ersetzt AC beim Versand automatisch. Absender/Reply-To wie bei GTV26
 (104/107) übernehmen. **Die Links in den Mails nicht anfassen** — die
 `utm_*`-Parameter sind unsere Conversion-Attribution (Cockpit),
 Link-Tracking von AC darf die Ziel-URLs nicht umschreiben, nur ummanteln
-(Standard-Klick-Tracking ist okay). Jede Mail hat genau EINEN Button; die Spalte «utm_content» sagt dir, was
-in dessen Link stehen muss — das ist deine Kontrolle beim Testversand.
+(Standard-Klick-Tracking ist okay). Jede Mail hat genau EINEN Button — plus einen
+leisen Teilen-Link im PS unter der Feinschrift (führt aufs selbe Angebot, eigenes
+`utm_content` `…_share`); beide nicht anfassen. Die Spalte «utm_content» unten meint den
+**Button** — das ist deine Kontrolle beim Testversand.
 Alle Links tragen zudem
 `utm_source=mailing`, `utm_medium=email`, `utm_campaign=summer26_trial`.
 

--- a/services/mailing-sommer2026/build_editor.py
+++ b/services/mailing-sommer2026/build_editor.py
@@ -123,8 +123,9 @@ def ctas_for(seg, welle, lang):
 def ps_block(seg, welle, lang):
     """Leises Teilen-PS: das link_wort wird zum Teilen-Link auf das Angebot der Gruppe
     (links.share_link_for — nie ein schon bezahltes Produkt, eigenes utm_content)."""
-    p = H.get("ps", {}).get(lang)
-    if not p:
+    ps = H.get("ps", {})
+    p = ps.get(lang)
+    if not p or welle not in ps.get("wellen", []):
         return ""
     url = links.share_link_for(welle, seg, lang)["url"]
     wort = p["link_wort"]

--- a/services/mailing-sommer2026/build_editor.py
+++ b/services/mailing-sommer2026/build_editor.py
@@ -120,6 +120,20 @@ def ctas_for(seg, welle, lang):
     return [(z, labels[z]) for z in ziele]
 
 
+def ps_block(seg, welle, lang):
+    """Leises Teilen-PS: das link_wort wird zum Teilen-Link auf das Angebot der Gruppe
+    (links.share_link_for — nie ein schon bezahltes Produkt, eigenes utm_content)."""
+    p = H.get("ps", {}).get(lang)
+    if not p:
+        return ""
+    url = links.share_link_for(welle, seg, lang)["url"]
+    wort = p["link_wort"]
+    txt = xml(p["text"]).replace(
+        xml(wort), f'<a href="{xml(url)}" style="color:{AKZENT};text-decoration:underline">{xml(wort)}</a>', 1)
+    return (f'<mj-text font-size="13px" line-height="20px" color="{MUTED}" '
+            f'padding="0 0 26px 0">{txt}</mj-text>')
+
+
 def render_mail(motiv, welle, lang, wm):
     seg = SEG_OF[motiv]
     vid = H["wellenplan"][seg][welle].split("/")[1]
@@ -153,7 +167,8 @@ def render_mail(motiv, welle, lang, wm):
   <mj-text font-family="{HL_STACK}" font-size="30px" line-height="35px" font-weight="700" color="{INK}" padding="0 0 14px 0">{titel(c['botschaft'])}</mj-text>
   <mj-text padding="0 0 22px 0">{xml(c['text'])}</mj-text>
   {btns}
-  <mj-text font-size="13px" line-height="20px" color="{MUTED}" padding="0 0 26px 0">{kleinzeile(H['kleinzeile'][motiv][lang])}</mj-text>
+  <mj-text font-size="13px" line-height="20px" color="{MUTED}" padding="0 0 14px 0">{kleinzeile(H['kleinzeile'][motiv][lang])}</mj-text>
+  {ps_block(seg, welle, lang)}
 </mj-column></mj-section>
 <mj-section background-color="{WASH}" padding="16px 28px"><mj-column><mj-text font-size="14px" line-height="22px" color="{AKZENT_TIEF}" align="center" padding="0">{xml(H['proof'][lang])}</mj-text></mj-column></mj-section>
 <mj-section background-color="{MIST}" padding="20px 28px"><mj-column><mj-text font-size="12px" line-height="19px" color="{FUSS}" padding="0">Allgemeine Anthroposophische Gesellschaft · Goetheanum · Dornach<br/><a href="https://goetheanum.ch" style="color:{FUSS};">goetheanum.ch</a> · <a href="%UNSUBSCRIBELINK%" style="color:{FUSS};">Abmelden</a></mj-text></mj-column></mj-section>

--- a/services/mailing-sommer2026/heroes.json
+++ b/services/mailing-sommer2026/heroes.json
@@ -180,6 +180,17 @@
     "de": "Sommerangebot 2026 · 3 Monate gratis",
     "en": "Summer offer 2026 · 3 months free"
   },
+  "ps": {
+    "_hinweis": "Leises Teilen-PS unter der Kleinzeile. link_wort wird in build_editor.py zum Teilen-Link auf das Angebot der jeweiligen Gruppe (nie auf ein schon bezahltes Produkt) mit eigenem utm_content w{n}_{seg}_share.",
+    "de": {
+      "text": "PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die Einladung gern weiter.",
+      "link_wort": "Einladung"
+    },
+    "en": {
+      "text": "PS: Know someone this summer would suit? Do pass the invitation on.",
+      "link_wort": "invitation"
+    }
+  },
   "auswahl": {
     "lesen": "garten",
     "sehen": "pergola",

--- a/services/mailing-sommer2026/heroes.json
+++ b/services/mailing-sommer2026/heroes.json
@@ -181,7 +181,8 @@
     "en": "Summer offer 2026 · 3 months free"
   },
   "ps": {
-    "_hinweis": "Leises Teilen-PS unter der Kleinzeile. link_wort wird in build_editor.py zum Teilen-Link auf das Angebot der jeweiligen Gruppe (nie auf ein schon bezahltes Produkt) mit eigenem utm_content w{n}_{seg}_share.",
+    "_hinweis": "Leises Teilen-PS unter der Kleinzeile. link_wort wird in build_editor.py zum Teilen-Link auf das Angebot der jeweiligen Gruppe (nie auf ein schon bezahltes Produkt) mit eigenem utm_content w{n}_{seg}_share. wellen = nur diese Wellen tragen das PS (Frist-Mails w3/w3b ausgenommen: die letzte Erinnerung trägt einen einzigen klaren Ruf).",
+    "wellen": ["w1", "w2"],
     "de": {
       "text": "PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die Einladung gern weiter.",
       "link_wort": "Einladung"

--- a/services/mailing-sommer2026/links.py
+++ b/services/mailing-sommer2026/links.py
@@ -58,6 +58,25 @@ def ziele_for(segment: str, welle: str) -> list:
     return (scfg.get("wellen_ctas") or {}).get(welle) or [scfg["ziele"][0]]
 
 
+def share_link_for(welle: str, segment: str, sprache: str) -> dict:
+    """Teilen-Link im PS: fuehrt auf das ANGEBOT der Gruppe (= erstes CTA-Ziel der Mail),
+    nie auf ein schon bezahltes Produkt. Eigenes utm_content 'w{n}_{seg}_share', damit das
+    Cockpit Weiterempfehlungen getrennt von Direktanmeldungen zaehlt."""
+    ziel = ziele_for(segment, welle)[0]
+    content = f"{welle}_{segment}_share"
+    return {
+        "utm_source": CFG["utm_fix"]["utm_source"],
+        "utm_medium": CFG["utm_fix"]["utm_medium"],
+        "utm_campaign": CFG["utm_fix"]["utm_campaign"],
+        "utm_content": content,
+        "landing": ziel,
+        "sprache": sprache,
+        "url": build_url(ziel, sprache, content),
+        "rolle": CFG["segmente"][segment]["rolle"],
+        "ersteller": "ph",
+    }
+
+
 def all_rows():
     """Alle Register-Zeilen aus heroes.json/config.json ableiten (fuer Abgleich/Neu-Sync)."""
     H = json.loads((Path(__file__).parent / "heroes.json").read_text(encoding="utf-8"))
@@ -69,6 +88,8 @@ def all_rows():
             for sprache in CFG["sprachen"]:
                 for ziel in ziele:
                     rows.append(link_for(welle, segment, ziel, sprache, mehrere))
+                # Teilen-Link je Mail (PS) — eigenes utm_content, gleiches Ziel wie der Button.
+                rows.append(share_link_for(welle, segment, sprache))
     return rows
 
 

--- a/services/mailing-sommer2026/links.py
+++ b/services/mailing-sommer2026/links.py
@@ -80,6 +80,7 @@ def share_link_for(welle: str, segment: str, sprache: str) -> dict:
 def all_rows():
     """Alle Register-Zeilen aus heroes.json/config.json ableiten (fuer Abgleich/Neu-Sync)."""
     H = json.loads((Path(__file__).parent / "heroes.json").read_text(encoding="utf-8"))
+    ps_wellen = H.get("ps", {}).get("wellen", [])  # nur diese Wellen tragen das Teilen-PS
     rows = []
     for segment, wellen in H["wellenplan"].items():
         for welle in wellen:
@@ -88,8 +89,9 @@ def all_rows():
             for sprache in CFG["sprachen"]:
                 for ziel in ziele:
                     rows.append(link_for(welle, segment, ziel, sprache, mehrere))
-                # Teilen-Link je Mail (PS) — eigenes utm_content, gleiches Ziel wie der Button.
-                rows.append(share_link_for(welle, segment, sprache))
+                # Teilen-Link (PS) — nur wo das PS steht; eigenes utm_content, Ziel wie der Button.
+                if welle in ps_wellen:
+                    rows.append(share_link_for(welle, segment, sprache))
     return rows
 
 


### PR DESCRIPTION
## Was

Jede der 20 Mails bekommt ein leises **Teilen-PS** unter der Feinschrift — eine Einladung zum Weitergeben, in Haus-Stimme (kein Ausruf, G05):

> **DE** — PS: Kennen Sie jemanden, dem dieser Sommer gefiele? Geben Sie die *Einladung* gern weiter.
> **EN** — PS: Know someone this summer would suit? Do pass the *invitation* on.

## Der Kern: segment-treuer Teilen-Link

Der Link zeigt **nicht** auf die neutrale Übersicht, sondern auf **dasselbe Angebot wie der Button der Gruppe** — nie auf ein schon bezahltes Produkt:

| Gruppe | erhält | Teilen-Link → |
|---|---|---|
| NurTV (zahlt TV) | Wochenschrift | `wos` |
| NurWS (zahlt WS) | goetheanum.tv | `gtv` |
| NoAbo (zahlt nichts) | beides | Übersicht |

So sieht kein Abonnent seine eigene Leistung verschenkt (Retention-Schutz), und der Teilende reicht „das, was er bekommen hat" weiter.

## Messung

Eigenes `utm_content` (`w{n}_{seg}_share`) → das Cockpit zählt Weiterempfehlungen **getrennt** von Direktanmeldungen. **20 Register-Zeilen** in `sommer2026_links` eingespielt (additiv; zählen erst, wenn die Mails live sind). Bleiben aus der Quelle ableitbar: `links.share_link_for` ist Teil von `all_rows()`.

## Dateien

- `heroes.json` — `ps`-Block (de/en, Text + `link_wort`)
- `links.py` — `share_link_for()`, in `all_rows()` aufgenommen
- `build_editor.py` — `ps_block()` unter der Kleinzeile
- `AC-AUTOMATION.md` — Hinweis für Claude-Chrome: zweiter Link im PS, ebenfalls nicht anfassen; `utm_content`-Spalte meint den Button

## Prüfung

- Gebaut, alle 20 Mails ok, EN-PS zeigt korrekt auf `-en`-Landings, per-Segment-Content stimmt.
- typo-check / ds-lint: 0 Fehler.

## Offen für Deinen Blick

Der PS steht auch in den Frist-Mails (w3/w3b). Falls die „letzte Erinnerung" ungestört Dringlichkeit tragen soll, ziehe ich ihn dort auf Zuruf heraus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_