### PR TITLE
Backstage-Schublade neu strukturiert: acht Welten, Labor mit Unterwelten

### DIFF
--- a/design-system/nav.css
+++ b/design-system/nav.css
@@ -187,6 +187,13 @@ html.has-onpage{scroll-padding-top:calc(var(--header-h) + 46px)}
 .dsnav-group>summary .arr{color:var(--muted);font-weight:var(--w-text);transition:transform .15s}
 .dsnav-group[open]>summary .arr{transform:rotate(90deg)}
 
+/* Unterwelten: eine Ebene tiefer verschachtelt (Labor → Ligaturen, Schriftpflege,
+   Geparktes, Überreste). Ruhiger als die Oberwelt – Titel kleiner und weniger fett;
+   Bereich und Einträge eingerückt, damit die Verschachtelung lesbar ist. */
+.dsnav-group .dsnav-group{border-bottom:0;border-top:1px solid var(--line-soft)}
+.dsnav-group .dsnav-group>summary{padding-left:36px;font-weight:var(--w-klar);font-size:15px}
+.dsnav-group .dsnav-group .dsnav-link{padding-left:48px}
+
 .dsnav-link{display:flex;align-items:center;gap:10px;min-height:var(--tap);padding:6px 22px;text-decoration:none;color:var(--ink)}
 .dsnav-home{border-bottom:1px solid var(--line-soft);margin-bottom:var(--s2)}
 .dsnav-link:hover{background:var(--soft)}

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -128,19 +128,23 @@
     { id: "anwendungen", label: "Anwendungen",
       intro: "Fertige Vorlagen zum Übernehmen – Wallpaper, Präsentationen.", cats: ["anwendung"] }
   ];
-  // Nur intern zusätzlich – die Backstage-Welten (A/B/C-Qualifizierung).
-  // Kuratierte Reihenfolge; Manifest-Kategorien, die hier fehlen, laufen beim
-  // Laden automatisch als eigene Backstage-Welt hinten nach (Sicherheitsnetz).
+  // Nur intern zusätzlich – die Backstage-Welten. Kuratierte Reihenfolge: erst die
+  // Redaktions- und Beobachtungs-Welten, dann das Labor als Sammelort für Erprobung
+  // und Abgelegtes. Das Labor trägt Unterwelten (verschachtelte Kisten) – die
+  // Etiketten je Werkzeug (Beta/Entwurf/intern/geparkt) sagen ohnehin, was
+  // öffentlich ist. Manifest-Kategorien, die hier fehlen, laufen beim Laden
+  // automatisch als eigene Welt nach (Sicherheitsnetz).
   var INTERN_EXTRA = [
-    { id: "vorbereitung", label: "In Vorbereitung", intro: "In Arbeit – noch nicht freigegeben.", cats: ["vorbereitung"] },
-    { id: "ligaturen", label: "Ligaturen", intro: "Die Kiste nur für die Ligaturen.", cats: ["ligaturen"] },
-    { id: "schriftpflege", label: "Schriftpflege", intro: "Grotesk, Gewichte und Mischsatz prüfen.", cats: ["schriftpflege"] },
     { id: "kampagne", label: "Kampagne", intro: "Kampagnen planen, verlinken, mailen, zählen.", cats: ["kampagne"] },
-    { id: "statistik", label: "Statistik", intro: "Nutzungszahlen aller Werkzeuge.", cats: ["statistik"] },
     { id: "schau", label: "Schau & Mockups", intro: "Präsentations-Mockups und Studien.", cats: ["schau"] },
-    { id: "geparkt", label: "Geparktes", intro: "Konzepte, die später kommen.", cats: ["geparkt"] },
-    { id: "archiv", label: "Archiv", intro: "Frühere Stände, eingefroren.", cats: ["archiv"] },
-    { id: "labor", label: "Labor", intro: "Skizzen und Spezialtools – zum Ausprobieren vor dem Teilen.", cats: ["labor"] }
+    { id: "statistik", label: "Statistik", intro: "Nutzungszahlen aller Werkzeuge.", cats: ["statistik"] },
+    { id: "labor", label: "Labor", intro: "Erprobung und Abgelegtes – zum Ausprobieren, mit verschachtelten Kisten.",
+      cats: ["labor"], sub: [
+        { id: "ligaturen", label: "Ligaturen", intro: "Die Kiste nur für die Ligaturen.", cats: ["ligaturen"] },
+        { id: "schriftpflege", label: "Schriftpflege", intro: "Grotesk, Gewichte und Mischsatz prüfen.", cats: ["schriftpflege"] },
+        { id: "geparkt", label: "Geparktes", intro: "Konzepte, die später kommen.", cats: ["geparkt"] },
+        { id: "archiv", label: "Überreste", intro: "Frühere Stände, eingefroren.", cats: ["archiv"] }
+    ] }
   ];
   var PUBLIC_IDS = WORLDS.map(function (w) { return w.id; });
 
@@ -164,10 +168,11 @@
     return ROOT + h.replace(/^\//, "");
   }
   function isExternal(h) { return /^https?:/i.test(h) && h.indexOf(ROOT) !== 0; }
-  function worldFor(catId) {
-    var all = WORLDS.concat(INTERN_EXTRA);
-    for (var i = 0; i < all.length; i++) { if (all[i].cats.indexOf(catId) !== -1) return all[i]; }
-    return null;
+  // Alle Kategorien einer Welt inklusive ihrer Unterwelten (flach).
+  function catsOf(w) {
+    var cs = (w.cats || []).slice();
+    (w.sub || []).forEach(function (s) { cs = cs.concat(catsOf(s)); });
+    return cs;
   }
   function currentFile() { var p = location.pathname.replace(/\/+$/, ""); return p.slice(p.lastIndexOf("/") + 1); }
   function isActiveTool(t) {
@@ -433,10 +438,9 @@
   var ALL = [];
   function bySlug(slug) { return ALL.filter(function (t) { return t.slug === slug; })[0]; }
 
-  function currentWorldId() {
-    for (var i = 0; i < ALL.length; i++) {
-      if (isActiveTool(ALL[i])) { var w = worldFor(ALL[i].cat); return w ? w.id : null; }
-    }
+  // Kategorie der aktiven Seite – so öffnet sich ihre Welt (und Unterwelt).
+  function currentCat() {
+    for (var i = 0; i < ALL.length; i++) { if (isActiveTool(ALL[i])) return ALL[i].cat; }
     return null;
   }
 
@@ -458,14 +462,25 @@
     return a;
   }
 
-  function groupEl(w, tools, open) {
+  // Eine Welt als aufklappbarer Bereich. Unterwelten verschachteln sich als eigene
+  // Bereiche darunter (Labor → Ligaturen, Schriftpflege, Geparktes, Überreste).
+  // Leere Welten (kein Werkzeug, keine gefüllte Unterwelt) entfallen. curCat =
+  // Kategorie der aktiven Seite: ihre Welt und Unterwelt stehen offen.
+  function worldGroupEl(w, curCat) {
+    var tools = ALL.filter(function (t) {
+      return (w.cats || []).indexOf(t.cat) !== -1 && INTERN_PIN.indexOf(t.slug) === -1;
+    });
+    var subs = (w.sub || []).map(function (s) { return worldGroupEl(s, curCat); })
+                            .filter(function (n) { return n; });
+    if (!tools.length && !subs.length) return null;
     var g = el("details", "dsnav-group");
     g.setAttribute("data-world", w.id);
-    g.open = open;
+    g.open = catsOf(w).indexOf(curCat) !== -1;
     // Das Menü koordiniert, es erklärt nicht: nur Titel, kein Beiwerk-Text.
     g.appendChild(el("summary", null,
       '<span class="ttl">' + w.label + '</span><span class="arr">›</span>'));
     tools.forEach(function (t) { g.appendChild(linkEl(t)); });
+    subs.forEach(function (n) { g.appendChild(n); });
     return g;
   }
 
@@ -503,18 +518,15 @@
       pub.forEach(function (t) { drawerBody.appendChild(linkEl(t)); });
     } else {
       // intern: erst die angehefteten Redaktions-Werkzeuge (ganz oben), dann
-      // nach Backstage-Welten gruppiert (kurze, scannbare Bereiche).
-      var cur = currentWorldId();
+      // nach Backstage-Welten gruppiert; Unterwelten verschachteln sich (Labor).
+      var curCat = currentCat();
       INTERN_PIN.forEach(function (slug) {
         var t = bySlug(slug);
         if (t) drawerBody.appendChild(linkEl(t));
       });
       WORLDS.concat(INTERN_EXTRA).forEach(function (w) {
-        var tools = ALL.filter(function (t) {
-          return w.cats.indexOf(t.cat) !== -1 && INTERN_PIN.indexOf(t.slug) === -1;
-        });
-        if (!tools.length) return;
-        drawerBody.appendChild(groupEl(w, tools, w.id === cur));
+        var node = worldGroupEl(w, curCat);
+        if (node) drawerBody.appendChild(node);
       });
     }
     applySearch();
@@ -526,7 +538,7 @@
     // Sicherheitsnetz: Manifest-Kategorien ohne Welt werden automatisch eigene
     // Backstage-Welten (Titel/Intro aus tools.json) — eine neue Kategorie im
     // Manifest verschwindet damit nie mehr stillschweigend aus dem Menü.
-    var known = WORLDS.concat(INTERN_EXTRA).reduce(function (a, w) { return a.concat(w.cats); }, []);
+    var known = WORLDS.concat(INTERN_EXTRA).reduce(function (a, w) { return a.concat(catsOf(w)); }, []);
     (m.categories || []).forEach(function (c) {
       if (c && c.id && known.indexOf(c.id) === -1) {
         INTERN_EXTRA.push({ id: c.id, label: c.title || c.id, intro: c.intro || "", cats: [c.id] });

--- a/tools.json
+++ b/tools.json
@@ -29,11 +29,6 @@
       "intro": "Fertige Vorlagen zum Übernehmen – Wallpaper, Präsentationen."
     },
     {
-      "id": "vorbereitung",
-      "title": "In Vorbereitung",
-      "intro": "In Arbeit – noch nicht für die Breite freigegeben. Intern sichtbar."
-    },
-    {
       "id": "ligaturen",
       "title": "Ligaturen",
       "intro": "Die Kiste nur für die Ligaturen – Werkschau, Überlagerung, Abstände."
@@ -257,7 +252,7 @@
     },
     {
       "slug": "cover",
-      "cat": "vorbereitung",
+      "cat": "generatoren",
       "status": "entwurf",
       "tag": "Goetheanum TV",
       "title": "Cover-Generator",
@@ -267,7 +262,7 @@
     },
     {
       "slug": "briefschaften",
-      "cat": "vorbereitung",
+      "cat": "generatoren",
       "status": "entwurf",
       "tag": "Korrespondenz",
       "title": "Briefschaften",
@@ -277,7 +272,7 @@
     },
     {
       "slug": "schilder",
-      "cat": "vorbereitung",
+      "cat": "generatoren",
       "status": "entwurf",
       "tag": "Orientierung",
       "title": "Schilder",
@@ -288,7 +283,7 @@
     },
     {
       "slug": "bewegte-schrift",
-      "cat": "vorbereitung",
+      "cat": "labor",
       "status": "entwurf",
       "tag": "Erprobung",
       "title": "Bewegte Schrift",


### PR DESCRIPTION
## Warum

Die Intern-Schublade war mit **dreizehn gleichrangigen Bereichen** unübersichtlich geworden. Weil die Etiketten je Werkzeug (Beta/Entwurf/intern/geparkt) ohnehin sagen, was öffentlich ist, ordnet die Schublade jetzt **nach Thema statt nach Reifegrad** — mit verschachtelten Unterwelten fürs Backstage.

## Vorher → Nachher (Intern-Schublade)

| vorher (13 Bereiche) | nachher (8 Oberwelten) |
|---|---|
| Werkzeuge · Schrift · Elemente · Anwendungen | **Werkzeuge**¹ · **Schrift** · **Elemente** · **Anwendungen** |
| In Vorbereitung | *(aufgelöst → verteilt)* |
| Ligaturen · Schriftpflege | → Unterwelten von Labor |
| Kampagne · Statistik · Schau & Mockups | **Kampagne** · **Schau & Mockups** · **Statistik** |
| Geparktes · Archiv · Labor | **Labor** ▾ Ligaturen · Schriftpflege · Geparktes · **Überreste**² |

¹ Werkzeuge nimmt jetzt Cover-Generator, Briefschaften, Schilder auf (bleiben als Entwurf intern).
² «Überreste» = vormals Archiv. Bewegte Schrift steht direkt im Labor.

## Änderung

**`tools.json`**
- Cover-Generator, Briefschaften, Schilder → Kategorie `generatoren` (Werkzeuge).
- Bewegte Schrift → `labor`.
- Kategorie `vorbereitung` aufgelöst (reifegrad-basiert, jetzt entbehrlich — **G03**).

**`nav.js`**
- Neues Feld `sub`: eine Welt kann Unterwelten tragen. Rendering rekursiv (`worldGroupEl`), leere Welten/Unterwelten entfallen.
- Die aktive Seite öffnet ihre Welt **und** ihre Unterwelt (`catsOf`/`currentCat`).
- Sicherheitsnetz erkennt auch verschachtelte Kategorien (kein Doppel-Eintrag).

**`nav.css`**
- Unterwelten ruhiger und eingerückt (Titel 15 px/klar ≥ **B03**-Floor, nur Tokens — **B05**).

## Geprüft (Chromium/Playwright, hell + dunkel)

- Acht Oberwelten in der Intern-Schublade; Labor mit vier Unterwelten (Ligaturen 3 · Schriftpflege 3 · Geparktes 4 · Überreste 1).
- Werkzeuge enthält Cover/Briefschaften/Schilder; kein Top-Level «In Vorbereitung» mehr.
- Aktive Unterwelt-Seite (`ligvorschau`) klappt Labor **und** Ligaturen auf, andere bleiben zu.
- **Öffentliche Schublade unverändert** (flach, nur live/beta) — die neuen Entwürfe bleiben intern.
- Keine Seiten-/Konsolenfehler. `typo-check` ✓ · `ds-lint` 100 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QDrXvBpLkmb8PLP5j8NhX

---
_Generated by [Claude Code](https://claude.ai/code/session_014QDrXvBpLkmb8PLP5j8NhX)_