### PR TITLE
Sortierer: Direkt speichern über Edge Function (Token serverseitig)

### DIFF
--- a/services/kistenpflege/sortierer-commit/index.ts
+++ b/services/kistenpflege/sortierer-commit/index.ts
@@ -1,0 +1,136 @@
+// =============================================================================
+// sortierer-commit · Supabase Edge Function — der Sortierer speichert direkt
+// -----------------------------------------------------------------------------
+// Nimmt vom Sortierer die drei Reihenfolgen (schublade/karten/karussell) und
+// schreibt AUSSCHLIESSLICH das Feld «reihenfolge» in die tools.json auf GitHub —
+// per Contents-API, mit dem aktuellen Stand als Basis (kein Stale-Clobber).
+// Alles andere in der Datei bleibt byte-genau. Ein GitHub-Token liegt server-
+// seitig (Secret), nie im Browser. Ein Passwort (SORTIERER_SECRET) sperrt den
+// Zugang; die Wirkfläche ist bewusst winzig (nur Menü-Reihenfolge, per Git
+// jederzeit rückholbar).
+//
+// Secrets (im Supabase-Projekt setzen):
+//   GITHUB_TOKEN      Fine-grained PAT, nur dieses Repo, Contents: Read+Write
+//   GITHUB_REPO       "phtok/goeloggen" (Vorgabe, wenn leer)
+//   GITHUB_BRANCH     "main" (Vorgabe, wenn leer)
+//   SORTIERER_SECRET  frei gewähltes, langes Passwort
+// Quelle im Repo: services/kistenpflege/sortierer-commit/index.ts
+// =============================================================================
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+const TOKEN  = Deno.env.get("GITHUB_TOKEN") || "";
+const REPO   = Deno.env.get("GITHUB_REPO") || "phtok/goeloggen";
+const BRANCH = Deno.env.get("GITHUB_BRANCH") || "main";
+const SECRET = Deno.env.get("SORTIERER_SECRET") || "";
+const PATH   = "tools.json";
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "content-type, x-sortierer-secret",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS, "Content-Type": "application/json" },
+  });
+}
+
+// UTF-8-sichere Base64-Umwandlung (atob/btoa sind Latin-1).
+function b64ToText(b64: string): string {
+  const bin = atob(b64.replace(/\n/g, ""));
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+function textToB64(t: string): string {
+  const bytes = new TextEncoder().encode(t);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+const arr = (a: string[]) => "[" + a.map((s) => JSON.stringify(s)).join(", ") + "]";
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: CORS });
+  if (req.method !== "POST") return json(405, { error: "Nur POST." });
+  if (!TOKEN || !SECRET) return json(500, { error: "Funktion nicht konfiguriert (GITHUB_TOKEN / SORTIERER_SECRET fehlen)." });
+
+  // Passwort-Sperre.
+  if ((req.headers.get("x-sortierer-secret") || "") !== SECRET) {
+    return json(401, { error: "Passwort falsch." });
+  }
+
+  const body = await req.json().catch(() => null);
+  const r = body && body.reihenfolge;
+  const ok3 = r && ["schublade", "karten", "karussell"].every(
+    (k) => Array.isArray(r[k]) && r[k].every((s: unknown) => typeof s === "string"),
+  );
+  if (!ok3) return json(400, { error: "reihenfolge (schublade/karten/karussell als Slug-Listen) fehlt." });
+
+  const gh = {
+    Authorization: `Bearer ${TOKEN}`,
+    Accept: "application/vnd.github+json",
+    "User-Agent": "sortierer-commit",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  // Aktuellen Stand holen (Text + sha).
+  const getRes = await fetch(
+    `https://api.github.com/repos/${REPO}/contents/${encodeURIComponent(PATH)}?ref=${BRANCH}`,
+    { headers: gh },
+  );
+  if (!getRes.ok) return json(502, { error: "tools.json bei GitHub nicht lesbar.", status: getRes.status });
+  const cur = await getRes.json();
+  const text = b64ToText(cur.content || "");
+
+  // Nur bekannte Slugs zulassen (kein Fremd-String in die Datei).
+  let known: Set<string>;
+  try {
+    const parsed = JSON.parse(text);
+    known = new Set((parsed.tools || []).map((t: { slug?: string }) => t.slug).filter(Boolean));
+    known.add("empfehlungen"); // Karussell-Extra ohne eigenes Werkzeug
+  } catch {
+    return json(500, { error: "tools.json (aktuell) ist kein gültiges JSON." });
+  }
+  const clean = (a: string[]) => a.filter((s) => known.has(s));
+  const neu = { schublade: clean(r.schublade), karten: clean(r.karten), karussell: clean(r.karussell) };
+
+  // $hinweis aus dem Ist-Stand bewahren.
+  const hm = text.match(/"\$hinweis":\s*("(?:[^"\\]|\\.)*")/);
+  const hinweis = hm ? hm[1] : JSON.stringify("Vom Sortierer gepflegte Reihenfolgen (Slugs). Startseite und Schublade lesen sie; fehlt ein Eintrag, gilt die eingebaute Vorgabe. Verlauf = Git.");
+  const block =
+    '"reihenfolge": {\n' +
+    '    "$hinweis": ' + hinweis + ',\n' +
+    '    "schublade": ' + arr(neu.schublade) + ',\n' +
+    '    "karten": ' + arr(neu.karten) + ',\n' +
+    '    "karussell": ' + arr(neu.karussell) + "\n" +
+    "  }";
+
+  // Nur den reihenfolge-Block ersetzen (Rest byte-genau).
+  const re = /"reihenfolge"\s*:\s*\{[\s\S]*?\n {2}\}/;
+  const next = re.test(text)
+    ? text.replace(re, block)
+    : text.replace(/\n\}\s*$/, ",\n  " + block + "\n}");
+
+  if (next === text) return json(200, { ok: true, unchanged: true });
+  try { JSON.parse(next); } catch { return json(500, { error: "Ergebnis wäre ungültiges JSON – nichts geschrieben." }); }
+
+  // Committen.
+  const putRes = await fetch(`https://api.github.com/repos/${REPO}/contents/${encodeURIComponent(PATH)}`, {
+    method: "PUT",
+    headers: gh,
+    body: JSON.stringify({
+      message: "Sortierer: Reihenfolge aktualisiert",
+      content: textToB64(next),
+      sha: cur.sha,
+      branch: BRANCH,
+    }),
+  });
+  if (!putRes.ok) {
+    return json(502, { error: "Schreiben bei GitHub fehlgeschlagen.", status: putRes.status, detail: (await putRes.text()).slice(0, 300) });
+  }
+  const put = await putRes.json();
+  return json(200, { ok: true, commit: put.commit && put.commit.sha });
+});

--- a/sortierer.html
+++ b/sortierer.html
@@ -24,6 +24,7 @@
   .status{margin-block:var(--s4);background:var(--field-bg);border-radius:12px;
     box-shadow:inset 3px 0 0 var(--gold-deep);padding:var(--s3) var(--s4);
     font-size:var(--t-small);line-height:1.5;color:var(--ink)}
+  .status.err{box-shadow:inset 3px 0 0 var(--bad)}
 
   .spalten{display:grid;gap:var(--s5)}
   @media(min-width:820px){ .spalten{grid-template-columns:repeat(3,1fr)} }
@@ -71,7 +72,8 @@
   <div class="toolbar">
     <span class="spacer"></span>
     <button class="btn" id="zuruecksetzen" type="button">Auf Datei-Stand zurück</button>
-    <button class="btn primary" id="export" type="button">tools.json exportieren</button>
+    <button class="btn" id="export" type="button">Exportieren</button>
+    <button class="btn primary" id="speichern" type="button">Direkt speichern</button>
   </div>
 
   <p class="status" id="status" role="status" hidden></p>
@@ -98,6 +100,11 @@
 "use strict";
 (function(){
   var LS = "sortierer-entwurf-v1";
+  // Direkt-Speichern über die Edge Function (Token liegt serverseitig, nie hier).
+  var SB = "https://dagcsnfrlbpxcmdimnrw.supabase.co";
+  var FUNKTION = SB + "/functions/v1/sortierer-commit";
+  var PUBKEY = "sb_publishable_SXhY0mrhXjdTnjbJ5Uobtg_zAXW_xGY";
+  var SECRET_LS = "sortierer-secret";
   var PUBLIC = ["generatoren", "schrift", "system", "anwendung"];
   var LISTEN = [
     { key:"schublade", label:"Schublade", hint:"Öffentliches Menü (Burger) – von oben nach unten." },
@@ -234,10 +241,51 @@
     }
     var blob = new Blob([text], { type: "application/json" });
     var a = document.createElement("a"); a.href = URL.createObjectURL(blob); a.download = "tools.json"; a.click();
-    var s = document.getElementById("status");
-    s.textContent = "tools.json exportiert. Jetzt committen – Startseite und Schublade übernehmen die Reihenfolge.";
-    s.hidden = false;
+    status("tools.json exportiert. Jetzt committen – Startseite und Schublade übernehmen die Reihenfolge.");
   }
+
+  function status(msg, err){
+    var s = document.getElementById("status");
+    s.textContent = msg; s.hidden = false;
+    s.classList.toggle("err", !!err);
+  }
+
+  // Direkt speichern: schickt nur die drei Reihenfolgen an die Edge Function, die
+  // sie serverseitig in die tools.json auf GitHub committet. Das Passwort bleibt
+  // im Browser; ist der Server noch nicht eingerichtet, hilft «Exportieren».
+  function speichern(){
+    var secret = "";
+    try { secret = localStorage.getItem(SECRET_LS) || ""; } catch (e) {}
+    if (!secret) {
+      secret = (window.prompt("Passwort fürs Direkt-Speichern (einmalig, bleibt in diesem Browser):") || "").trim();
+      if (!secret) return;
+      try { localStorage.setItem(SECRET_LS, secret); } catch (e) {}
+    }
+    status("Speichere …");
+    fetch(FUNKTION, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-sortierer-secret": secret, "apikey": PUBKEY, "Authorization": "Bearer " + PUBKEY },
+      body: JSON.stringify({ reihenfolge: { schublade: daten.schublade, karten: daten.karten, karussell: daten.karussell } })
+    }).then(function (r) {
+      return r.json().catch(function () { return {}; }).then(function (j) { return { ok: r.ok, code: r.status, j: j }; });
+    }).then(function (res) {
+      if (res.ok && res.j && res.j.ok) {
+        if (res.j.unchanged) { status("Nichts zu speichern – schon aktuell."); return; }
+        var sha = (res.j.commit || "").slice(0, 7);
+        status("Gespeichert und committet" + (sha ? " (" + sha + ")" : "") + ". Startseite und Schublade übernehmen es in ~1 Minute.");
+      } else if (res.code === 401) {
+        try { localStorage.removeItem(SECRET_LS); } catch (e) {}
+        status("Passwort falsch – beim nächsten Speichern neu eingeben.", true);
+      } else if (res.code === 500 && res.j && /konfiguriert/.test(res.j.error || "")) {
+        status("Server noch nicht eingerichtet (Token/Passwort fehlen). Nutze solange «Exportieren».", true);
+      } else {
+        status("Konnte nicht direkt speichern (" + ((res.j && res.j.error) || res.code) + "). Nutze «Exportieren».", true);
+      }
+    }).catch(function () {
+      status("Netzwerkfehler beim Speichern. Nutze «Exportieren».", true);
+    });
+  }
+  document.getElementById("speichern").addEventListener("click", speichern);
   document.getElementById("export").addEventListener("click", exportieren);
   document.getElementById("zuruecksetzen").addEventListener("click", function(){
     if(confirm("Lokalen Zwischenstand verwerfen und den Datei-Stand laden?")){


### PR DESCRIPTION
## Auswahl ② umgesetzt

Der Sortierer speichert mit **einem Klick** — kein Export/Upload/Chat mehr. Der GitHub-Token liegt **serverseitig** (Supabase-Secret), nie im Browser.

## Was drin ist

**`services/kistenpflege/sortierer-commit/index.ts`** (neue Edge Function)
- Nimmt nur die drei Reihenfolgen und schreibt **ausschliesslich** das Feld `reihenfolge` in `tools.json` (GitHub Contents-API, aktueller Stand als Basis → **kein Stale-Clobber**). Rest byte-genau → schlanker Diff.
- **Passwort-Sperre** (`SORTIERER_SECRET`). Wirkfläche bewusst winzig und **per Git rückholbar**; nur bekannte Slugs zugelassen; Ergebnis wird als JSON validiert, bevor committet wird. UTF-8-sichere Base64.

**`sortierer.html`**
- «Direkt speichern» (Passwort einmalig, bleibt im Browser) neben «Exportieren» (Fallback). Klare Statusmeldungen (Commit-SHA bei Erfolg; 401 löscht das Passwort; sonst → Export).

**Keine Secrets im Repo** — die Funktion liest sie aus der Umgebung.

## Aktivieren (dein Teil, einmalig)

Ich kann von hier aus weder deployen noch Secrets setzen (Schreibrechte brauchen eine interaktive Freigabe, die hier fehlt). Drei Schritte:

1. **Fine-grained GitHub-Token** anlegen — nur Repo `phtok/goeloggen`, Permission **Contents: Read and write**.
2. **Secrets im Supabase-Projekt** (`dagcsnfrlbpxcmdimnrw`) setzen:
   - `GITHUB_TOKEN` = dein Token · `SORTIERER_SECRET` = ein langes, frei gewähltes Passwort · (optional `GITHUB_REPO`, `GITHUB_BRANCH`)
3. **Funktion deployen** (Konvention wie deine anderen Funktionen, ohne JWT-Zwang):
   ```
   supabase functions deploy sortierer-commit --no-verify-jwt --project-ref dagcsnfrlbpxcmdimnrw
   ```
Danach im Sortierer «Direkt speichern» → einmal das `SORTIERER_SECRET` eingeben → fertig.

## Geprüft

- Textchirurgie **offline** gegen die echte `tools.json`: gültiges JSON, nur `reihenfolge` geändert, Fremd-Slug gefiltert, **1-Zeilen-Diff**.
- Sortierer-Aufruf im Browser **gemockt**: postet `reihenfolge` + Passwort-Header, zeigt Commit-SHA; 401 löscht das Passwort; Export-Fallback intakt.
- `typo-check` ✓ · `ds-lint` 100 %.

## Sicherheitsmodell (bewusst)

Offener Endpunkt, aber: Passwort-gesperrt · kann **nur** `reihenfolge` ändern (kein anderer Datei-Inhalt, kein anderer Pfad) · Token nicht auslesbar · jede Änderung ein Git-Commit (revertierbar). Empfehlung: langes `SORTIERER_SECRET`, Token nur mit Contents-Write auf dieses eine Repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QDrXvBpLkmb8PLP5j8NhX

---
_Generated by [Claude Code](https://claude.ai/code/session_014QDrXvBpLkmb8PLP5j8NhX)_