### PR TITLE
Wallpaper-Generator ist noch nicht öffentlich: Karte entfernen

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -113,7 +113,7 @@
     {
       "slug": "wallpaper-generator",
       "cat": "generatoren",
-      "status": "beta",
+      "status": "intern",
       "tag": "Wallpaper",
       "title": "Wallpaper-Generator",
       "short": "Wallpaper",

--- a/wallpaper.html
+++ b/wallpaper.html
@@ -37,13 +37,6 @@
     <div class="kicker">Hausgrafik · Anwendungen</div>
     <h1>Wallpaper</h1>
     <p class="lede">Desktop-Hintergründe in 2500 × 1406. Auf ein Motiv tippen lädt die Datei herunter.</p>
-    <p style="margin-top:var(--s4)">
-      <a class="shot" href="apps/wallpaper-generator/"
-         style="display:inline-flex;align-items:center;gap:var(--s2);padding:var(--s3) var(--s4);width:auto">
-        <span>Neu: eigenes Wallpaper in deiner Sektionsfarbe gestalten</span>
-        <span class="dl">Zum Generator →</span>
-      </a>
-    </p>
   </div>
 
   <div class="grid" id="grid"></div>


### PR DESCRIPTION
## Warum

Der **Wallpaper-Generator** (Entwurfsstand) erschien öffentlich — als Karte auf der Startseite (Status `beta` = öffentlich) und als Teaser auf der Wallpaper-Seite. Er ist noch nicht freigegeben.

## Änderung

- **`tools.json`**: `wallpaper-generator` Status `beta` → `intern`. Damit fällt die Karte aus allen öffentlichen Flächen (Startseite-Karten, öffentliche Schublade); intern bleibt das Werkzeug sichtbar (mit Etikett «intern»).
- **`wallpaper.html`**: den «Zum Generator»-Teaser entfernt (führte öffentlich zum nicht-freigegebenen Werkzeug).

## Geprüft (Chromium/Playwright)

- Startseite: keine Wallpaper-Generator-Karte mehr (14 Karten, Generator raus).
- Wallpaper-Seite: kein Teaser-Link mehr.
- Karussell zeigt weiterhin nur «Wallpaper» (die freigegebene Anwendung).
- Keine Fehler. `typo-check` ✓ · `ds-lint` 100 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QDrXvBpLkmb8PLP5j8NhX

---
_Generated by [Claude Code](https://claude.ai/code/session_014QDrXvBpLkmb8PLP5j8NhX)_