### PR TITLE
Werkzeugpost in der Backstage-Schublade ganz oben anheften

### DIFF
--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -475,6 +475,11 @@
   var FLAT_ORDER = ["logo-generator", "signatur", "visitenkarten", "schriften", "icons",
     "uebersetzungen", "sektionsfarben", "typografie", "karten", "powerpoint",
     "editor", "wallpaper", "design-system"];
+  // Backstage angeheftet: täglich gebrauchte Redaktions-Werkzeuge stehen in der
+  // Intern-Schublade ganz oben – über den Welten, kurzer Griff statt in einer
+  // Welt vergraben (Werkzeugpost = Redaktionstisch der Monatsmail). Angeheftete
+  // erscheinen nicht zusätzlich in ihrer Welt (G03 – Doppelung weglassen).
+  var INTERN_PIN = ["werkzeugpost"];
   var PUBLIC_CATS = WORLDS.reduce(function (a, w) { return a.concat(w.cats); }, []);
 
   function renderDrawer() {
@@ -497,10 +502,17 @@
       pub.sort(function (a, b) { return rank(a) - rank(b); });
       pub.forEach(function (t) { drawerBody.appendChild(linkEl(t)); });
     } else {
-      // intern: nach Backstage-Welten gruppiert (kurze, scannbare Bereiche).
+      // intern: erst die angehefteten Redaktions-Werkzeuge (ganz oben), dann
+      // nach Backstage-Welten gruppiert (kurze, scannbare Bereiche).
       var cur = currentWorldId();
+      INTERN_PIN.forEach(function (slug) {
+        var t = bySlug(slug);
+        if (t) drawerBody.appendChild(linkEl(t));
+      });
       WORLDS.concat(INTERN_EXTRA).forEach(function (w) {
-        var tools = ALL.filter(function (t) { return w.cats.indexOf(t.cat) !== -1; });
+        var tools = ALL.filter(function (t) {
+          return w.cats.indexOf(t.cat) !== -1 && INTERN_PIN.indexOf(t.slug) === -1;
+        });
         if (!tools.length) return;
         drawerBody.appendChild(groupEl(w, tools, w.id === cur));
       });


### PR DESCRIPTION
## Worum es geht

In der **Intern-/Backend-Ansicht** des Menüs (Schublade, `„intern"` tippen) stand die **Werkzeugpost** — der Redaktionstisch der Monatsmail — in der Welt ‹Kampagne› vergraben. Sie wird täglich gebraucht und bekommt jetzt einen kurzen Griff: **angeheftet ganz oben**, direkt unter der Startseite, über allen Welten.

## Änderung

- `design-system/nav.js`: neue Liste `INTERN_PIN` (Slugs) — dasselbe Muster wie `FLAT_ORDER`, aus dem Fundament heraus statt freihändig je Seite.
- In der Intern-Schublade werden die angehefteten Werkzeuge zuerst gerendert (ganz oben), danach die Welten.
- Angeheftete erscheinen **nicht zusätzlich** in ihrer Welt (**G03 — Doppelung weglassen**); die Welt ‹Kampagne› behält ihre übrigen sechs Einträge.
- Nur die Intern-Schublade betroffen; die **öffentliche Liste bleibt unverändert** (Werkzeugpost ist `status: intern` und erscheint dort ohnehin nicht).

## Geprüft

Im echten Browser (Chromium/Playwright) die Werkzeugpost-Seite mit `?intern` geöffnet, Schublade gelesen:

```
0. LINK  „Startseite"
1. LINK  „Werkzeugpost — Redaktion"   ← angeheftet, ganz oben
2. GROUP [werkzeuge] „Werkzeuge"
…
9. GROUP [kampagne]  „Kampagne"  → Sommer-Zähler, UTM-Generator, Mail-Editor,
                                    Grenzgänger (Lead-Agent), Grenzgänger (Wellen-Mails),
                                    Kampagnen-Drehbuch   ← ohne Werkzeugpost, keine Doppelung
```

Startseite bleibt Anker Nr. 0, Werkzeugpost sitzt darunter an der Spitze, keine Doppelung, ‹Kampagne› intakt. Keine Seiten-/Konsolenfehler. `typo-check` und `ds-lint --staged` grün (100 %).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QDrXvBpLkmb8PLP5j8NhX

---
_Generated by [Claude Code](https://claude.ai/code/session_014QDrXvBpLkmb8PLP5j8NhX)_