### PR TITLE
Sommer-Zähler: Metricool als Quelle der Social-Media-Zahlen

### DIFF
--- a/apps/sommer-zaehler/aktivitaeten.html
+++ b/apps/sommer-zaehler/aktivitaeten.html
@@ -38,6 +38,8 @@
     </div>
     <div class="zb-legende" id="zbLegende"></div>
 
+    <div id="quelleSocial"></div>
+
     <details class="zb-form" id="mfForm">
       <summary>Aktivität eintragen</summary>
       <div class="card soft">

--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -118,6 +118,17 @@
   /* Reichweite je Kanal – Aufschlüsselung unter der Kette (nutzt die .stream-Balken). */
   .funnel .reach-kanal{margin-top:var(--s6);padding-top:var(--s5);border-top:1px solid var(--line-soft)}
   .funnel .reach-kanal .rk-h{font-family:var(--font-text);font-size:var(--t-small);color:var(--ink);font-weight:600;margin-bottom:var(--s4)}
+  /* Aufklappbarer Kanal-Balken: Summary trägt den Balken, darunter die Quellen-Liste. */
+  .funnel .reach-detail{margin-bottom:var(--s5)}
+  .funnel .reach-detail:last-of-type{margin-bottom:0}
+  .funnel .reach-detail>summary{list-style:none;cursor:pointer;display:block;border-radius:var(--r-pill)}
+  .funnel .reach-detail>summary::-webkit-details-marker{display:none}
+  .funnel .reach-detail>summary:focus-visible{outline:2px solid var(--gold-ink);outline-offset:3px}
+  .funnel .reach-detail>summary .stream{margin-bottom:0}
+  .funnel .reach-detail .rk-caret{display:inline-block;width:0;height:0;margin-left:8px;vertical-align:middle;border-left:5px solid var(--muted);border-top:4px solid transparent;border-bottom:4px solid transparent;transition:transform .2s ease}
+  .funnel .reach-detail[open] .rk-caret{transform:rotate(90deg)}
+  .funnel .reach-detail .quellen{margin:var(--s3) 0 var(--s4);padding-left:var(--s4);border-left:2px solid var(--line-soft)}
+  .funnel .reach-detail .quellen .qz-hint{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);padding:8px 0;line-height:1.5}
 
   /* Attribution nach Motiv (utm_content) – feiner als der kanal-Bucket. */
   .motive{margin-top:var(--s6)}

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -37,7 +37,15 @@
       { key:'andere',     label:'Andere',         rolle:'' }
     ],
     // Kosten der Aktion (Euro) – stehen auf 0, echte Zahlen werden erfragt.
-    zahlenProvisorisch: true       // blendet den Hinweis auf Beispielwerte ein
+    zahlenProvisorisch: true,      // blendet den Hinweis auf Beispielwerte ein
+    // Externe Quelle der Social-Media-Zahlen (Reichweite/Klicks je Kanal).
+    // Metricool gibt die Zahlen nur im geschützten Dashboard aus – ein Live-Abgriff
+    // aus dem Browser ist nicht möglich. Darum ablesen und je Aktivität eintragen.
+    quelleSocial: {
+      label: 'Metricool · Kampagnen-Auswertung',
+      url:   'https://app.metricool.com/reporting/campaigns-dashboard/public?token=eyJ6aXAiOiJERUYiLCJhbGciOiJIUzUxMiJ9.eJxVztFSgkAUgOF3ObcywhrCxh3VTLLWZmZmNU2Dy5Lgrhzg5AhN7x7jXZf_d_X_QPqdQfQOOyJsI9dNEcdWU1OoqjJjVVn4cKBICSIW8ouQ-YwFDhy2-X_QJxyAs-lk6p3B0icaiEBjU6_atpJHafY66b6sElsSM755NJORZFjGwdO8v85ewxN7vkoal4tDvWyThUrucS1fVOnFYo_Ey5u7oq770L_t5w9Wr5ualqsyrUaoWrmIdZG7lF_yYOfHb8UmnOVCd4EHDlCHejjBLDUE5zM6Ds3g9w85oFAH.cL8xJiluV4VRcqD2tsOIXKgpvI7UfN_fbvREgPpiP_r0T0JTBfS_vH2cnrq50d-kogWBjyZLE_OMINhFqo8dIw',
+      takt:  'Empfehlung: wöchentlich (montags) übernehmen; in der Schlussspurt-Woche ab 3. August täglich.'
+    }
   };
 
   var SB  = 'https://dagcsnfrlbpxcmdimnrw.supabase.co';
@@ -208,6 +216,28 @@
     var note = document.createElement('div'); note.className = 'fnote';
     note.textContent = 'Reichweite und Klicks kommen aus den Aktivitäten – je Eintrag erfassen (auch später über Bearbeiten). Abschlüsse und Geblieben zählt das Cockpit live aus den Anmeldungen.';
     host.appendChild(note);
+  }
+
+  // ── Quelle der Social-Media-Zahlen (Metricool) ─────────────────────────────
+  // Reichweite und Klicks der Social-Kanäle liegen nicht im Backend, sondern in
+  // Metricool. Der Block nennt die Quelle mit Link und den Übernahme-Takt; die
+  // Zahlen selbst trägt man je Aktivität ein (Reichweite/Klicks). Element-gewächtert,
+  // erscheint also nur auf Seiten mit einem #quelleSocial-Container.
+  function renderQuelleSocial(){
+    var host = el('quelleSocial'); if (!host) return;
+    var q = CONFIG.quelleSocial; if (!q) return;
+    host.innerHTML = '';
+    var row = document.createElement('div'); row.className = 'landing';
+    var lab = document.createElement('span'); lab.className = 'meta';
+    lab.textContent = 'Quelle · Social-Media-Zahlen';
+    var a = document.createElement('a'); a.className = 'btn';
+    a.href = q.url; a.target = '_blank'; a.rel = 'noopener';
+    a.textContent = q.label;
+    row.appendChild(lab); row.appendChild(a);
+    var note = document.createElement('p'); note.className = 'provisorisch';
+    note.textContent = 'Reichweite und Klicks der Social-Media-Kanäle kommen aus Metricool. ' +
+      q.takt + ' Ein automatischer Abruf ist nicht möglich – die abgelesenen Zahlen je Aktivität eintragen.';
+    host.appendChild(row); host.appendChild(note);
   }
 
   // ── Attribution nach Motiv (utm_content) ───────────────────────────────────
@@ -789,6 +819,7 @@
   // ── Laden ──────────────────────────────────────────────────────────────────
   function load(){
     renderDeadline();
+    renderQuelleSocial();
     if(CONFIG.zahlenProvisorisch && el('provisorisch')){
       el('provisorisch').textContent = 'Zielmarken, Preise und die Bleibe-Quote sind vorläufig hinterlegt – sobald die echten Werte gesetzt sind, rechnet das Cockpit unverändert weiter.';
     }

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -187,11 +187,14 @@
       host.appendChild(lvl);
     });
     // Reichweite je Kanal – aus den Aktivitäten summiert (Social, Newsletter, …).
-    var reach = {}, klick = {};
+    // Neben der Summe je Kanal auch die einzelnen Aktivitäten sammeln, damit der
+    // Balken zu einer Liste der Quellen aufklappt (Herkunft der Reichweite prüfbar).
+    var reach = {}, klick = {}, quellen = {};
     (massnahmen || []).forEach(function(m){
       var r = Number(m.reichweite) || 0, k = Number(m.klicks) || 0, kn = m.kanal || 'andere';
       if (r) reach[kn] = (reach[kn] || 0) + r;
       if (k) klick[kn] = (klick[kn] || 0) + k;
+      if (r || k) (quellen[kn] = quellen[kn] || []).push({ name:m.massnahme || '—', tag:m.tag, reichweite:r, klicks:k });
     });
     var kanalItems = Object.keys(reach).map(function(kn){ return { kanal:kn, reach:reach[kn], klick:klick[kn] || 0 }; })
                                        .sort(function(a, b){ return b.reach - a.reach; });
@@ -201,15 +204,50 @@
       var head = document.createElement('div'); head.className = 'rk-h'; head.textContent = 'Reichweite je Kanal';
       box.appendChild(head);
       kanalItems.forEach(function(x){
+        // Jeder Kanal-Balken ist aufklappbar (details/summary) und listet darunter
+        // die einzelnen Quellen (Aktivitäten), die die Reichweite ausmachen.
+        var det = document.createElement('details'); det.className = 'reach-detail';
+        var sum = document.createElement('summary');
         var row = document.createElement('div'); row.className = 'stream';
         row.innerHTML = '<div class="top2"><span class="name"></span>' +
           '<span class="val"><b></b> <span class="g"></span></span></div>' +
           '<div class="track"><span></span></div>';
+        var qs = (quellen[x.kanal] || []).slice().sort(function(a, b){ return b.reichweite - a.reichweite; });
         row.querySelector('.name').textContent = KANAL_LABEL[x.kanal] || x.kanal;
+        var caret = document.createElement('span'); caret.className = 'rk-caret'; caret.setAttribute('aria-hidden', 'true');
+        row.querySelector('.name').appendChild(caret);
         row.querySelector('.val b').textContent = fmt(x.reach);
-        row.querySelector('.val .g').textContent = x.klick ? (fmt(x.klick) + ' Klicks') : '';
+        var g = x.klick ? (fmt(x.klick) + ' Klicks') : '';
+        if (qs.length) g += (g ? ' · ' : '') + qs.length + (qs.length === 1 ? ' Quelle' : ' Quellen');
+        row.querySelector('.val .g').textContent = g;
         row.querySelector('.track > span').style.width = Math.max(3, Math.round(x.reach / kmax * 100)) + '%';
-        box.appendChild(row);
+        sum.appendChild(row); det.appendChild(sum);
+
+        var list = document.createElement('div'); list.className = 'quellen';
+        qs.forEach(function(q){
+          var qr = document.createElement('div'); qr.className = 'motrow';
+          var mc = document.createElement('span'); mc.className = 'mc'; mc.textContent = q.name;
+          if (q.tag){ var ms = document.createElement('span'); ms.className = 'ms';
+            ms.textContent = new Date(q.tag + 'T00:00:00').toLocaleDateString('de-CH', { day:'numeric', month:'numeric' });
+            mc.appendChild(ms); }
+          var mn = document.createElement('span'); mn.className = 'mn';
+          mn.textContent = fmt(q.reichweite) + (q.klicks ? (' · ' + fmt(q.klicks) + ' Klicks') : '');
+          qr.appendChild(mc); qr.appendChild(mn); list.appendChild(qr);
+        });
+        if (!qs.length){
+          var leer = document.createElement('div'); leer.className = 'qz-hint';
+          leer.textContent = 'Keine Einzel-Quellen erfasst.'; list.appendChild(leer);
+        }
+        // Social: die externe Quelle (Metricool) direkt aus der Liste verlinken.
+        if (x.kanal === 'social' && CONFIG.quelleSocial){
+          var qlink = document.createElement('div'); qlink.className = 'qz-hint';
+          qlink.appendChild(document.createTextNode('Quelle der Zahlen: '));
+          var qa = document.createElement('a'); qa.href = CONFIG.quelleSocial.url;
+          qa.target = '_blank'; qa.rel = 'noopener'; qa.textContent = CONFIG.quelleSocial.label;
+          qlink.appendChild(qa); list.appendChild(qlink);
+        }
+        det.appendChild(list);
+        box.appendChild(det);
       });
       host.appendChild(box);
     }

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -97,6 +97,7 @@
     <div class="panel" style="margin-top:var(--s5)">
       <div class="funnel" id="funnel"><div class="empty">lädt …</div></div>
     </div>
+    <div id="quelleSocial" style="margin-top:var(--s5)"></div>
   </section>
 
 


### PR DESCRIPTION
## Worum es geht

Neue Quelle für den Sommer-Zähler: das öffentliche **Metricool Kampagnen-Dashboard** liefert Reichweite und Klicks der Social-Media-Kanäle. Diese Zahlen liegen nicht im Werkzeug-Backend, sondern nur bei Metricool.

Der PR bindet die Quelle als **klar benannten Quellen-Block mit Link** ein – dort, wo die Zahlen gebraucht werden:

- **Aktivitäten** (Aktionen) – direkt beim Eintragen von Reichweite/Klicks.
- **Cockpit → Wirkung** (Auswertung) – unter der Wirkungskette Reichweite → Klicks → Abschlüsse → Geblieben.

## Umsetzung

- Zentral in `campaign.js`: `CONFIG.quelleSocial` (Label, öffentlicher Link, Übernahme-Takt) + `renderQuelleSocial()`. Eine Quelle der Wahrheit, element-gewächtert – erscheint auf jeder Seite mit einem `#quelleSocial`-Container.
- `aktivitaeten.html` und `index.html`: je ein `#quelleSocial`-Container.
- Nur kanonische Klassen wiederverwendet (`.landing`/`.meta`/`.btn`/`.provisorisch`), keine neue Gestalt erfunden.

Regel-IDs: DS04 (kanonische Rollen wiederverwendet), B01 (Link = volles Blau + Weiss über `.btn`), G05/G03 (keine Versalien/Unterstreichung, Entbehrliches weggelassen), B03 (Meta-Label ≥15). `typo-check` und `ds-lint --staged` grün (Score 100 %). Funktion mit jsdom auf beiden Seiten geprüft (Label, Link, `target=_blank`/`rel=noopener`, Notiz).

## Update-Takt (Empfehlung)

**Wöchentlich (montags)** genügt und ist so im Hinweistext hinterlegt; in der **Schlussspurt-Woche ab 3. August täglich**. Begründung: Der Trichter bewegt sich bei einer Abo-Aktion in Wochenschritten sinnvoll; tägliche Social-Zahlen sind Rauschen und reine Fleissarbeit. Nur zum Schluss lohnt der engere Takt.

## Kein Live-Abgriff

Metricool gibt die Zahlen nur im geschützten Dashboard aus (kurzlebige Sitzungs-Tokens, kein Fremd-Abruf aus dem Browser). Darum werden Reichweite/Klicks **abgelesen und je Aktivität eingetragen** – die Quelle macht die Herkunft eindeutig und einen Klick weit.

## Zu beachten

Der Link enthält den öffentlichen Freigabe-Token des Dashboards und steht damit im Seitenquelltext (die Seiten sind `noindex`, aber öffentlich ausgeliefert). Das entspricht der ausdrücklichen Bitte, den Link als Quelle beizulegen; wer den Link hat, sieht die Kampagnen-Auswertung (nur Aggregate, keine Personendaten).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113udovPGTQRSwtoetP7xkg

---
_Generated by [Claude Code](https://claude.ai/code/session_0113udovPGTQRSwtoetP7xkg)_