### PR TITLE
Schilder: Ethik als Spiel – zweispaltig mit Piktogrammen und treffenden Titeln

### DIFF
--- a/apps/schilder/index.html
+++ b/apps/schilder/index.html
@@ -47,6 +47,18 @@
   .hero{padding-block:clamp(40px,7vw,64px) var(--s4)}
   .hero .lede{margin-top:var(--s4);max-width:62ch}
 
+  /* Ethik als Spiel: zweispaltig, Piktogramm + treffender Titel + Häppchen
+     (nach Vorbild der Elf Empfehlungen der E-Mail-Signatur). */
+  .ethik{font-family:var(--font-text)}
+  @media(min-width:720px){.ethik{columns:2;column-gap:var(--s8)}}
+  .et-item{break-inside:avoid;margin:0 0 var(--s6)}
+  .et-item h3{font-family:var(--font-display);font-weight:var(--w-strong);font-size:var(--t-h3);margin:0 0 var(--s2)}
+  .et-item p{font-size:var(--t-small);line-height:1.6;color:var(--ink);margin:0;max-width:46ch}
+  .et-item p a{color:var(--gold-ink);text-decoration:underline;text-underline-offset:.15em}
+  .et-pikto{width:48px;height:48px;display:block;margin-bottom:var(--s2);fill:none;stroke:var(--muted);stroke-width:2.4;stroke-linecap:round;stroke-linejoin:round}
+  .et-pikto .acc{stroke:var(--gold-ink)}
+  .et-pikto .slash{stroke:var(--bad);opacity:.8}
+
   /* Zwei Spalten: links die Bedienung, rechts die Vorschau (klebt mit). */
   .work{display:grid;grid-template-columns:minmax(320px,1fr) minmax(360px,1.05fr);gap:var(--s8);align-items:start}
   @media(max-width:960px){.work{grid-template-columns:1fr}.preview{order:-1;position:static}}
@@ -485,41 +497,49 @@
   <section id="ethik">
     <div class="shead">
       <h2>Kleine Ethik der Beschilderung</h2>
-      <p>Was ein gutes Schild ausmacht – und was das Arbeiten damit sinnstiftend macht.</p>
+      <p>Acht Häppchen statt Gesetzbuch – was das Arbeiten mit Schildern sinnstiftend macht.</p>
     </div>
-    <div class="prose lese">
-      <p><strong>Ein Schild ist ein Dienst am Gast, nicht eine Botschaft an sich.</strong> Es steht dort,
-        wo jemand eine Frage hat, und beantwortet sie – ruhig, klar, in einem Atemzug lesbar. Wer davorsteht,
-        soll nicht ein Plakat bewundern, sondern schneller weitergehen können.</p>
-
-      <p><strong>Wenige Mittel, präzise gesetzt.</strong> Ein Schild trägt eine Sache. Eine Ansage, ein Ziel,
-        eine Zeit, ein Zeichen. Was man weglassen kann, lässt man weg (G03) – jede entbehrliche Zeile kostet
-        Aufmerksamkeit, die dem Wesentlichen fehlt.</p>
-
-      <p><strong>Keine Logos.</strong> Auf ein Schild gehört kein Signet. Die Hausschrift und die Klarheit der
-        Form machen es zur erkennbaren Autorität – das Haus spricht durch <em>wie</em> es gesetzt ist, nicht
-        durch eine Marke in der Ecke. Ein Logo würde nur behaupten, was die Form ohnehin zeigt.</p>
-
-      <p><strong>Zweisprachig, gleichwertig.</strong> Deutsch über Englisch, gleicher Grad, nur im Gewicht
-        unterschieden (Deutlich über Klar). Der Gast aus der Ferne wird gleich ernst genommen wie der von
-        nebenan – Betont wird mit dem Schnitt, nie mit Versalien, Sperren oder Unterstreichen (G05).</p>
-
-      <p><strong>Weiss auf Blau ist das Leitsystem.</strong> Der blaue Grund führt – er gehört allein den
-        Schildern, die einen Weg zeigen. Alle Ansagen, akut oder statisch, stehen dunkel auf Weiss. Wird der
-        blaue Grund beliebig, verliert er seine Kraft (B01: auf Farbe steht Weiss).</p>
-
-      <p><strong>Lesbar aus Distanz.</strong> Ein Schild wird im Vorbeigehen gelesen, oft schräg, oft schlecht
-        beleuchtet. Darum gross genug, kontrastreich, in Originalgrösse gedruckt – lieber ein Format grösser als
-        eine Zeile enger. Und montiert auf Augenhöhe, wo die Frage entsteht.</p>
-
-      <p><strong>Der QR-Code zählt mit – anonym.</strong> Wo ein Schild auf mehr verweist, führt ein Kurzlink
-        aus dem <a href="../qr-generator/">QR-Generator</a> dorthin. So wird nachvollziehbar, ob das Schild
-        genutzt wird – gemessen werden nur Zeitpunkt und Code, keine Personen. Nur der Gebrauch legitimiert das
-        Schild; was niemand liest, kommt weg.</p>
-
-      <p><strong>Ein Schild ist vergänglich.</strong> Es hängt für eine Situation, nicht für die Ewigkeit. Nimm
-        es ab, wenn die Situation vorbei ist. Ein veraltetes Schild schadet mehr als gar keines – es lehrt den
-        Gast, den Schildern zu misstrauen.</p>
+    <div class="ethik">
+      <div class="et-item">
+        <svg class="et-pikto" viewBox="0 0 48 48" aria-hidden="true"><path d="M24 6v30"/><path d="M10 12h20l4 5-4 5H10z" class="acc"/><path d="M18 42h12"/></svg>
+        <h3>Dienst, kein Denkmal</h3>
+        <p>Ein Schild beantwortet eine Frage. Wer davorsteht, soll weitergehen können – nicht ein Plakat bewundern.</p>
+      </div>
+      <div class="et-item">
+        <svg class="et-pikto" viewBox="0 0 48 48" aria-hidden="true"><circle cx="24" cy="24" r="5" class="acc"/><path d="M24 6v6M24 36v6M6 24h6M36 24h6"/></svg>
+        <h3>Eine Sache genügt</h3>
+        <p>Ein Ziel, eine Zeit, ein Zeichen. Jede Zeile zu viel stiehlt der einen, die zählt, die Aufmerksamkeit.</p>
+      </div>
+      <div class="et-item">
+        <svg class="et-pikto" viewBox="0 0 48 48" aria-hidden="true"><path d="M24 8l14 5v9c0 9-6 14-14 17-8-3-14-8-14-17v-9z"/><line x1="9" y1="41" x2="39" y2="7" class="slash"/></svg>
+        <h3>Kein Logo nötig</h3>
+        <p>Die Hausschrift ist der Absender. Ein Signet würde nur lauter behaupten, was die Form längst zeigt.</p>
+      </div>
+      <div class="et-item">
+        <svg class="et-pikto" viewBox="0 0 48 48" aria-hidden="true"><rect x="6" y="10" width="24" height="16" rx="3"/><path d="M14 26l-3 5 8-5"/><rect x="20" y="22" width="22" height="14" rx="3" class="acc"/></svg>
+        <h3>Zwei Zungen, ein Ton</h3>
+        <p>Deutsch über Englisch, gleich gross. Betont wird mit dem Schnitt – nie mit Versalien oder Unterstrich.</p>
+      </div>
+      <div class="et-item">
+        <svg class="et-pikto" viewBox="0 0 48 48" aria-hidden="true"><path d="M8 24h26" class="acc"/><path d="M26 14l10 10-10 10" class="acc"/></svg>
+        <h3>Blau zeigt den Weg</h3>
+        <p>Weiss auf Blau führt und gehört dem Leitsystem. Ansagen stehen dunkel auf Weiss – so bleibt Blau ein Versprechen.</p>
+      </div>
+      <div class="et-item">
+        <svg class="et-pikto" viewBox="0 0 48 48" aria-hidden="true"><path d="M4 24c5.5-8 13-12 20-12s14.5 4 20 12c-5.5 8-13 12-20 12S9.5 32 4 24z"/><circle cx="24" cy="24" r="5" class="acc"/></svg>
+        <h3>Aus zehn Metern</h3>
+        <p>Gross, kontrastreich, in Originalgrösse gedruckt, auf Augenhöhe gehängt. Ein Schild, das man suchen muss, hat verloren.</p>
+      </div>
+      <div class="et-item">
+        <svg class="et-pikto" viewBox="0 0 48 48" aria-hidden="true"><rect x="8" y="8" width="12" height="12" rx="1"/><rect x="28" y="8" width="12" height="12" rx="1"/><rect x="8" y="28" width="12" height="12" rx="1"/><path d="M28 28h5v5M40 33v7M33 40h-5" class="acc"/></svg>
+        <h3>Der QR zählt leise mit</h3>
+        <p>Ein Kurzlink aus dem <a href="../qr-generator/">QR-Generator</a> zeigt, ob gelesen wird – anonym, nur Zeitpunkt und Code.</p>
+      </div>
+      <div class="et-item">
+        <svg class="et-pikto" viewBox="0 0 48 48" aria-hidden="true"><circle cx="24" cy="24" r="16"/><path d="M24 14v10l7 4" class="acc"/></svg>
+        <h3>Nimm mich wieder ab</h3>
+        <p>Ein Schild gilt für eine Situation, nicht für die Ewigkeit. Ein veraltetes schadet mehr als gar keines.</p>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Was

Die **kleine Ethik der Beschilderung** von Fliesstext auf ein Spiel umgestellt – nach Vorbild der *Elf Empfehlungen* der E-Mail-Signatur: zweispaltig, je ein Strich-Piktogramm, ein treffender Titel und ein kurzer Satz. Häppchen statt Gesetzbuch.

Die acht Häppchen: **Dienst, kein Denkmal · Eine Sache genügt · Kein Logo nötig · Zwei Zungen, ein Ton · Blau zeigt den Weg · Aus zehn Metern · Der QR zählt leise mit · Nimm mich wieder ab.**

## Wie

- Piktogramme als Inline-SVG im Stil der Signatur-Empfehlungen (Strich, `--muted` mit `--gold-ink`-Akzent, `--bad`-Slash) – folgen Hell/Dunkel über die Tokens.
- Zwei Spalten ab 720px (`columns:2`), `break-inside:avoid`; Lesetext in Source Sans, Titel in der Hausschrift (Laut).

## Prüfung

- `ds-lint` **100 %**, `typo-check` konform.
- Im Browser (Chromium) gerendert: 8 Karten, 8 Piktogramme, sauberer Zweispalter, Titel/Häppchen lesbar.

## Offen (nächster Schritt)

- **Eigener, vektorbasierter PDF-Export** statt Browser-Druck (nach Vorbild des Kartentools) – folgt als eigener, fokussierter Schritt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013whsL6oA2sRXKnC2wtJXGd

---
_Generated by [Claude Code](https://claude.ai/code/session_013whsL6oA2sRXKnC2wtJXGd)_