### PR TITLE
Kistenpflege: Backend-Welt mit Sortierer; Reihenfolgen aus einer Quelle

### DIFF
--- a/apps/werkzeugpost/index.html
+++ b/apps/werkzeugpost/index.html
@@ -117,7 +117,8 @@
 </head>
 <body>
 
-<script src="../../design-system/nav.js" data-root="../../" data-variant="werkzeug"></script>
+<script src="../../design-system/nav.js" data-root="../../" data-active="werkzeugpost"
+        data-onpage="Stats:../../statistik.html|Sortierer:../../sortierer.html|Post:../../apps/werkzeugpost/"></script>
 
 <main class="wrap">
 

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -135,9 +135,9 @@
   // öffentlich ist. Manifest-Kategorien, die hier fehlen, laufen beim Laden
   // automatisch als eigene Welt nach (Sicherheitsnetz).
   var INTERN_EXTRA = [
+    { id: "kistenpflege", label: "Kistenpflege", intro: "Die Werkzeuge selbst pflegen – Stats, Sortierer, Post.", cats: ["kistenpflege"] },
     { id: "kampagne", label: "Kampagne", intro: "Kampagnen planen, verlinken, mailen, zählen.", cats: ["kampagne"] },
     { id: "schau", label: "Schau & Mockups", intro: "Präsentations-Mockups und Studien.", cats: ["schau"] },
-    { id: "statistik", label: "Statistik", intro: "Nutzungszahlen aller Werkzeuge.", cats: ["statistik"] },
     { id: "labor", label: "Labor", intro: "Erprobung und Abgelegtes – zum Ausprobieren, mit verschachtelten Kisten.",
       cats: ["labor"], sub: [
         { id: "ligaturen", label: "Ligaturen", intro: "Die Kiste nur für die Ligaturen.", cats: ["ligaturen"] },
@@ -468,7 +468,7 @@
   // Kategorie der aktiven Seite: ihre Welt und Unterwelt stehen offen.
   function worldGroupEl(w, curCat) {
     var tools = ALL.filter(function (t) {
-      return (w.cats || []).indexOf(t.cat) !== -1 && INTERN_PIN.indexOf(t.slug) === -1;
+      return (w.cats || []).indexOf(t.cat) !== -1;
     });
     var subs = (w.sub || []).map(function (s) { return worldGroupEl(s, curCat); })
                             .filter(function (n) { return n; });
@@ -484,17 +484,13 @@
     return g;
   }
 
-  // Öffentliche Reihenfolge (flach) – wie die Startseite; nur der Editor
-  // steht tiefer, direkt vor Wallpaper (noch nicht reif — Entscheid
-  // Auftraggeber, 8. Juli 2026). Unbekannte ans Ende.
-  var FLAT_ORDER = ["logo-generator", "signatur", "visitenkarten", "schriften", "icons",
+  // Öffentliche Reihenfolge (flach) – wie die Startseite. Vom Sortierer gepflegt
+  // (tools.json → reihenfolge.schublade); fehlt sie, gilt diese eingebaute
+  // Vorgabe. Unbekannte ans Ende.
+  var DEFAULT_FLAT_ORDER = ["logo-generator", "signatur", "visitenkarten", "schriften", "icons",
     "uebersetzungen", "sektionsfarben", "typografie", "karten", "powerpoint",
     "editor", "wallpaper", "design-system"];
-  // Backstage angeheftet: täglich gebrauchte Redaktions-Werkzeuge stehen in der
-  // Intern-Schublade ganz oben – über den Welten, kurzer Griff statt in einer
-  // Welt vergraben (Werkzeugpost = Redaktionstisch der Monatsmail). Angeheftete
-  // erscheinen nicht zusätzlich in ihrer Welt (G03 – Doppelung weglassen).
-  var INTERN_PIN = ["werkzeugpost"];
+  var FLAT_ORDER = DEFAULT_FLAT_ORDER;
   var PUBLIC_CATS = WORLDS.reduce(function (a, w) { return a.concat(w.cats); }, []);
 
   function renderDrawer() {
@@ -517,13 +513,9 @@
       pub.sort(function (a, b) { return rank(a) - rank(b); });
       pub.forEach(function (t) { drawerBody.appendChild(linkEl(t)); });
     } else {
-      // intern: erst die angehefteten Redaktions-Werkzeuge (ganz oben), dann
-      // nach Backstage-Welten gruppiert; Unterwelten verschachteln sich (Labor).
+      // intern: nach Backstage-Welten gruppiert; Unterwelten verschachteln sich
+      // (Labor). Kistenpflege bündelt Stats · Sortierer · Post.
       var curCat = currentCat();
-      INTERN_PIN.forEach(function (slug) {
-        var t = bySlug(slug);
-        if (t) drawerBody.appendChild(linkEl(t));
-      });
       WORLDS.concat(INTERN_EXTRA).forEach(function (w) {
         var node = worldGroupEl(w, curCat);
         if (node) drawerBody.appendChild(node);
@@ -535,6 +527,11 @@
   // --- Manifest laden --------------------------------------------------------
   fetch(TOOLS).then(function (r) { return r.json(); }).then(function (m) {
     ALL = m.tools || [];
+    // Reihenfolge der öffentlichen Schublade: vom Sortierer gepflegt (eine Quelle),
+    // sonst die eingebaute Vorgabe.
+    if (m.reihenfolge && m.reihenfolge.schublade && m.reihenfolge.schublade.length) {
+      FLAT_ORDER = m.reihenfolge.schublade;
+    }
     // Sicherheitsnetz: Manifest-Kategorien ohne Welt werden automatisch eigene
     // Backstage-Welten (Titel/Intro aus tools.json) — eine neue Kategorie im
     // Manifest verschwindet damit nie mehr stillschweigend aus dem Menü.

--- a/index.html
+++ b/index.html
@@ -228,15 +228,19 @@
     a.innerHTML = visual(t) + '<h2>' + t.title + ' <span class="arr">›</span></h2>';
     return a;
   }
-  function buildCarousel(byslug){
+  function buildCarousel(byslug, order){
     // Karussell-Extra (kein eigenes Werkzeug): die elf E-Mail-Gebote.
     byslug["empfehlungen"] = byslug["empfehlungen"] || {
       slug: "empfehlungen", title: "Diese Mail wird gelesen",
       href: "apps/signatur-generator/#empfehlungen"
     };
+    // Teaser-Zeilen je Slug; die Reihenfolge pflegt der Sortierer
+    // (tools.json → reihenfolge.karussell), sonst gilt die DISCOVER-Vorgabe.
+    var LINES = {}; DISCOVER.forEach(function(d){ LINES[d.slug] = d.line; });
+    var slugs = (order && order.length) ? order : DISCOVER.map(function(d){ return d.slug; });
     var car = document.getElementById("carousel");
-    var items = DISCOVER.map(function(d){ return { d:d, t:byslug[d.slug] }; })
-                        .filter(function(x){ return x.t; });
+    var items = slugs.map(function(slug){ return { line: LINES[slug] || "", t: byslug[slug] }; })
+                     .filter(function(x){ return x.t; });
     if (items.length < 2) { car.remove(); return; }   // Karussell erst ab zwei Folien
 
     var track = document.createElement("div"); track.className = "track";
@@ -244,7 +248,7 @@
       var a = document.createElement("a"); a.className = "slide"; a.href = x.t.href;
       if (isExt(x.t.href)) { a.target = "_blank"; a.rel = "noopener"; }
       a.innerHTML = visual(x.t) +
-        '<span class="copy"><h2>' + x.t.title + '</h2><p>' + x.d.line + '</p>' +
+        '<span class="copy"><h2>' + x.t.title + '</h2><p>' + x.line + '</p>' +
         '<span class="go">Ansehen ›</span></span>';
       track.appendChild(a);
     });
@@ -301,14 +305,17 @@
   }
 
   function render(man){
-    // Öffentliche Welten (Backstage wie schau/schriftpflege/statistik bleibt draussen).
+    // Öffentliche Welten (Backstage wie schau/schriftpflege/kistenpflege bleibt draussen).
     var PUBLIC = ["generatoren", "schrift", "system", "anwendung"];
     var tools = (man.tools || []).filter(function(t){
       return PUBLIC.indexOf(t.cat) >= 0 && (t.status === "live" || t.status === "beta");
     });
     var byslug = {}; tools.forEach(function(t){ byslug[t.slug] = t; });
-    buildCarousel(byslug);
-    var rank = function(t){ var k = ORDER.indexOf(t.slug); return k < 0 ? 999 : k; };
+    // Reihenfolgen pflegt der Sortierer (tools.json → reihenfolge); sonst die Vorgaben.
+    var R = man.reihenfolge || {};
+    buildCarousel(byslug, R.karussell);
+    var kartenOrder = (R.karten && R.karten.length) ? R.karten : ORDER;
+    var rank = function(t){ var k = kartenOrder.indexOf(t.slug); return k < 0 ? 999 : k; };
     tools.sort(function(a,b){ return rank(a) - rank(b); });
     var grid = document.getElementById("cards");
     tools.forEach(function(t){ grid.appendChild(tile(t)); });

--- a/sortierer.html
+++ b/sortierer.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex" />
+<title>Sortierer — Kistenpflege · Goetheanum</title>
+<meta name="description" content="Schublade, Karussell und Karten der Startseite selbst ordnen und die Reihenfolge exportieren." />
+<link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
+
+<link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/base.css" />
+<link rel="stylesheet" href="design-system/nav.css" />
+
+<style>
+  .hero{padding-block:clamp(28px,5vw,52px) var(--s5)}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(26px,4.4vw,44px);line-height:1.06;letter-spacing:-.01em;max-width:20ch}
+  .hero .lede{margin-top:var(--s4);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:64ch}
+  .hero .lede code{font-family:var(--font-text);background:var(--field-bg);padding:.05em .35em;border-radius:6px}
+
+  .toolbar{display:flex;gap:var(--s2);flex-wrap:wrap;align-items:center;margin-block:var(--s5)}
+  .toolbar .spacer{flex:1 1 auto}
+
+  .status{margin-block:var(--s4);background:var(--field-bg);border-radius:12px;
+    box-shadow:inset 3px 0 0 var(--gold-deep);padding:var(--s3) var(--s4);
+    font-size:var(--t-small);line-height:1.5;color:var(--ink)}
+
+  .spalten{display:grid;gap:var(--s5)}
+  @media(min-width:820px){ .spalten{grid-template-columns:repeat(3,1fr)} }
+
+  .kiste{border:1px solid var(--line);border-radius:16px;background:var(--paper);overflow:hidden;display:flex;flex-direction:column}
+  .kiste-kopf{padding:var(--s4) var(--s4) var(--s3);border-bottom:1px solid var(--line)}
+  .kiste-kopf h2{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(18px,2.4vw,22px);line-height:1.1}
+  .kiste-kopf p{color:var(--muted);font-size:var(--t-small);line-height:1.4;margin-top:2px}
+
+  .liste{list-style:none;margin:0;padding:var(--s2);display:flex;flex-direction:column;gap:var(--s2)}
+  .zeile{display:flex;align-items:center;gap:var(--s2);background:var(--field-bg);border-radius:12px;
+    padding:6px 6px 6px var(--s3);cursor:grab}
+  .zeile.zieht{opacity:.5}
+  .zeile.ueber{box-shadow:inset 0 0 0 2px var(--gold-deep)}
+  .zeile .griff{flex:0 0 auto;color:var(--muted);font-size:18px;line-height:1;cursor:grab;user-select:none;width:22px;text-align:center}
+  .zeile .wer{flex:1;min-width:0}
+  .zeile .wer b{font-family:var(--font-text);font-weight:600;font-size:var(--t-body,16px);line-height:1.25;display:block;
+    white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .zeile .wer small{color:var(--muted);font-size:var(--t-micro)}
+  .zeile .rang{flex:0 0 auto;color:var(--muted);font-family:var(--font-text);font-size:var(--t-micro);min-width:2ch;text-align:right}
+  .zeile-ordnung{display:flex;flex-direction:column;gap:2px;flex:0 0 auto}
+  .zeile-ordnung .btn{min-width:var(--tap);min-height:var(--tap);padding:0;display:grid;place-items:center}
+  @media(min-width:820px){ .zeile-ordnung .btn{min-height:34px} }
+
+  .hinweisbox{background:var(--field-bg);border-radius:12px;padding:var(--s4);font-size:var(--t-small);line-height:1.55;margin-top:var(--s6)}
+  .hinweisbox code{font-family:var(--font-text);background:var(--paper);padding:.05em .35em;border-radius:6px}
+  .hinweisbox strong{font-family:var(--font);font-weight:var(--w-deutlich)}
+</style>
+</head>
+<body>
+<script src="design-system/nav.js" data-root="./" data-active="sortierer"
+        data-onpage="Stats:statistik.html|Sortierer:sortierer.html|Post:apps/werkzeugpost/"></script>
+
+<main class="wrap">
+
+  <section class="hero">
+    <span class="kicker">Kistenpflege · Sortierer</span>
+    <h1>Reihenfolgen selbst ordnen</h1>
+    <p class="lede">Ziehen (oder mit den Pfeilen) ordnen: die <em>Schublade</em> (öffentliches Menü),
+      das <em>Karussell</em> und die <em>Karten</em> der Startseite. Eine Quelle, ein Verlauf:
+      <em>Exportieren</em> schreibt die <code>tools.json</code> mit dem Feld <code>reihenfolge</code>,
+      die ihr committet. Startseite und Schublade lesen sie dann.</p>
+  </section>
+
+  <div class="toolbar">
+    <span class="spacer"></span>
+    <button class="btn" id="zuruecksetzen" type="button">Auf Datei-Stand zurück</button>
+    <button class="btn primary" id="export" type="button">tools.json exportieren</button>
+  </div>
+
+  <p class="status" id="status" role="status" hidden></p>
+
+  <div class="spalten" id="spalten" aria-live="polite"></div>
+
+  <div class="hinweisbox">
+    <strong>So wirkt es.</strong> Der Sortierer ändert nur das Feld <code>reihenfolge</code> in der
+    <code>tools.json</code> – alles andere bleibt unangetastet. Nach dem <em>Exportieren</em> die Datei
+    committen; Startseite und Schublade übernehmen die neue Reihenfolge. Ordnen geschieht hier im Browser
+    (Zwischenstand lokal). <code>Auf Datei-Stand zurück</code> verwirft den Zwischenstand.
+  </div>
+
+</main>
+
+<footer class="ds-footer">
+  <div class="wrap frow">
+    <span><strong>Goetheanum</strong> · Kistenpflege</span>
+    <span><a href="design-system/">Design-System</a></span>
+  </div>
+</footer>
+
+<script>
+"use strict";
+(function(){
+  var LS = "sortierer-entwurf-v1";
+  var PUBLIC = ["generatoren", "schrift", "system", "anwendung"];
+  var LISTEN = [
+    { key:"schublade", label:"Schublade", hint:"Öffentliches Menü (Burger) – von oben nach unten." },
+    { key:"karussell", label:"Karussell", hint:"Entdecker-Karussell auf der Startseite." },
+    { key:"karten",    label:"Karten",    hint:"Kachel-Raster auf der Startseite." }
+  ];
+
+  var rohText = "";      // tools.json als Text (für formatschonenden Export)
+  var quelle = null;     // tools.json geparst
+  var titel = {};        // slug → Anzeigename
+  var daten = { schublade:[], karten:[], karussell:[] };
+  var zieht = null;      // {key, index} beim Ziehen
+
+  function esc(s){ return (s||"").replace(/[&<>"]/g, function(c){ return {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;"}[c]; }); }
+  function ladeEntwurf(){ try{ var r=localStorage.getItem(LS); return r?JSON.parse(r):null; }catch(e){ return null; } }
+  function sichern(){ try{ localStorage.setItem(LS, JSON.stringify(daten)); }catch(e){} }
+
+  function laden(){
+    fetch("tools.json").then(function(r){ return r.text(); }).then(function(txt){
+      rohText = txt; quelle = JSON.parse(txt);
+      // Anzeigename wie auf den Flächen (Karte/Schublade zeigen den Titel).
+      (quelle.tools||[]).forEach(function(t){ if(t.slug) titel[t.slug] = t.title || t.short || t.slug; });
+      titel["empfehlungen"] = titel["empfehlungen"] || "Diese Mail wird gelesen";
+
+      var R = quelle.reihenfolge || {};
+      var draft = ladeEntwurf();
+      ["schublade","karten","karussell"].forEach(function(k){
+        daten[k] = (draft && Array.isArray(draft[k])) ? draft[k].slice()
+                 : (Array.isArray(R[k]) ? R[k].slice() : []);
+      });
+      // Schublade und Karten decken genau die öffentlichen Werkzeuge ab:
+      // fehlende anhängen, verschwundene entfernen (Karussell bleibt kuratiert).
+      var publik = (quelle.tools||[]).filter(function(t){
+        return PUBLIC.indexOf(t.cat) >= 0 && (t.status === "live" || t.status === "beta");
+      }).map(function(t){ return t.slug; });
+      ["schublade","karten"].forEach(function(k){
+        daten[k] = daten[k].filter(function(s){ return publik.indexOf(s) >= 0; });
+        publik.forEach(function(s){ if(daten[k].indexOf(s) < 0) daten[k].push(s); });
+      });
+      zeichnen();
+    }).catch(function(){
+      document.getElementById("spalten").innerHTML =
+        '<p style="color:var(--muted)">tools.json konnte nicht geladen werden.</p>';
+    });
+  }
+
+  function zeichnen(){
+    var wrap = document.getElementById("spalten");
+    wrap.innerHTML = "";
+    LISTEN.forEach(function(L){
+      var kiste = document.createElement("section"); kiste.className = "kiste";
+      var kopf = '<div class="kiste-kopf"><h2>'+esc(L.label)+'</h2><p>'+esc(L.hint)+'</p></div>';
+      var lis = daten[L.key].map(function(slug, i){
+        var name = titel[slug] || slug;
+        return '<li class="zeile" draggable="true" data-key="'+L.key+'" data-index="'+i+'">'+
+                 '<span class="griff" aria-hidden="true">⠿</span>'+
+                 '<span class="rang">'+(i+1)+'</span>'+
+                 '<span class="wer"><b>'+esc(name)+'</b><small>'+esc(slug)+'</small></span>'+
+                 '<span class="zeile-ordnung">'+
+                   '<button class="btn" type="button" data-hoch="'+L.key+':'+i+'" '+(i===0?'disabled':'')+' aria-label="'+esc(name)+' nach oben">↑</button>'+
+                   '<button class="btn" type="button" data-runter="'+L.key+':'+i+'" '+(i===daten[L.key].length-1?'disabled':'')+' aria-label="'+esc(name)+' nach unten">↓</button>'+
+                 '</span>'+
+               '</li>';
+      }).join("");
+      kiste.innerHTML = kopf + '<ul class="liste" data-key="'+L.key+'">'+lis+'</ul>';
+      wrap.appendChild(kiste);
+    });
+  }
+
+  function verschiebe(key, from, to){
+    var a = daten[key];
+    if(to < 0 || to >= a.length) return;
+    var x = a.splice(from, 1)[0];
+    a.splice(to, 0, x);
+    sichern(); zeichnen();
+  }
+
+  // Pfeil-Knöpfe (barrierefrei, auch mobil)
+  document.getElementById("spalten").addEventListener("click", function(e){
+    var h = e.target.closest("[data-hoch]"), r = e.target.closest("[data-runter]");
+    if(h){ var p=h.getAttribute("data-hoch").split(":"); verschiebe(p[0], +p[1], +p[1]-1); }
+    else if(r){ var q=r.getAttribute("data-runter").split(":"); verschiebe(q[0], +q[1], +q[1]+1); }
+  });
+
+  // Ziehen (Drag-and-drop) – nur innerhalb derselben Liste
+  var wrapEl = document.getElementById("spalten");
+  wrapEl.addEventListener("dragstart", function(e){
+    var li = e.target.closest(".zeile"); if(!li) return;
+    zieht = { key: li.getAttribute("data-key"), index: +li.getAttribute("data-index") };
+    li.classList.add("zieht");
+    try{ e.dataTransfer.effectAllowed = "move"; e.dataTransfer.setData("text/plain", ""); }catch(x){}
+  });
+  wrapEl.addEventListener("dragend", function(){
+    zieht = null;
+    Array.prototype.forEach.call(wrapEl.querySelectorAll(".zeile"), function(z){ z.classList.remove("zieht","ueber"); });
+  });
+  wrapEl.addEventListener("dragover", function(e){
+    var li = e.target.closest(".zeile"); if(!li || !zieht) return;
+    if(li.getAttribute("data-key") !== zieht.key) return;   // nicht über Listen hinweg
+    e.preventDefault();
+    Array.prototype.forEach.call(wrapEl.querySelectorAll(".zeile.ueber"), function(z){ z.classList.remove("ueber"); });
+    li.classList.add("ueber");
+  });
+  wrapEl.addEventListener("drop", function(e){
+    var li = e.target.closest(".zeile"); if(!li || !zieht) return;
+    if(li.getAttribute("data-key") !== zieht.key) return;
+    e.preventDefault();
+    var to = +li.getAttribute("data-index");
+    verschiebe(zieht.key, zieht.index, to);
+    zieht = null;
+  });
+
+  // Export: nur das Feld reihenfolge in der tools.json ersetzen (Rest byte-genau
+  // erhalten → schlanker Git-Diff). Fällt der Textersatz aus, wird neu serialisiert.
+  function bausteinReihenfolge(){
+    var arr = function(a){ return "[" + a.map(function(s){ return JSON.stringify(s); }).join(", ") + "]"; };
+    var hinweis = (quelle.reihenfolge && quelle.reihenfolge.$hinweis) ||
+      "Vom Sortierer gepflegte Reihenfolgen (Slugs). Startseite und Schublade lesen sie; fehlt ein Eintrag, gilt die eingebaute Vorgabe. Verlauf = Git.";
+    return '"reihenfolge": {\n' +
+      '    "$hinweis": ' + JSON.stringify(hinweis) + ',\n' +
+      '    "schublade": ' + arr(daten.schublade) + ',\n' +
+      '    "karten": ' + arr(daten.karten) + ',\n' +
+      '    "karussell": ' + arr(daten.karussell) + '\n' +
+      '  }';
+  }
+  function exportieren(){
+    var text;
+    if(/"reihenfolge"\s*:\s*\{[\s\S]*?\n  \}/.test(rohText)){
+      text = rohText.replace(/"reihenfolge"\s*:\s*\{[\s\S]*?\n  \}/, bausteinReihenfolge());
+    } else {
+      var obj = JSON.parse(JSON.stringify(quelle));
+      obj.reihenfolge = { $hinweis: (quelle.reihenfolge||{}).$hinweis || "", schublade: daten.schublade, karten: daten.karten, karussell: daten.karussell };
+      text = JSON.stringify(obj, null, 2);
+    }
+    var blob = new Blob([text], { type: "application/json" });
+    var a = document.createElement("a"); a.href = URL.createObjectURL(blob); a.download = "tools.json"; a.click();
+    var s = document.getElementById("status");
+    s.textContent = "tools.json exportiert. Jetzt committen – Startseite und Schublade übernehmen die Reihenfolge.";
+    s.hidden = false;
+  }
+  document.getElementById("export").addEventListener("click", exportieren);
+  document.getElementById("zuruecksetzen").addEventListener("click", function(){
+    if(confirm("Lokalen Zwischenstand verwerfen und den Datei-Stand laden?")){
+      try{ localStorage.removeItem(LS); }catch(e){}
+      location.reload();
+    }
+  });
+
+  laden();
+})();
+</script>
+</body>
+</html>

--- a/statistik.html
+++ b/statistik.html
@@ -46,7 +46,8 @@
 </style>
 </head>
 <body>
-<script src="design-system/nav.js" data-root="./" data-section="statistik" data-active="statistik"></script>
+<script src="design-system/nav.js" data-root="./" data-active="statistik"
+        data-onpage="Stats:statistik.html|Sortierer:sortierer.html|Post:apps/werkzeugpost/"></script>
 
 <main class="wrap">
   <div class="hero">

--- a/tools.json
+++ b/tools.json
@@ -44,9 +44,9 @@
       "intro": "Werkzeuge der Kampagnenarbeit – planen, verlinken, mailen, zählen. Gebaut für die Sommer-Aktion, wiederverwendbar für jede dreistufige Kampagne."
     },
     {
-      "id": "statistik",
-      "title": "Statistik",
-      "intro": "Nutzungszahlen aller Werkzeuge – nur der Gebrauch legitimiert den Bau."
+      "id": "kistenpflege",
+      "title": "Kistenpflege",
+      "intro": "Die Werkzeuge selbst pflegen – Zahlen ansehen (Stats), Reihenfolgen ordnen (Sortierer), die Monatsmail schreiben (Post). Startet mit Stats."
     },
     {
       "id": "schau",
@@ -394,12 +394,24 @@
     },
     {
       "slug": "statistik",
-      "cat": "statistik",
+      "cat": "kistenpflege",
       "status": "beta",
       "tag": "Zahlen",
-      "title": "Statistik",
+      "title": "Stats",
+      "short": "Stats",
       "href": "statistik.html",
       "desc": "Anonyme Nutzungszahlen aller Werkzeuge."
+    },
+    {
+      "slug": "sortierer",
+      "cat": "kistenpflege",
+      "status": "intern",
+      "tag": "Kistenpflege",
+      "title": "Sortierer",
+      "short": "Sortierer",
+      "href": "sortierer.html",
+      "desc": "Schublade, Karussell und Karten der Startseite selbst ordnen – ziehen, Reihenfolge exportieren, committen. Eine Quelle (tools.json → reihenfolge), Verlauf = Git.",
+      "such": "Sortierer Reihenfolge ordnen sortieren Schublade Karussell Karten Startseite Menü Navigation Kistenpflege"
     },
     {
       "slug": "sommer-zaehler",
@@ -458,7 +470,7 @@
     },
     {
       "slug": "werkzeugpost",
-      "cat": "kampagne",
+      "cat": "kistenpflege",
       "status": "intern",
       "tag": "Neu",
       "title": "Werkzeugpost — Redaktion",
@@ -613,5 +625,11 @@
       "href": "https://github.com/phtok/goeloggen/blob/main/docs/gestaltungsspielraum-entwurf.md",
       "desc": "Foto-Richtlinie in drei Richtungen und vier Ansätze zu erlaubter Varianz – zur Ratifizierung."
     }
-  ]
+  ],
+  "reihenfolge": {
+    "$hinweis": "Vom Sortierer gepflegte Reihenfolgen (Slugs). Startseite und Schublade lesen sie; fehlt ein Eintrag, gilt die eingebaute Vorgabe. Verlauf = Git.",
+    "schublade": ["logo-generator", "signatur", "visitenkarten", "schriften", "icons", "uebersetzungen", "sektionsfarben", "typografie", "karten", "powerpoint", "editor", "wallpaper", "design-system"],
+    "karten": ["logo-generator", "signatur", "visitenkarten", "schriften", "icons", "uebersetzungen", "qr-generator", "kurzlink", "typografie", "powerpoint", "wallpaper", "karten", "sektionsfarben", "design-system", "editor"],
+    "karussell": ["signatur", "empfehlungen", "karten", "wallpaper", "powerpoint", "visitenkarten", "logo-generator", "schriften", "uebersetzungen", "icons", "sektionsfarben", "typografie", "editor", "design-system"]
+  }
 }


### PR DESCRIPTION
## Worum es geht

Neue Backstage-Welt **Kistenpflege** bündelt die Werkzeug-Pflege unter **einem** Schubladen-Eintrag (entlastet die Schublade): **Stats · Sortierer · Post**, verbunden durch eine gemeinsame Seitenleiste; öffnet auf Stats.

Kern ist der neue **Sortierer** — «wo ich selbst sortieren kann».

## Struktur (Schublade)

- Eigene Welt «Statistik» **aufgelöst**, Werkzeugpost **nicht mehr oben angeheftet** — beide wohnen jetzt in **Kistenpflege**.
- `tools.json`: neue Kategorie `kistenpflege`; Statistik → «Stats»; Werkzeugpost hinein; Kampagne behält den Rest (6 Werkzeuge).
- Gemeinsame Seitenleiste (`data-onpage`) auf Stats · Sortierer · Post.

## Sortierer (neu, `sortierer.html`)

- Ordnet **Schublade**, **Karussell** und **Karten** der Startseite per **Ziehen** oder **Pfeilen** (barrierefrei, Fingerziele ≥ `--tap`).
- Reihenfolge wird **Daten**: `tools.json` → Feld `reihenfolge` (`schublade`/`karten`/`karussell`). **Startseite** (`index.html`) und **Schublade** (`nav.js`) lesen sie; fehlt sie, gilt die eingebaute Vorgabe → nichts bricht. **Eine Quelle, Verlauf = Git.**
- **Export** ersetzt nur das Feld `reihenfolge` (Rest byte-genau erhalten → schlanker Diff); Zwischenstand lokal, «Auf Datei-Stand zurück» verwirft ihn (Werkzeugpost-Muster). Schublade/Karten decken genau die öffentlichen Werkzeuge ab.

## Geprüft (Chromium/Playwright, hell + dunkel)

- Startseite **unverändert** (Vorgabe = Ist-Zustand): Karten + Karussell wie zuvor, kein Wallpaper-Generator.
- Schublade intern: **Kistenpflege**-Gruppe mit Stats/Sortierer/Werkzeugpost; keine Statistik-Welt, kein Pin; Kampagne ohne Werkzeugpost.
- Sortierer: drei Listen, Umsortieren wirkt, **Export = gültige `tools.json`** (alle 47 Werkzeuge erhalten, `reihenfolge` aktualisiert).
- `typo-check` ✓ · `ds-lint` 100 % (4 Seiten). **B01/B02/B03/B05** gewahrt (nur Tokens).

## Bewusst NICHT gebaut — deine Entscheidung: «Lokalisierung der Nutzer» in den Stats

Das berührt das dokumentierte Prinzip **«ohne IP, ohne Personendaten, nur anonyme Summen»** und braucht eine **Supabase-Backend-Änderung**. Optionen:

1. **Ohne IP: Browser-Zeitzone/Sprache** — bleibt im Datenschutz-Prinzip, kein Backend; ungenauer.
2. **Land aus IP, nicht gespeichert** — server-seitig grob das Land, nur die Landsumme; genauer, weicht «kein IP» auf, braucht Backend.
3. **Weglassen.**

Sag, welche — dann baue ich die Stats-Erweiterung separat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QDrXvBpLkmb8PLP5j8NhX

---
_Generated by [Claude Code](https://claude.ai/code/session_014QDrXvBpLkmb8PLP5j8NhX)_