### PR TITLE
September-Mail aufs Mobilmass gekürzt; Anhang, Adresse und Redaktion konzipiert

### DIFF
--- a/docs/werkzeuge-mailplan.md
+++ b/docs/werkzeuge-mailplan.md
@@ -72,12 +72,14 @@ Wiedererkennbarkeit *ist* die halbe Wirkung:
    gemeinsame Identität: nicht als Schulung, sondern als kleine Erzählung.
    Über zehn Monate ergibt das eine CI-Schule, die nie wie eine wirkt.
 5. **Gruss + PS**: beide Namen, herzlich, kurz. Das PS ist die meistgelesene
-   Zeile jeder Mail — dort wohnen Vorfreude («im Oktober kommt …»), die Zahl
-   des Vormonats oder eine menschliche Note. Das PS nie verschenken.
+   Zeile jeder Mail — dort wohnt Vorfreude («im Oktober folgt …»), die Zahl
+   des Vormonats oder eine menschliche Note. Das PS nie verschenken — und
+   **nie länger als eine Zeile**: nur ein kurzes PS wird als Erstes gelesen.
 
-**Länge:** 120–180 Wörter Haupttext, eine Bildschirmhöhe, Lesezeit unter einer
-Minute. Wenn eine Mail länger wird, ist es zwei Mails — dann wartet die zweite
-Hälfte auf ihren eigenen Monat.
+**Länge:** Prüfmass ist der Mobilscreen — die ganze Mail (Betreff bis PS)
+ohne Scrollen. Das heisst in der Praxis: rund 100–120 Wörter Haupttext,
+Lesezeit unter einer Minute. Wenn eine Mail länger wird, ist es zwei Mails —
+dann wartet die zweite Hälfte auf ihren eigenen Monat.
 
 **Die Mail teasert, die Seite argumentiert.** Die vollständige Begründung
 (Empfehlungen, Merkblätter, Warum-Erklärungen) wohnt auf der Werkzeug-Seite —
@@ -144,7 +146,47 @@ Bild ist besser als ein dekoratives.
 - **Juni-Bilanz** speist die Priorisierung des nächsten Jahrgangs
   (Phase 3 des Fahrplans: wachsen entlang des Bedarfs).
 
-## 7. Muster: die September-Mail
+## 7. Anhang, Adresse, Redaktion
+
+### Der Anhang: ein sammelbares Merkblatt pro Monat
+Jede Mail trägt genau einen Anhang: **ein A4-Merkblatt (PDF)** zum Werkzeug
+des Monats — dieselbe Gestalt jeden Monat, nummeriert (*Blatt 1 von 10*),
+Fusszeile mit Adresse und QR (aus dem eigenen QR-Generator). Nach einem Jahr
+ergibt das eine kleine Hausmappe. Der Anhang hält das Versprechen der
+Büroklammer: Hier wartet wirklich ein Dokument, keine Werbung. Die
+Werkzeug-Seiten liefern die PDFs zum Teil schon (die elf Empfehlungen haben
+einen PDF-Knopf); was fehlt, wird je Monat ergänzt. Die Merkblätter bleiben
+zusätzlich auf der jeweiligen Werkzeug-Seite verlinkt.
+
+### Die Adresse in allen Köpfen: werkzeuge.goetheanum.ch
+- **Ein Name, ein Ort.** Kommuniziert wird immer nur die Wurzel
+  `werkzeuge.goetheanum.ch` — nie Deep-Links, nie «hier klicken». Die Adresse
+  ist sprechbar und erklärt sich selbst; das ist ihr Vorteil, also zeigen wir
+  sie nackt.
+- **Immer derselbe Platz.** Schritt 1 jeder Mail beginnt mit der Adresse;
+  die Fusszeile jedes Merkblatts trägt sie; gedruckt begleitet sie ein QR.
+- **Mündlich verwenden.** In Sitzungen und Antworten heisst es konsequent
+  «steht auf werkzeuge punkt goetheanum punkt ch» — eine Adresse, die man
+  aussprechen kann, wird erinnert.
+
+### Die Redaktion: gegenlesen im Werkzeug, versenden als Mensch
+Für die Texte der kommenden Monate entsteht eine **Redaktionsseite** nach dem
+bewährten Muster der Kampagnen-Mail-Editoren (`apps/mail-editor/`,
+`apps/grenzgaenger-mails/`): alle Monats-Mails aus **einer Quelle**
+(`services/werkzeugpost/mails.json`), je Monat eine Karte mit Status
+(Entwurf · bereit · versandt), jedes Feld kommentierbar, Änderungen laufen
+als Commits — damit ist jede Fassung minimal nachvollziehbar (Verlauf =
+Git-History, auf der Seite verlinkt).
+
+**Versand bewusst nicht automatisiert:** Die Mail predigt ‹Auftritt des
+Hauses, Stimme eines Menschen› — dann muss sie auch aus dem persönlichen
+Postfach von Philipp oder Stefan kommen, mit echter Signatur, antwortbar.
+Die Redaktionsseite bietet darum einen **Übernehmen-Knopf** (fertiger Text
+in die Zwischenablage, wie beim Signatur-Generator), versandt wird im
+eigenen Mailprogramm. Ein automatisierter Versand (Worker/ActiveCampaign,
+wie in der Sommer-Aktion) bleibt möglich, wenn die Serie ihn später braucht.
+
+## 8. Muster: die September-Mail
 
 *Die Mail teasert, die Seite argumentiert: Die Argumente (Freiheit im Detail,
 Vertrauen durch Erkennbarkeit, elf Empfehlungen, Merkblatt, Schweiz-Fussnote)
@@ -155,35 +197,31 @@ auf den Rest neugierig.*
 >
 > Liebe Mitarbeitende
 >
-> Wir möchten in einer Reihe monatlicher Mails Werkzeuge vorstellen, die
-> unsere Arbeit erleichtern und unseren gemeinsamen Auftritt stärken. Den
-> Anfang macht das kleinste mit der grössten Wirkung: die E-Mail-Signatur.
+> Einmal im Monat stellen wir euch ein Werkzeug vor, das die Arbeit
+> erleichtert und unseren gemeinsamen Auftritt stärkt. Den Anfang macht das
+> kleinste mit der grössten Wirkung: die E-Mail-Signatur.
 >
 > Jede Mail aus dem Haus ist ein kleiner Auftritt des Goetheanum — und
 > zugleich die Stimme eines Menschen. Eine Signatur, die beides zeigt, ist in
 > drei Minuten eingerichtet:
 >
-> 1. Signatur-Werkzeug öffnen: \[Link]
+> 1. Signatur-Werkzeug öffnen: werkzeuge.goetheanum.ch
 > 2. Name, Aufgabe, Sektion eintragen — die Vorschau zeigt sofort das Ergebnis
 > 3. Kopieren, in Outlook/Apple Mail einsetzen, fertig.
 >
 > Zwei Zeilen sind gesetzt, alles Weitere wählst du selbst — die Signatur ist
-> deine, keine Uniform.
+> deine, keine Uniform. Auf der Seite warten dazu elf entspannte Empfehlungen
+> für E-Mails, die gelesen werden.
 >
-> Auf der Seite wartet mehr: warum die Signatur ohne Bild auskommt, was das
-> PS kann (der meistgelesene Platz jeder Mail) — und elf entspannte
-> Empfehlungen für E-Mails, die gelesen werden. Unsere liebste: Die kürzeste
-> Mail ist oft die freundlichste.
->
-> Wenn etwas klemmt oder fehlt: einfach antworten, wir lesen alles.
+> Wenn etwas klemmt: einfach antworten, wir lesen alles.
 >
 > Herzlich
 > Philipp Tok & Stefan Hasler
 >
-> PS: Im Oktober bringen wir die Hausschrift auf euren Rechner. Bis dahin
-> zählen wir mit — wie viele Signaturen schafft der September?
+> PS: Im Oktober folgt die Hausschrift für euren Rechner.
 
 ---
 
-*Nächster Schritt: Serienname und Anrede (Sie/ihr) mit dem Auftraggeber
-festlegen, Verteiler klären, September-Mail aus dem Muster finalisieren.*
+*Nächste Schritte: Serienname und Anrede (Sie/ihr) festlegen, Verteiler
+klären, Redaktionsseite (`apps/werkzeugpost/` + `services/werkzeugpost/`)
+bauen, Merkblatt-Reihe gestalten, September-Mail finalisieren.*


### PR DESCRIPTION
## Was dieser PR ändert

Fünfte Runde am Werkzeuge-Mailplan (`docs/werkzeuge-mailplan.md`), nach Rückmeldung des Auftraggebers:

**Muster-Mail gekürzt** (Ziel: ganze Mail auf dem Mobilscreen ohne Scrollen, ~100 Wörter):
- Zitat-Schluss «Unsere liebste: …» entfällt; der Empfehlungs-Hinweis ist in den Freiheits-Absatz gefaltet.
- PS auf eine Zeile («Im Oktober folgt die Hausschrift für euren Rechner»); der Zähler entfällt im September.
- Schritt 1 nennt die nackte Adresse `werkzeuge.goetheanum.ch`.
- Regeln nachgezogen: PS nie länger als eine Zeile; Prüfmass der Länge ist der Mobilscreen.

**Neuer Abschnitt 7 «Anhang, Adresse, Redaktion»:**
- Ein sammelbares A4-Merkblatt (PDF) pro Mail, nummeriert, gleiche Gestalt, Fusszeile mit Adresse + QR — nach einem Jahr eine kleine Hausmappe.
- Verankerung der Adresse: nur die Wurzel kommunizieren, immer derselbe Platz (Schritt 1, Merkblatt-Fusszeile), sprechbar verwenden.
- Redaktionsseite nach dem Muster von `apps/mail-editor/`: alle Monats-Mails aus einer Quelle (`services/werkzeugpost/mails.json`), kommentierbar, Verlauf = Git-History; Versand bewusst nicht automatisiert (Übernehmen-Knopf, versandt wird aus dem persönlichen Postfach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPT5AKuUgjThxUNighRLBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPT5AKuUgjThxUNighRLBk)_