### PR TITLE
Werkzeugpost: Editor-Overlay deckt mobil voll (keine durchscheinende Liste)

### DIFF
--- a/apps/werkzeugpost/index.html
+++ b/apps/werkzeugpost/index.html
@@ -45,16 +45,20 @@
     .werkstatt{display:grid;grid-template-columns:340px 1fr;gap:var(--s5);align-items:start}
   }
   .editor-spalte{
-    position:fixed;inset:0;z-index:60;background:var(--paper);
-    display:flex;flex-direction:column;
+    position:fixed;top:0;left:0;width:100vw;height:100dvh;z-index:60;background:var(--paper);
+    display:flex;flex-direction:column;overflow:hidden;
     transform:translateX(100%);transition:transform .22s ease;
     visibility:hidden;
   }
   body.editor-offen .editor-spalte{transform:none;visibility:visible}
+  /* Hintergrund (Liste) nicht mitscrollen, solange der Editor offen ist. */
+  @media(max-width:899px){ body.editor-offen{overflow:hidden} }
   @media(min-width:900px){
-    .editor-spalte{position:sticky;top:var(--s4);transform:none;visibility:visible;
+    .editor-spalte{position:sticky;top:var(--s4);left:auto;width:auto;height:auto;transform:none;visibility:visible;
       z-index:1;border:1px solid var(--line);border-radius:16px;max-height:calc(100vh - var(--s8));overflow:hidden}
   }
+  /* Höhenkette: Editor füllt die Spalte, nur der Körper scrollt. */
+  #editor{display:flex;flex-direction:column;flex:1;min-height:0}
 
   .editor-kopf{display:flex;align-items:center;gap:var(--s3);padding:var(--s3) var(--s4);
     border-bottom:1px solid var(--line);flex:0 0 auto}
@@ -67,7 +71,7 @@
     padding:var(--s2) var(--s4);border-bottom:1px solid var(--line);flex:0 0 auto}
   .editor-leiste .anlass{color:var(--muted);font-size:var(--t-small);flex:1;min-width:12ch}
 
-  .editor-koerper{flex:1;overflow:auto;display:flex;flex-direction:column;padding:var(--s4);gap:var(--s3)}
+  .editor-koerper{flex:1;min-height:0;overflow:auto;display:flex;flex-direction:column;padding:var(--s4);gap:var(--s3)}
   .betreff-zeile{display:flex;align-items:baseline;gap:var(--s2);border-bottom:1px solid var(--line);padding-bottom:var(--s3)}
   .betreff-zeile .lab{color:var(--muted);font-size:var(--t-small);flex:0 0 auto}
   .betreff-zeile input{flex:1;border:0;background:none;font-family:var(--font);font-weight:var(--w-deutlich);
@@ -203,6 +207,8 @@ function listeZeichnen(){
 }
 
 // ---------- Editor ----------
+const mobil = () => window.matchMedia("(max-width:899px)").matches;
+
 function oeffnen(id){
   aktiv = id;
   const g = findG(id);
@@ -210,6 +216,7 @@ function oeffnen(id){
   box.hidden = false;
   document.getElementById("editor-spalte").classList.add("hat-inhalt");
   document.body.classList.add("editor-offen");
+  if(mobil()){ document.documentElement.style.overflow = "hidden"; }
   box.innerHTML = `
     <div class="editor-kopf">
       <button class="rund" type="button" data-schliessen aria-label="Schliessen">✕</button>
@@ -240,6 +247,7 @@ function oeffnen(id){
 function schliessen(){
   aktiv = null;
   document.body.classList.remove("editor-offen");
+  document.documentElement.style.overflow = "";
   const sp = document.getElementById("editor-spalte");
   sp.classList.remove("hat-inhalt");
   document.getElementById("editor").hidden = true;


### PR DESCRIPTION
## Was dieser PR behebt

Die „afunktionale Überlagerung" auf dem Handy: Der Vollbild-Editor deckte den Bildschirm nicht wirklich — seine Inhalte liefen über, Kopf (✕) und Fuss (Knöpfe) waren weggescrollt, und dahinter schien die Liste durch.

**Ursache & Fix:**
- Die Höhenkette war unterbrochen — `#editor` war kein Flex-Container, darum griff „Kopf fix, Körper scrollt" nicht. Jetzt ist `#editor` eine Flex-Spalte (`flex:1; min-height:0`), nur `.editor-koerper` scrollt.
- Der Overlay-Rahmen deckt jetzt scrollbar-unabhängig voll (`width:100vw; height:100dvh`).
- Beim Öffnen wird das Dokument-Scrollen gesperrt (Hintergrund bleibt stehen), beim Schliessen wieder frei — nur auf Mobil, der Desktop bleibt Master-Detail.

**Getestet** (Playwright): Mobil deckt der Editor die volle Breite (390/390), alle Trefferpunkte landen im Editor, Kopf und Knöpfe sichtbar; Desktop zeigt Liste links + Editor rechts ohne Scroll-Lock; keine JS-Fehler. ds-lint 100 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPT5AKuUgjThxUNighRLBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPT5AKuUgjThxUNighRLBk)_