### PR TITLE
QR/Kurzlink: Löschknöpfe reagieren live auf den Backstage-Schalter

### DIFF
--- a/apps/qr-generator/index.html
+++ b/apps/qr-generator/index.html
@@ -815,6 +815,9 @@
   el('kurzCode').value = neuerCode();
   setModus(startModus);
   ladeRegister();
+  // Backstage-Umschaltung (nav.js feuert „goe:intern") sofort spiegeln, damit
+  // die Löschknöpfe erscheinen/verschwinden – ohne Reload.
+  window.addEventListener('goe:intern', ladeRegister);
 </script>
 
 </body>


### PR DESCRIPTION
## Was

Fix: Die Löschfunktion für Kurzlinks war vorhanden, erschien im Register aber **nur, wenn der Backstage-Modus schon beim Laden aktiv war**. Wer Backstage bei offener Seite einschaltete, sah keine Löschknöpfe – wirkte wie «fehlt».

Jetzt hört das Register auf das Event `goe:intern` (von `nav.js` beim Umschalten gefeuert) und lädt sich neu: Löschknöpfe erscheinen und verschwinden **live**, ohne Reload.

## Verifiziert

- Playwright gegen das echte Backend: 0 Löschknöpfe → Backstage an (Event) → 3 Knöpfe → Backstage aus → 0. Keine JS-Fehler.
- `typo-check` und `ds-lint` auf der Tool-Seite: 0 Fehler, 0 Hinweise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4)_