### PR TITLE
Werkzeuge-Mail für Mitarbeitende: Jahresplan ab September

### DIFF
--- a/docs/werkzeuge-mailplan.md
+++ b/docs/werkzeuge-mailplan.md
@@ -1,0 +1,161 @@
+# Werkzeuge-Mail für Mitarbeitende — Jahresplan
+
+*Monatliche Mail ab September 2026: je Monat ein Werkzeug. Absender: Philipp Tok
+und Stefan Hasler, je nach Werkzeug mit Co-Autorin oder Co-Autor. Grundlage:
+Strategieblatt (`docs/strategie.md`) — Durchsetzung gelingt nicht über Verbote,
+sondern weil der konforme Weg der einfachste ist. Die Mail ist die Einladung
+auf diesen Weg.*
+
+---
+
+## 1. Das Prinzip
+
+**Eine Mail. Ein Werkzeug. Eine Handlung. Ein Monat.**
+
+Jede Mail stellt genau ein Werkzeug vor, verlangt genau eine kleine Handlung
+(drei Minuten, ein Link) und erzählt genau ein Stück Haus-Identität. Niemals
+zwei Werkzeuge, niemals eine Linkliste, niemals ein Handbuch. Die Serie wirkt
+nicht durch die einzelne Mail, sondern durch den Rhythmus: nach einem Jahr
+haben alle zehnmal erlebt, dass das Haus ihnen Arbeit *abnimmt* — und nebenbei
+zehn kleine Kapitel der gemeinsamen Gestalt gelesen.
+
+**Serienname-Vorschlag:** «Aus der Werkzeugkiste» — als wiederkehrender
+Betreff-Vorspann («Aus der Werkzeugkiste: …»), damit die Mail im Postfach
+sofort als Folge der Serie erkennbar ist.
+
+## 2. Der Jahresbogen — Abfolge und Anlass
+
+Die Reihenfolge folgt drei Logiken zugleich: **Saison** (was gerade ansteht),
+**Aufbau** (jedes Werkzeug bereitet das nächste vor) und **Aufwandskurve**
+(mit dem kleinsten Griff beginnen, Vertrauen aufbauen, dann Grösseres).
+
+| Monat | Werkzeug | Warum jetzt | Blick dahinter (Identitätsstück) |
+|---|---|---|---|
+| **September** | **Signatur** | Saisonauftakt, alle kehren zurück; kleinster Aufwand, grösster kollektiver Effekt — der perfekte Serien-Start | Aus dem Haus gehen täglich hunderte Mails; die Signatur ist die häufigste Geste des Hauses. Einheit entsteht aus vielen kleinen, übereinstimmenden Gesten. |
+| **Oktober** | **Schriften** (Office-Schriften installieren) | Die Stimme des Hauses auf jeden Rechner — und die stille Voraussetzung für den November | Warum die Schnitte Flüstern bis Schreien heissen; betont wird mit Laut, nie mit Unterstreichen oder VERSALIEN. |
+| **November** | **PowerPoint-Vorlagen** | Jahresberichte, Gremien, Tagungen zum Jahresende; baut sichtbar auf dem Oktober auf («die Schriften habt ihr schon») | Eine Folie im Hausbild wirkt, bevor das erste Wort gesprochen ist — und eingebettete Schriften reisen mit. |
+| **Dezember** | **Wallpaper** | Der besinnliche Monat: die einzige Mail, die *nichts* verlangt — ein Geschenk, elf Bilder, fertig | Das Haus auf dem eigenen Schreibtisch. Zugehörigkeit braucht manchmal keinen Zweck. |
+| **Januar** | **Visitenkarten** | Neues Jahr, neue Rollen, Karten werden nachbestellt; erster Druck-Workflow der Serie | Die Visitenkarte ist die kleinste Bühne des Hauses — druckfertig ohne Layoutprogramm, ohne Wartezeit. |
+| **Februar** | **Logos** | Das Herzstück, bewusst erst jetzt: nach fünf guten Erfahrungen ist der Boden bereit für das erklärungsbedürftigste Thema | 34 Organisationen, eine Familie: warum die Logos aus *einem* System kommen statt aus vielen Inseln — und warum das jede Sektion stärker macht, nicht kleiner. |
+| **März** | **QR-Code-Generator** | Frühjahr ist Plakat- und Programmzeit fürs Sommerhalbjahr; Anmeldungen, Flyer, Aushänge | Die Brücke von Papier zu Web — im Hausstil, ohne Fremddienst, ohne Tracking von Personen. Datensparsamkeit ist ein Hauswert, kein Zufall. |
+| **April** | **Campus-Karte** | Die Besucherströme des Sommers stehen bevor: Wegleitungen, Anfahrten, Parkflächen für die Tagungen | Gastfreundschaft beginnt vor der Ankunft — ein korrekter Lageplan ist die erste Begrüssung. |
+| **Mai** | **Übersetzungen** | Die internationalen Sommertagungen werfen ihre Schatten: EN/FR/ES-Material entsteht jetzt in den Sekretariaten | Das Haus spricht vier Sprachen — mit geprüften Begriffen statt improvisierten. Co-Autorin: eine Stimme aus den Sekretariaten. |
+| **Juni** | **Icons** + Jahresbilanz | Kleines, freudiges Werkzeug vor der Sommerpause — und im selben Brief: die Zahlen des Jahres und die Wunschliste | 45 Zeichen, eine Handschrift. Dazu die Bilanz: was wurde wie oft genutzt («nur der Gebrauch legitimiert den Bau») und die Frage: *Welches Werkzeug fehlt euch?* Die Antworten priorisieren den nächsten Jahrgang. |
+
+**Juli/August: Pause.** Die Serie atmet mit dem Haus. Der Wiederbeginn im
+September ist dann selbst schon ein Ritual.
+
+### Flex-Regel für neue Werkzeuge
+
+Briefschaften, Schilder, Cover-Generator und Editor stehen auf Entwurf. Geht
+eines davon während des Jahres live, **verdrängt es das saisonal schwächste
+Bestandswerkzeug** aus dem Plan (zuerst Icons, dann Wallpaper wäre tauschbar —
+aber nie die Saison-Anker September/Dezember/April). Briefschaften passt
+natürlich in den Januar (Korrespondenz-Monat, dann rückt Visitenkarten in den
+Februar und Logos in den März), Schilder in den April (Leitsystem vor der
+Sommersaison). Der Plan ist ein Bogen, kein Gesetz.
+
+## 3. Die Bauform jeder Mail
+
+Jede Mail hat dieselben fünf Bausteine in derselben Reihenfolge — die
+Wiedererkennbarkeit *ist* die halbe Wirkung:
+
+1. **Der Anlass** (1 Satz): warum dieses Werkzeug *jetzt*. Nie «wir möchten
+   vorstellen», immer ein Haken im Kalender der Lesenden.
+2. **Das Werkzeug** (1 Satz): was es tut, in der Sprache des Ergebnisses
+   («druckfertige Visitenkarte»), nicht der Technik («Generator mit
+   PDF-Export»).
+3. **Der Weg** (3 nummerierte Schritte): Link öffnen, eintragen, übernehmen.
+   Wer nur diesen Block liest, kann handeln. Ein einziger Link pro Mail.
+4. **Der Blick dahinter** (2–3 Sätze): das Identitätsstück aus der Tabelle —
+   warum es so gestaltet ist, welche Haltung dahinter steht. Hier wächst die
+   gemeinsame Identität: nicht als Schulung, sondern als kleine Erzählung.
+   Über zehn Monate ergibt das eine CI-Schule, die nie wie eine wirkt.
+5. **Gruss + PS**: beide Namen, herzlich, kurz. Das PS ist die meistgelesene
+   Zeile jeder Mail — dort wohnen Vorfreude («im Oktober kommt …»), die Zahl
+   des Vormonats oder eine menschliche Note. Das PS nie verschenken.
+
+**Länge:** 120–180 Wörter Haupttext, eine Bildschirmhöhe, Lesezeit unter einer
+Minute. Wenn eine Mail länger wird, ist es zwei Mails — dann wartet die zweite
+Hälfte auf ihren eigenen Monat.
+
+**Bild:** genau eines, wenn es trägt — am stärksten als Vorher/Nachher-Miniatur
+(die alte wilde Signatur neben der neuen) oder als Ergebnis-Ausschnitt. Kein
+Bild ist besser als ein dekoratives.
+
+## 4. Ton und Argumentation
+
+- **Kollegial, warm, konkret.** Die Absender sind zwei Menschen, die etwas
+  gebaut haben und es gern zeigen — keine Stabsstelle, die etwas verordnet.
+  Erste Person Plural («wir haben gebaut»), direkte Anrede.
+- **Nie Pflicht, immer Erleichterung.** Kein «ab sofort gilt», kein «bitte
+  verwenden Sie ausschliesslich». Die Argumentation ist immer: *das hier ist
+  schneller und schöner als der bisherige Weg.* Wer die Werkzeuge aus Freude
+  nutzt, bleibt; wer sie aus Pflicht nutzt, weicht aus (Strategieblatt, Abschnitt 4).
+- **Würde ohne Steifheit.** Das Haus darf in diesen Mails lächeln. Humor ja —
+  aber als Wärme, nie als Ironie über das Haus oder die Lesenden.
+- **Ehrlichkeit als Stilmittel.** Beta heisst Beta; «sagt uns, was klemmt»
+  steht in jeder Mail mit. Rückmeldekanal = direkte Antwort auf die Mail, keine
+  Formulare.
+- **Die Zahlenschleife.** Jede Mail nennt im PS die anonyme Nutzungszahl des
+  Vormonats («83 Signaturen im September — das Haus schreibt schon mit einer
+  Stimme»). Das Statistik-Werkzeug liefert die Zahl, die Mail macht daraus
+  Gemeinschaftsgefühl: Ich bin nicht allein umgestiegen. Nichts baut Identität
+  verlässlicher als der sichtbare Beweis, dass die anderen mitmachen.
+
+## 5. Absender und Co-Autorenschaft
+
+- **Beide unterschreiben immer** — Philipp Tok und Stefan Hasler. Einer führt
+  die Feder (kann monatlich wechseln), die Mail spricht als «wir».
+- **Co-Autorin/Co-Autor**, wo ein Werkzeug eine fachliche Patenschaft hat:
+  die Sekretariats-Stimme bei den Übersetzungen, künftig die Hausdruckerei bei
+  den Briefschaften. Die dritte Unterschrift zeigt: das Werkzeug gehört dem
+  Haus, nicht der Grafik.
+- **Dogfooding:** die Mail selbst trägt selbstverständlich die Signatur aus dem
+  Signatur-Generator — vom ersten Versand an.
+
+## 6. Praktisches
+
+- **Versand:** erster Dienstagvormittag des Monats, immer derselbe Tag —
+  der Rhythmus macht die Serie zum Ritual. Dezember-Mail vor dem
+  Weihnachtstrubel (erste Woche).
+- **Messung:** Nutzungszahlen je Werkzeug im Monatsfenster nach Versand
+  (Statistik-Werkzeug); die Zahl wandert ins PS der Folgemail. Keine
+  personenbezogene Messung — Datensparsamkeit gilt auch hier.
+- **Juni-Bilanz** speist die Priorisierung des nächsten Jahrgangs
+  (Phase 3 des Fahrplans: wachsen entlang des Bedarfs).
+
+## 7. Muster: die September-Mail
+
+> **Betreff:** Aus der Werkzeugkiste: Drei Minuten, und jede Mail trägt das Haus
+>
+> Liebe Kolleginnen und Kollegen
+>
+> Zum Saisonbeginn das kleinste Werkzeug mit der grössten Wirkung: die
+> gemeinsame E-Mail-Signatur.
+>
+> Aus dem Haus gehen täglich hunderte Mails. Jede ist ein kleiner Auftritt des
+> Goetheanum — und bisher sieht fast jeder anders aus. Das ändert sich in drei
+> Minuten:
+>
+> 1. Signatur-Werkzeug öffnen: \[Link]
+> 2. Name, Aufgabe, Sektion eintragen — die Vorschau zeigt sofort das Ergebnis
+> 3. Kopieren, in Outlook einsetzen, fertig
+>
+> **Der Blick dahinter:** Einheit entsteht nicht aus grossen Gesten, sondern
+> aus vielen kleinen, die übereinstimmen. Die Signatur ist die häufigste Geste
+> des Hauses — hunderte Male am Tag.
+>
+> Wenn etwas klemmt oder fehlt: einfach auf diese Mail antworten, wir lesen
+> alles.
+>
+> Herzlich
+> Philipp Tok & Stefan Hasler
+>
+> PS: Im Oktober bringen wir die Hausschrift auf euren Rechner. Bis dahin
+> zählen wir mit — wie viele Signaturen schafft der September?
+
+---
+
+*Nächster Schritt: Serienname und Anrede (Sie/ihr) mit dem Auftraggeber
+festlegen, Verteiler klären, September-Mail aus dem Muster finalisieren.*

--- a/tools.json
+++ b/tools.json
@@ -575,6 +575,12 @@
       "desc": "Ausführungs-Spezifikation der fünf Lead-Schleifen: Seelenkalender, Archiv-Sog, Partner-Kit, Atomisierung, Schenken."
     },
     {
+      "title": "Werkzeuge-Mail — Jahresplan",
+      "tag": "Kommunikation",
+      "href": "https://github.com/phtok/goeloggen/blob/main/docs/werkzeuge-mailplan.md",
+      "desc": "Monatliche Mitarbeitenden-Mail ab September: je Monat ein Werkzeug — Abfolge, Bauform, Ton, Muster-Mail."
+    },
+    {
       "title": "Gestaltungsspielraum (Entwurf)",
       "href": "https://github.com/phtok/goeloggen/blob/main/docs/gestaltungsspielraum-entwurf.md",
       "desc": "Foto-Richtlinie in drei Richtungen und vier Ansätze zu erlaubter Varianz – zur Ratifizierung."


### PR DESCRIPTION
## Was dieser PR enthält

Konzeptdokument `docs/werkzeuge-mailplan.md`: die monatliche Werkzeuge-Mail an die Mitarbeitenden ab September 2026 — je Monat ein Werkzeug, Absender Philipp Tok & Stefan Hasler (mit Co-Autorenschaft je Werkzeug).

- **Jahresbogen Sept–Juni:** Signatur → Schriften → PowerPoint → Wallpaper (Dezember-Geschenk) → Visitenkarten → Logos → QR → Campus-Karte → Übersetzungen → Icons + Jahresbilanz. Abfolge nach Saison, Aufbau (jedes Werkzeug bereitet das nächste vor) und Aufwandskurve; Flex-Regel für Werkzeuge, die während des Jahres live gehen.
- **Bauform:** fünf feste Bausteine (Anlass · Werkzeug · Weg in 3 Schritten · Blick dahinter · Gruss + PS), 120–180 Wörter, ein Link pro Mail.
- **Ton & Argumentation:** kollegial statt verordnend, nie Pflicht, immer Erleichterung; Zahlenschleife aus dem Statistik-Werkzeug im PS als Gemeinschaftsbeweis.
- **Muster:** die September-Mail (Signatur) ausformuliert.
- Eintrag im Manifest (`tools.json`, Abschnitt `docs`).

Reines Dokumentations-/Manifest-Update, keine Code- oder Gestaltflächen berührt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPT5AKuUgjThxUNighRLBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPT5AKuUgjThxUNighRLBk)_