### PR TITLE
Sehen/Lesen w1: ergänzend statt ersetzend, konkret, Betreff aus dem Gehalt

### DIFF
--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -99,7 +99,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 12.07.2026, 17.35 Uhr · <code>cf5b3b0</code></p>
+  <p class="subline">Stand dieses Builds: 12.07.2026, 18.47 Uhr · <code>6314f7a</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -146,7 +146,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#footer')">senden</button></div></div></div></div></section>
 <section class="segment"><h2>Lesen · Die Wochenschrift — nurtv</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W1 · DE<a href="mails/mail_lesen_w1_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Denken, das über die Woche hinausreicht — 3 Monate gratis</div><div class="ib-a">Drei Monate kostenlos mitlesen — wo der Sommer Sie hinträgt. Bis 8. August.</div></div>
+  <div class="inbox"><div class="ib-b">Denken, das über die Woche hinausreicht — 3 Monate gratis</div><div class="ib-a">«Und wenn das Leben aus den Sternen käme?» und das ganze Archiv — jede Woche neu. Bis 8. August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -256,7 +256,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Drei Monate kostenlos mitlesen — wo der Sommer Sie hinträgt. Bis 8. August.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>«Und wenn das Leben aus den Sternen käme?» und das ganze Archiv — jede Woche neu. Bis 8. August.</div>
   <div aria-label=&quot;Denken, das über die Woche hinausreicht — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -350,7 +350,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Ergänzend zu dem, was Sie auf goetheanum.tv sehen, denkt die Wochenschrift weiter — schwarz auf weiss, jede Woche neu: Aufsätze und Zeitsymptome zu Themen wie «Bäume» oder «Biografiearbeit», dazu das ganze Archiv seit 2023, das mit Ihrem Abo offen bleibt. Nicht was die Autoren wissen, sondern wie sie suchen.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Ergänzend zu dem, was Sie auf goetheanum.tv sehen, denkt die Wochenschrift weiter — schwarz auf weiss, jede Woche neu: «Den Frieden herbeidenken», «Und wenn das Leben aus den Sternen käme?», «Biografiearbeit als Weg zum Ich». Dazu das ganze Archiv seit 2023, das mit Ihrem Abo offen bleibt. Nicht was die Autoren wissen, sondern wie sie suchen.</div>
                       </td>
                     </tr>
                     <tr>
@@ -445,7 +445,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W1 · EN<a href="mails/mail_lesen_w1_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Thinking that reaches beyond the week — 3 months free</div><div class="ib-a">Three months free to read — wherever summer takes you. Until 8 August.</div></div>
+  <div class="inbox"><div class="ib-b">Thinking that reaches beyond the week — 3 months free</div><div class="ib-a">«What if life came from the stars?» and the whole archive — new each week. Until 8 August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -555,7 +555,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months free to read — wherever summer takes you. Until 8 August.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>«What if life came from the stars?» and the whole archive — new each week. Until 8 August.</div>
   <div aria-label=&quot;Thinking that reaches beyond the week — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -649,7 +649,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Alongside what you watch on goetheanum.tv, the weekly thinks on — in black and white, new each week: essays and reflections on the times, on themes like «Trees» or «Biography work», plus the whole archive since 2023, which stays open with your subscription. Not what the authors know, but how they search.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Alongside what you watch on goetheanum.tv, the weekly thinks on — in black and white, new each week: «Envisioning peace», «What if life came from the stars?», «Biography work as a path to the self». Plus the whole archive since 2023, which stays open with your subscription. Not what the authors know, but how they search.</div>
                       </td>
                     </tr>
                     <tr>
@@ -1930,7 +1930,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#gesamt')">senden</button></div></div></div></div></div></div></div></section><section class="segment"><h2>Sehen · goetheanum.tv — nurws</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W1 · DE<a href="mails/mail_sehen_w1_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Sehen, wie Menschen laut denken — 3 Monate gratis</div><div class="ib-a">Von Burnout bis «Greening the Desert» — über 800 Beiträge, nah am Goetheanum, wohin der Sommer Sie trägt.</div></div>
+  <div class="inbox"><div class="ib-b">Sehen, wie Menschen laut denken — 3 Monate gratis</div><div class="ib-a">«Kann man Glück lernen?» und über 800 weitere Beiträge — nah am Goetheanum, wohin der Sommer Sie trägt.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -2040,7 +2040,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Von Burnout bis «Greening the Desert» — über 800 Beiträge, nah am Goetheanum, wohin der Sommer Sie trägt.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>«Kann man Glück lernen?» und über 800 weitere Beiträge — nah am Goetheanum, wohin der Sommer Sie trägt.</div>
   <div aria-label=&quot;Sehen, wie Menschen laut denken — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -2134,7 +2134,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Ergänzend zu den Artikeln, die Sie jede Woche lesen, steht Ihnen die ganze Mediathek offen — über 800 Beiträge, wöchentlich neu: ein Vortrag über Burnout, die Reihe «Greening the Desert» über das Ergrünen der Wüste, Gespräche über Frieden und Medizin. Vorträge, Reportagen und Aufführungen, die Sie ganz nah ans Leben am Goetheanum bringen — selbst aus grosser Entfernung.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Ergänzend zu den Artikeln, die Sie jede Woche lesen, steht Ihnen die ganze Mediathek offen — über 800 Beiträge, wöchentlich neu: «Dieser Krieg muss enden. Jetzt.», «Kann man Glück lernen?», dazu die Reihe, in der die Sahara ergrünt. Vorträge, Reportagen und Aufführungen, die Sie ganz nah ans Leben am Goetheanum bringen — selbst aus grosser Entfernung.</div>
                       </td>
                     </tr>
                     <tr>
@@ -2229,7 +2229,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W1 · EN<a href="mails/mail_sehen_w1_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Watch people think out loud — 3 months free</div><div class="ib-a">From burnout to «Greening the Desert» — over 800 pieces, close to the Goetheanum, wherever summer takes you.</div></div>
+  <div class="inbox"><div class="ib-b">Watch people think out loud — 3 months free</div><div class="ib-a">«Can we learn to be happy?» and over 800 more — close to the Goetheanum, wherever summer takes you.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -2339,7 +2339,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>From burnout to «Greening the Desert» — over 800 pieces, close to the Goetheanum, wherever summer takes you.</div>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>«Can we learn to be happy?» and over 800 more — close to the Goetheanum, wherever summer takes you.</div>
   <div aria-label=&quot;Watch people think out loud — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
@@ -2433,7 +2433,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Alongside the articles you read each week, the whole media library is open to you — over 800 pieces, new every week: a lecture on burnout, the series «Greening the Desert» on making the desert green again, conversations on peace and medicine. Lectures, reportage and performances that bring you close to life at the Goetheanum — even from a great distance.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Alongside the articles you read each week, the whole media library is open to you — over 800 pieces, new every week: «This war must end. Now.», «Can we learn to be happy?», and the series «Greening the Desert», in which the Sahara turns green. Lectures, reportage and performances that bring you close to life at the Goetheanum — even from a great distance.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -99,7 +99,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 12.07.2026, 11.28 Uhr · <code>c3b867b</code></p>
+  <p class="subline">Stand dieses Builds: 12.07.2026, 17.10 Uhr · <code>a8ce332</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -146,13 +146,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#footer')">senden</button></div></div></div></div></section>
 <section class="segment"><h2>Lesen · Die Wochenschrift — nurtv</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W1 · DE<a href="mails/mail_lesen_w1_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Was Sie sehen, jetzt auch lesen — 3 Monate gratis</div><div class="ib-a">Drei Monate kostenlos mitlesen — wo der Sommer Sie hinträgt. Bis 8. August.</div></div>
+  <div class="inbox"><div class="ib-b">Was der Bildschirm anstösst, weiterlesen — 3 Monate gratis</div><div class="ib-a">Drei Monate kostenlos mitlesen — wo der Sommer Sie hinträgt. Bis 8. August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Was Sie sehen, jetzt auch lesen — 3 Monate gratis</title>
+  <title>Was der Bildschirm anstösst, weiterlesen — 3 Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -257,7 +257,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
   <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Drei Monate kostenlos mitlesen — wo der Sommer Sie hinträgt. Bis 8. August.</div>
-  <div aria-label=&quot;Was Sie sehen, jetzt auch lesen — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div aria-label=&quot;Was der Bildschirm anstösst, weiterlesen — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -344,13 +344,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>Jede Woche ein Stück weiter&#160;sehen.</div>
+                          <div style=&quot;text-wrap:balance&quot;>Was der Bildschirm anstösst, denkt die Seite&#160;weiter.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter: Woche für Woche schreiben dort Menschen, die einer Frage ihr Leben gewidmet haben — nicht was sie wissen, sondern wie sie suchen. Wer mitliest, kommt mit anderen Augen in die eigene Woche zurück.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Ergänzend zu dem, was Sie auf goetheanum.tv sehen, denkt die Wochenschrift weiter — schwarz auf weiss, jede Woche neu: Aufsätze und Zeitsymptome zu Themen wie «Bäume» oder «Biografiearbeit», dazu das ganze Archiv seit 2023, das mit Ihrem Abo offen bleibt. Nicht was die Autoren wissen, sondern wie sie suchen.</div>
                       </td>
                     </tr>
                     <tr>
@@ -445,13 +445,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W1 · EN<a href="mails/mail_lesen_w1_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">What you watch, now also read — 3 months free</div><div class="ib-a">Three months free to read — wherever summer takes you. Until 8 August.</div></div>
+  <div class="inbox"><div class="ib-b">What the screen sparks, read on — 3 months free</div><div class="ib-a">Three months free to read — wherever summer takes you. Until 8 August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>What you watch, now also read — 3 months free</title>
+  <title>What the screen sparks, read on — 3 months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -556,7 +556,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
   <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months free to read — wherever summer takes you. Until 8 August.</div>
-  <div aria-label=&quot;What you watch, now also read — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div aria-label=&quot;What the screen sparks, read on — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -643,13 +643,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>See a little further every&#160;week.</div>
+                          <div style=&quot;text-wrap:balance&quot;>What the screen sparks, the page thinks&#160;through.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you watch on goetheanum.tv you can read on in the weekly: week after week, people who have given their lives to a question write down not what they know but how they search. Read along, and you return to your own week with different eyes.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Alongside what you watch on goetheanum.tv, the weekly thinks on — in black and white, new each week: essays and reflections on the times, on themes like «Trees» or «Biography work», plus the whole archive since 2023, which stays open with your subscription. Not what the authors know, but how they search.</div>
                       </td>
                     </tr>
                     <tr>
@@ -1342,7 +1342,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#gesamt')">senden</button></div></div></div></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3 · DE<a href="mails/mail_lesen_w3_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Bis Samstag: drei Monate mitlesen, kostenlos</div><div class="ib-a">Drei Gratis-Monate zum Mitlesen — nur noch bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Was Sie sehen, jetzt auch lesen — bis Samstag</div></div>
+  <div class="inbox"><div class="ib-b">Bis Samstag: drei Monate mitlesen, kostenlos</div><div class="ib-a">Drei Gratis-Monate zum Mitlesen — nur noch bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Weiterlesen, was der Bildschirm anstiess — bis Samstag</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -1636,7 +1636,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3 · EN<a href="mails/mail_lesen_w3_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Until Saturday: three months of reading, free</div><div class="ib-a">Three free months to read along — only until Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> What you watch, now also read — until Saturday</div></div>
+  <div class="inbox"><div class="ib-b">Until Saturday: three months of reading, free</div><div class="ib-a">Three free months to read along — only until Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Read on from what the screen sparked — until Saturday</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -1930,13 +1930,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#gesamt')">senden</button></div></div></div></div></div></div></div></section><section class="segment"><h2>Sehen · goetheanum.tv — nurws</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W1 · DE<a href="mails/mail_sehen_w1_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Was Sie lesen, jetzt auch sehen — 3 Monate gratis</div><div class="ib-a">Über 800 Vorträge und Gespräche, die Ihrem Lesen Tiefe geben — wohin der Sommer Sie trägt.</div></div>
+  <div class="inbox"><div class="ib-b">So nah am Goetheanum, selbst aus der Ferne — 3 Monate gratis</div><div class="ib-a">Von Burnout bis «Greening the Desert» — über 800 Beiträge, nah am Goetheanum, wohin der Sommer Sie trägt.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Was Sie lesen, jetzt auch sehen — 3 Monate gratis</title>
+  <title>So nah am Goetheanum, selbst aus der Ferne — 3 Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -2040,8 +2040,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Über 800 Vorträge und Gespräche, die Ihrem Lesen Tiefe geben — wohin der Sommer Sie trägt.</div>
-  <div aria-label=&quot;Was Sie lesen, jetzt auch sehen — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Von Burnout bis «Greening the Desert» — über 800 Beiträge, nah am Goetheanum, wohin der Sommer Sie trägt.</div>
+  <div aria-label=&quot;So nah am Goetheanum, selbst aus der Ferne — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -2128,13 +2128,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>Zusehen, wie jemand&#160;denkt.</div>
+                          <div style=&quot;text-wrap:balance&quot;>So nah am Goetheanum, wo immer Sie&#160;sind.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: Auf goetheanum.tv denken Menschen laut, in über 800 Vorträgen und Gesprächen. Sie hören das Zögern und das Finden mit — alles, was auf der gedruckten Seite unsichtbar bleibt.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Ergänzend zu den Artikeln, die Sie jede Woche lesen, steht Ihnen die ganze Mediathek offen — über 800 Beiträge, wöchentlich neu: ein Vortrag über Burnout, die Reihe «Greening the Desert» über das Ergrünen der Wüste, Gespräche über Frieden und Medizin. Vorträge, Reportagen und Aufführungen, die Sie ganz nah ans Leben am Goetheanum bringen — selbst aus grosser Entfernung.</div>
                       </td>
                     </tr>
                     <tr>
@@ -2229,13 +2229,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W1 · EN<a href="mails/mail_sehen_w1_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">What you read, now also watch — 3 months free</div><div class="ib-a">Over 800 lectures and conversations that deepen your reading — wherever summer takes you.</div></div>
+  <div class="inbox"><div class="ib-b">So close to the Goetheanum, even from afar — 3 months free</div><div class="ib-a">From burnout to «Greening the Desert» — over 800 pieces, close to the Goetheanum, wherever summer takes you.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>What you read, now also watch — 3 months free</title>
+  <title>So close to the Goetheanum, even from afar — 3 months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -2339,8 +2339,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Over 800 lectures and conversations that deepen your reading — wherever summer takes you.</div>
-  <div aria-label=&quot;What you read, now also watch — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>From burnout to «Greening the Desert» — over 800 pieces, close to the Goetheanum, wherever summer takes you.</div>
+  <div aria-label=&quot;So close to the Goetheanum, even from afar — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -2427,13 +2427,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>Watch someone&#160;think.</div>
+                          <div style=&quot;text-wrap:balance&quot;>Close to the Goetheanum, wherever you&#160;are.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you read each week you can now watch and hear: on goetheanum.tv, people think out loud, in over 800 lectures and conversations. You hear the hesitation and the finding — everything the printed page keeps invisible.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Alongside the articles you read each week, the whole media library is open to you — over 800 pieces, new every week: a lecture on burnout, the series «Greening the Desert» on making the desert green again, conversations on peace and medicine. Lectures, reportage and performances that bring you close to life at the Goetheanum — even from a great distance.</div>
                       </td>
                     </tr>
                     <tr>
@@ -3126,7 +3126,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#gesamt')">senden</button></div></div></div></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3 · DE<a href="mails/mail_sehen_w3_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Nur noch bis Samstag: drei Monate gratis</div><div class="ib-a">Eine Minute für drei Monate goetheanum.tv: gratis zu Ihrem Abo — bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Was Sie lesen, jetzt auch sehen — bis Samstag</div></div>
+  <div class="inbox"><div class="ib-b">Nur noch bis Samstag: drei Monate gratis</div><div class="ib-a">Eine Minute für drei Monate goetheanum.tv: gratis zu Ihrem Abo — bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Die ganze Mediathek, ergänzend — bis Samstag</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -3420,7 +3420,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3 · EN<a href="mails/mail_sehen_w3_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Only until Saturday: three months free</div><div class="ib-a">One minute for three months of goetheanum.tv — free with your subscription, until Saturday.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> What you read, now also watch — until Saturday</div></div>
+  <div class="inbox"><div class="ib-b">Only until Saturday: three months free</div><div class="ib-a">One minute for three months of goetheanum.tv — free with your subscription, until Saturday.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> The whole media library, alongside your reading — until Saturday</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>

--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -99,7 +99,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 12.07.2026, 17.10 Uhr · <code>a8ce332</code></p>
+  <p class="subline">Stand dieses Builds: 12.07.2026, 17.35 Uhr · <code>cf5b3b0</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -146,13 +146,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#footer')">senden</button></div></div></div></div></section>
 <section class="segment"><h2>Lesen · Die Wochenschrift — nurtv</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W1 · DE<a href="mails/mail_lesen_w1_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Was der Bildschirm anstösst, weiterlesen — 3 Monate gratis</div><div class="ib-a">Drei Monate kostenlos mitlesen — wo der Sommer Sie hinträgt. Bis 8. August.</div></div>
+  <div class="inbox"><div class="ib-b">Denken, das über die Woche hinausreicht — 3 Monate gratis</div><div class="ib-a">Drei Monate kostenlos mitlesen — wo der Sommer Sie hinträgt. Bis 8. August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Was der Bildschirm anstösst, weiterlesen — 3 Monate gratis</title>
+  <title>Denken, das über die Woche hinausreicht — 3 Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -257,7 +257,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
   <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Drei Monate kostenlos mitlesen — wo der Sommer Sie hinträgt. Bis 8. August.</div>
-  <div aria-label=&quot;Was der Bildschirm anstösst, weiterlesen — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div aria-label=&quot;Denken, das über die Woche hinausreicht — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -344,7 +344,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>Was der Bildschirm anstösst, denkt die Seite&#160;weiter.</div>
+                          <div style=&quot;text-wrap:balance&quot;>Lesen, das in Ihnen&#160;weiterarbeitet.</div>
                         </div>
                       </td>
                     </tr>
@@ -445,13 +445,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W1 · EN<a href="mails/mail_lesen_w1_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">What the screen sparks, read on — 3 months free</div><div class="ib-a">Three months free to read — wherever summer takes you. Until 8 August.</div></div>
+  <div class="inbox"><div class="ib-b">Thinking that reaches beyond the week — 3 months free</div><div class="ib-a">Three months free to read — wherever summer takes you. Until 8 August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>What the screen sparks, read on — 3 months free</title>
+  <title>Thinking that reaches beyond the week — 3 months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -556,7 +556,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
   <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months free to read — wherever summer takes you. Until 8 August.</div>
-  <div aria-label=&quot;What the screen sparks, read on — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div aria-label=&quot;Thinking that reaches beyond the week — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -643,7 +643,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>What the screen sparks, the page thinks&#160;through.</div>
+                          <div style=&quot;text-wrap:balance&quot;>Reading that keeps working in&#160;you.</div>
                         </div>
                       </td>
                     </tr>
@@ -1342,7 +1342,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#gesamt')">senden</button></div></div></div></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3 · DE<a href="mails/mail_lesen_w3_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Bis Samstag: drei Monate mitlesen, kostenlos</div><div class="ib-a">Drei Gratis-Monate zum Mitlesen — nur noch bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Weiterlesen, was der Bildschirm anstiess — bis Samstag</div></div>
+  <div class="inbox"><div class="ib-b">Bis Samstag: drei Monate mitlesen, kostenlos</div><div class="ib-a">Drei Gratis-Monate zum Mitlesen — nur noch bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Bis Samstag: Denken, das über die Woche hinausreicht</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -1636,7 +1636,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3 · EN<a href="mails/mail_lesen_w3_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Until Saturday: three months of reading, free</div><div class="ib-a">Three free months to read along — only until Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Read on from what the screen sparked — until Saturday</div></div>
+  <div class="inbox"><div class="ib-b">Until Saturday: three months of reading, free</div><div class="ib-a">Three free months to read along — only until Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Until Saturday: thinking that reaches beyond the week</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -1930,13 +1930,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#gesamt')">senden</button></div></div></div></div></div></div></div></section><section class="segment"><h2>Sehen · goetheanum.tv — nurws</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W1 · DE<a href="mails/mail_sehen_w1_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">So nah am Goetheanum, selbst aus der Ferne — 3 Monate gratis</div><div class="ib-a">Von Burnout bis «Greening the Desert» — über 800 Beiträge, nah am Goetheanum, wohin der Sommer Sie trägt.</div></div>
+  <div class="inbox"><div class="ib-b">Sehen, wie Menschen laut denken — 3 Monate gratis</div><div class="ib-a">Von Burnout bis «Greening the Desert» — über 800 Beiträge, nah am Goetheanum, wohin der Sommer Sie trägt.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>So nah am Goetheanum, selbst aus der Ferne — 3 Monate gratis</title>
+  <title>Sehen, wie Menschen laut denken — 3 Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -2041,7 +2041,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
   <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Von Burnout bis «Greening the Desert» — über 800 Beiträge, nah am Goetheanum, wohin der Sommer Sie trägt.</div>
-  <div aria-label=&quot;So nah am Goetheanum, selbst aus der Ferne — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div aria-label=&quot;Sehen, wie Menschen laut denken — 3 Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -2229,13 +2229,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w1_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w1_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W1 · EN<a href="mails/mail_sehen_w1_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">So close to the Goetheanum, even from afar — 3 months free</div><div class="ib-a">From burnout to «Greening the Desert» — over 800 pieces, close to the Goetheanum, wherever summer takes you.</div></div>
+  <div class="inbox"><div class="ib-b">Watch people think out loud — 3 months free</div><div class="ib-a">From burnout to «Greening the Desert» — over 800 pieces, close to the Goetheanum, wherever summer takes you.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>So close to the Goetheanum, even from afar — 3 months free</title>
+  <title>Watch people think out loud — 3 months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -2340,7 +2340,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
   <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>From burnout to «Greening the Desert» — over 800 pieces, close to the Goetheanum, wherever summer takes you.</div>
-  <div aria-label=&quot;So close to the Goetheanum, even from afar — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div aria-label=&quot;Watch people think out loud — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -3126,7 +3126,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w2_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#gesamt')">senden</button></div></div></div></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3 · DE<a href="mails/mail_sehen_w3_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Nur noch bis Samstag: drei Monate gratis</div><div class="ib-a">Eine Minute für drei Monate goetheanum.tv: gratis zu Ihrem Abo — bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Die ganze Mediathek, ergänzend — bis Samstag</div></div>
+  <div class="inbox"><div class="ib-b">Nur noch bis Samstag: drei Monate gratis</div><div class="ib-a">Eine Minute für drei Monate goetheanum.tv: gratis zu Ihrem Abo — bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Bis Samstag: sehen, wie Menschen laut denken</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
@@ -3420,7 +3420,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#gesamt')">senden</button></div></div></div></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3 · EN<a href="mails/mail_sehen_w3_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Only until Saturday: three months free</div><div class="ib-a">One minute for three months of goetheanum.tv — free with your subscription, until Saturday.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> The whole media library, alongside your reading — until Saturday</div></div>
+  <div class="inbox"><div class="ib-b">Only until Saturday: three months free</div><div class="ib-a">One minute for three months of goetheanum.tv — free with your subscription, until Saturday.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Until Saturday: watch people think out loud</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>

--- a/apps/mail-editor/mails/mail_lesen_w1_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Was der Bildschirm anstösst, weiterlesen — 3 Monate gratis</title>
+  <title>Denken, das über die Woche hinausreicht — 3 Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -108,7 +108,7 @@
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Drei Monate kostenlos mitlesen — wo der Sommer Sie hinträgt. Bis 8. August.</div>
-  <div aria-label="Was der Bildschirm anstösst, weiterlesen — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div aria-label="Denken, das über die Woche hinausreicht — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -195,7 +195,7 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">Was der Bildschirm anstösst, denkt die Seite&#160;weiter.</div>
+                          <div style="text-wrap:balance">Lesen, das in Ihnen&#160;weiterarbeitet.</div>
                         </div>
                       </td>
                     </tr>

--- a/apps/mail-editor/mails/mail_lesen_w1_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_de.html
@@ -107,7 +107,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Drei Monate kostenlos mitlesen — wo der Sommer Sie hinträgt. Bis 8. August.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">«Und wenn das Leben aus den Sternen käme?» und das ganze Archiv — jede Woche neu. Bis 8. August.</div>
   <div aria-label="Denken, das über die Woche hinausreicht — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -201,7 +201,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Ergänzend zu dem, was Sie auf goetheanum.tv sehen, denkt die Wochenschrift weiter — schwarz auf weiss, jede Woche neu: Aufsätze und Zeitsymptome zu Themen wie «Bäume» oder «Biografiearbeit», dazu das ganze Archiv seit 2023, das mit Ihrem Abo offen bleibt. Nicht was die Autoren wissen, sondern wie sie suchen.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Ergänzend zu dem, was Sie auf goetheanum.tv sehen, denkt die Wochenschrift weiter — schwarz auf weiss, jede Woche neu: «Den Frieden herbeidenken», «Und wenn das Leben aus den Sternen käme?», «Biografiearbeit als Weg zum Ich». Dazu das ganze Archiv seit 2023, das mit Ihrem Abo offen bleibt. Nicht was die Autoren wissen, sondern wie sie suchen.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_lesen_w1_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Was Sie sehen, jetzt auch lesen — 3 Monate gratis</title>
+  <title>Was der Bildschirm anstösst, weiterlesen — 3 Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -108,7 +108,7 @@
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Drei Monate kostenlos mitlesen — wo der Sommer Sie hinträgt. Bis 8. August.</div>
-  <div aria-label="Was Sie sehen, jetzt auch lesen — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div aria-label="Was der Bildschirm anstösst, weiterlesen — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -195,13 +195,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">Jede Woche ein Stück weiter&#160;sehen.</div>
+                          <div style="text-wrap:balance">Was der Bildschirm anstösst, denkt die Seite&#160;weiter.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter: Woche für Woche schreiben dort Menschen, die einer Frage ihr Leben gewidmet haben — nicht was sie wissen, sondern wie sie suchen. Wer mitliest, kommt mit anderen Augen in die eigene Woche zurück.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Ergänzend zu dem, was Sie auf goetheanum.tv sehen, denkt die Wochenschrift weiter — schwarz auf weiss, jede Woche neu: Aufsätze und Zeitsymptome zu Themen wie «Bäume» oder «Biografiearbeit», dazu das ganze Archiv seit 2023, das mit Ihrem Abo offen bleibt. Nicht was die Autoren wissen, sondern wie sie suchen.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_lesen_w1_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>What you watch, now also read — 3 months free</title>
+  <title>What the screen sparks, read on — 3 months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -108,7 +108,7 @@
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months free to read — wherever summer takes you. Until 8 August.</div>
-  <div aria-label="What you watch, now also read — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div aria-label="What the screen sparks, read on — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -195,13 +195,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">See a little further every&#160;week.</div>
+                          <div style="text-wrap:balance">What the screen sparks, the page thinks&#160;through.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you watch on goetheanum.tv you can read on in the weekly: week after week, people who have given their lives to a question write down not what they know but how they search. Read along, and you return to your own week with different eyes.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Alongside what you watch on goetheanum.tv, the weekly thinks on — in black and white, new each week: essays and reflections on the times, on themes like «Trees» or «Biography work», plus the whole archive since 2023, which stays open with your subscription. Not what the authors know, but how they search.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_lesen_w1_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>What the screen sparks, read on — 3 months free</title>
+  <title>Thinking that reaches beyond the week — 3 months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -108,7 +108,7 @@
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months free to read — wherever summer takes you. Until 8 August.</div>
-  <div aria-label="What the screen sparks, read on — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div aria-label="Thinking that reaches beyond the week — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -195,7 +195,7 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">What the screen sparks, the page thinks&#160;through.</div>
+                          <div style="text-wrap:balance">Reading that keeps working in&#160;you.</div>
                         </div>
                       </td>
                     </tr>

--- a/apps/mail-editor/mails/mail_lesen_w1_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_en.html
@@ -107,7 +107,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months free to read — wherever summer takes you. Until 8 August.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">«What if life came from the stars?» and the whole archive — new each week. Until 8 August.</div>
   <div aria-label="Thinking that reaches beyond the week — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -201,7 +201,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Alongside what you watch on goetheanum.tv, the weekly thinks on — in black and white, new each week: essays and reflections on the times, on themes like «Trees» or «Biography work», plus the whole archive since 2023, which stays open with your subscription. Not what the authors know, but how they search.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Alongside what you watch on goetheanum.tv, the weekly thinks on — in black and white, new each week: «Envisioning peace», «What if life came from the stars?», «Biography work as a path to the self». Plus the whole archive since 2023, which stays open with your subscription. Not what the authors know, but how they search.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_sehen_w1_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Was Sie lesen, jetzt auch sehen — 3 Monate gratis</title>
+  <title>So nah am Goetheanum, selbst aus der Ferne — 3 Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Über 800 Vorträge und Gespräche, die Ihrem Lesen Tiefe geben — wohin der Sommer Sie trägt.</div>
-  <div aria-label="Was Sie lesen, jetzt auch sehen — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Von Burnout bis «Greening the Desert» — über 800 Beiträge, nah am Goetheanum, wohin der Sommer Sie trägt.</div>
+  <div aria-label="So nah am Goetheanum, selbst aus der Ferne — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -195,13 +195,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">Zusehen, wie jemand&#160;denkt.</div>
+                          <div style="text-wrap:balance">So nah am Goetheanum, wo immer Sie&#160;sind.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: Auf goetheanum.tv denken Menschen laut, in über 800 Vorträgen und Gesprächen. Sie hören das Zögern und das Finden mit — alles, was auf der gedruckten Seite unsichtbar bleibt.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Ergänzend zu den Artikeln, die Sie jede Woche lesen, steht Ihnen die ganze Mediathek offen — über 800 Beiträge, wöchentlich neu: ein Vortrag über Burnout, die Reihe «Greening the Desert» über das Ergrünen der Wüste, Gespräche über Frieden und Medizin. Vorträge, Reportagen und Aufführungen, die Sie ganz nah ans Leben am Goetheanum bringen — selbst aus grosser Entfernung.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_sehen_w1_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>So nah am Goetheanum, selbst aus der Ferne — 3 Monate gratis</title>
+  <title>Sehen, wie Menschen laut denken — 3 Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -108,7 +108,7 @@
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Von Burnout bis «Greening the Desert» — über 800 Beiträge, nah am Goetheanum, wohin der Sommer Sie trägt.</div>
-  <div aria-label="So nah am Goetheanum, selbst aus der Ferne — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div aria-label="Sehen, wie Menschen laut denken — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">

--- a/apps/mail-editor/mails/mail_sehen_w1_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_de.html
@@ -107,7 +107,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Von Burnout bis «Greening the Desert» — über 800 Beiträge, nah am Goetheanum, wohin der Sommer Sie trägt.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">«Kann man Glück lernen?» und über 800 weitere Beiträge — nah am Goetheanum, wohin der Sommer Sie trägt.</div>
   <div aria-label="Sehen, wie Menschen laut denken — 3 Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -201,7 +201,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Ergänzend zu den Artikeln, die Sie jede Woche lesen, steht Ihnen die ganze Mediathek offen — über 800 Beiträge, wöchentlich neu: ein Vortrag über Burnout, die Reihe «Greening the Desert» über das Ergrünen der Wüste, Gespräche über Frieden und Medizin. Vorträge, Reportagen und Aufführungen, die Sie ganz nah ans Leben am Goetheanum bringen — selbst aus grosser Entfernung.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Ergänzend zu den Artikeln, die Sie jede Woche lesen, steht Ihnen die ganze Mediathek offen — über 800 Beiträge, wöchentlich neu: «Dieser Krieg muss enden. Jetzt.», «Kann man Glück lernen?», dazu die Reihe, in der die Sahara ergrünt. Vorträge, Reportagen und Aufführungen, die Sie ganz nah ans Leben am Goetheanum bringen — selbst aus grosser Entfernung.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_sehen_w1_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>What you read, now also watch — 3 months free</title>
+  <title>So close to the Goetheanum, even from afar — 3 months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Over 800 lectures and conversations that deepen your reading — wherever summer takes you.</div>
-  <div aria-label="What you read, now also watch — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">From burnout to «Greening the Desert» — over 800 pieces, close to the Goetheanum, wherever summer takes you.</div>
+  <div aria-label="So close to the Goetheanum, even from afar — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -195,13 +195,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">Watch someone&#160;think.</div>
+                          <div style="text-wrap:balance">Close to the Goetheanum, wherever you&#160;are.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you read each week you can now watch and hear: on goetheanum.tv, people think out loud, in over 800 lectures and conversations. You hear the hesitation and the finding — everything the printed page keeps invisible.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Alongside the articles you read each week, the whole media library is open to you — over 800 pieces, new every week: a lecture on burnout, the series «Greening the Desert» on making the desert green again, conversations on peace and medicine. Lectures, reportage and performances that bring you close to life at the Goetheanum — even from a great distance.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_sehen_w1_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_en.html
@@ -107,7 +107,7 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">From burnout to «Greening the Desert» — over 800 pieces, close to the Goetheanum, wherever summer takes you.</div>
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">«Can we learn to be happy?» and over 800 more — close to the Goetheanum, wherever summer takes you.</div>
   <div aria-label="Watch people think out loud — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
@@ -201,7 +201,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Alongside the articles you read each week, the whole media library is open to you — over 800 pieces, new every week: a lecture on burnout, the series «Greening the Desert» on making the desert green again, conversations on peace and medicine. Lectures, reportage and performances that bring you close to life at the Goetheanum — even from a great distance.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Alongside the articles you read each week, the whole media library is open to you — over 800 pieces, new every week: «This war must end. Now.», «Can we learn to be happy?», and the series «Greening the Desert», in which the Sahara turns green. Lectures, reportage and performances that bring you close to life at the Goetheanum — even from a great distance.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_sehen_w1_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>So close to the Goetheanum, even from afar — 3 months free</title>
+  <title>Watch people think out loud — 3 months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -108,7 +108,7 @@
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">From burnout to «Greening the Desert» — over 800 pieces, close to the Goetheanum, wherever summer takes you.</div>
-  <div aria-label="So close to the Goetheanum, even from afar — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div aria-label="Watch people think out loud — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">

--- a/services/mailing-sommer2026/AC-AUTOMATION.md
+++ b/services/mailing-sommer2026/AC-AUTOMATION.md
@@ -120,23 +120,23 @@ Alle Links tragen zudem
 
 | Welle | Sprache | Betreff | Alt-Betreff (nur w3-Zweig «Nicht-Öffner») | utm_content | HTML-Quelle |
 |---|---|---|---|---|---|
-| w1 | DE | Was Sie sehen, jetzt auch lesen — 3 Monate gratis | — | `w1_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w1_de.html |
-| w1 | EN | What you watch, now also read — 3 months free | — | `w1_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w1_en.html |
+| w1 | DE | Was der Bildschirm anstösst, weiterlesen — 3 Monate gratis | — | `w1_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w1_de.html |
+| w1 | EN | What the screen sparks, read on — 3 months free | — | `w1_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w1_en.html |
 | w2 | DE | Drei Monate mitlesen, danach entscheiden Sie. | — | `w2_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w2_de.html |
 | w2 | EN | Three months of reading — then you decide. | — | `w2_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w2_en.html |
-| w3 | DE | Bis Samstag: drei Monate mitlesen, kostenlos | Was Sie sehen, jetzt auch lesen — bis Samstag | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_de.html |
-| w3 | EN | Until Saturday: three months of reading, free | What you watch, now also read — until Saturday | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_en.html |
+| w3 | DE | Bis Samstag: drei Monate mitlesen, kostenlos | Weiterlesen, was der Bildschirm anstiess — bis Samstag | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_de.html |
+| w3 | EN | Until Saturday: three months of reading, free | Read on from what the screen sparked — until Saturday | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_en.html |
 
 ### S26 · NurWS→TV (Angebot: goetheanum.tv sehen)
 
 | Welle | Sprache | Betreff | Alt-Betreff (nur w3-Zweig «Nicht-Öffner») | utm_content | HTML-Quelle |
 |---|---|---|---|---|---|
-| w1 | DE | Was Sie lesen, jetzt auch sehen — 3 Monate gratis | — | `w1_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w1_de.html |
-| w1 | EN | What you read, now also watch — 3 months free | — | `w1_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w1_en.html |
+| w1 | DE | So nah am Goetheanum, selbst aus der Ferne — 3 Monate gratis | — | `w1_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w1_de.html |
+| w1 | EN | So close to the Goetheanum, even from afar — 3 months free | — | `w1_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w1_en.html |
 | w2 | DE | Ihr Sommer hat noch Abende frei | — | `w2_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w2_de.html |
 | w2 | EN | Your summer still has evenings free | — | `w2_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w2_en.html |
-| w3 | DE | Nur noch bis Samstag: drei Monate gratis | Was Sie lesen, jetzt auch sehen — bis Samstag | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_de.html |
-| w3 | EN | Only until Saturday: three months free | What you read, now also watch — until Saturday | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_en.html |
+| w3 | DE | Nur noch bis Samstag: drei Monate gratis | Die ganze Mediathek, ergänzend — bis Samstag | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_de.html |
+| w3 | EN | Only until Saturday: three months free | The whole media library, alongside your reading — until Saturday | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_en.html |
 
 ### S26 · NoAbo (beide Angebote; jede Mail führt mit einem Button zur Übersicht)
 

--- a/services/mailing-sommer2026/AC-AUTOMATION.md
+++ b/services/mailing-sommer2026/AC-AUTOMATION.md
@@ -120,23 +120,23 @@ Alle Links tragen zudem
 
 | Welle | Sprache | Betreff | Alt-Betreff (nur w3-Zweig «Nicht-Öffner») | utm_content | HTML-Quelle |
 |---|---|---|---|---|---|
-| w1 | DE | Was der Bildschirm anstösst, weiterlesen — 3 Monate gratis | — | `w1_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w1_de.html |
-| w1 | EN | What the screen sparks, read on — 3 months free | — | `w1_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w1_en.html |
+| w1 | DE | Denken, das über die Woche hinausreicht — 3 Monate gratis | — | `w1_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w1_de.html |
+| w1 | EN | Thinking that reaches beyond the week — 3 months free | — | `w1_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w1_en.html |
 | w2 | DE | Drei Monate mitlesen, danach entscheiden Sie. | — | `w2_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w2_de.html |
 | w2 | EN | Three months of reading — then you decide. | — | `w2_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w2_en.html |
-| w3 | DE | Bis Samstag: drei Monate mitlesen, kostenlos | Weiterlesen, was der Bildschirm anstiess — bis Samstag | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_de.html |
-| w3 | EN | Until Saturday: three months of reading, free | Read on from what the screen sparked — until Saturday | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_en.html |
+| w3 | DE | Bis Samstag: drei Monate mitlesen, kostenlos | Bis Samstag: Denken, das über die Woche hinausreicht | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_de.html |
+| w3 | EN | Until Saturday: three months of reading, free | Until Saturday: thinking that reaches beyond the week | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_en.html |
 
 ### S26 · NurWS→TV (Angebot: goetheanum.tv sehen)
 
 | Welle | Sprache | Betreff | Alt-Betreff (nur w3-Zweig «Nicht-Öffner») | utm_content | HTML-Quelle |
 |---|---|---|---|---|---|
-| w1 | DE | So nah am Goetheanum, selbst aus der Ferne — 3 Monate gratis | — | `w1_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w1_de.html |
-| w1 | EN | So close to the Goetheanum, even from afar — 3 months free | — | `w1_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w1_en.html |
+| w1 | DE | Sehen, wie Menschen laut denken — 3 Monate gratis | — | `w1_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w1_de.html |
+| w1 | EN | Watch people think out loud — 3 months free | — | `w1_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w1_en.html |
 | w2 | DE | Ihr Sommer hat noch Abende frei | — | `w2_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w2_de.html |
 | w2 | EN | Your summer still has evenings free | — | `w2_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w2_en.html |
-| w3 | DE | Nur noch bis Samstag: drei Monate gratis | Die ganze Mediathek, ergänzend — bis Samstag | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_de.html |
-| w3 | EN | Only until Saturday: three months free | The whole media library, alongside your reading — until Saturday | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_en.html |
+| w3 | DE | Nur noch bis Samstag: drei Monate gratis | Bis Samstag: sehen, wie Menschen laut denken | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_de.html |
+| w3 | EN | Only until Saturday: three months free | Until Saturday: watch people think out loud | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_en.html |
 
 ### S26 · NoAbo (beide Angebote; jede Mail führt mit einem Button zur Übersicht)
 

--- a/services/mailing-sommer2026/heroes.json
+++ b/services/mailing-sommer2026/heroes.json
@@ -221,16 +221,16 @@
         "de": {
           "betreff": "Denken, das über die Woche hinausreicht — 3 Monate gratis",
           "botschaft": "Lesen, das in Ihnen weiterarbeitet.",
-          "text": "Ergänzend zu dem, was Sie auf goetheanum.tv sehen, denkt die Wochenschrift weiter — schwarz auf weiss, jede Woche neu: Aufsätze und Zeitsymptome zu Themen wie «Bäume» oder «Biografiearbeit», dazu das ganze Archiv seit 2023, das mit Ihrem Abo offen bleibt. Nicht was die Autoren wissen, sondern wie sie suchen.",
+          "text": "Ergänzend zu dem, was Sie auf goetheanum.tv sehen, denkt die Wochenschrift weiter — schwarz auf weiss, jede Woche neu: «Den Frieden herbeidenken», «Und wenn das Leben aus den Sternen käme?», «Biografiearbeit als Weg zum Ich». Dazu das ganze Archiv seit 2023, das mit Ihrem Abo offen bleibt. Nicht was die Autoren wissen, sondern wie sie suchen.",
           "alt": "Drei Monate im Freien lesen — gratis",
-          "preheader": "Drei Monate kostenlos mitlesen — wo der Sommer Sie hinträgt. Bis 8. August."
+          "preheader": "«Und wenn das Leben aus den Sternen käme?» und das ganze Archiv — jede Woche neu. Bis 8. August."
         },
         "en": {
           "betreff": "Thinking that reaches beyond the week — 3 months free",
           "botschaft": "Reading that keeps working in you.",
-          "text": "Alongside what you watch on goetheanum.tv, the weekly thinks on — in black and white, new each week: essays and reflections on the times, on themes like «Trees» or «Biography work», plus the whole archive since 2023, which stays open with your subscription. Not what the authors know, but how they search.",
+          "text": "Alongside what you watch on goetheanum.tv, the weekly thinks on — in black and white, new each week: «Envisioning peace», «What if life came from the stars?», «Biography work as a path to the self». Plus the whole archive since 2023, which stays open with your subscription. Not what the authors know, but how they search.",
           "alt": "Read in the open air — three months free",
-          "preheader": "Three months free to read — wherever summer takes you. Until 8 August."
+          "preheader": "«What if life came from the stars?» and the whole archive — new each week. Until 8 August."
         }
       },
       "w2": {
@@ -271,16 +271,16 @@
         "de": {
           "betreff": "Sehen, wie Menschen laut denken — 3 Monate gratis",
           "botschaft": "So nah am Goetheanum, wo immer Sie sind.",
-          "text": "Ergänzend zu den Artikeln, die Sie jede Woche lesen, steht Ihnen die ganze Mediathek offen — über 800 Beiträge, wöchentlich neu: ein Vortrag über Burnout, die Reihe «Greening the Desert» über das Ergrünen der Wüste, Gespräche über Frieden und Medizin. Vorträge, Reportagen und Aufführungen, die Sie ganz nah ans Leben am Goetheanum bringen — selbst aus grosser Entfernung.",
+          "text": "Ergänzend zu den Artikeln, die Sie jede Woche lesen, steht Ihnen die ganze Mediathek offen — über 800 Beiträge, wöchentlich neu: «Dieser Krieg muss enden. Jetzt.», «Kann man Glück lernen?», dazu die Reihe, in der die Sahara ergrünt. Vorträge, Reportagen und Aufführungen, die Sie ganz nah ans Leben am Goetheanum bringen — selbst aus grosser Entfernung.",
           "alt": "Die ganze Mediathek, ergänzend zu Ihrem Lesen — 3 Monate gratis",
-          "preheader": "Von Burnout bis «Greening the Desert» — über 800 Beiträge, nah am Goetheanum, wohin der Sommer Sie trägt."
+          "preheader": "«Kann man Glück lernen?» und über 800 weitere Beiträge — nah am Goetheanum, wohin der Sommer Sie trägt."
         },
         "en": {
           "betreff": "Watch people think out loud — 3 months free",
           "botschaft": "Close to the Goetheanum, wherever you are.",
-          "text": "Alongside the articles you read each week, the whole media library is open to you — over 800 pieces, new every week: a lecture on burnout, the series «Greening the Desert» on making the desert green again, conversations on peace and medicine. Lectures, reportage and performances that bring you close to life at the Goetheanum — even from a great distance.",
+          "text": "Alongside the articles you read each week, the whole media library is open to you — over 800 pieces, new every week: «This war must end. Now.», «Can we learn to be happy?», and the series «Greening the Desert», in which the Sahara turns green. Lectures, reportage and performances that bring you close to life at the Goetheanum — even from a great distance.",
           "alt": "The whole media library, alongside your reading — 3 months free",
-          "preheader": "From burnout to «Greening the Desert» — over 800 pieces, close to the Goetheanum, wherever summer takes you."
+          "preheader": "«Can we learn to be happy?» and over 800 more — close to the Goetheanum, wherever summer takes you."
         }
       },
       "w2": {

--- a/services/mailing-sommer2026/heroes.json
+++ b/services/mailing-sommer2026/heroes.json
@@ -219,16 +219,16 @@
     "lesen": {
       "w1": {
         "de": {
-          "betreff": "Was Sie sehen, jetzt auch lesen — 3 Monate gratis",
-          "botschaft": "Jede Woche ein Stück weiter sehen.",
-          "text": "Was Sie auf goetheanum.tv sehen, lesen Sie in der Wochenschrift weiter: Woche für Woche schreiben dort Menschen, die einer Frage ihr Leben gewidmet haben — nicht was sie wissen, sondern wie sie suchen. Wer mitliest, kommt mit anderen Augen in die eigene Woche zurück.",
+          "betreff": "Was der Bildschirm anstösst, weiterlesen — 3 Monate gratis",
+          "botschaft": "Was der Bildschirm anstösst, denkt die Seite weiter.",
+          "text": "Ergänzend zu dem, was Sie auf goetheanum.tv sehen, denkt die Wochenschrift weiter — schwarz auf weiss, jede Woche neu: Aufsätze und Zeitsymptome zu Themen wie «Bäume» oder «Biografiearbeit», dazu das ganze Archiv seit 2023, das mit Ihrem Abo offen bleibt. Nicht was die Autoren wissen, sondern wie sie suchen.",
           "alt": "Drei Monate im Freien lesen — gratis",
           "preheader": "Drei Monate kostenlos mitlesen — wo der Sommer Sie hinträgt. Bis 8. August."
         },
         "en": {
-          "betreff": "What you watch, now also read — 3 months free",
-          "botschaft": "See a little further every week.",
-          "text": "What you watch on goetheanum.tv you can read on in the weekly: week after week, people who have given their lives to a question write down not what they know but how they search. Read along, and you return to your own week with different eyes.",
+          "betreff": "What the screen sparks, read on — 3 months free",
+          "botschaft": "What the screen sparks, the page thinks through.",
+          "text": "Alongside what you watch on goetheanum.tv, the weekly thinks on — in black and white, new each week: essays and reflections on the times, on themes like «Trees» or «Biography work», plus the whole archive since 2023, which stays open with your subscription. Not what the authors know, but how they search.",
           "alt": "Read in the open air — three months free",
           "preheader": "Three months free to read — wherever summer takes you. Until 8 August."
         }
@@ -254,14 +254,14 @@
           "betreff": "Bis Samstag: drei Monate mitlesen, kostenlos",
           "botschaft": "Bis Samstag bleibt die Tür offen.",
           "text": "Diese Woche endet die Sommer-Aktion. Bis Samstag lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — und kommen mit anderen Augen in Ihre Woche zurück. Gefällt es nicht, kündigen Sie mit einem Klick.",
-          "alt": "Was Sie sehen, jetzt auch lesen — bis Samstag",
+          "alt": "Weiterlesen, was der Bildschirm anstiess — bis Samstag",
           "preheader": "Drei Gratis-Monate zum Mitlesen — nur noch bis Samstag, 8. August."
         },
         "en": {
           "betreff": "Until Saturday: three months of reading, free",
           "botschaft": "The door stays open until Saturday.",
           "text": "This week the summer offer ends. Until Saturday, read the weekly free for three months with your subscription — and return to your own week with different eyes. If it’s not for you, cancel in one click.",
-          "alt": "What you watch, now also read — until Saturday",
+          "alt": "Read on from what the screen sparked — until Saturday",
           "preheader": "Three free months to read along — only until Saturday, 8 August."
         }
       }
@@ -269,18 +269,20 @@
     "sehen": {
       "w1": {
         "de": {
-          "betreff": "Was Sie lesen, jetzt auch sehen — 3 Monate gratis",
-          "botschaft": "Zusehen, wie jemand denkt.",
-          "text": "Was Sie jede Woche lesen, können Sie jetzt auch sehen und hören: Auf goetheanum.tv denken Menschen laut, in über 800 Vorträgen und Gesprächen. Sie hören das Zögern und das Finden mit — alles, was auf der gedruckten Seite unsichtbar bleibt.",
-          "alt": "Dem Gelesenen zuhören — 3 Monate gratis",
-          "preheader": "Über 800 Vorträge und Gespräche, die Ihrem Lesen Tiefe geben — wohin der Sommer Sie trägt."
+          "betreff": "So nah am Goetheanum, selbst aus der Ferne — 3 Monate gratis",
+          "ab": "Über 800 Beiträge aus dem Goetheanum — 3 Monate gratis",
+          "botschaft": "So nah am Goetheanum, wo immer Sie sind.",
+          "text": "Ergänzend zu den Artikeln, die Sie jede Woche lesen, steht Ihnen die ganze Mediathek offen — über 800 Beiträge, wöchentlich neu: ein Vortrag über Burnout, die Reihe «Greening the Desert» über das Ergrünen der Wüste, Gespräche über Frieden und Medizin. Vorträge, Reportagen und Aufführungen, die Sie ganz nah ans Leben am Goetheanum bringen — selbst aus grosser Entfernung.",
+          "alt": "Die ganze Mediathek, ergänzend zu Ihrem Lesen — 3 Monate gratis",
+          "preheader": "Von Burnout bis «Greening the Desert» — über 800 Beiträge, nah am Goetheanum, wohin der Sommer Sie trägt."
         },
         "en": {
-          "betreff": "What you read, now also watch — 3 months free",
-          "botschaft": "Watch someone think.",
-          "text": "What you read each week you can now watch and hear: on goetheanum.tv, people think out loud, in over 800 lectures and conversations. You hear the hesitation and the finding — everything the printed page keeps invisible.",
-          "alt": "Listen to what you read — 3 months free",
-          "preheader": "Over 800 lectures and conversations that deepen your reading — wherever summer takes you."
+          "betreff": "So close to the Goetheanum, even from afar — 3 months free",
+          "ab": "Over 800 films from the Goetheanum — 3 months free",
+          "botschaft": "Close to the Goetheanum, wherever you are.",
+          "text": "Alongside the articles you read each week, the whole media library is open to you — over 800 pieces, new every week: a lecture on burnout, the series «Greening the Desert» on making the desert green again, conversations on peace and medicine. Lectures, reportage and performances that bring you close to life at the Goetheanum — even from a great distance.",
+          "alt": "The whole media library, alongside your reading — 3 months free",
+          "preheader": "From burnout to «Greening the Desert» — over 800 pieces, close to the Goetheanum, wherever summer takes you."
         }
       },
       "w2": {
@@ -304,14 +306,14 @@
           "betreff": "Nur noch bis Samstag: drei Monate gratis",
           "botschaft": "Bis Samstag ist Ihr Platz frei.",
           "text": "Noch ein paar Sommertage: goetheanum.tv, drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es in Ihnen nachklingt.",
-          "alt": "Was Sie lesen, jetzt auch sehen — bis Samstag",
+          "alt": "Die ganze Mediathek, ergänzend — bis Samstag",
           "preheader": "Eine Minute für drei Monate goetheanum.tv: gratis zu Ihrem Abo — bis Samstag, 8. August."
         },
         "en": {
           "betreff": "Only until Saturday: three months free",
           "botschaft": "Your seat stays free until Saturday.",
           "text": "A few summer days left: goetheanum.tv, three months free with your subscription — stay only if it stays with you.",
-          "alt": "What you read, now also watch — until Saturday",
+          "alt": "The whole media library, alongside your reading — until Saturday",
           "preheader": "One minute for three months of goetheanum.tv — free with your subscription, until Saturday."
         }
       }

--- a/services/mailing-sommer2026/heroes.json
+++ b/services/mailing-sommer2026/heroes.json
@@ -219,15 +219,15 @@
     "lesen": {
       "w1": {
         "de": {
-          "betreff": "Was der Bildschirm anstösst, weiterlesen — 3 Monate gratis",
-          "botschaft": "Was der Bildschirm anstösst, denkt die Seite weiter.",
+          "betreff": "Denken, das über die Woche hinausreicht — 3 Monate gratis",
+          "botschaft": "Lesen, das in Ihnen weiterarbeitet.",
           "text": "Ergänzend zu dem, was Sie auf goetheanum.tv sehen, denkt die Wochenschrift weiter — schwarz auf weiss, jede Woche neu: Aufsätze und Zeitsymptome zu Themen wie «Bäume» oder «Biografiearbeit», dazu das ganze Archiv seit 2023, das mit Ihrem Abo offen bleibt. Nicht was die Autoren wissen, sondern wie sie suchen.",
           "alt": "Drei Monate im Freien lesen — gratis",
           "preheader": "Drei Monate kostenlos mitlesen — wo der Sommer Sie hinträgt. Bis 8. August."
         },
         "en": {
-          "betreff": "What the screen sparks, read on — 3 months free",
-          "botschaft": "What the screen sparks, the page thinks through.",
+          "betreff": "Thinking that reaches beyond the week — 3 months free",
+          "botschaft": "Reading that keeps working in you.",
           "text": "Alongside what you watch on goetheanum.tv, the weekly thinks on — in black and white, new each week: essays and reflections on the times, on themes like «Trees» or «Biography work», plus the whole archive since 2023, which stays open with your subscription. Not what the authors know, but how they search.",
           "alt": "Read in the open air — three months free",
           "preheader": "Three months free to read — wherever summer takes you. Until 8 August."
@@ -254,14 +254,14 @@
           "betreff": "Bis Samstag: drei Monate mitlesen, kostenlos",
           "botschaft": "Bis Samstag bleibt die Tür offen.",
           "text": "Diese Woche endet die Sommer-Aktion. Bis Samstag lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — und kommen mit anderen Augen in Ihre Woche zurück. Gefällt es nicht, kündigen Sie mit einem Klick.",
-          "alt": "Weiterlesen, was der Bildschirm anstiess — bis Samstag",
+          "alt": "Bis Samstag: Denken, das über die Woche hinausreicht",
           "preheader": "Drei Gratis-Monate zum Mitlesen — nur noch bis Samstag, 8. August."
         },
         "en": {
           "betreff": "Until Saturday: three months of reading, free",
           "botschaft": "The door stays open until Saturday.",
           "text": "This week the summer offer ends. Until Saturday, read the weekly free for three months with your subscription — and return to your own week with different eyes. If it’s not for you, cancel in one click.",
-          "alt": "Read on from what the screen sparked — until Saturday",
+          "alt": "Until Saturday: thinking that reaches beyond the week",
           "preheader": "Three free months to read along — only until Saturday, 8 August."
         }
       }
@@ -269,16 +269,14 @@
     "sehen": {
       "w1": {
         "de": {
-          "betreff": "So nah am Goetheanum, selbst aus der Ferne — 3 Monate gratis",
-          "ab": "Über 800 Beiträge aus dem Goetheanum — 3 Monate gratis",
+          "betreff": "Sehen, wie Menschen laut denken — 3 Monate gratis",
           "botschaft": "So nah am Goetheanum, wo immer Sie sind.",
           "text": "Ergänzend zu den Artikeln, die Sie jede Woche lesen, steht Ihnen die ganze Mediathek offen — über 800 Beiträge, wöchentlich neu: ein Vortrag über Burnout, die Reihe «Greening the Desert» über das Ergrünen der Wüste, Gespräche über Frieden und Medizin. Vorträge, Reportagen und Aufführungen, die Sie ganz nah ans Leben am Goetheanum bringen — selbst aus grosser Entfernung.",
           "alt": "Die ganze Mediathek, ergänzend zu Ihrem Lesen — 3 Monate gratis",
           "preheader": "Von Burnout bis «Greening the Desert» — über 800 Beiträge, nah am Goetheanum, wohin der Sommer Sie trägt."
         },
         "en": {
-          "betreff": "So close to the Goetheanum, even from afar — 3 months free",
-          "ab": "Over 800 films from the Goetheanum — 3 months free",
+          "betreff": "Watch people think out loud — 3 months free",
           "botschaft": "Close to the Goetheanum, wherever you are.",
           "text": "Alongside the articles you read each week, the whole media library is open to you — over 800 pieces, new every week: a lecture on burnout, the series «Greening the Desert» on making the desert green again, conversations on peace and medicine. Lectures, reportage and performances that bring you close to life at the Goetheanum — even from a great distance.",
           "alt": "The whole media library, alongside your reading — 3 months free",
@@ -306,14 +304,14 @@
           "betreff": "Nur noch bis Samstag: drei Monate gratis",
           "botschaft": "Bis Samstag ist Ihr Platz frei.",
           "text": "Noch ein paar Sommertage: goetheanum.tv, drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es in Ihnen nachklingt.",
-          "alt": "Die ganze Mediathek, ergänzend — bis Samstag",
+          "alt": "Bis Samstag: sehen, wie Menschen laut denken",
           "preheader": "Eine Minute für drei Monate goetheanum.tv: gratis zu Ihrem Abo — bis Samstag, 8. August."
         },
         "en": {
           "betreff": "Only until Saturday: three months free",
           "botschaft": "Your seat stays free until Saturday.",
           "text": "A few summer days left: goetheanum.tv, three months free with your subscription — stay only if it stays with you.",
-          "alt": "The whole media library, alongside your reading — until Saturday",
+          "alt": "Until Saturday: watch people think out loud",
           "preheader": "One minute for three months of goetheanum.tv — free with your subscription, until Saturday."
         }
       }


### PR DESCRIPTION
## Was

Behebt die Kollegen-Kritik „dasselbe, nur als Video" an den Cross-sell-Mails und macht die Welle-1-Opener konkret.

**Positionierung:** Das jeweils andere Medium wird als **Ergänzung** gerahmt, nie als Ersatz. Die „gleich-in-Video / gleich-in-Text"-Parallele (Betreff, Botschaft, Text, Alt) ist raus.

**Konkretheit aus echtem Bestand** (recherchiert, mit Ph verifiziert):
- Sehen: die Reihe «Greening the Desert», ein Vortrag über Burnout, Themen Frieden/Medizin, über 800 Beiträge.
- Lesen: WS-Themen «Bäume»/«Biografiearbeit», **das ganze Archiv seit 2023 als eigener Wert**. Kein Zukunfts-Versprechen (Redaktion entscheidet wöchentlich) — Themen als „zuletzt/Beispiel".

**Betreffe aus dem inhaltlichen Versprechen** (kein Medien-Rückbezug, kein Reizwort im Betreff), entschieden nach einer **virtuellen A/B-Runde** (drei Empfänger-Archetypen bewerteten je fünf Kandidaten):
- Sehen: **„Sehen, wie Menschen laut denken — 3 Monate gratis"**
- Lesen: **„Denken, das über die Woche hinausreicht — 3 Monate gratis"**

Frist-Alt-Betreffe und Botschaften ebenfalls aufs Inhaltliche gedreht. EN parallel. Register/utm unberührt (kein A/B nötig, Betreff-Wahl ist einzeilig).

## Prüfung

Gebaut, alle 20 Mails ok, AC-Prompt-Tabelle frisch, typo-check/ds-lint 0 Fehler.

## Nach dem Merge

Betroffen sind **Sehen w1 + Lesen w1** (Betreff, Botschaft, Text, Preheader) und die **w3-Alt-Betreffe** beider Richtungen. In AC das HTML dieser Schritte frisch laden und die Betreffzeilen nachziehen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_