### PR TITLE
Kurzlink sichtbar machen: zweite Tür (Modus-Umschalter + eigene Hub-Card)

### DIFF
--- a/apps/qr-generator/index.html
+++ b/apps/qr-generator/index.html
@@ -36,6 +36,10 @@
   .kurzrow{display:flex;gap:var(--s2);align-items:stretch;flex-wrap:wrap} .kurzrow input{flex:1;min-width:140px}
   .check{display:flex;align-items:center;gap:var(--s2);font-family:var(--font-text);font-size:var(--t-body);color:var(--ink);cursor:pointer;min-height:var(--tap)}
   .check input{width:20px;height:20px;accent-color:var(--blue)}
+  /* Modus-Umschalter QR-Code | Kurzlink – dieselbe App, zwei Türen. */
+  .seg.modus{margin-bottom:var(--s4)}
+  body[data-modus="kurzlink"] #typSeg,
+  body[data-modus="kurzlink"] .qr-only{display:none}
 
   /* Gestalt & Ausgabe: Regler links, Vorschau rechts. */
   .out{display:grid;grid-template-columns:1fr auto;gap:var(--s6);align-items:start}
@@ -102,14 +106,18 @@
 <main class="wrap">
 
   <section class="hero">
-    <h1>QR-Code-Generator</h1>
-    <p class="lede">QR-Codes im Hausstil – für Links, WLAN-Zugänge, Kontakte, E-Mail und Text. Link-Codes laufen auf Wunsch als Kurzlink und zählen ihre Scans: anonym und ohne Fremddienst.</p>
+    <div class="seg modus" id="modusSeg" role="group" aria-label="Modus">
+      <button type="button" data-modus="qr" aria-pressed="true">QR-Code</button>
+      <button type="button" data-modus="kurzlink" aria-pressed="false">Kurzlink</button>
+    </div>
+    <h1 id="titel">QR-Code-Generator</h1>
+    <p class="lede" id="lede">QR-Codes im Hausstil – für Links, WLAN-Zugänge, Kontakte, E-Mail und Text. Link-Codes laufen auf Wunsch als Kurzlink und zählen ihre Scans: anonym und ohne Fremddienst.</p>
   </section>
 
   <section>
     <div class="shead">
-      <h2>Inhalt</h2>
-      <p>Was der Code beim Scannen auslösen soll. Nur Link-Codes können zählen – alles andere steht fest im Code selbst.</p>
+      <h2 id="inhaltTitel">Inhalt</h2>
+      <p id="inhaltText">Was der Code beim Scannen auslösen soll. Nur Link-Codes können zählen – alles andere steht fest im Code selbst.</p>
     </div>
 
     <div class="card soft">
@@ -126,7 +134,7 @@
           <span class="lab">Ziel-Adresse (URL)</span>
           <input id="linkUrl" type="url" placeholder="https://goetheanum.ch/veranstaltungen" autocomplete="off" />
         </label>
-        <label class="check span2">
+        <label class="check span2 qr-only">
           <input type="checkbox" id="kurzToggle" checked />
           <span>Kurzlink mit Scan-Statistik (empfohlen)</span>
         </label>
@@ -225,14 +233,14 @@
 
   <section>
     <div class="shead">
-      <h2>Gestalt und Ausgabe</h2>
-      <p>Drei Stile, drei Farben – immer dunkel auf Weiss, damit jede Kamera den Code liest. SVG für Druck und Layout, PNG für Mail und Web.</p>
+      <h2 id="gestaltTitel">Gestalt und Ausgabe</h2>
+      <p id="gestaltText">Drei Stile, drei Farben – immer dunkel auf Weiss, damit jede Kamera den Code liest. SVG für Druck und Layout, PNG für Mail und Web.</p>
     </div>
 
     <div class="card soft">
       <div class="out">
         <div>
-          <div class="gopt">
+          <div class="gopt qr-only">
             <span class="lab">Modulstil</span>
             <div class="seg" id="stilSeg" role="group" aria-label="Modulstil">
               <button type="button" data-stil="fliessend" aria-pressed="true">Fliessend</button>
@@ -241,7 +249,7 @@
               <button type="button" data-stil="kanten" aria-pressed="false">Kanten</button>
             </div>
           </div>
-          <div class="gopt">
+          <div class="gopt qr-only">
             <span class="lab">Farbe</span>
             <div class="seg" id="farbSeg" role="group" aria-label="Farbe">
               <button type="button" data-farbe="tinte" aria-pressed="true">Tinte</button>
@@ -761,9 +769,51 @@
     }).catch(function(){ body.innerHTML = '<tr><td class="empty" colspan="6">Register nicht ladbar.</td></tr>'; });
   }
 
+  // --- Modus: QR-Code | Kurzlink (dieselbe App, zwei Türen) -------------------
+  var TEXTE = {
+    qr: {
+      titel: 'QR-Code-Generator',
+      lede: 'QR-Codes im Hausstil – für Links, WLAN-Zugänge, Kontakte, E-Mail und Text. Link-Codes laufen auf Wunsch als Kurzlink und zählen ihre Scans: anonym und ohne Fremddienst.',
+      inhaltTitel: 'Inhalt',
+      inhaltText: 'Was der Code beim Scannen auslösen soll. Nur Link-Codes können zählen – alles andere steht fest im Code selbst.',
+      gestaltTitel: 'Gestalt und Ausgabe',
+      gestaltText: 'Drei Stile, drei Farben – immer dunkel auf Weiss, damit jede Kamera den Code liest. SVG für Druck und Layout, PNG für Mail und Web.'
+    },
+    kurzlink: {
+      titel: 'Kurzlink',
+      lede: 'Eine kurze, hauseigene Adresse (tools.goetheanum.ch/s/…) statt langer Links – tippbar, QR-tauglich, nach dem Druck umhängbar, ohne Fremddienst. Jeder Aufruf wird still gezählt.',
+      inhaltTitel: 'Ziel',
+      inhaltText: 'Die lange Adresse, auf die der Kurzlink weiterleiten soll.',
+      gestaltTitel: 'Als QR-Code (optional)',
+      gestaltText: 'Denselben Kurzlink gleich als QR herunterladen – SVG für Druck und Layout, PNG für Mail und Web.'
+    }
+  };
+  var modus = 'qr';
+  function setModus(m){
+    modus = (m && String(m).indexOf('kurzlink') === 0) ? 'kurzlink' : 'qr';
+    document.body.setAttribute('data-modus', modus);
+    el('modusSeg').querySelectorAll('button').forEach(function(b){ b.setAttribute('aria-pressed', b.dataset.modus === modus ? 'true' : 'false'); });
+    var t = TEXTE[modus];
+    el('titel').textContent = t.titel; el('lede').textContent = t.lede;
+    el('inhaltTitel').textContent = t.inhaltTitel; el('inhaltText').textContent = t.inhaltText;
+    el('gestaltTitel').textContent = t.gestaltTitel; el('gestaltText').textContent = t.gestaltText;
+    if(modus === 'kurzlink'){
+      // Kurzlink-erst: auf Link zwingen, Kurzlink immer an, Code-Feld sichtbar.
+      typ = 'link';
+      el('typSeg').querySelectorAll('button').forEach(function(b){ b.setAttribute('aria-pressed', b.dataset.typ === 'link' ? 'true' : 'false'); });
+      ['link','wlan','kontakt','email','text'].forEach(function(p){ el('pane-' + p).hidden = (p !== 'link'); });
+      el('kurzToggle').checked = true; el('kurzFeld').hidden = false;
+    }
+    try { history.replaceState(null, '', modus === 'kurzlink' ? '?modus=kurzlink' : location.pathname); } catch(e){}
+    render();
+  }
+  segWire('modusSeg', 'modus', setModus);
+
   // --- Start ---------------------------------------------------------------------
+  var params = new URLSearchParams(location.search);
+  var startModus = params.get('modus') || (location.hash === '#kurzlink' ? 'kurzlink' : 'qr');
   el('kurzCode').value = neuerCode();
-  render();
+  setModus(startModus);
   ladeRegister();
 </script>
 

--- a/index.html
+++ b/index.html
@@ -105,6 +105,11 @@
   .thumb .wp{width:96px;height:54px;border-radius:6px;overflow:hidden;display:block}
   .thumb .wp img{width:100%;height:100%;object-fit:cover;display:block}
 
+  /* Kurzlink: zwei ineinander gehängte Kettenglieder – das Zeichen für ‹Link›,
+     einfarbig über Token (theme-fähig). */
+  .thumb .lnk{width:58px;height:58px;display:block}
+  .thumb .lnk g{fill:none;stroke:var(--ink);stroke-width:3.6;stroke-linecap:round}
+
   /* Entdecker-Karussell – Hinweis auf weniger Bekanntes, oben über den Karten. */
   .carousel{position:relative;margin-bottom:var(--s8);border:1px solid var(--line);
     border-radius:var(--r-card);background:var(--soft);overflow:hidden}
@@ -165,7 +170,7 @@
   // Webfont wohnt jetzt in Schriften, Zeichen in Logos – darum keine eigene Karte.
   // Neue Ordnung (Entscheid Auftraggeber, 8. Juli 2026).
   var ORDER = ["logo-generator","signatur","visitenkarten","schriften",
-    "icons","uebersetzungen","qr-generator","typografie","powerpoint",
+    "icons","uebersetzungen","qr-generator","kurzlink","typografie","powerpoint",
     "wallpaper","karten","sektionsfarben","design-system",
     "editor"];
   // Entdecker-Karussell: ausgewählte Werkzeuge, je ein Teaser.
@@ -207,6 +212,7 @@
     "editor":          '<span class="ed"><i></i><i class="mk"></i><i></i></span>', // Text mit offener Frage
     "karten":          '<svg class="karte" viewBox="0 0 100 68" preserveAspectRatio="xMidYMid slice" aria-hidden="true"><rect width="100" height="68" fill="#8abfe5"/><path d="M-4 52 Q40 40 104 54" stroke="#ffffff" stroke-width="4.2" fill="none" stroke-linecap="round"/><path d="M30 -4 Q44 30 40 72" stroke="#ffffff" stroke-width="4.2" fill="none" stroke-linecap="round"/><path d="M50 34 L96 46" stroke="#ffffff" stroke-width="3.4" fill="none" stroke-linecap="round"/><rect x="40" y="22" width="26" height="20" rx="6" fill="#0067b2"/><circle cx="70" cy="24" r="4.2" fill="#caa04e" stroke="#ffffff" stroke-width="1.4"/><circle cx="33" cy="50" r="4.2" fill="#ec5f6c" stroke="#ffffff" stroke-width="1.4"/></svg>', // schematisches Campus-Zeichen, kein Grundriss
     "qr-generator":    '<img class="qrg qrgl" src="assets/qr-werkzeug.svg" alt=""><img class="qrg qrgd" src="assets/qr-werkzeug-dark.svg" alt="">', // echter QR, Light + Dark (invertiert)
+    "kurzlink":        '<svg class="lnk" viewBox="0 0 48 48" aria-hidden="true"><g transform="rotate(-45 24 24)"><rect x="5" y="17.5" width="24" height="13" rx="6.5"/><rect x="19" y="17.5" width="24" height="13" rx="6.5"/></g></svg>', // zwei Kettenglieder = ein Link
     "empfehlungen":    '<span class="spec" style="color:var(--gold-ink)">11</span>' // die elf Gebote
   };
   function visual(t){

--- a/tools.json
+++ b/tools.json
@@ -192,6 +192,17 @@
       "such": "QR Code Generator Kurzlink WLAN WiFi vCard Kontakt E-Mail Statistik Scans"
     },
     {
+      "slug": "kurzlink",
+      "cat": "generatoren",
+      "status": "live",
+      "tag": "Kurzlink",
+      "title": "Kurzlink",
+      "short": "Kurzlink",
+      "href": "apps/qr-generator/?modus=kurzlink",
+      "desc": "Eine kurze, hauseigene Adresse statt langer Links – tippbar, QR-tauglich, nach dem Druck umhängbar, ohne Fremddienst.",
+      "such": "Kurzlink Link Kürzer Shortlink URL kurze Adresse Weiterleitung tools.goetheanum.ch"
+    },
+    {
       "slug": "gtv-naming",
       "cat": "schau",
       "status": "beta",

--- a/tools/build_tool_aliases.py
+++ b/tools/build_tool_aliases.py
@@ -31,7 +31,10 @@ def main(site: str) -> None:
         if (root / slug).exists() or (root / f"{slug}.html").exists():
             print(f"alias übersprungen (Kollision): /{slug}")
             continue
-        target = "../" + (href if href.endswith("/") else href + "/")
+        # Kein Schrägstrich anhängen, wenn der Pfad eine Query/Anker trägt
+        # (z. B. apps/qr-generator/?modus=kurzlink) – sonst bräche das Ziel.
+        hrefn = href if (href.endswith("/") or "?" in href or "#" in href) else href + "/"
+        target = "../" + hrefn
         d = root / slug
         d.mkdir(parents=True)
         (d / "index.html").write_text(STUB.format(t=target), encoding="utf-8")


### PR DESCRIPTION
## Was

Der QR-Generator ist zugleich ein hauseigener Link-Kürzer mit Zähler – das war unsichtbar. Jetzt: **dieselbe App, zwei Türen.**

- **Modus-Umschalter im Werkzeug** (`QR-Code | Kurzlink`): im Kurzlink-Modus läuft die Ansicht **link-erst** – «Ziel-Adresse → Kurzlink anlegen», der QR wird zur optionalen Zugabe («Als QR-Code (optional)»), Typwahl (WLAN/Kontakt/…) und QR-Stile treten zurück, die Texte passen sich an. Der Modus lebt in `?modus=kurzlink` (teilbar, per History gesetzt).
- **Neue Hub-Card «Kurzlink»** mit eigenem Emblem (zwei Kettenglieder – der Kurzlink selbst ist der Zieher, **kein** Statistik-Motiv), direkt nach dem QR-Generator. Zeigt auf `apps/qr-generator/?modus=kurzlink`.
- **`build_tool_aliases.py`**: hängt bei Pfaden mit Query/Anker keinen `/` mehr an, damit der Alias `/kurzlink/` sauber auf den Kurzlink-Modus zielt.

Kein doppelter Code, kein doppeltes Backend – eine Engine, zwei Zugänge.

## Verifiziert

- Werkzeug in beiden Modi gerendert (QR ↔ Kurzlink), Umschalten setzt Titel/Texte und `?modus=`, keine JS-Fehler.
- Hub-Card «Kurzlink» erscheint nach dem QR-Generator, Emblem theme-fähig, href korrekt.
- Alias-Builder erzeugt `/kurzlink/ → ../apps/qr-generator/?modus=kurzlink`.
- `typo-check` und `ds-lint` auf `index.html` und der Tool-Seite: 0 Fehler, 0 Hinweise; `tools.json` valide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4)_