### PR TITLE
Archiv: fester QR klein am Zeilenanfang (Klick lädt)

### DIFF
--- a/apps/qr-generator/index.html
+++ b/apps/qr-generator/index.html
@@ -86,6 +86,10 @@
   .codes .mini:hover{color:var(--blue)}
   .codes .mini.weg:hover{color:var(--bad)}
   .codes td.dat{font-variant-numeric:tabular-nums;white-space:nowrap}
+  .codes th.qh,.codes td.qz{width:44px;padding-right:6px}
+  .qmini{display:block;width:38px;height:38px;padding:2px;background:none;border:0;cursor:pointer;border-radius:6px}
+  .qmini svg{display:block;width:100%;height:100%}
+  .qmini:hover{background:var(--soft)}
   .tablewrap{overflow-x:auto;margin-top:var(--s4)}
   .empty{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small)}
   .zwischen{margin-top:var(--s8)}
@@ -326,8 +330,8 @@
       </div>
       <div class="tablewrap">
         <table class="codes">
-          <thead><tr><th>Code</th><th>Ziel</th><th>angelegt</th><th class="num">Scans</th><th>letzter Scan</th><th></th></tr></thead>
-          <tbody id="codesBody"><tr><td class="empty" colspan="6">lädt …</td></tr></tbody>
+          <thead><tr><th class="qh"></th><th>Code</th><th>Ziel</th><th>angelegt</th><th class="num">Scans</th><th>letzter Scan</th><th></th></tr></thead>
+          <tbody id="codesBody"><tr><td class="empty" colspan="7">lädt …</td></tr></tbody>
         </table>
       </div>
     </div>
@@ -739,32 +743,44 @@
     var body = el('codesBody');
     rpc('qr_links_public').then(function(rows){
       body.innerHTML = '';
-      if(!rows || !rows.length){ body.innerHTML = '<tr><td class="empty" colspan="6">Noch keine Codes angelegt.</td></tr>'; return; }
+      if(!rows || !rows.length){ body.innerHTML = '<tr><td class="empty" colspan="7">Noch keine Codes angelegt.</td></tr>'; return; }
       var backstage = imBackstage();
       rows.forEach(function(x){
         var tr = document.createElement('tr');
-        tr.innerHTML = '<td class="cd"></td><td class="zi"></td><td class="dat"></td><td class="num"></td><td class="dat"></td><td class="act"></td>';
+        tr.innerHTML = '<td class="qz"></td><td class="cd"></td><td class="zi"></td><td class="dat"></td><td class="num"></td><td class="dat"></td><td class="act"></td>';
+        // Der feste QR des Kurzlinks (fliessend) – klein am Zeilenanfang, Klick lädt.
+        var kurz = SHORTBASE + x.code;
+        var qbtn = document.createElement('button');
+        qbtn.type = 'button'; qbtn.className = 'qmini';
+        qbtn.setAttribute('aria-label', 'QR von ' + x.code + ' herunterladen');
+        qbtn.title = 'QR herunterladen';
+        try { qbtn.innerHTML = qrSvg(kurz, 'fliessend', '#141414', '#ffffff'); } catch(e){ qbtn.textContent = 'QR'; }
+        qbtn.addEventListener('click', function(){
+          var svg = qbtn.querySelector('svg'); if(!svg) return;
+          dlBlob(new Blob([svg.outerHTML], { type: 'image/svg+xml' }), 'qr_' + x.code + '.svg');
+        });
+        tr.children[0].appendChild(qbtn);
         var a = document.createElement('a');
-        a.href = SHORTBASE + x.code; a.target = '_blank'; a.rel = 'noopener'; a.textContent = x.code;
-        tr.children[0].appendChild(a);
-        tr.children[1].textContent = x.url;
-        tr.children[2].textContent = new Date(x.created_at).toLocaleDateString('de-CH');
-        tr.children[3].textContent = Number(x.scans).toLocaleString('de-CH');
-        tr.children[4].textContent = fmtZeit(x.letzter_scan);
+        a.href = kurz; a.target = '_blank'; a.rel = 'noopener'; a.textContent = x.code;
+        tr.children[1].appendChild(a);
+        tr.children[2].textContent = x.url;
+        tr.children[3].textContent = new Date(x.created_at).toLocaleDateString('de-CH');
+        tr.children[4].textContent = Number(x.scans).toLocaleString('de-CH');
+        tr.children[5].textContent = fmtZeit(x.letzter_scan);
         var zeig = document.createElement('button');
         zeig.type = 'button'; zeig.className = 'mini'; zeig.textContent = 'Verlauf';
         zeig.addEventListener('click', function(){ zeigeStats(x.code); el('statDetail').scrollIntoView({ behavior: 'smooth', block: 'nearest' }); });
-        tr.children[5].appendChild(zeig);
+        tr.children[6].appendChild(zeig);
         if(backstage){
           var weg = document.createElement('button');
           weg.type = 'button'; weg.className = 'mini weg'; weg.textContent = 'Löschen';
           weg.setAttribute('aria-label', 'Kurzlink löschen');
           weg.addEventListener('click', function(){ loescheCode(x.code); });
-          tr.children[5].appendChild(weg);
+          tr.children[6].appendChild(weg);
         }
         body.appendChild(tr);
       });
-    }).catch(function(){ body.innerHTML = '<tr><td class="empty" colspan="6">Register nicht ladbar.</td></tr>'; });
+    }).catch(function(){ body.innerHTML = '<tr><td class="empty" colspan="7">Register nicht ladbar.</td></tr>'; });
   }
 
   // --- Modus: QR-Code | Kurzlink (dieselbe App, zwei Türen) -------------------


### PR DESCRIPTION
## Was

Im Kurzlink-Register («Alle Kurzlinks») steht jetzt der **feste QR** des Codes klein am **Anfang jeder Zeile** – statt eines Download-Knopfs. Er entsteht deterministisch aus dem Kurzlink (Fliessend), zeigt also immer denselben Code, «wie erstellt». Ein Klick lädt ihn als SVG.

Design-Varianten bleiben bewusst dem Werkzeug oben vorbehalten; das Archiv zeigt den kanonischen Code, kein Neu-Designen – genau wie gewünscht.

## Verifiziert

- Register rendert Mini-QR je Zeile (Playwright, echtes Backend), Klick lädt `qr_<code>.svg`, keine JS-Fehler.
- `typo-check`/`ds-lint`: 0 Fehler, 0 Hinweise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4)_