### PR TITLE
Lesen-Mails: neue Betreffe (A/B) + w3-Text mit Teilen-PS zusammengeführt

### DIFF
--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -99,7 +99,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 12.07.2026, 7.50 Uhr · <code>68e5e9e</code></p>
+  <p class="subline">Stand dieses Builds: 12.07.2026, 8.03 Uhr · <code>5a67375</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -744,13 +744,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#gesamt')">senden</button></div></div></div></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W2 · DE<a href="mails/mail_lesen_w2_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Ihr Sommer hat noch Seiten frei</div><div class="ib-a">Bis 8. August: die Wochenschrift drei Monate gratis zu Ihrem Abo — sie liest sich überall.</div></div>
+  <div class="inbox"><div class="ib-b">Drei Monate Lesestoff, geschenkt zu Ihrem Abo</div><div class="ib-a">Bis 8. August: die Wochenschrift drei Monate gratis zu Ihrem Abo — sie liest sich überall.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Ihr Sommer hat noch Seiten frei</title>
+  <title>Drei Monate Lesestoff, geschenkt zu Ihrem Abo</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -855,7 +855,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
   <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Bis 8. August: die Wochenschrift drei Monate gratis zu Ihrem Abo — sie liest sich überall.</div>
-  <div aria-label=&quot;Ihr Sommer hat noch Seiten frei&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div aria-label=&quot;Drei Monate Lesestoff, geschenkt zu Ihrem Abo&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -1043,13 +1043,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W2 · EN<a href="mails/mail_lesen_w2_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Your summer still has pages to turn</div><div class="ib-a">Until 8 August: three months of the weekly, free with your subscription — it goes where you go.</div></div>
+  <div class="inbox"><div class="ib-b">Three months of reading, free with your subscription</div><div class="ib-a">Until 8 August: three months of the weekly, free with your subscription — it goes where you go.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Your summer still has pages to turn</title>
+  <title>Three months of reading, free with your subscription</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -1154,7 +1154,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
   <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Until 8 August: three months of the weekly, free with your subscription — it goes where you go.</div>
-  <div aria-label=&quot;Your summer still has pages to turn&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div aria-label=&quot;Three months of reading, free with your subscription&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -1342,13 +1342,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#gesamt')">senden</button></div></div></div></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3 · DE<a href="mails/mail_lesen_w3_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Nur noch bis Samstag: drei Monate gratis</div><div class="ib-a">Eine Minute für drei Monate Lesezeit: die Wochenschrift gratis zu Ihrem Abo — bis Samstag.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Was Sie sehen, jetzt auch lesen — bis Samstag</div></div>
+  <div class="inbox"><div class="ib-b">Bis Samstag: drei Monate mitlesen, geschenkt</div><div class="ib-a">Drei Gratis-Monate zum Mitlesen — nur noch bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Was Sie sehen, jetzt auch lesen — bis Samstag</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Nur noch bis Samstag: drei Monate gratis</title>
+  <title>Bis Samstag: drei Monate mitlesen, geschenkt</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -1452,8 +1452,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Eine Minute für drei Monate Lesezeit: die Wochenschrift gratis zu Ihrem Abo — bis Samstag.</div>
-  <div aria-label=&quot;Nur noch bis Samstag: drei Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Drei Gratis-Monate zum Mitlesen — nur noch bis Samstag, 8. August.</div>
+  <div aria-label=&quot;Bis Samstag: drei Monate mitlesen, geschenkt&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -1546,7 +1546,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Noch ein paar Sommertage lang: die Wochenschrift, drei Monate gratis zu Ihrem Abo. Wenn sie Ihnen nicht ans Herz wächst, kündigen Sie einfach.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Diese Woche endet die Sommer-Aktion. Bis Samstag lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — und kommen mit anderen Augen in Ihre Woche zurück. Gefällt es nicht, kündigen Sie mit einem Klick.</div>
                       </td>
                     </tr>
                     <tr>
@@ -1636,13 +1636,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3 · EN<a href="mails/mail_lesen_w3_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Only until Saturday: three months free</div><div class="ib-a">One minute for three months: the weekly, free with your subscription — until Saturday.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> What you watch, now also read — until Saturday</div></div>
+  <div class="inbox"><div class="ib-b">Until Saturday: three months of reading, as a gift</div><div class="ib-a">Three free months to read along — only until Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> What you watch, now also read — until Saturday</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Only until Saturday: three months free</title>
+  <title>Until Saturday: three months of reading, as a gift</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -1746,8 +1746,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>One minute for three months: the weekly, free with your subscription — until Saturday.</div>
-  <div aria-label=&quot;Only until Saturday: three months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three free months to read along — only until Saturday, 8 August.</div>
+  <div aria-label=&quot;Until Saturday: three months of reading, as a gift&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -1840,7 +1840,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>A few summer days remain: the weekly, free for three months with your subscription. If it doesn’t grow on you, simply cancel.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>This week the summer offer ends. Until Saturday, read the weekly free for three months with your subscription — and return to your own week with different eyes. If it’s not for you, cancel in one click.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_lesen_w2_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Ihr Sommer hat noch Seiten frei</title>
+  <title>Drei Monate Lesestoff, geschenkt zu Ihrem Abo</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -108,7 +108,7 @@
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Bis 8. August: die Wochenschrift drei Monate gratis zu Ihrem Abo — sie liest sich überall.</div>
-  <div aria-label="Ihr Sommer hat noch Seiten frei" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div aria-label="Drei Monate Lesestoff, geschenkt zu Ihrem Abo" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">

--- a/apps/mail-editor/mails/mail_lesen_w2_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Your summer still has pages to turn</title>
+  <title>Three months of reading, free with your subscription</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -108,7 +108,7 @@
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Until 8 August: three months of the weekly, free with your subscription — it goes where you go.</div>
-  <div aria-label="Your summer still has pages to turn" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div aria-label="Three months of reading, free with your subscription" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">

--- a/apps/mail-editor/mails/mail_lesen_w3_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Nur noch bis Samstag: drei Monate gratis</title>
+  <title>Bis Samstag: drei Monate mitlesen, geschenkt</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Eine Minute für drei Monate Lesezeit: die Wochenschrift gratis zu Ihrem Abo — bis Samstag.</div>
-  <div aria-label="Nur noch bis Samstag: drei Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Drei Gratis-Monate zum Mitlesen — nur noch bis Samstag, 8. August.</div>
+  <div aria-label="Bis Samstag: drei Monate mitlesen, geschenkt" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -201,7 +201,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Noch ein paar Sommertage lang: die Wochenschrift, drei Monate gratis zu Ihrem Abo. Wenn sie Ihnen nicht ans Herz wächst, kündigen Sie einfach.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Diese Woche endet die Sommer-Aktion. Bis Samstag lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — und kommen mit anderen Augen in Ihre Woche zurück. Gefällt es nicht, kündigen Sie mit einem Klick.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_lesen_w3_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Only until Saturday: three months free</title>
+  <title>Until Saturday: three months of reading, as a gift</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">One minute for three months: the weekly, free with your subscription — until Saturday.</div>
-  <div aria-label="Only until Saturday: three months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three free months to read along — only until Saturday, 8 August.</div>
+  <div aria-label="Until Saturday: three months of reading, as a gift" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -201,7 +201,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">A few summer days remain: the weekly, free for three months with your subscription. If it doesn’t grow on you, simply cancel.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">This week the summer offer ends. Until Saturday, read the weekly free for three months with your subscription — and return to your own week with different eyes. If it’s not for you, cancel in one click.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/mailing-sommer2026/AC-AUTOMATION.md
+++ b/services/mailing-sommer2026/AC-AUTOMATION.md
@@ -122,10 +122,10 @@ Alle Links tragen zudem
 |---|---|---|---|---|---|
 | w1 | DE | Was Sie sehen, jetzt auch lesen — 3 Monate gratis | — | `w1_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w1_de.html |
 | w1 | EN | What you watch, now also read — 3 months free | — | `w1_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w1_en.html |
-| w2 | DE | Ihr Sommer hat noch Seiten frei | — | `w2_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w2_de.html |
-| w2 | EN | Your summer still has pages to turn | — | `w2_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w2_en.html |
-| w3 | DE | Nur noch bis Samstag: drei Monate gratis | Was Sie sehen, jetzt auch lesen — bis Samstag | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_de.html |
-| w3 | EN | Only until Saturday: three months free | What you watch, now also read — until Saturday | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_en.html |
+| w2 | DE | Drei Monate Lesestoff, geschenkt zu Ihrem Abo | — | `w2_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w2_de.html |
+| w2 | EN | Three months of reading, free with your subscription | — | `w2_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w2_en.html |
+| w3 | DE | Bis Samstag: drei Monate mitlesen, geschenkt | Was Sie sehen, jetzt auch lesen — bis Samstag | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_de.html |
+| w3 | EN | Until Saturday: three months of reading, as a gift | What you watch, now also read — until Saturday | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_en.html |
 
 ### S26 · NurWS→TV (Angebot: goetheanum.tv sehen)
 

--- a/services/mailing-sommer2026/heroes.json
+++ b/services/mailing-sommer2026/heroes.json
@@ -235,14 +235,14 @@
       },
       "w2": {
         "de": {
-          "betreff": "Ihr Sommer hat noch Seiten frei",
+          "betreff": "Drei Monate Lesestoff, geschenkt zu Ihrem Abo",
           "botschaft": "Ein Sommer über den eigenen Rand hinaus.",
           "text": "Noch bis 8. August lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — Lesestoff, der in Ihnen weiterarbeitet, wenn der Bildschirm dunkel ist.",
           "alt": "Lesestoff, der den Sommer überdauert — gratis",
           "preheader": "Bis 8. August: die Wochenschrift drei Monate gratis zu Ihrem Abo — sie liest sich überall."
         },
         "en": {
-          "betreff": "Your summer still has pages to turn",
+          "betreff": "Three months of reading, free with your subscription",
           "botschaft": "A summer beyond your own horizon.",
           "text": "Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark.",
           "alt": "Reading that outlasts the summer — free",
@@ -251,18 +251,18 @@
       },
       "w3": {
         "de": {
-          "betreff": "Nur noch bis Samstag: drei Monate gratis",
+          "betreff": "Bis Samstag: drei Monate mitlesen, geschenkt",
           "botschaft": "Bis Samstag bleibt die Tür offen.",
-          "text": "Noch ein paar Sommertage lang: die Wochenschrift, drei Monate gratis zu Ihrem Abo. Wenn sie Ihnen nicht ans Herz wächst, kündigen Sie einfach.",
+          "text": "Diese Woche endet die Sommer-Aktion. Bis Samstag lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — und kommen mit anderen Augen in Ihre Woche zurück. Gefällt es nicht, kündigen Sie mit einem Klick.",
           "alt": "Was Sie sehen, jetzt auch lesen — bis Samstag",
-          "preheader": "Eine Minute für drei Monate Lesezeit: die Wochenschrift gratis zu Ihrem Abo — bis Samstag."
+          "preheader": "Drei Gratis-Monate zum Mitlesen — nur noch bis Samstag, 8. August."
         },
         "en": {
-          "betreff": "Only until Saturday: three months free",
+          "betreff": "Until Saturday: three months of reading, as a gift",
           "botschaft": "The door stays open until Saturday.",
-          "text": "A few summer days remain: the weekly, free for three months with your subscription. If it doesn’t grow on you, simply cancel.",
+          "text": "This week the summer offer ends. Until Saturday, read the weekly free for three months with your subscription — and return to your own week with different eyes. If it’s not for you, cancel in one click.",
           "alt": "What you watch, now also read — until Saturday",
-          "preheader": "One minute for three months: the weekly, free with your subscription — until Saturday."
+          "preheader": "Three free months to read along — only until Saturday, 8 August."
         }
       }
     },


### PR DESCRIPTION
## Was

Reconciliation Deiner Textänderungen aus der Forecast-Session (Branch `claude/summer-campaign-forecast-j116m8`) mit dem Teilen-PS-Stand auf `main`. Der Build lief in jener Session nicht (dort fehlt `mjml`/`cairosvg`); hier gebaut und geprüft.

**Zusammengeführt (3-Wege-Merge auf `heroes.json`, konfliktfrei — verschiedene Stellen):**
- `lesen` w2 Betreff (A/B): „Ihr Sommer hat noch Seiten frei" → **„Drei Monate Lesestoff, geschenkt zu Ihrem Abo"** (DE/EN)
- `lesen` w3 Betreff + Fliesstext + Preheader geschärft (DE/EN): „Bis Samstag: drei Monate mitlesen, geschenkt"
- Das Teilen-PS (w1/w2, segment-treuer Link) bleibt unangetastet erhalten.

**Nicht enthalten:** die `forecast/`-Nachfass-Strecke aus derselben Session (Prognose + Onboarding, ~1400 Zeilen) — die bleibt auf ihrem Branch, bis Du sie separat einbringen willst.

## Folgen

- Neu gebaut, alle 20 Mails ok. AC-Prompt-Tabelle frisch erzeugt — die neuen Betreffe stehen drin.
- Register unberührt: `utm_content` hängt an Welle/Segment, nicht am Betreff.

## Nach dem Merge

Die geänderten `lesen`-Mails (w2/w3) müssen in AC einmal frisch von den URLs geladen werden — **Betreffe haben sich geändert**, hier also auch die Betreffzeile in AC nachziehen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_