### PR TITLE
Werkzeugpost: Liste + Vollbild-Editor statt Box-Wand, robustes Übernehmen

### DIFF
--- a/apps/werkzeugpost/index.html
+++ b/apps/werkzeugpost/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="robots" content="noindex" />
 <title>Werkzeugpost — Redaktion · Goetheanum</title>
-<meta name="description" content="Redaktionstisch der monatlichen Werkzeug-Mail: Texte vorbereiten, umsortieren, gegenlesen und übernehmen." />
+<meta name="description" content="Redaktionstisch der monatlichen Werkzeug-Mail: Texte vorbereiten, ordnen, gegenlesen und übernehmen." />
 <link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
 
 <link rel="stylesheet" href="../../design-system/tokens.css" />
@@ -13,61 +13,95 @@
 <link rel="stylesheet" href="../../design-system/nav.css" />
 
 <style>
-  .hero{padding-block:clamp(32px,6vw,60px) var(--s6)}
-  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(28px,4.6vw,46px);line-height:1.06;letter-spacing:-.01em;max-width:20ch}
-  .hero .lede{margin-top:var(--s5);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:60ch}
+  .hero{padding-block:clamp(28px,5vw,52px) var(--s5)}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(26px,4.4vw,44px);line-height:1.06;letter-spacing:-.01em;max-width:20ch}
+  .hero .lede{margin-top:var(--s4);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:60ch}
 
   .toolbar{display:flex;gap:var(--s2);flex-wrap:wrap;align-items:center;margin-block:var(--s5)}
   .toolbar .spacer{flex:1 1 auto}
 
-  /* Monatskarten */
-  .ausgabe{margin-bottom:var(--s5)}
-  .ausgabe-kopf{display:flex;gap:var(--s3);align-items:baseline;flex-wrap:wrap}
-  .ausgabe-kopf h3{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(19px,2.4vw,24px);margin:0}
-  .ausgabe-kopf .werk{color:var(--muted);font-size:var(--t-small)}
-  .ordnung{display:flex;gap:var(--s1);margin-left:auto}
-  .ordnung .btn{min-width:var(--tap);padding-inline:var(--s2)}
-
-  .pille{display:inline-flex;align-items:center;gap:.4em;padding:.2em .7em;border-radius:999px;font-family:var(--font-text);font-size:var(--t-small);font-weight:600;line-height:1.4}
-  .pille[data-status="entwurf"]{background:var(--field-bg);color:var(--muted)}
+  .pille{display:inline-flex;align-items:center;padding:.15em .6em;border-radius:999px;font-family:var(--font-text);font-size:var(--t-micro);font-weight:600;line-height:1.4;white-space:nowrap}
+  .pille[data-status="entwurf"]{background:var(--field-bg);color:var(--muted);box-shadow:inset 0 0 0 1px var(--line)}
   .pille[data-status="in_redaktion"]{background:var(--gold-deep);color:var(--on-accent)}
   .pille[data-status="bereit"]{background:var(--ok);color:var(--on-accent)}
   .pille[data-status="versandt"]{background:var(--blue-solid);color:var(--on-accent)}
 
-  .raster{display:grid;gap:var(--s5);margin-top:var(--s4)}
-  @media(min-width:900px){.raster{grid-template-columns:1fr minmax(300px,340px)}}
+  /* ---------- Liste ---------- */
+  .liste{display:grid;gap:var(--s2)}
+  .zeile{display:flex;align-items:stretch;gap:var(--s2);background:var(--soft,var(--field-bg));border-radius:14px;overflow:hidden}
+  .zeile-waehlen{flex:1;display:flex;flex-direction:column;gap:.25em;align-items:flex-start;text-align:left;
+    background:none;border:0;padding:var(--s4);cursor:pointer;min-height:var(--tap);font:inherit;color:var(--ink)}
+  .zeile-waehlen:hover{background:var(--field-bg)}
+  .zeile-waehlen .z-top{display:flex;gap:var(--s2);align-items:baseline;flex-wrap:wrap}
+  .zeile-waehlen b{font-family:var(--font);font-weight:var(--w-klar);font-size:clamp(17px,2.2vw,20px)}
+  .zeile-waehlen small{color:var(--muted);font-size:var(--t-small)}
+  .zeile-waehlen .z-anlass{color:var(--muted);font-size:var(--t-small);line-height:1.4}
+  .zeile-ordnung{display:flex;flex-direction:column;justify-content:center;gap:2px;padding-right:var(--s2)}
+  .zeile-ordnung .btn{min-width:var(--tap);min-height:34px;padding:0}
 
-  /* Auf dem Handy IST der Bildschirm der Rahmen: Mockup weg, das Textfeld
-     wird selbst zur vollflächigen, direkt bearbeitbaren Anzeige der Mail. */
-  .vorschau-spalte{display:none}
-  @media(min-width:900px){.vorschau-spalte{display:block}}
-  .mailfeld{font-size:16px;line-height:1.5;min-height:60vh}
-  @media(min-width:900px){.mailfeld{min-height:0}}
+  /* ---------- Editor (Vollbild mobil, Detail-Spalte am grossen Schirm) ---------- */
+  .werkstatt{position:relative}
+  @media(min-width:900px){
+    .werkstatt{display:grid;grid-template-columns:340px 1fr;gap:var(--s5);align-items:start}
+  }
+  .editor-spalte{
+    position:fixed;inset:0;z-index:60;background:var(--paper);
+    display:flex;flex-direction:column;
+    transform:translateX(100%);transition:transform .22s ease;
+    visibility:hidden;
+  }
+  body.editor-offen .editor-spalte{transform:none;visibility:visible}
+  @media(min-width:900px){
+    .editor-spalte{position:sticky;top:var(--s4);transform:none;visibility:visible;
+      z-index:1;border:1px solid var(--line);border-radius:16px;max-height:calc(100vh - var(--s8));overflow:hidden}
+  }
 
-  .feld-gruppe{display:grid;gap:var(--s3)}
-  .zeichen{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);text-align:right}
+  .editor-kopf{display:flex;align-items:center;gap:var(--s3);padding:var(--s3) var(--s4);
+    border-bottom:1px solid var(--line);flex:0 0 auto}
+  .editor-kopf strong{flex:1;font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(18px,2.4vw,22px);min-width:0}
+  .rund{width:var(--tap);height:var(--tap);border-radius:999px;border:0;background:var(--field-bg);
+    color:var(--ink);font-size:20px;line-height:1;cursor:pointer;display:grid;place-items:center;flex:0 0 auto}
+  .rund:hover{background:var(--soft,var(--field-bg));box-shadow:inset 0 0 0 1px var(--line)}
+
+  .editor-leiste{display:flex;gap:var(--s3);align-items:center;flex-wrap:wrap;
+    padding:var(--s2) var(--s4);border-bottom:1px solid var(--line);flex:0 0 auto}
+  .editor-leiste .anlass{color:var(--muted);font-size:var(--t-small);flex:1;min-width:12ch}
+
+  .editor-koerper{flex:1;overflow:auto;display:flex;flex-direction:column;padding:var(--s4);gap:var(--s3)}
+  .betreff-zeile{display:flex;align-items:baseline;gap:var(--s2);border-bottom:1px solid var(--line);padding-bottom:var(--s3)}
+  .betreff-zeile .lab{color:var(--muted);font-size:var(--t-small);flex:0 0 auto}
+  .betreff-zeile input{flex:1;border:0;background:none;font-family:var(--font);font-weight:var(--w-deutlich);
+    font-size:clamp(20px,3vw,26px);line-height:1.2;padding:0;color:var(--ink)}
+  .betreff-zeile input:focus{outline:none}
+  .mailfeld{flex:1;border:0;background:none;resize:none;padding:0;
+    font-family:var(--font-text);font-size:16px;line-height:1.55;color:var(--ink);min-height:40vh}
+  .mailfeld:focus{outline:none}
+
+  .zeichen{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted)}
   .zeichen.warn{color:var(--blue);font-weight:600}
 
-  /* Mobil-Vorschau: echtes Telefon-Mockup */
-  .telefon{margin:0 auto;max-width:300px;background:#111;border-radius:28px;padding:10px} /* # ds-ok: Gerätefarbe des Telefon-Mockups, keine Themefläche */
-  .telefon-schirm{background:var(--paper);border-radius:20px;padding:var(--s4);min-height:420px;overflow:hidden;font-family:var(--font-text)}
-  .tv-betreff{font-weight:700;font-size:15px;line-height:1.35;margin-bottom:var(--s2);padding-bottom:var(--s2);border-bottom:1px solid var(--line)}
-  .tv-body{font-size:14px;line-height:1.5;white-space:pre-wrap}
-  .tv-hint{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);text-align:center;margin-top:var(--s2)}
-  .tv-hint.warn{color:var(--blue);font-weight:600}
+  .editor-fuss{flex:0 0 auto;display:flex;gap:var(--s2);flex-wrap:wrap;align-items:center;
+    padding:var(--s3) var(--s4);border-top:1px solid var(--line)}
+  .editor-fuss .spacer{flex:1}
+
+  .editor-leer{display:none}
+  @media(min-width:900px){
+    .editor-leer{display:grid;place-items:center;min-height:40vh;color:var(--muted);
+      border:1px dashed var(--line);border-radius:16px;padding:var(--s6);text-align:center}
+    body.editor-offen .editor-leer{display:none}
+    .editor-spalte:not(.hat-inhalt){display:none}
+  }
 
   /* Tisch */
-  .tisch{margin-top:var(--s4)}
-  .tisch summary{cursor:pointer;font-family:var(--font);font-weight:var(--w-klar)}
+  .tisch summary{cursor:pointer;font-family:var(--font);font-weight:var(--w-klar);padding:var(--s2) 0}
   .stuhl{display:flex;gap:var(--s3);padding:var(--s3) 0;border-top:1px solid var(--line)}
-  .stuhl:first-of-type{border-top:0}
   .stuhl .wer{flex:0 0 8.5em}
   .stuhl .wer b{font-family:var(--font);font-weight:var(--w-klar);display:block}
   .stuhl .wer small{color:var(--muted);font-size:var(--t-micro)}
   .stuhl .kern{flex:1;font-family:var(--font-text);font-size:var(--t-small);line-height:1.5}
-  .kein-tisch{color:var(--muted);font-size:var(--t-small);font-style:normal}
+  .kein-tisch{color:var(--muted);font-size:var(--t-small)}
 
-  .hinweis{background:var(--field-bg);border-radius:12px;padding:var(--s4);font-size:var(--t-small);line-height:1.55;margin-top:var(--s4)}
+  .hinweis{background:var(--field-bg);border-radius:12px;padding:var(--s4);font-size:var(--t-small);line-height:1.55;margin-top:var(--s5)}
   .hinweis code{font-family:var(--font-text);background:var(--paper);padding:.05em .35em;border-radius:6px}
 </style>
 </head>
@@ -80,10 +114,9 @@
   <section class="hero">
     <span class="kicker">Werkzeugpost · Redaktion</span>
     <h1>Der Redaktionstisch</h1>
-    <p class="lede">Hier stehen die Mails der kommenden Monate bereit — für Philipp und Stefan
-      zum Vorbereiten, Umsortieren und Gegenlesen. Eine Quelle, ein Verlauf: Änderungen
-      werden als geänderte <code>mails.json</code> exportiert und committet — so bleibt jede
-      Fassung nachvollziehbar. Versandt wird aus dem eigenen Postfach.</p>
+    <p class="lede">Die Mails der kommenden Monate — zum Ordnen und Anwählen in der Liste,
+      zum Schreiben im Vollbild. Eine Quelle, ein Verlauf: <em>Exportieren</em> schreibt die
+      <code>mails.json</code>, die ihr committet. Versandt wird aus dem eigenen Postfach.</p>
   </section>
 
   <div class="toolbar">
@@ -94,17 +127,22 @@
     <button class="btn primary" id="export" type="button">mails.json exportieren</button>
   </div>
 
-  <div id="liste" aria-live="polite"></div>
+  <div class="werkstatt">
+    <div class="liste-spalte">
+      <div class="liste" id="liste" aria-live="polite"></div>
+    </div>
+    <div class="editor-spalte" id="editor-spalte" role="dialog" aria-label="Mail bearbeiten">
+      <div class="editor-leer" id="editor-leer">Wähle links eine Ausgabe, um sie zu schreiben.</div>
+      <div id="editor" hidden></div>
+    </div>
+  </div>
 
   <div class="hinweis">
-    <strong>So arbeitet der Tisch.</strong> Die sieben Personas lesen jede Mail unabhängig
-    gegen (Sekretariat, Technik, Wissenschaft, Betrieb, Texterin, Leitung, Marken-Gast) —
-    eine neue Runde stösst der Redakteur an, die Voten erscheinen dann je Ausgabe im
-    Feld <code>tisch</code>. Bearbeiten und Umsortieren geschieht hier im Browser
-    (Zwischenstand liegt lokal); erst <em>Exportieren</em> schreibt die neue
-    <code>mails.json</code>, die ihr committet. <strong>Reihenfolge</strong> tauscht ihr mit
-    den Pfeilen, <strong>Themen zusammenlegen</strong> fasst zwei Ausgaben zu einer, neue
-    kommen mit <em>+ Ausgabe</em> hinzu.
+    <strong>So arbeitet der Tisch.</strong> Sieben Personas lesen jede Mail unabhängig gegen
+    (Sekretariat, Technik, Wissenschaft, Betrieb, Texterin, Leitung, Marken-Gast) — eine neue
+    Runde stösst der Redakteur an, die Voten erscheinen je Ausgabe im Editor. Bearbeiten und
+    Ordnen geschieht hier im Browser (Zwischenstand lokal); erst <em>Exportieren</em> schreibt
+    die neue <code>mails.json</code>, die ihr committet.
   </div>
 
 </main>
@@ -119,225 +157,198 @@
 <script>
 const ROOT = "../../services/werkzeugpost/";
 const LS = "werkzeugpost-entwurf-v1";
-let daten = null, personas = [], dirty = false;
+let daten = null, personas = [], aktiv = null;
 
-const T_BODY_WARN = 950;   // Zeichen: darüber passt es kaum auf einen Mobilscreen
-const T_BETREFF_WARN = 60; // Zeichen: Betreff-Abschneidung im Postfach
+const T_BODY_WARN = 950;
+const T_BETREFF_WARN = 60;
 
 async function laden(){
   const roh = localStorage.getItem(LS);
-  if(roh){
-    try{ daten = JSON.parse(roh); dirty = true; }catch(e){ daten = null; }
-  }
+  if(roh){ try{ daten = JSON.parse(roh); }catch(e){ daten = null; } }
   const [m, p] = await Promise.all([
     daten ? Promise.resolve(daten) : fetch(ROOT+"mails.json").then(r=>r.json()),
     fetch(ROOT+"personas.json").then(r=>r.json())
   ]);
   daten = m; personas = p.personas;
-  zeichnen();
+  listeZeichnen();
 }
 
-function personaName(id){ const p = personas.find(x=>x.id===id); return p ? p.name : id; }
-function personaRolle(id){ const p = personas.find(x=>x.id===id); return p ? p.rolle : ""; }
+const esc = s => (s||"").replace(/[&<>]/g, c=>({"&":"&amp;","<":"&lt;",">":"&gt;"}[c]));
+const findG = id => daten.ausgaben.find(x=>x.id===id);
+const personaName = id => (personas.find(x=>x.id===id)||{}).name || id;
+const personaRolle = id => (personas.find(x=>x.id===id)||{}).rolle || "";
+function sichern(){ localStorage.setItem(LS, JSON.stringify(daten)); }
+function statusLabel(s){ return s.replace("_"," "); }
 
-function sichern(){ localStorage.setItem(LS, JSON.stringify(daten)); dirty = true; }
-
-function esc(s){ return (s||"").replace(/[&<>]/g, c=>({"&":"&amp;","<":"&lt;",">":"&gt;"}[c])); }
-
-function zeichnen(){
-  const liste = document.getElementById("liste");
+// ---------- Liste ----------
+function listeZeichnen(){
   const a = [...daten.ausgaben].sort((x,y)=>x.pos-y.pos);
-  liste.innerHTML = "";
-  a.forEach((g, i)=>{
-    liste.appendChild(karte(g, i, a.length));
-  });
-  liste.querySelectorAll(".mailfeld").forEach(wachsen);
-}
-
-// Textfeld wächst mit dem Inhalt — die ganze Mail ohne inneres Scrollen.
-function wachsen(t){ t.style.height="auto"; t.style.height=(t.scrollHeight+4)+"px"; }
-
-function karte(g, i, n){
-  const el = document.createElement("section");
-  el.className = "card soft ausgabe";
-  const werk = (g.werkzeuge||[]).join(" · ");
-  const betreffLen = (g.betreff||"").length;
-  const bodyLen = (g.body||"").length;
-
-  el.innerHTML = `
-    <div class="ausgabe-kopf">
-      <h3>${esc(g.monat)}</h3>
-      <span class="werk">${esc(werk)}</span>
-      <select class="pille-select" data-id="${g.id}" aria-label="Status" style="margin-left:var(--s2)">
-        ${daten.status_werte.map(s=>`<option value="${s}" ${s===g.status?"selected":""}>${s.replace("_"," ")}</option>`).join("")}
-      </select>
-      <span class="ordnung">
+  const l = document.getElementById("liste");
+  l.innerHTML = a.map((g,i)=>{
+    const werk = (g.werkzeuge||[]).join(" · ");
+    return `<div class="zeile">
+      <button class="zeile-waehlen" data-oeffnen="${g.id}">
+        <span class="z-top"><b>${esc(g.monat)}</b>
+          <span class="pille" data-status="${g.status}">${statusLabel(g.status)}</span></span>
+        <small>${esc(werk)}</small>
+        <span class="z-anlass">${esc(g.anlass||"")}</span>
+      </button>
+      <span class="zeile-ordnung">
         <button class="btn" type="button" data-hoch="${g.id}" ${i===0?"disabled":""} aria-label="nach oben">↑</button>
-        <button class="btn" type="button" data-runter="${g.id}" ${i===n-1?"disabled":""} aria-label="nach unten">↓</button>
+        <button class="btn" type="button" data-runter="${g.id}" ${i===a.length-1?"disabled":""} aria-label="nach unten">↓</button>
       </span>
-    </div>
-    <p style="color:var(--muted);font-size:var(--t-small);margin:var(--s2) 0 0">${esc(g.anlass||"")}</p>
-
-    <div class="raster">
-      <div class="feld-gruppe">
-        <label class="field">
-          <span class="lab">Betreff</span>
-          <input type="text" data-feld="betreff" data-id="${g.id}" value="${esc(g.betreff)}" />
-        </label>
-        <div class="zeichen ${betreffLen>T_BETREFF_WARN?"warn":""}">${betreffLen} Zeichen${betreffLen>T_BETREFF_WARN?" · wird evtl. abgeschnitten":""}</div>
-        <label class="field">
-          <span class="lab">Text der Mail</span>
-          <textarea class="mailfeld" data-feld="body" data-id="${g.id}" rows="16">${esc(g.body)}</textarea>
-        </label>
-        <div class="zeichen ${bodyLen>T_BODY_WARN?"warn":""}">${bodyLen} Zeichen${bodyLen>T_BODY_WARN?" · länger als ein Mobilscreen":""}</div>
-        <div style="display:flex;gap:var(--s2);flex-wrap:wrap">
-          <button class="btn primary" type="button" data-uebernehmen="${g.id}">Mail übernehmen (kopieren)</button>
-          <button class="btn" type="button" data-loeschen="${g.id}">Ausgabe entfernen</button>
-        </div>
-      </div>
-
-      <div class="vorschau-spalte">
-        <div class="telefon" aria-hidden="false">
-          <div class="telefon-schirm">
-            <div class="tv-betreff">${esc(g.betreff)||"&nbsp;"}</div>
-            <div class="tv-body">${esc(g.body)||"&nbsp;"}</div>
-          </div>
-        </div>
-        <div class="tv-hint ${bodyLen>T_BODY_WARN?"warn":""}">${bodyLen>T_BODY_WARN?"Zu lang — kürzen, bis alles ohne Scrollen sichtbar ist":"Vorschau auf dem Telefon"}</div>
-      </div>
-    </div>
-
-    ${tischPanel(g)}
-  `;
-  return el;
+    </div>`;
+  }).join("");
+  if(aktiv && !findG(aktiv)) aktiv = null;
 }
+
+// ---------- Editor ----------
+function oeffnen(id){
+  aktiv = id;
+  const g = findG(id);
+  const box = document.getElementById("editor");
+  box.hidden = false;
+  document.getElementById("editor-spalte").classList.add("hat-inhalt");
+  document.body.classList.add("editor-offen");
+  box.innerHTML = `
+    <div class="editor-kopf">
+      <button class="rund" type="button" data-schliessen aria-label="Schliessen">✕</button>
+      <strong>${esc(g.monat)}</strong>
+      <select class="status-select" aria-label="Status">
+        ${daten.status_werte.map(s=>`<option value="${s}" ${s===g.status?"selected":""}>${statusLabel(s)}</option>`).join("")}
+      </select>
+    </div>
+    <div class="editor-koerper">
+      <div class="betreff-zeile">
+        <span class="lab">Betreff</span>
+        <input type="text" data-feld="betreff" value="${esc(g.betreff)}" placeholder="Betreff …" />
+      </div>
+      <textarea class="mailfeld" data-feld="body" placeholder="Text der Mail …">${esc(g.body)}</textarea>
+      <div class="zeichen ${(g.body||"").length>T_BODY_WARN?"warn":""}" id="zaehler">${(g.body||"").length} Zeichen${(g.body||"").length>T_BODY_WARN?" · länger als ein Mobilscreen":""}</div>
+      ${tischPanel(g)}
+    </div>
+    <div class="editor-fuss">
+      <button class="btn primary" type="button" data-mailto>In Mail-App öffnen</button>
+      <button class="btn" type="button" data-kopieren>Text kopieren</button>
+      <span class="spacer"></span>
+      <button class="btn" type="button" data-loeschen>Entfernen</button>
+    </div>`;
+  const ta = box.querySelector(".mailfeld");
+  requestAnimationFrame(()=>wachsen(ta));
+}
+
+function schliessen(){
+  aktiv = null;
+  document.body.classList.remove("editor-offen");
+  const sp = document.getElementById("editor-spalte");
+  sp.classList.remove("hat-inhalt");
+  document.getElementById("editor").hidden = true;
+}
+
+function wachsen(t){ if(!t) return; t.style.height="auto"; t.style.height=(t.scrollHeight+4)+"px"; }
 
 function tischPanel(g){
   const t = g.tisch;
   if(!t){
     return `<details class="tisch"><summary>Redaktionstisch</summary>
-      <p class="kein-tisch">Noch keine Runde. Der Redakteur legt den Entwurf den sieben Personas vor —
-      dann stehen ihre Voten hier. Personas: ${personas.map(p=>esc(p.name)).join(", ")}.</p></details>`;
+      <p class="kein-tisch">Noch keine Runde. Der Redakteur legt den Entwurf den sieben Personas vor.
+      Personas: ${personas.map(p=>esc(p.name)).join(", ")}.</p></details>`;
   }
   const stuehle = (t.voten||[]).map(v=>`
-    <div class="stuhl">
-      <div class="wer"><b>${esc(personaName(v.persona))}</b><small>${esc(personaRolle(v.persona))}</small></div>
-      <div class="kern">${esc(v.kern)}</div>
-    </div>`).join("");
-  return `<details class="tisch" open><summary>Redaktionstisch — Runde ${t.runde} (${esc(t.datum)})</summary>
-    <p style="color:var(--muted);font-size:var(--t-small);margin:var(--s2) 0">Vorgelegt: ${esc(t.vorgelegter_entwurf||"")}</p>
+    <div class="stuhl"><div class="wer"><b>${esc(personaName(v.persona))}</b><small>${esc(personaRolle(v.persona))}</small></div>
+    <div class="kern">${esc(v.kern)}</div></div>`).join("");
+  return `<details class="tisch"><summary>Redaktionstisch — Runde ${t.runde} (${esc(t.datum)})</summary>
+    <p style="color:var(--muted);font-size:var(--t-small)">Vorgelegt: ${esc(t.vorgelegter_entwurf||"")}</p>
     ${stuehle}</details>`;
 }
 
-// ---- Ereignisse ----
+// ---------- robustes Kopieren ----------
+function melden(btn, text){ const alt=btn.textContent; btn.textContent="✓ "+text; setTimeout(()=>btn.textContent=alt,1600); }
+function kopieren(text, btn){
+  if(navigator.clipboard && window.isSecureContext){
+    navigator.clipboard.writeText(text).then(()=>melden(btn,"kopiert")).catch(()=>fallbackKopie(text,btn));
+  } else { fallbackKopie(text,btn); }
+}
+function fallbackKopie(text, btn){
+  const ta=document.createElement("textarea");
+  ta.value=text; ta.setAttribute("readonly",""); ta.style.position="fixed"; ta.style.top="-1000px";
+  document.body.appendChild(ta); ta.select(); ta.setSelectionRange(0,text.length);
+  let ok=false; try{ ok=document.execCommand("copy"); }catch(e){}
+  document.body.removeChild(ta);
+  if(ok) melden(btn,"kopiert"); else alert("Kopieren nicht möglich — bitte Text markieren und kopieren.");
+}
+
+// ---------- Ereignisse ----------
 document.addEventListener("input", e=>{
   const f = e.target.dataset.feld;
-  if(f){
-    const g = daten.ausgaben.find(x=>x.id===e.target.dataset.id);
-    if(g){ g[f] = e.target.value; sichern();
-      // Zeichenzähler live, ohne Neuzeichnen des Felds (Fokus halten)
-      const box = e.target.closest(".feld-gruppe");
-      const len = e.target.value.length;
-      if(f==="betreff"){ const z=box.querySelectorAll(".zeichen")[0]; z.textContent=len+" Zeichen"+(len>T_BETREFF_WARN?" · wird evtl. abgeschnitten":""); z.classList.toggle("warn",len>T_BETREFF_WARN); }
-      if(f==="body"){
-        wachsen(e.target);
-        const z=box.querySelectorAll(".zeichen")[1]; z.textContent=len+" Zeichen"+(len>T_BODY_WARN?" · länger als ein Mobilscreen":""); z.classList.toggle("warn",len>T_BODY_WARN);
-        const card=e.target.closest(".ausgabe"); card.querySelector(".tv-body").textContent=e.target.value;
-        const h=card.querySelector(".tv-hint"); h.textContent=len>T_BODY_WARN?"Zu lang — kürzen, bis alles ohne Scrollen sichtbar ist":"Vorschau auf dem Telefon"; h.classList.toggle("warn",len>T_BODY_WARN);
-      }
-      if(f==="betreff"){ e.target.closest(".ausgabe").querySelector(".tv-betreff").textContent=e.target.value; }
-    }
+  if(!f || !aktiv) return;
+  const g = findG(aktiv); if(!g) return;
+  g[f] = e.target.value; sichern();
+  if(f==="body"){
+    wachsen(e.target);
+    const z=document.getElementById("zaehler"); const len=e.target.value.length;
+    z.textContent=len+" Zeichen"+(len>T_BODY_WARN?" · länger als ein Mobilscreen":"");
+    z.classList.toggle("warn",len>T_BODY_WARN);
   }
 });
 
 document.addEventListener("change", e=>{
-  if(e.target.classList.contains("pille-select")){
-    const g = daten.ausgaben.find(x=>x.id===e.target.dataset.id);
-    if(g){ g.status = e.target.value; sichern(); }
+  if(e.target.classList.contains("status-select") && aktiv){
+    const g=findG(aktiv); if(g){ g.status=e.target.value; sichern(); listeZeichnen(); }
   }
 });
 
 document.addEventListener("click", e=>{
-  const t = e.target;
-  if(t.dataset.hoch || t.dataset.runter){
-    const id = t.dataset.hoch || t.dataset.runter;
-    tauschen(id, t.dataset.hoch ? -1 : +1); return;
-  }
-  if(t.dataset.uebernehmen){
-    const g = daten.ausgaben.find(x=>x.id===t.dataset.uebernehmen);
-    const text = "Betreff: "+g.betreff+"\n\n"+g.body;
-    navigator.clipboard.writeText(text).then(()=>{ t.textContent="✓ kopiert"; setTimeout(()=>t.textContent="Mail übernehmen (kopieren)",1600); });
-    return;
-  }
-  if(t.dataset.loeschen){
-    const g = daten.ausgaben.find(x=>x.id===t.dataset.loeschen);
-    if(confirm("Ausgabe «"+g.monat+"» entfernen?")){
-      daten.ausgaben = daten.ausgaben.filter(x=>x.id!==t.dataset.loeschen);
-      renumerieren(); sichern(); zeichnen();
-    }
-    return;
-  }
+  const t = e.target.closest("button"); if(!t) return;
+  const d = t.dataset;
+  if(d.oeffnen){ oeffnen(d.oeffnen); return; }
+  if("schliessen" in d){ schliessen(); return; }
+  if(d.hoch || d.runter){ tauschen(d.hoch||d.runter, d.hoch?-1:+1); return; }
+  if("kopieren" in d && aktiv){ const g=findG(aktiv); kopieren("Betreff: "+g.betreff+"\n\n"+g.body, t); return; }
+  if("mailto" in d && aktiv){ const g=findG(aktiv);
+    location.href="mailto:?subject="+encodeURIComponent(g.betreff)+"&body="+encodeURIComponent(g.body); return; }
+  if("loeschen" in d && aktiv){ const g=findG(aktiv);
+    if(confirm("Ausgabe «"+g.monat+"» entfernen?")){ daten.ausgaben=daten.ausgaben.filter(x=>x.id!==aktiv); renumerieren(); sichern(); schliessen(); listeZeichnen(); } return; }
   if(t.id==="neu"){ neueAusgabe(); return; }
   if(t.id==="zusammenlegen"){ zusammenlegen(); return; }
   if(t.id==="export"){ exportieren(); return; }
-  if(t.id==="zuruecksetzen"){
-    if(confirm("Lokalen Zwischenstand verwerfen und den Datei-Stand laden?")){
-      localStorage.removeItem(LS); location.reload();
-    }
-    return;
-  }
+  if(t.id==="zuruecksetzen"){ if(confirm("Lokalen Zwischenstand verwerfen und den Datei-Stand laden?")){ localStorage.removeItem(LS); location.reload(); } return; }
 });
 
-function tauschen(id, richtung){
-  const a = [...daten.ausgaben].sort((x,y)=>x.pos-y.pos);
-  const idx = a.findIndex(x=>x.id===id);
-  const ziel = idx + richtung;
-  if(ziel<0 || ziel>=a.length) return;
-  const p1 = a[idx].pos, p2 = a[ziel].pos;
-  a[idx].pos = p2; a[ziel].pos = p1;
-  sichern(); zeichnen();
-}
+document.addEventListener("keydown", e=>{ if(e.key==="Escape" && aktiv) schliessen(); });
 
-function renumerieren(){
-  [...daten.ausgaben].sort((x,y)=>x.pos-y.pos).forEach((g,i)=>g.pos=i+1);
+function tauschen(id, richtung){
+  const a=[...daten.ausgaben].sort((x,y)=>x.pos-y.pos);
+  const i=a.findIndex(x=>x.id===id), j=i+richtung;
+  if(j<0||j>=a.length) return;
+  const p=a[i].pos; a[i].pos=a[j].pos; a[j].pos=p;
+  sichern(); listeZeichnen();
 }
+function renumerieren(){ [...daten.ausgaben].sort((x,y)=>x.pos-y.pos).forEach((g,i)=>g.pos=i+1); }
 
 function neueAusgabe(){
-  const monat = prompt("Monat / Titel der neuen Ausgabe?", "");
-  if(!monat) return;
-  const maxPos = Math.max(0, ...daten.ausgaben.map(g=>g.pos));
-  daten.ausgaben.push({
-    id: "neu-"+monat.toLowerCase().replace(/[^a-z0-9]+/g,"-").replace(/^-|-$/g,""),
-    pos: maxPos+1, monat, status:"entwurf", werkzeuge:[], anlass:"",
-    betreff:"", body:"", anhang:{titel:"",blatt:"",status:"offen"}, tisch:null
-  });
-  sichern(); zeichnen();
+  const monat=prompt("Monat / Titel der neuen Ausgabe?",""); if(!monat) return;
+  const maxPos=Math.max(0,...daten.ausgaben.map(g=>g.pos));
+  const id="neu-"+monat.toLowerCase().replace(/[^a-z0-9]+/g,"-").replace(/^-|-$/g,"")+"-"+(maxPos+1);
+  daten.ausgaben.push({id,pos:maxPos+1,monat,status:"entwurf",werkzeuge:[],anlass:"",betreff:"",body:"",anhang:{titel:"",blatt:"",status:"offen"},tisch:null});
+  sichern(); listeZeichnen(); oeffnen(id);
 }
-
 function zusammenlegen(){
-  const a = [...daten.ausgaben].sort((x,y)=>x.pos-y.pos);
-  const liste = a.map((g,i)=>`${i+1}) ${g.monat}`).join("\n");
-  const erste = parseInt(prompt("Zwei Ausgaben zusammenlegen.\nNummer der ERSTEN (behält Platz und Text):\n\n"+liste, ""),10);
-  if(!erste) return;
-  const zweite = parseInt(prompt("Nummer der ZWEITEN (wird eingefügt und entfernt):", ""),10);
-  if(!zweite || zweite===erste) return;
-  const g1 = a[erste-1], g2 = a[zweite-1];
-  if(!g1 || !g2) return;
-  g1.werkzeuge = [...(g1.werkzeuge||[]), ...(g2.werkzeuge||[])];
-  g1.anlass = (g1.anlass||"") + (g2.anlass?(" + "+g2.anlass):"");
-  g1.body = (g1.body||"") + "\n\n— zusammengelegt aus «"+g2.monat+"» —\n\n" + (g2.body||"");
-  daten.ausgaben = daten.ausgaben.filter(x=>x.id!==g2.id);
-  renumerieren(); sichern(); zeichnen();
+  const a=[...daten.ausgaben].sort((x,y)=>x.pos-y.pos);
+  const liste=a.map((g,i)=>`${i+1}) ${g.monat}`).join("\n");
+  const e1=parseInt(prompt("Zwei Ausgaben zusammenlegen.\nNummer der ERSTEN (behält Platz und Text):\n\n"+liste,""),10); if(!e1) return;
+  const e2=parseInt(prompt("Nummer der ZWEITEN (wird eingefügt und entfernt):",""),10); if(!e2||e2===e1) return;
+  const g1=a[e1-1], g2=a[e2-1]; if(!g1||!g2) return;
+  g1.werkzeuge=[...(g1.werkzeuge||[]),...(g2.werkzeuge||[])];
+  g1.anlass=(g1.anlass||"")+(g2.anlass?(" + "+g2.anlass):"");
+  g1.body=(g1.body||"")+"\n\n— zusammengelegt aus «"+g2.monat+"» —\n\n"+(g2.body||"");
+  daten.ausgaben=daten.ausgaben.filter(x=>x.id!==g2.id);
+  renumerieren(); sichern(); listeZeichnen();
 }
-
 function exportieren(){
   renumerieren();
-  const clean = JSON.parse(JSON.stringify(daten));
-  const blob = new Blob([JSON.stringify(clean, null, 2)+"\n"], {type:"application/json"});
-  const a = document.createElement("a");
-  a.href = URL.createObjectURL(blob);
-  a.download = "mails.json";
-  a.click();
+  const blob=new Blob([JSON.stringify(JSON.parse(JSON.stringify(daten)),null,2)+"\n"],{type:"application/json"});
+  const a=document.createElement("a"); a.href=URL.createObjectURL(blob); a.download="mails.json"; a.click();
 }
 
 laden();


### PR DESCRIPTION
## Was dieser PR ändert

Grundumbau der Redaktionsseite nach Rückmeldung (zu viele Boxen, keine gleichzeitige Ansicht aller Inhalte nötig; Vollbild-Editor fürs Handy; Kopieren war kaputt):

**Master-Detail statt Box-Wand:**
- **Liste** — kompakte Zeilen (Monat, Status-Pille, Werkzeug, Anlass) zum Übersehen, **Ordnen** (↑↓) und **Anwählen**.
- **Vollbild-Editor** im Apple-Mail-Muster: Tippen auf eine Zeile öffnet ihn (mobil als Vollbild-Overlay, am grossen Schirm als Detail-Spalte neben der Liste). ✕ zum Schliessen, Betreff gross, Text vollflächig und mitwachsend — kein Mockup, keine Box-im-Box.

**Übernehmen zuverlässig:**
- **«In Mail-App öffnen»** (mailto) — füllt den Verfassen-Bildschirm des eigenen Mailprogramms mit Betreff und Text; das ist der natürliche Weg auf dem Handy.
- **«Text kopieren»** mit robustem Fallback (`execCommand`), falls die Clipboard-API fehlt — behebt das fehlgeschlagene Kopieren.

**Getestet:** Browser-Rauchtest (Playwright, Mobil-Viewport) — Liste rendert (10 Zeilen), Editor öffnet/schliesst, Zähler live, Kopieren legt den vollständigen Text in die Zwischenablage, keine JS-Fehler. ds-lint 100 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPT5AKuUgjThxUNighRLBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPT5AKuUgjThxUNighRLBk)_