### PR TITLE
Kurzlink löschen: kein Passwort mehr, Backstage genügt

### DIFF
--- a/apps/qr-generator/index.html
+++ b/apps/qr-generator/index.html
@@ -721,16 +721,14 @@
   el('statBtn').addEventListener('click', function(){ zeigeStats(el('statCode').value); });
   el('statCode').addEventListener('keydown', function(ev){ if(ev.key === 'Enter') zeigeStats(this.value); });
 
-  // Löschen: Knopf nur im Backstage-Modus (Schalter aus nav.js), der echte
-  // Riegel ist das Team-Passwort in der RPC qr_link_loeschen.
+  // Löschen: Knopf nur im Backstage-Modus (Schalter aus nav.js) – kein Passwort
+  // (Beschluss: Backstage genügt als Schutz). Nur eine Rückfrage gegen Versehen.
   function imBackstage(){ try { return localStorage.getItem('goeNavIntern') === '1'; } catch(e){ return false; } }
   function loescheCode(code){
-    var pw = window.prompt('Team-Passwort, um „' + code + '“ endgültig zu löschen (Kurzlink und Zählung):');
-    if(pw === null || pw === '') return;
-    rpc('qr_link_loeschen', { p_code: code, p_passwort: pw })
+    if(!window.confirm('Kurzlink „' + code + '“ endgültig löschen? Der Link und seine Zählung sind dann weg.')) return;
+    rpc('qr_link_loeschen', { p_code: code })
       .then(function(ergebnis){
         if(ergebnis === 'ok'){ statSay('Code „' + code + '“ gelöscht.'); el('statDetail').hidden = true; ladeRegister(); }
-        else if(ergebnis === 'passwort'){ statSay('Falsches Passwort – nichts gelöscht.', true); }
         else { statSay('Code „' + code + '“ nicht gefunden.', true); }
       })
       .catch(function(){ statSay('Löschen nicht erreichbar.', true); });
@@ -760,7 +758,7 @@
         if(backstage){
           var weg = document.createElement('button');
           weg.type = 'button'; weg.className = 'mini weg'; weg.textContent = 'Löschen';
-          weg.setAttribute('aria-label', 'Kurzlink löschen (Team-Passwort nötig)');
+          weg.setAttribute('aria-label', 'Kurzlink löschen');
           weg.addEventListener('click', function(){ loescheCode(x.code); });
           tr.children[5].appendChild(weg);
         }

--- a/services/qr-generator/README.md
+++ b/services/qr-generator/README.md
@@ -43,18 +43,17 @@ Zählung. Wer hier einen Kurzlink anlegt, veröffentlicht ihn – für nicht
 | `qr_links_public()` | anon | Offenes Register: alle QR-Kurzlinks mit Ziel und Zählung |
 | `qr_stats_public(p_code)` | anon | Summe, letzter Scan, Ziel-URL (beide Register) |
 | `qr_stats_tage(p_code)` | anon | Scans je Tag, letzte 30 Tage |
-| `qr_link_loeschen(p_code, p_passwort)` | anon, Team-Passwort | Löschen: `ok` · `passwort` · `unbekannt` (Zählung geht mit) |
+| `qr_link_loeschen(p_code)` | anon | Löschen: `ok` · `unbekannt` (Zählung geht mit) |
 | `kurzlink_aufloesen(p_code)` | nur service_role | Auflösen + Zählen für die Function `go` |
 
 ## Bewusste Entscheide (v1)
 
-- **Löschen nur mit Team-Passwort** (Beschluss 10.7.2026, revidiert vom
-  Auftraggeber): der Lösch-Knopf im Register erscheint nur im Backstage-Modus,
-  der echte Riegel ist das Passwort in `qr_link_loeschen` (Hash in `qr_config`,
-  Muster Multiplikatoren, Präfix `goe-qr:`). Ein offener Löschweg würde
-  gedruckte Codes gefährden. Passwort ändern: neuen Hash in `qr_config`
-  setzen (`update qr_config set value = encode(extensions.digest('goe-qr:' ||
-  lower(trim('NEU')), 'sha256'), 'hex') where key = 'loeschen_pw_hash'`).
+- **Löschen ohne Passwort, Backstage genügt** (Beschluss 11.7.2026): der
+  Lösch-Knopf im Register erscheint nur im Backstage-Modus (Client-Schalter
+  `goeNavIntern`); `qr_link_loeschen(p_code)` ist für anon offen. Bewusst in
+  Kauf genommen: die RPC ist damit technisch von jedem aufrufbar (Backstage
+  schützt nur den Knopf, nicht den Endpunkt) – vertretbar, weil Kurzlinks
+  wiederherstellbar sind und das Register ohnehin öffentlich ist.
 - **Fallback unbekannter Codes:** bleibt vorerst die Sommer-Landingpage (in
   `go/index.ts`); nach der Kampagne auf eine neutrale Seite stellen.
 - **Geparkt für v2:** Logo in der QR-Mitte (erzwingt Fehlerkorrektur H und

--- a/services/qr-generator/schema.sql
+++ b/services/qr-generator/schema.sql
@@ -106,36 +106,22 @@ language sql security definer set search_path to 'public' as $$
 $$;
 grant execute on function public.qr_stats_tage(text) to anon, authenticated;
 
--- Löschtaste (Migration «qr_link_loeschen_mit_passwort», Beschluss 10.7.2026,
--- revidiert): Löschen im Werkzeug, aber nur mit Team-Passwort (Muster
--- Multiplikatoren: Hash in versiegelter Config, Präfix 'goe-qr:', Vergleich
--- gross/klein- und leerzeichen-unabhängig). Der Knopf erscheint nur im
--- Backstage-Modus; der echte Riegel ist die RPC.
-create table if not exists public.qr_config (
-  key   text primary key,
-  value text not null
-);
-alter table public.qr_config enable row level security;
-revoke all on table public.qr_config from anon, authenticated;
--- Schlüssel in qr_config:
---   loeschen_pw_hash : sha256('goe-qr:' || lower(trim(passwort))), hex
-
-create or replace function public.qr_link_loeschen(p_code text, p_passwort text)
+-- Löschtaste (Migration «qr_link_loeschen_ohne_passwort», Beschluss 11.7.2026):
+-- Löschen im Werkzeug OHNE Passwort – der Backstage-Modus (Client-Schalter)
+-- genügt als Schutz. Der Knopf erscheint nur im Backstage; die RPC ist für anon
+-- offen (Kurzlinks sind wiederherstellbar, das Register ohnehin öffentlich).
+create or replace function public.qr_link_loeschen(p_code text)
 returns text language plpgsql security definer set search_path to 'public' as $$
 declare v_code text := lower(trim(coalesce(p_code,''))); n int;
 begin
-  if not exists (
-    select 1 from public.qr_config c
-     where c.key = 'loeschen_pw_hash'
-       and c.value = encode(extensions.digest('goe-qr:' || lower(trim(coalesce(p_passwort,''))), 'sha256'), 'hex')
-  ) then return 'passwort'; end if;
+  if v_code = '' then return 'unvollstaendig'; end if;
   delete from public.qr_links where code = v_code;
   get diagnostics n = row_count;
   if n = 0 then return 'unbekannt'; end if;
   delete from public.link_hits where code = v_code;   -- Zählung geht mit dem Code
   return 'ok';
 end; $$;
-grant execute on function public.qr_link_loeschen(text, text) to anon, authenticated;
+grant execute on function public.qr_link_loeschen(text) to anon, authenticated;
 
 -- Auflösen + Zählen in EINEM Rundgang – nur für die Edge Function (service_role).
 create or replace function public.kurzlink_aufloesen(p_code text)


### PR DESCRIPTION
## Was

Beschluss revidiert: **kein Team-Passwort** beim Löschen. Der Lösch-Knopf bleibt Backstage-only, fragt aber nur noch einmal zur Sicherheit nach (`confirm`) statt nach einem Passwort.

- Backend: `qr_link_loeschen(p_code)` ist jetzt einargumentig und für anon offen; die passwortpflichtige 2-Arg-Fassung und die `qr_config`-Tabelle sind entfernt (Migration `qr_link_loeschen_ohne_passwort`, **deployt**).
- Frontend: `window.prompt(Passwort)` → `window.confirm(…)`, RPC-Aufruf ohne `p_passwort`, aria-Label angepasst.
- README/schema angeglichen.

**Sicherheits-Hinweis (bewusst in Kauf genommen):** Die RPC ist damit technisch von jedem aufrufbar – Backstage schützt nur den Knopf im Client, nicht den Endpunkt. Vertretbar, weil Kurzlinks wiederherstellbar sind und das Register ohnehin öffentlich ist.

## Verifiziert

- curl: anlegen → löschen (ohne Passwort) `ok` → erneut `unbekannt`; alte 2-Arg-Signatur weg (PGRST202).
- UI (Playwright, Backstage): Rückfrage statt Passwort, Code gelöscht, Zeile verschwindet, keine JS-Fehler.
- `typo-check`/`ds-lint`: 0 Fehler, 0 Hinweise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4)_