### PR TITLE
QR: nur noch Fliessend; Archiv zweizeilig mit kopierbarem Kurzlink

### DIFF
--- a/apps/qr-generator/index.html
+++ b/apps/qr-generator/index.html
@@ -75,23 +75,26 @@
   .spark .dl{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted)}
   .ziel{margin-top:var(--s4)}
 
-  .codes{width:100%;border-collapse:collapse;font-family:var(--font-text);font-size:var(--t-small);min-width:520px}
-  .codes th,.codes td{padding:10px 12px;border-bottom:1px solid var(--line-soft);text-align:left;vertical-align:top}
-  .codes thead th{color:var(--muted);font-weight:600;font-size:var(--t-micro)}
-  .codes td.num,.codes th.num{text-align:right;font-variant-numeric:tabular-nums lining-nums}
-  .codes .cd a{font-family:var(--font-mono,var(--font-text));color:var(--blue)}
-  .codes .zi{color:var(--muted);word-break:break-all}
-  .codes .act{text-align:right;white-space:nowrap}
-  .codes .mini{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);background:none;border:0;cursor:pointer;padding:4px 6px;min-height:var(--tap)}
-  .codes .mini:hover{color:var(--blue)}
-  .codes .mini.weg:hover{color:var(--bad)}
-  .codes td.dat{font-variant-numeric:tabular-nums;white-space:nowrap}
-  .codes th.qh,.codes td.qz{width:44px;padding-right:6px}
-  .qmini{display:block;width:38px;height:38px;padding:2px;background:none;border:0;cursor:pointer;border-radius:6px}
+  /* Register als zweizeilige Liste – der volle Kurzlink zum Kopieren obenauf,
+     Ziel + Zahlen darunter. Keine breiten Tabellenzeilen. */
+  .arch{margin-top:var(--s4);font-family:var(--font-text)}
+  .arch-row{display:flex;align-items:flex-start;gap:var(--s3);padding:var(--s3) 0;border-bottom:1px solid var(--line-soft)}
+  .arch-main{flex:1;min-width:0}
+  .arch-akt{white-space:nowrap;display:flex;flex-direction:column;align-items:flex-end}
+  .kurz{display:inline-flex;align-items:center;gap:var(--s2);font-family:var(--font-mono,var(--font-text));font-size:var(--t-small);color:var(--blue);background:none;border:0;cursor:pointer;padding:0;max-width:100%}
+  .kurz .txt{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .kurz .ci{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);flex:none}
+  .kurz:hover .ci{color:var(--blue)}
+  .arch-meta{margin-top:4px;font-size:var(--t-micro);color:var(--muted);display:flex;flex-wrap:wrap;gap:2px var(--s3)}
+  .arch-meta .zi{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:100%}
+  .arch-meta b{font-weight:600;color:var(--ink);font-variant-numeric:tabular-nums}
+  .mini{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);background:none;border:0;cursor:pointer;padding:4px 6px;min-height:var(--tap)}
+  .mini:hover{color:var(--blue)}
+  .mini.weg:hover{color:var(--bad)}
+  .qmini{display:block;width:40px;height:40px;padding:2px;background:none;border:0;cursor:pointer;border-radius:6px;flex:none}
   .qmini svg{display:block;width:100%;height:100%}
   .qmini:hover{background:var(--soft)}
-  .tablewrap{overflow-x:auto;margin-top:var(--s4)}
-  .empty{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small)}
+  .empty{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small);padding:var(--s3) 0}
   .zwischen{margin-top:var(--s8)}
 
   @media (max-width:640px){
@@ -245,15 +248,6 @@
       <div class="out">
         <div>
           <div class="gopt qr-only">
-            <span class="lab">Modulstil</span>
-            <div class="seg" id="stilSeg" role="group" aria-label="Modulstil">
-              <button type="button" data-stil="fliessend" aria-pressed="true">Fliessend</button>
-              <button type="button" data-stil="punkte" aria-pressed="false">Punkte</button>
-              <button type="button" data-stil="weich" aria-pressed="false">Weich</button>
-              <button type="button" data-stil="kanten" aria-pressed="false">Kanten</button>
-            </div>
-          </div>
-          <div class="gopt qr-only">
             <span class="lab">Farbe</span>
             <div class="seg" id="farbSeg" role="group" aria-label="Farbe">
               <button type="button" data-farbe="tinte" aria-pressed="true">Tinte</button>
@@ -328,12 +322,7 @@
         <h3>Alle Kurzlinks</h3>
         <p>Das offene Register: jeder hier angelegte Code mit Ziel und Zählung – <q>Verlauf</q> holt die Tageskurve nach oben.</p>
       </div>
-      <div class="tablewrap">
-        <table class="codes">
-          <thead><tr><th class="qh"></th><th>Code</th><th>Ziel</th><th>angelegt</th><th class="num">Scans</th><th>letzter Scan</th><th></th></tr></thead>
-          <tbody id="codesBody"><tr><td class="empty" colspan="7">lädt …</td></tr></tbody>
-        </table>
-      </div>
+      <div class="arch" id="codesBody"><div class="empty">lädt …</div></div>
     </div>
   </section>
 
@@ -558,7 +547,6 @@
     ['link','wlan','kontakt','email','text'].forEach(function(t){ el('pane-' + t).hidden = (t !== v); });
     render();
   });
-  segWire('stilSeg', 'stil', function(v){ stil = v; render(); });
   segWire('farbSeg', 'farbe', function(v){ farbe = v; el('weissHint').hidden = (v !== 'weiss'); render(); });
   segWire('fmtSeg', 'fmt', function(v){ fmt = v; el('sizeOpt').hidden = (v !== 'png'); });
   segWire('sizeSeg', 'size', function(v){ size = Number(v); });
@@ -743,44 +731,63 @@
     var body = el('codesBody');
     rpc('qr_links_public').then(function(rows){
       body.innerHTML = '';
-      if(!rows || !rows.length){ body.innerHTML = '<tr><td class="empty" colspan="7">Noch keine Codes angelegt.</td></tr>'; return; }
+      body.innerHTML = '';
+      if(!rows || !rows.length){ body.innerHTML = '<div class="empty">Noch keine Codes angelegt.</div>'; return; }
       var backstage = imBackstage();
       rows.forEach(function(x){
-        var tr = document.createElement('tr');
-        tr.innerHTML = '<td class="qz"></td><td class="cd"></td><td class="zi"></td><td class="dat"></td><td class="num"></td><td class="dat"></td><td class="act"></td>';
-        // Der feste QR des Kurzlinks (fliessend) – klein am Zeilenanfang, Klick lädt.
-        var kurz = SHORTBASE + x.code;
+        var kurz = SHORTBASE + x.code;                       // voller Kurzlink
+        var kurzKurz = kurz.replace(/^https?:\/\//, '');     // angezeigt ohne Schema
+
+        var row = document.createElement('div'); row.className = 'arch-row';
+
+        // Fester QR (fliessend) – klein, Klick lädt ihn als SVG.
         var qbtn = document.createElement('button');
         qbtn.type = 'button'; qbtn.className = 'qmini';
-        qbtn.setAttribute('aria-label', 'QR von ' + x.code + ' herunterladen');
-        qbtn.title = 'QR herunterladen';
+        qbtn.setAttribute('aria-label', 'QR von ' + x.code + ' herunterladen'); qbtn.title = 'QR herunterladen';
         try { qbtn.innerHTML = qrSvg(kurz, 'fliessend', '#141414', '#ffffff'); } catch(e){ qbtn.textContent = 'QR'; }
         qbtn.addEventListener('click', function(){
           var svg = qbtn.querySelector('svg'); if(!svg) return;
           dlBlob(new Blob([svg.outerHTML], { type: 'image/svg+xml' }), 'qr_' + x.code + '.svg');
         });
-        tr.children[0].appendChild(qbtn);
-        var a = document.createElement('a');
-        a.href = kurz; a.target = '_blank'; a.rel = 'noopener'; a.textContent = x.code;
-        tr.children[1].appendChild(a);
-        tr.children[2].textContent = x.url;
-        tr.children[3].textContent = new Date(x.created_at).toLocaleDateString('de-CH');
-        tr.children[4].textContent = Number(x.scans).toLocaleString('de-CH');
-        tr.children[5].textContent = fmtZeit(x.letzter_scan);
+        row.appendChild(qbtn);
+
+        // Mitte: Zeile 1 = voller Kurzlink zum Kopieren, Zeile 2 = Ziel + Zahlen.
+        var main = document.createElement('div'); main.className = 'arch-main';
+        var kbtn = document.createElement('button');
+        kbtn.type = 'button'; kbtn.className = 'kurz'; kbtn.title = 'Kurzlink kopieren';
+        kbtn.innerHTML = '<span class="txt"></span><span class="ci">kopieren</span>';
+        kbtn.querySelector('.txt').textContent = kurzKurz;
+        kbtn.addEventListener('click', function(){
+          navigator.clipboard.writeText(kurz).then(function(){
+            var ci = kbtn.querySelector('.ci'); ci.textContent = 'kopiert ✓';
+            setTimeout(function(){ ci.textContent = 'kopieren'; }, 1600);
+          }, function(){});
+        });
+        var meta = document.createElement('div'); meta.className = 'arch-meta';
+        var zi = document.createElement('span'); zi.className = 'zi'; zi.textContent = '→ ' + x.url;
+        var sc = document.createElement('span'); sc.innerHTML = '<b></b> Scans'; sc.querySelector('b').textContent = Number(x.scans).toLocaleString('de-CH');
+        var ls = document.createElement('span'); ls.textContent = 'zuletzt ' + fmtZeit(x.letzter_scan);
+        meta.appendChild(zi); meta.appendChild(sc); meta.appendChild(ls);
+        main.appendChild(kbtn); main.appendChild(meta);
+        row.appendChild(main);
+
+        // Rechts: Aktionen.
+        var akt = document.createElement('div'); akt.className = 'arch-akt';
         var zeig = document.createElement('button');
         zeig.type = 'button'; zeig.className = 'mini'; zeig.textContent = 'Verlauf';
         zeig.addEventListener('click', function(){ zeigeStats(x.code); el('statDetail').scrollIntoView({ behavior: 'smooth', block: 'nearest' }); });
-        tr.children[6].appendChild(zeig);
+        akt.appendChild(zeig);
         if(backstage){
           var weg = document.createElement('button');
           weg.type = 'button'; weg.className = 'mini weg'; weg.textContent = 'Löschen';
           weg.setAttribute('aria-label', 'Kurzlink löschen');
           weg.addEventListener('click', function(){ loescheCode(x.code); });
-          tr.children[6].appendChild(weg);
+          akt.appendChild(weg);
         }
-        body.appendChild(tr);
+        row.appendChild(akt);
+        body.appendChild(row);
       });
-    }).catch(function(){ body.innerHTML = '<tr><td class="empty" colspan="7">Register nicht ladbar.</td></tr>'; });
+    }).catch(function(){ body.innerHTML = '<div class="empty">Register nicht ladbar.</div>'; });
   }
 
   // --- Modus: QR-Code | Kurzlink (dieselbe App, zwei Türen) -------------------
@@ -791,7 +798,7 @@
       inhaltTitel: 'Inhalt',
       inhaltText: 'Was der Code beim Scannen auslösen soll. Nur Link-Codes können zählen – alles andere steht fest im Code selbst.',
       gestaltTitel: 'Gestalt und Ausgabe',
-      gestaltText: 'Drei Stile, drei Farben – immer dunkel auf Weiss, damit jede Kamera den Code liest. SVG für Druck und Layout, PNG für Mail und Web.'
+      gestaltText: 'Farbe und Format wählen – immer dunkel auf Weiss, damit jede Kamera den Code liest. SVG für Druck und Layout, PNG für Mail und Web.'
     },
     kurzlink: {
       titel: 'Kurzlink',


### PR DESCRIPTION
## Was

Zwei Wünsche:

- **Design-Optionen eingeschränkt** (Beschluss): der Modulstil-Wähler (Punkte/Weich/Kanten) entfällt – **nur noch Fliessend**, der Haus-Look. Die **Farbe bleibt** (funktional: Weiss = Freistellen auf Dunklem). Der Renderer kann weiterhin alle Stile (Archiv/Card nutzen Fliessend), nur die Auswahl im Werkzeug ist weg.
- **Archiv zweizeilig statt breiter Tabelle**: Zeile 1 = der **volle Kurzlink** (`tools.goetheanum.ch/s/…`) zum Kopieren (ein Klick → «kopiert ✓»); Zeile 2 = Ziel + Scans + letzter Scan. Links der feste Fliessend-QR (Klick lädt als SVG), rechts Verlauf/Löschen. Lange Ziele werden abgeschnitten – **keine breiten Zeilen** mehr, auch auf dem Handy.

## Verifiziert

- Playwright (echtes Backend): 2 Einträge, Mini-QRs da, voller Kurzlink angezeigt + Kopieren-Feedback, Modulstil-Wähler entfernt (`#stilSeg` = 0), Farbe bleibt (`#farbSeg` = 1). Keine JS-Fehler.
- `typo-check`/`ds-lint`: 0 Fehler, 0 Hinweise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6BeQvwDT9Frr7TbtFYiW4)_