### PR TITLE
Sortierer-Reihenfolge übernommen: QR und Kurzlink weiter nach vorn

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -628,8 +628,8 @@
   ],
   "reihenfolge": {
     "$hinweis": "Vom Sortierer gepflegte Reihenfolgen (Slugs). Startseite und Schublade lesen sie; fehlt ein Eintrag, gilt die eingebaute Vorgabe. Verlauf = Git.",
-    "schublade": ["logo-generator", "signatur", "visitenkarten", "schriften", "icons", "uebersetzungen", "sektionsfarben", "typografie", "karten", "powerpoint", "editor", "wallpaper", "design-system"],
-    "karten": ["logo-generator", "signatur", "visitenkarten", "schriften", "icons", "uebersetzungen", "qr-generator", "kurzlink", "typografie", "powerpoint", "wallpaper", "karten", "sektionsfarben", "design-system", "editor"],
+    "schublade": ["logo-generator", "signatur", "visitenkarten", "schriften", "icons", "qr-generator", "kurzlink", "uebersetzungen", "sektionsfarben", "typografie", "karten", "powerpoint", "wallpaper", "design-system"],
+    "karten": ["logo-generator", "signatur", "visitenkarten", "schriften", "icons", "uebersetzungen", "qr-generator", "kurzlink", "typografie", "powerpoint", "wallpaper", "karten", "sektionsfarben", "design-system"],
     "karussell": ["signatur", "empfehlungen", "karten", "wallpaper", "powerpoint", "visitenkarten", "logo-generator", "schriften", "uebersetzungen", "icons", "sektionsfarben", "typografie", "editor", "design-system"]
   }
 }


### PR DESCRIPTION
## Was

Deinen Sortierer-Export angewandt — aber **nur das Feld `reihenfolge`**, auf den aktuellen `main` gelegt (nicht die ganze, ältere Datei, damit nichts Neueres verloren geht).

- **Schublade**: QR-Code-Generator und Kurzlink direkt hinter Icons.
- **Karten**: unverändert bis auf Aufräumen.
- `editor` (Status `intern`) fällt aus beiden Listen — öffentlich ohnehin nie gezeigt (die Flächen filtern `live`/`beta`). Karussell unverändert.

Werkzeuge, Kategorien und Docs **byte-gleich** zu `main`. `typo-check` ✓ · `ds-lint` ✓.

> Hinweis: Dieser «Export → Upload → Commit»-Weg ist genau der, den du loswerden willst — dazu im Chat ein Vorschlag zur direkten Integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QDrXvBpLkmb8PLP5j8NhX

---
_Generated by [Claude Code](https://claude.ai/code/session_014QDrXvBpLkmb8PLP5j8NhX)_