### PR TITLE
Stats: «Woher» nach Browser-Zeitzone – kein IP, kein Backend-Umbau

### DIFF
--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -90,15 +90,28 @@
   // Werkzeuge mit JS-Download rufen window.goeStat('download', name) selbst auf.
   var STAT_SB = "https://dagcsnfrlbpxcmdimnrw.supabase.co";
   var STAT_KEY = "sb_publishable_SXhY0mrhXjdTnjbJ5Uobtg_zAXW_xGY";
-  function goeStat(event, label) {
-    if (!ACTIVE || !event) return;
+  function goeBump(tool, event, label) {
     try {
       fetch(STAT_SB + "/rest/v1/rpc/goeloggen_bump", {
         method: "POST", keepalive: true,
         headers: { "Content-Type": "application/json", "apikey": STAT_KEY, "Authorization": "Bearer " + STAT_KEY },
-        body: JSON.stringify({ p_tool: ACTIVE, p_event: event, p_label: (label || "").slice(0, 160) })
+        body: JSON.stringify({ p_tool: tool, p_event: event, p_label: (label || "").slice(0, 160) })
       }).catch(function () {});
     } catch (e) {}
+  }
+  function goeStat(event, label) {
+    if (!ACTIVE || !event) return;
+    goeBump(ACTIVE, event, label);
+    // Grob-Region je Seitenaufruf: die ZEITZONE des Browsers (z. B. „Europe/Zurich")
+    // – kein IP, keine Personendaten, nur eine anonyme Summe je Zeitzone. Gezählt
+    // über dieselbe (tool,event,label)-Zählung mit dem reservierten Schlüssel
+    // „__region" (die Statistik blendet ihn aus der Werkzeugliste aus).
+    if (event === "view") {
+      var tz = "";
+      try { tz = (Intl.DateTimeFormat().resolvedOptions().timeZone || ""); } catch (e) {}
+      if (!tz) { try { tz = (navigator.language || ""); } catch (e) {} }
+      if (tz) goeBump("__region", "view", tz);
+    }
   }
   window.goeStat = goeStat;
   goeStat("view", "");

--- a/statistik.html
+++ b/statistik.html
@@ -62,6 +62,12 @@
     <div class="bars" id="alleBars"><div class="empty">lädt …</div></div>
   </section>
 
+  <section id="sec-region">
+    <div class="app-h"><h2>Woher</h2><span class="meta" id="regionMeta"></span></div>
+    <div class="chart-t">SEITENAUFRUFE NACH ZEITZONE · AUS DEM BROWSER, KEIN IP</div>
+    <div class="bars" id="regionBars"><div class="empty">lädt …</div></div>
+  </section>
+
   <section id="sec-landing">
     <div class="app-h"><h2>Landing-Page</h2><span class="meta" id="landMeta"></span></div>
     <div class="cards">
@@ -150,6 +156,12 @@
     else { st.className='muted'; st.textContent='Stand: ' + new Date().toLocaleString('de-CH'); }
   }
 
+  // Zeitzone lesbar machen: "Europe/Zurich" → "Zurich · Europe"; Sprachcodes bleiben.
+  function zoneLabel(z){
+    var p = String(z || '').split('/');
+    return (p.length >= 2) ? (p[p.length-1].replace(/_/g, ' ') + ' · ' + p[0]) : String(z || '');
+  }
+
   // ---- Alle Werkzeuge (generisch, mitwachsend) ----
   Promise.all([
     rpc('goeloggen_stats'),
@@ -157,8 +169,13 @@
   ]).then(function(res){
     var rows = res[0] || [], man = res[1], labels = {};
     if (man && man.tools) man.tools.forEach(function(t){ labels[t.slug] = t.title; });
-    var byTool = {};
+    var byTool = {}, regions = {};
     rows.forEach(function(r){
+      // Grob-Region (Zeitzone) statt Werkzeug: eigene Auswertung, nicht in der Werkzeugliste.
+      if (r.tool === '__region') {
+        if (r.event === 'view' && r.label) regions[r.label] = (regions[r.label] || 0) + Number(r.n);
+        return;
+      }
       var t = byTool[r.tool] || (byTool[r.tool] = { views:0, downloads:0, last:'' });
       if (r.event === 'view') t.views += Number(r.n);
       else if (r.event === 'download') t.downloads += Number(r.n);
@@ -172,6 +189,12 @@
     }));
     var lastA = rows.reduce(function(m,r){ return (r.updated_at > m) ? r.updated_at : m; }, '');
     document.getElementById('alleMeta').textContent = lastA ? 'zuletzt ' + when(lastA) : 'noch keine Daten';
+    // Woher: Balken nach Zeitzone (aus dem Browser, kein IP).
+    var rItems = Object.keys(regions).map(function(z){ return { label: zoneLabel(z), value: regions[z] }; })
+                   .sort(function(a,b){ return b.value - a.value; });
+    bars(document.getElementById('regionBars'), rItems);
+    document.getElementById('regionMeta').textContent = rItems.length
+      ? (rItems.length + (rItems.length === 1 ? ' Zeitzone' : ' Zeitzonen')) : 'noch keine Daten';
     done++; finish();
   }).catch(function(){
     document.getElementById('alleBars').innerHTML = '<div class="err">nicht ladbar</div>';


### PR DESCRIPTION
## Auswahl A umgesetzt

«Lokalisierung der Nutzer» über die **Zeitzone des Browsers** (z. B. `Europe/Zurich`) — **kein IP, keine Personendaten**, nur anonyme Summen je Zeitzone. Bleibt im dokumentierten Datenschutz-Prinzip der Statistik.

## Kein Backend-Umbau nötig

Die bestehende Zählung `goeloggen_counters (tool, event, label)` trägt die Region schon — ich zähle über den reservierten Schlüssel **`__region`** (label = Zeitzone). **Keine Schema-/RPC-Änderung**, kein Eingriff in die Produktion.

- **`nav.js`**: `goeStat` zählt je Seitenaufruf zusätzlich die Grob-Region — `Intl.DateTimeFormat().resolvedOptions().timeZone` (Fallback `navigator.language`) über `goeBump("__region","view",tz)`.
- **`statistik.html`**: neuer Abschnitt **«Woher»** — Balken nach Zeitzone (`Europe/Zurich` → «Zurich · Europe»), absteigend; `__region` wird aus der Werkzeugliste ausgeblendet.

## Geprüft (Chromium/Playwright, Supabase gemockt — keine Prod-Daten berührt)

- Auf `view` feuern **zwei** Zählungen: das Werkzeug **und** `__region` mit der Zeitzone.
- Abschnitt «Woher» zeigt die Zeitzonen sortiert; Sprachcode-Fallback (`de-CH`) bleibt wie er ist.
- `__region` taucht **nicht** in der Werkzeugliste auf; echte Werkzeuge unverändert.
- Keine Fehler. `typo-check` ✓ · `ds-lint` 100 %.

Damit ist die Kistenpflege-Struktur (Stats · Sortierer · Post) vollständig; offen bleibt nur noch das **«?»** — sag, was dort hin soll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QDrXvBpLkmb8PLP5j8NhX

---
_Generated by [Claude Code](https://claude.ai/code/session_014QDrXvBpLkmb8PLP5j8NhX)_