### PR TITLE
Frist-Mails (w3/w3b): Geschäftsführer-Kurs eingearbeitet — direkt, ohne Drückerkolonne

### DIFF
--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -109,7 +109,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 12.07.2026, 19.37 Uhr · <code>701abd4</code></p>
+  <p class="subline">Stand dieses Builds: 13.07.2026, 11.19 Uhr · <code>8e0a536</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -1356,13 +1356,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#gesamt')">senden</button></div></div></div>
   <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Three months of reading — then you decide.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Until 8 August: three months of the weekly, free with your subscription — it goes where you go.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">A summer beyond your own horizon.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#text')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3 · DE<a href="mails/mail_lesen_w3_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Bis Samstag: drei Monate mitlesen, kostenlos</div><div class="ib-a">Drei Gratis-Monate zum Mitlesen — nur noch bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Bis Samstag: Denken, das über die Woche hinausreicht</div></div>
+  <div class="inbox"><div class="ib-b">Bis Samstag: drei Monate gratis lesen — dann schliesst die Aktion</div><div class="ib-a">Drei Monate Wochenschrift gratis — nur noch bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Bis Samstag: drei Monate mitlesen, kostenlos</title>
+  <title>Bis Samstag: drei Monate gratis lesen — dann schliesst die Aktion</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -1466,8 +1466,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Drei Gratis-Monate zum Mitlesen — nur noch bis Samstag, 8. August.</div>
-  <div aria-label=&quot;Bis Samstag: drei Monate mitlesen, kostenlos&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Drei Monate Wochenschrift gratis — nur noch bis Samstag, 8. August.</div>
+  <div aria-label=&quot;Bis Samstag: drei Monate gratis lesen — dann schliesst die Aktion&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -1554,13 +1554,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>Bis Samstag bleibt die Tür&#160;offen.</div>
+                          <div style=&quot;text-wrap:balance&quot;>Am Samstag schliesst die&#160;Tür.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Diese Woche endet die Sommer-Aktion. Bis Samstag lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — und kommen mit anderen Augen in Ihre Woche zurück. Gefällt es nicht, kündigen Sie mit einem Klick.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — beginnen Sie jetzt, und entscheiden erst danach, ob sie bleibt.</div>
                       </td>
                     </tr>
                     <tr>
@@ -1649,15 +1649,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Bis Samstag: drei Monate mitlesen, kostenlos</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Drei Gratis-Monate zum Mitlesen — nur noch bis Samstag, 8. August.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Bis Samstag bleibt die Tür offen.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Diese Woche endet die Sommer-Aktion. Bis Samstag lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — und kommen mit anderen Augen in Ihre Woche zurück. Gefällt es nicht, kündigen Sie mit einem Klick.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Bis Samstag: Denken, das über die Woche hinausreicht</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#alt')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Bis Samstag: drei Monate gratis lesen — dann schliesst die Aktion</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Drei Monate Wochenschrift gratis — nur noch bis Samstag, 8. August.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Am Samstag schliesst die Tür.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — beginnen Sie jetzt, und entscheiden erst danach, ob sie bleibt.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#alt')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3 · EN<a href="mails/mail_lesen_w3_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Until Saturday: three months of reading, free</div><div class="ib-a">Three free months to read along — only until Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Until Saturday: thinking that reaches beyond the week</div></div>
+  <div class="inbox"><div class="ib-b">Until Saturday: three months of the weekly, free — then the offer closes</div><div class="ib-a">Three months of the weekly, free — only until Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> On Saturday your free trial of the weekly ends — if you still want it.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Until Saturday: three months of reading, free</title>
+  <title>Until Saturday: three months of the weekly, free — then the offer closes</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -1761,8 +1761,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three free months to read along — only until Saturday, 8 August.</div>
-  <div aria-label=&quot;Until Saturday: three months of reading, free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of the weekly, free — only until Saturday, 8 August.</div>
+  <div aria-label=&quot;Until Saturday: three months of the weekly, free — then the offer closes&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -1849,13 +1849,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>The door stays open until&#160;Saturday.</div>
+                          <div style=&quot;text-wrap:balance&quot;>On Saturday the door&#160;closes.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>This week the summer offer ends. Until Saturday, read the weekly free for three months with your subscription — and return to your own week with different eyes. If it’s not for you, cancel in one click.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>On Saturday, 8 August, the summer offer ends. Until then, read the weekly free for three months with your subscription — begin now, and decide only afterwards whether it stays.</div>
                       </td>
                     </tr>
                     <tr>
@@ -1944,7 +1944,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Until Saturday: three months of reading, free</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Three free months to read along — only until Saturday, 8 August.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">The door stays open until Saturday.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">This week the summer offer ends. Until Saturday, read the weekly free for three months with your subscription — and return to your own week with different eyes. If it’s not for you, cancel in one click.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Until Saturday: thinking that reaches beyond the week</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#alt')">vorschlagen</button></label></details></div></div></div></div></section><section class="segment"><h2>Sehen · goetheanum.tv — nurws</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Until Saturday: three months of the weekly, free — then the offer closes</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Three months of the weekly, free — only until Saturday, 8 August.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">On Saturday the door closes.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">On Saturday, 8 August, the summer offer ends. Until then, read the weekly free for three months with your subscription — begin now, and decide only afterwards whether it stays.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">On Saturday your free trial of the weekly ends — if you still want it.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#alt')">vorschlagen</button></label></details></div></div></div></div></section><section class="segment"><h2>Sehen · goetheanum.tv — nurws</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W1 · DE<a href="mails/mail_sehen_w1_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
   <div class="inbox"><div class="ib-b">Sehen, wie Menschen laut denken — 3 Monate gratis</div><div class="ib-a">«Kann man Glück lernen?» und über 800 weitere Beiträge — nah am Goetheanum, wohin der Sommer Sie trägt.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
@@ -3146,13 +3146,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#gesamt')">senden</button></div></div></div>
   <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Your summer still has evenings free</textarea><button type="button" onclick="vorschlag(this,'sehen_w2_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">goetheanum.tv, three months free with your subscription — evenings that linger. By 8 August.</textarea><button type="button" onclick="vorschlag(this,'sehen_w2_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Pull up a chair.</textarea><button type="button" onclick="vorschlag(this,'sehen_w2_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">An evening on goetheanum.tv is an evening in the company of people who have worked on a question all their lives — thinking out loud rather than reciting finished answers. Until 8 August: three months free with your subscription.</textarea><button type="button" onclick="vorschlag(this,'sehen_w2_en#text')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3 · DE<a href="mails/mail_sehen_w3_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Nur noch bis Samstag: drei Monate gratis</div><div class="ib-a">Eine Minute für drei Monate goetheanum.tv: gratis zu Ihrem Abo — bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Bis Samstag: sehen, wie Menschen laut denken</div></div>
+  <div class="inbox"><div class="ib-b">Bis Samstag: drei Monate goetheanum.tv gratis — dann schliesst die Aktion</div><div class="ib-a">Eine Minute genügt: drei Monate goetheanum.tv gratis — bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Am Samstag endet Ihr Gratis-Test von goetheanum.tv — falls Sie ihn noch wollen.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Nur noch bis Samstag: drei Monate gratis</title>
+  <title>Bis Samstag: drei Monate goetheanum.tv gratis — dann schliesst die Aktion</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -3256,8 +3256,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Eine Minute für drei Monate goetheanum.tv: gratis zu Ihrem Abo — bis Samstag, 8. August.</div>
-  <div aria-label=&quot;Nur noch bis Samstag: drei Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Eine Minute genügt: drei Monate goetheanum.tv gratis — bis Samstag, 8. August.</div>
+  <div aria-label=&quot;Bis Samstag: drei Monate goetheanum.tv gratis — dann schliesst die Aktion&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -3344,13 +3344,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>Bis Samstag ist Ihr Platz&#160;frei.</div>
+                          <div style=&quot;text-wrap:balance&quot;>Am Samstag schliesst die&#160;Aktion.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Noch ein paar Sommertage: goetheanum.tv, drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es in Ihnen nachklingt.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin sehen Sie goetheanum.tv drei Monate gratis zu Ihrem Abo — beginnen Sie jetzt, und entscheiden erst danach, ob es bleibt.</div>
                       </td>
                     </tr>
                     <tr>
@@ -3439,15 +3439,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Nur noch bis Samstag: drei Monate gratis</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Eine Minute für drei Monate goetheanum.tv: gratis zu Ihrem Abo — bis Samstag, 8. August.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Bis Samstag ist Ihr Platz frei.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Noch ein paar Sommertage: goetheanum.tv, drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es in Ihnen nachklingt.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Bis Samstag: sehen, wie Menschen laut denken</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#alt')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Bis Samstag: drei Monate goetheanum.tv gratis — dann schliesst die Aktion</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Eine Minute genügt: drei Monate goetheanum.tv gratis — bis Samstag, 8. August.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Am Samstag schliesst die Aktion.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin sehen Sie goetheanum.tv drei Monate gratis zu Ihrem Abo — beginnen Sie jetzt, und entscheiden erst danach, ob es bleibt.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Am Samstag endet Ihr Gratis-Test von goetheanum.tv — falls Sie ihn noch wollen.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#alt')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3 · EN<a href="mails/mail_sehen_w3_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Only until Saturday: three months free</div><div class="ib-a">One minute for three months of goetheanum.tv — free with your subscription, until Saturday.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Until Saturday: watch people think out loud</div></div>
+  <div class="inbox"><div class="ib-b">Until Saturday: three months of goetheanum.tv, free — then the offer closes</div><div class="ib-a">One minute is enough: three months of goetheanum.tv, free — until Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> On Saturday your free trial of goetheanum.tv ends — if you still want it.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Only until Saturday: three months free</title>
+  <title>Until Saturday: three months of goetheanum.tv, free — then the offer closes</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -3551,8 +3551,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>One minute for three months of goetheanum.tv — free with your subscription, until Saturday.</div>
-  <div aria-label=&quot;Only until Saturday: three months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>One minute is enough: three months of goetheanum.tv, free — until Saturday, 8 August.</div>
+  <div aria-label=&quot;Until Saturday: three months of goetheanum.tv, free — then the offer closes&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -3639,13 +3639,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>Your seat stays free until&#160;Saturday.</div>
+                          <div style=&quot;text-wrap:balance&quot;>On Saturday the offer&#160;closes.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>A few summer days left: goetheanum.tv, three months free with your subscription — stay only if it stays with you.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>On Saturday, 8 August, the summer offer ends. Until then, watch goetheanum.tv free for three months with your subscription — begin now, and decide only afterwards whether it stays.</div>
                       </td>
                     </tr>
                     <tr>
@@ -3734,7 +3734,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Only until Saturday: three months free</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">One minute for three months of goetheanum.tv — free with your subscription, until Saturday.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Your seat stays free until Saturday.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">A few summer days left: goetheanum.tv, three months free with your subscription — stay only if it stays with you.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Until Saturday: watch people think out loud</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#alt')">vorschlagen</button></label></details></div></div></div></div></section><section class="segment"><h2>Beides · Das ganze Goetheanum — noabo</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Until Saturday: three months of goetheanum.tv, free — then the offer closes</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">One minute is enough: three months of goetheanum.tv, free — until Saturday, 8 August.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">On Saturday the offer closes.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">On Saturday, 8 August, the summer offer ends. Until then, watch goetheanum.tv free for three months with your subscription — begin now, and decide only afterwards whether it stays.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">On Saturday your free trial of goetheanum.tv ends — if you still want it.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#alt')">vorschlagen</button></label></details></div></div></div></div></section><section class="segment"><h2>Beides · Das ganze Goetheanum — noabo</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W1 · DE<a href="mails/mail_beides_w1_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
   <div class="inbox"><div class="ib-b">Ein Sommer mit dem Goetheanum — 3 Monate gratis</div><div class="ib-a">Lesen oder schauen — oder beides: drei Monate kostenlos, bis 8. August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
@@ -4936,13 +4936,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#gesamt')">senden</button></div></div></div>
   <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Read, watch — or simply both</textarea><button type="button" onclick="vorschlag(this,'beides_w2_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">The weekly and goetheanum.tv, three months free — food for thought all summer. By 8 August.</textarea><button type="button" onclick="vorschlag(this,'beides_w2_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Thinking in good company.</textarea><button type="button" onclick="vorschlag(this,'beides_w2_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">An essay in the morning, a lecture in the evening — and in between you notice your own thoughts reaching further than usual. Three months free, sign up by 8 August.</textarea><button type="button" onclick="vorschlag(this,'beides_w2_en#text')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3 · DE<a href="mails/mail_beides_w3_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Am Samstag endet die Sommer-Aktion</div><div class="ib-a">Drei Monate lesen oder schauen, gratis — nur noch bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Drei Monate Goetheanum — lesen, sehen oder beides</div></div>
+  <div class="inbox"><div class="ib-b">Bis Samstag: drei Monate Goetheanum gratis — dann schliesst die Aktion</div><div class="ib-a">Drei Monate lesen oder schauen, gratis — nur noch bis Samstag, 8. August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Am Samstag endet Ihr Gratis-Test — falls Sie ihn noch wollen.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Am Samstag endet die Sommer-Aktion</title>
+  <title>Bis Samstag: drei Monate Goetheanum gratis — dann schliesst die Aktion</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -5047,7 +5047,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
   <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Drei Monate lesen oder schauen, gratis — nur noch bis Samstag, 8. August.</div>
-  <div aria-label=&quot;Am Samstag endet die Sommer-Aktion&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div aria-label=&quot;Bis Samstag: drei Monate Goetheanum gratis — dann schliesst die Aktion&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -5134,13 +5134,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>Lesen, sehen oder beides — Ihre&#160;Wahl.</div>
+                          <div style=&quot;text-wrap:balance&quot;>Bis Samstag — lesen, sehen oder&#160;beides.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Noch bis Samstag: drei Monate kostenlos lesen oder sehen — danach entscheiden Sie, ob es weitergeht.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin lesen und/oder sehen Sie das Goetheanum drei Monate gratis — beginnen Sie jetzt, und entscheiden erst danach, ob es weitergeht.</div>
                       </td>
                     </tr>
                     <tr>
@@ -5229,15 +5229,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Am Samstag endet die Sommer-Aktion</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Drei Monate lesen oder schauen, gratis — nur noch bis Samstag, 8. August.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Lesen, sehen oder beides — Ihre Wahl.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Noch bis Samstag: drei Monate kostenlos lesen oder sehen — danach entscheiden Sie, ob es weitergeht.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Drei Monate Goetheanum — lesen, sehen oder beides</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#alt')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Bis Samstag: drei Monate Goetheanum gratis — dann schliesst die Aktion</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Drei Monate lesen oder schauen, gratis — nur noch bis Samstag, 8. August.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Bis Samstag — lesen, sehen oder beides.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin lesen und/oder sehen Sie das Goetheanum drei Monate gratis — beginnen Sie jetzt, und entscheiden erst danach, ob es weitergeht.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Am Samstag endet Ihr Gratis-Test — falls Sie ihn noch wollen.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#alt')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3 · EN<a href="mails/mail_beides_w3_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">The summer offer ends on Saturday</div><div class="ib-a">Three months of reading or watching, free — only until Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Three months of Goetheanum — read, watch or both</div></div>
+  <div class="inbox"><div class="ib-b">Until Saturday: three months of the Goetheanum, free — then the offer closes</div><div class="ib-a">Three months of reading or watching, free — only until Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> On Saturday your free trial ends — if you still want it.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>The summer offer ends on Saturday</title>
+  <title>Until Saturday: three months of the Goetheanum, free — then the offer closes</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -5342,7 +5342,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
   <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of reading or watching, free — only until Saturday, 8 August.</div>
-  <div aria-label=&quot;The summer offer ends on Saturday&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div aria-label=&quot;Until Saturday: three months of the Goetheanum, free — then the offer closes&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -5429,13 +5429,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot;>Reading, watching or both — your&#160;choice.</div>
+                          <div style=&quot;text-wrap:balance&quot;>Until Saturday — read, watch or&#160;both.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Until Saturday: three months free to read or watch — after that, you decide whether it continues.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>On Saturday, 8 August, the summer offer ends. Until then, read and/or watch the Goetheanum free for three months — begin now, and decide only afterwards whether it continues.</div>
                       </td>
                     </tr>
                     <tr>
@@ -5524,15 +5524,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">The summer offer ends on Saturday</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Three months of reading or watching, free — only until Saturday, 8 August.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Reading, watching or both — your choice.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Until Saturday: three months free to read or watch — after that, you decide whether it continues.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Three months of Goetheanum — read, watch or both</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#alt')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Until Saturday: three months of the Goetheanum, free — then the offer closes</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Three months of reading or watching, free — only until Saturday, 8 August.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Until Saturday — read, watch or both.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">On Saturday, 8 August, the summer offer ends. Until then, read and/or watch the Goetheanum free for three months — begin now, and decide only afterwards whether it continues.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">On Saturday your free trial ends — if you still want it.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#alt')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3B · DE<a href="mails/mail_beides_w3b_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Morgen ist Schluss</div><div class="ib-a">Drei Monate Goetheanum, gratis und jederzeit kündbar — anmelden bis morgen, Samstag, 8. August.</div></div>
+  <div class="inbox"><div class="ib-b">Morgen schliesst die Aktion</div><div class="ib-a">Drei Monate Goetheanum, gratis und jederzeit kündbar — anmelden bis morgen, Samstag, 8. August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Morgen ist Schluss</title>
+  <title>Morgen schliesst die Aktion</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -5637,7 +5637,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
   <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Drei Monate Goetheanum, gratis und jederzeit kündbar — anmelden bis morgen, Samstag, 8. August.</div>
-  <div aria-label=&quot;Morgen ist Schluss&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div aria-label=&quot;Morgen schliesst die Aktion&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -5730,7 +5730,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute, und Sie haben drei Monate Zeit, dem nachzugehen.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Morgen, am 8. August, schliesst das Sommerangebot. Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute jetzt, und Sie haben drei Monate Zeit, dem nachzugehen.</div>
                       </td>
                     </tr>
                     <tr>
@@ -5819,15 +5819,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Morgen ist Schluss</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Drei Monate Goetheanum, gratis und jederzeit kündbar — anmelden bis morgen, Samstag, 8. August.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Sie waren schon da — ein Schritt fehlt noch.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute, und Sie haben drei Monate Zeit, dem nachzugehen.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#text')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Morgen schliesst die Aktion</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Drei Monate Goetheanum, gratis und jederzeit kündbar — anmelden bis morgen, Samstag, 8. August.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Sie waren schon da — ein Schritt fehlt noch.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Morgen, am 8. August, schliesst das Sommerangebot. Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute jetzt, und Sie haben drei Monate Zeit, dem nachzugehen.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#text')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3B · EN<a href="mails/mail_beides_w3b_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">It ends tomorrow</div><div class="ib-a">Three months of the Goetheanum, free, cancel anytime — sign up by tomorrow, Saturday 8 August.</div></div>
+  <div class="inbox"><div class="ib-b">Tomorrow the offer closes</div><div class="ib-a">Three months of the Goetheanum, free, cancel anytime — sign up by tomorrow, Saturday 8 August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>It ends tomorrow</title>
+  <title>Tomorrow the offer closes</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -5932,7 +5932,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
   <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of the Goetheanum, free, cancel anytime — sign up by tomorrow, Saturday 8 August.</div>
-  <div aria-label=&quot;It ends tomorrow&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div aria-label=&quot;Tomorrow the offer closes&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
@@ -6025,7 +6025,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>What you looked at spoke to you for a reason — one minute, and you have three months to follow it.</div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;>Tomorrow, 8 August, the summer offer closes. What you looked at spoke to you for a reason — one minute now, and you have three months to follow it.</div>
                       </td>
                     </tr>
                     <tr>
@@ -6114,7 +6114,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">It ends tomorrow</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Three months of the Goetheanum, free, cancel anytime — sign up by tomorrow, Saturday 8 August.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">You’ve already had a look — one step to go.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">What you looked at spoke to you for a reason — one minute, and you have three months to follow it.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#text')">vorschlagen</button></label></details></div></div></div></div></section>
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Tomorrow the offer closes</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Three months of the Goetheanum, free, cancel anytime — sign up by tomorrow, Saturday 8 August.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">You’ve already had a look — one step to go.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Tomorrow, 8 August, the summer offer closes. What you looked at spoke to you for a reason — one minute now, and you have three months to follow it.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#text')">vorschlagen</button></label></details></div></div></div></div></section>
 </main>
 
 <footer class="ds-footer"><div class="wrap"><div class="frow">

--- a/apps/mail-editor/mails/mail_beides_w3_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Am Samstag endet die Sommer-Aktion</title>
+  <title>Bis Samstag: drei Monate Goetheanum gratis — dann schliesst die Aktion</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -108,7 +108,7 @@
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Drei Monate lesen oder schauen, gratis — nur noch bis Samstag, 8. August.</div>
-  <div aria-label="Am Samstag endet die Sommer-Aktion" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div aria-label="Bis Samstag: drei Monate Goetheanum gratis — dann schliesst die Aktion" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -195,13 +195,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">Lesen, sehen oder beides — Ihre&#160;Wahl.</div>
+                          <div style="text-wrap:balance">Bis Samstag — lesen, sehen oder&#160;beides.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Noch bis Samstag: drei Monate kostenlos lesen oder sehen — danach entscheiden Sie, ob es weitergeht.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin lesen und/oder sehen Sie das Goetheanum drei Monate gratis — beginnen Sie jetzt, und entscheiden erst danach, ob es weitergeht.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_beides_w3_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>The summer offer ends on Saturday</title>
+  <title>Until Saturday: three months of the Goetheanum, free — then the offer closes</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -108,7 +108,7 @@
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of reading or watching, free — only until Saturday, 8 August.</div>
-  <div aria-label="The summer offer ends on Saturday" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div aria-label="Until Saturday: three months of the Goetheanum, free — then the offer closes" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -195,13 +195,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">Reading, watching or both — your&#160;choice.</div>
+                          <div style="text-wrap:balance">Until Saturday — read, watch or&#160;both.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Until Saturday: three months free to read or watch — after that, you decide whether it continues.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">On Saturday, 8 August, the summer offer ends. Until then, read and/or watch the Goetheanum free for three months — begin now, and decide only afterwards whether it continues.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_beides_w3b_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Morgen ist Schluss</title>
+  <title>Morgen schliesst die Aktion</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -108,7 +108,7 @@
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Drei Monate Goetheanum, gratis und jederzeit kündbar — anmelden bis morgen, Samstag, 8. August.</div>
-  <div aria-label="Morgen ist Schluss" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div aria-label="Morgen schliesst die Aktion" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -201,7 +201,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute, und Sie haben drei Monate Zeit, dem nachzugehen.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Morgen, am 8. August, schliesst das Sommerangebot. Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute jetzt, und Sie haben drei Monate Zeit, dem nachzugehen.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_beides_w3b_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>It ends tomorrow</title>
+  <title>Tomorrow the offer closes</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -108,7 +108,7 @@
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of the Goetheanum, free, cancel anytime — sign up by tomorrow, Saturday 8 August.</div>
-  <div aria-label="It ends tomorrow" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div aria-label="Tomorrow the offer closes" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -201,7 +201,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">What you looked at spoke to you for a reason — one minute, and you have three months to follow it.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Tomorrow, 8 August, the summer offer closes. What you looked at spoke to you for a reason — one minute now, and you have three months to follow it.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_lesen_w3_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Bis Samstag: drei Monate mitlesen, kostenlos</title>
+  <title>Bis Samstag: drei Monate gratis lesen — dann schliesst die Aktion</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Drei Gratis-Monate zum Mitlesen — nur noch bis Samstag, 8. August.</div>
-  <div aria-label="Bis Samstag: drei Monate mitlesen, kostenlos" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Drei Monate Wochenschrift gratis — nur noch bis Samstag, 8. August.</div>
+  <div aria-label="Bis Samstag: drei Monate gratis lesen — dann schliesst die Aktion" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -195,13 +195,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">Bis Samstag bleibt die Tür&#160;offen.</div>
+                          <div style="text-wrap:balance">Am Samstag schliesst die&#160;Tür.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Diese Woche endet die Sommer-Aktion. Bis Samstag lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — und kommen mit anderen Augen in Ihre Woche zurück. Gefällt es nicht, kündigen Sie mit einem Klick.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — beginnen Sie jetzt, und entscheiden erst danach, ob sie bleibt.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_lesen_w3_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Until Saturday: three months of reading, free</title>
+  <title>Until Saturday: three months of the weekly, free — then the offer closes</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three free months to read along — only until Saturday, 8 August.</div>
-  <div aria-label="Until Saturday: three months of reading, free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of the weekly, free — only until Saturday, 8 August.</div>
+  <div aria-label="Until Saturday: three months of the weekly, free — then the offer closes" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -195,13 +195,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">The door stays open until&#160;Saturday.</div>
+                          <div style="text-wrap:balance">On Saturday the door&#160;closes.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">This week the summer offer ends. Until Saturday, read the weekly free for three months with your subscription — and return to your own week with different eyes. If it’s not for you, cancel in one click.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">On Saturday, 8 August, the summer offer ends. Until then, read the weekly free for three months with your subscription — begin now, and decide only afterwards whether it stays.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_sehen_w3_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Nur noch bis Samstag: drei Monate gratis</title>
+  <title>Bis Samstag: drei Monate goetheanum.tv gratis — dann schliesst die Aktion</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Eine Minute für drei Monate goetheanum.tv: gratis zu Ihrem Abo — bis Samstag, 8. August.</div>
-  <div aria-label="Nur noch bis Samstag: drei Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Eine Minute genügt: drei Monate goetheanum.tv gratis — bis Samstag, 8. August.</div>
+  <div aria-label="Bis Samstag: drei Monate goetheanum.tv gratis — dann schliesst die Aktion" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -195,13 +195,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">Bis Samstag ist Ihr Platz&#160;frei.</div>
+                          <div style="text-wrap:balance">Am Samstag schliesst die&#160;Aktion.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Noch ein paar Sommertage: goetheanum.tv, drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es in Ihnen nachklingt.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin sehen Sie goetheanum.tv drei Monate gratis zu Ihrem Abo — beginnen Sie jetzt, und entscheiden erst danach, ob es bleibt.</div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_sehen_w3_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Only until Saturday: three months free</title>
+  <title>Until Saturday: three months of goetheanum.tv, free — then the offer closes</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">One minute for three months of goetheanum.tv — free with your subscription, until Saturday.</div>
-  <div aria-label="Only until Saturday: three months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">One minute is enough: three months of goetheanum.tv, free — until Saturday, 8 August.</div>
+  <div aria-label="Until Saturday: three months of goetheanum.tv, free — then the offer closes" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -195,13 +195,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance">Your seat stays free until&#160;Saturday.</div>
+                          <div style="text-wrap:balance">On Saturday the offer&#160;closes.</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">A few summer days left: goetheanum.tv, three months free with your subscription — stay only if it stays with you.</div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;">On Saturday, 8 August, the summer offer ends. Until then, watch goetheanum.tv free for three months with your subscription — begin now, and decide only afterwards whether it stays.</div>
                       </td>
                     </tr>
                     <tr>

--- a/services/mailing-sommer2026/AC-AUTOMATION.md
+++ b/services/mailing-sommer2026/AC-AUTOMATION.md
@@ -124,8 +124,8 @@ Alle Links tragen zudem
 | w1 | EN | Thinking that reaches beyond the week — 3 months free | — | `w1_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w1_en.html |
 | w2 | DE | Drei Monate mitlesen, danach entscheiden Sie. | — | `w2_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w2_de.html |
 | w2 | EN | Three months of reading — then you decide. | — | `w2_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w2_en.html |
-| w3 | DE | Bis Samstag: drei Monate mitlesen, kostenlos | Bis Samstag: Denken, das über die Woche hinausreicht | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_de.html |
-| w3 | EN | Until Saturday: three months of reading, free | Until Saturday: thinking that reaches beyond the week | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_en.html |
+| w3 | DE | Bis Samstag: drei Monate gratis lesen — dann schliesst die Aktion | Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen. | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_de.html |
+| w3 | EN | Until Saturday: three months of the weekly, free — then the offer closes | On Saturday your free trial of the weekly ends — if you still want it. | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_en.html |
 
 ### S26 · NurWS→TV (Angebot: goetheanum.tv sehen)
 
@@ -135,8 +135,8 @@ Alle Links tragen zudem
 | w1 | EN | Watch people think out loud — 3 months free | — | `w1_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w1_en.html |
 | w2 | DE | Ihr Sommer hat noch Abende frei | — | `w2_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w2_de.html |
 | w2 | EN | Your summer still has evenings free | — | `w2_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w2_en.html |
-| w3 | DE | Nur noch bis Samstag: drei Monate gratis | Bis Samstag: sehen, wie Menschen laut denken | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_de.html |
-| w3 | EN | Only until Saturday: three months free | Until Saturday: watch people think out loud | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_en.html |
+| w3 | DE | Bis Samstag: drei Monate goetheanum.tv gratis — dann schliesst die Aktion | Am Samstag endet Ihr Gratis-Test von goetheanum.tv — falls Sie ihn noch wollen. | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_de.html |
+| w3 | EN | Until Saturday: three months of goetheanum.tv, free — then the offer closes | On Saturday your free trial of goetheanum.tv ends — if you still want it. | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_en.html |
 
 ### S26 · NoAbo (beide Angebote; jede Mail führt mit einem Button zur Übersicht)
 
@@ -146,10 +146,10 @@ Alle Links tragen zudem
 | w1 | EN | A summer with the Goetheanum — 3 months free | — | `w1_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w1_en.html |
 | w2 | DE | Lesen, sehen — oder gleich beides | — | `w2_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w2_de.html |
 | w2 | EN | Read, watch — or simply both | — | `w2_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w2_en.html |
-| w3 | DE | Am Samstag endet die Sommer-Aktion | Drei Monate Goetheanum — lesen, sehen oder beides | `w3_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3_de.html |
-| w3 | EN | The summer offer ends on Saturday | Three months of Goetheanum — read, watch or both | `w3_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3_en.html |
-| w3b | DE | Morgen ist Schluss | — | `w3b_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3b_de.html |
-| w3b | EN | It ends tomorrow | — | `w3b_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3b_en.html |
+| w3 | DE | Bis Samstag: drei Monate Goetheanum gratis — dann schliesst die Aktion | Am Samstag endet Ihr Gratis-Test — falls Sie ihn noch wollen. | `w3_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3_de.html |
+| w3 | EN | Until Saturday: three months of the Goetheanum, free — then the offer closes | On Saturday your free trial ends — if you still want it. | `w3_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3_en.html |
+| w3b | DE | Morgen schliesst die Aktion | — | `w3b_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3b_de.html |
+| w3b | EN | Tomorrow the offer closes | — | `w3b_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3b_en.html |
 
 Macht **26 E-Mail-Schritte** insgesamt: 20 Mails, wobei die 6 w3-Mails je zweimal eingehängt werden (Standard- und Alt-Betreff, gleiches HTML).
 <!-- TABELLEN:END -->

--- a/services/mailing-sommer2026/heroes.json
+++ b/services/mailing-sommer2026/heroes.json
@@ -251,18 +251,18 @@
       },
       "w3": {
         "de": {
-          "betreff": "Bis Samstag: drei Monate mitlesen, kostenlos",
-          "botschaft": "Bis Samstag bleibt die Tür offen.",
-          "text": "Diese Woche endet die Sommer-Aktion. Bis Samstag lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — und kommen mit anderen Augen in Ihre Woche zurück. Gefällt es nicht, kündigen Sie mit einem Klick.",
-          "alt": "Bis Samstag: Denken, das über die Woche hinausreicht",
-          "preheader": "Drei Gratis-Monate zum Mitlesen — nur noch bis Samstag, 8. August."
+          "betreff": "Bis Samstag: drei Monate gratis lesen — dann schliesst die Aktion",
+          "botschaft": "Am Samstag schliesst die Tür.",
+          "text": "Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin lesen Sie die Wochenschrift drei Monate gratis zu Ihrem Abo — beginnen Sie jetzt, und entscheiden erst danach, ob sie bleibt.",
+          "alt": "Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen.",
+          "preheader": "Drei Monate Wochenschrift gratis — nur noch bis Samstag, 8. August."
         },
         "en": {
-          "betreff": "Until Saturday: three months of reading, free",
-          "botschaft": "The door stays open until Saturday.",
-          "text": "This week the summer offer ends. Until Saturday, read the weekly free for three months with your subscription — and return to your own week with different eyes. If it’s not for you, cancel in one click.",
-          "alt": "Until Saturday: thinking that reaches beyond the week",
-          "preheader": "Three free months to read along — only until Saturday, 8 August."
+          "betreff": "Until Saturday: three months of the weekly, free — then the offer closes",
+          "botschaft": "On Saturday the door closes.",
+          "text": "On Saturday, 8 August, the summer offer ends. Until then, read the weekly free for three months with your subscription — begin now, and decide only afterwards whether it stays.",
+          "alt": "On Saturday your free trial of the weekly ends — if you still want it.",
+          "preheader": "Three months of the weekly, free — only until Saturday, 8 August."
         }
       }
     },
@@ -301,18 +301,18 @@
       },
       "w3": {
         "de": {
-          "betreff": "Nur noch bis Samstag: drei Monate gratis",
-          "botschaft": "Bis Samstag ist Ihr Platz frei.",
-          "text": "Noch ein paar Sommertage: goetheanum.tv, drei Monate gratis zu Ihrem Abo — bleiben Sie nur, wenn es in Ihnen nachklingt.",
-          "alt": "Bis Samstag: sehen, wie Menschen laut denken",
-          "preheader": "Eine Minute für drei Monate goetheanum.tv: gratis zu Ihrem Abo — bis Samstag, 8. August."
+          "betreff": "Bis Samstag: drei Monate goetheanum.tv gratis — dann schliesst die Aktion",
+          "botschaft": "Am Samstag schliesst die Aktion.",
+          "text": "Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin sehen Sie goetheanum.tv drei Monate gratis zu Ihrem Abo — beginnen Sie jetzt, und entscheiden erst danach, ob es bleibt.",
+          "alt": "Am Samstag endet Ihr Gratis-Test von goetheanum.tv — falls Sie ihn noch wollen.",
+          "preheader": "Eine Minute genügt: drei Monate goetheanum.tv gratis — bis Samstag, 8. August."
         },
         "en": {
-          "betreff": "Only until Saturday: three months free",
-          "botschaft": "Your seat stays free until Saturday.",
-          "text": "A few summer days left: goetheanum.tv, three months free with your subscription — stay only if it stays with you.",
-          "alt": "Until Saturday: watch people think out loud",
-          "preheader": "One minute for three months of goetheanum.tv — free with your subscription, until Saturday."
+          "betreff": "Until Saturday: three months of goetheanum.tv, free — then the offer closes",
+          "botschaft": "On Saturday the offer closes.",
+          "text": "On Saturday, 8 August, the summer offer ends. Until then, watch goetheanum.tv free for three months with your subscription — begin now, and decide only afterwards whether it stays.",
+          "alt": "On Saturday your free trial of goetheanum.tv ends — if you still want it.",
+          "preheader": "One minute is enough: three months of goetheanum.tv, free — until Saturday, 8 August."
         }
       }
     },
@@ -351,33 +351,33 @@
       },
       "w3": {
         "de": {
-          "betreff": "Am Samstag endet die Sommer-Aktion",
-          "botschaft": "Lesen, sehen oder beides — Ihre Wahl.",
-          "text": "Noch bis Samstag: drei Monate kostenlos lesen oder sehen — danach entscheiden Sie, ob es weitergeht.",
-          "alt": "Drei Monate Goetheanum — lesen, sehen oder beides",
+          "betreff": "Bis Samstag: drei Monate Goetheanum gratis — dann schliesst die Aktion",
+          "botschaft": "Bis Samstag — lesen, sehen oder beides.",
+          "text": "Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin lesen und/oder sehen Sie das Goetheanum drei Monate gratis — beginnen Sie jetzt, und entscheiden erst danach, ob es weitergeht.",
+          "alt": "Am Samstag endet Ihr Gratis-Test — falls Sie ihn noch wollen.",
           "preheader": "Drei Monate lesen oder schauen, gratis — nur noch bis Samstag, 8. August."
         },
         "en": {
-          "betreff": "The summer offer ends on Saturday",
-          "botschaft": "Reading, watching or both — your choice.",
-          "text": "Until Saturday: three months free to read or watch — after that, you decide whether it continues.",
-          "alt": "Three months of Goetheanum — read, watch or both",
+          "betreff": "Until Saturday: three months of the Goetheanum, free — then the offer closes",
+          "botschaft": "Until Saturday — read, watch or both.",
+          "text": "On Saturday, 8 August, the summer offer ends. Until then, read and/or watch the Goetheanum free for three months — begin now, and decide only afterwards whether it continues.",
+          "alt": "On Saturday your free trial ends — if you still want it.",
           "preheader": "Three months of reading or watching, free — only until Saturday, 8 August."
         }
       },
       "w3b": {
         "de": {
-          "betreff": "Morgen ist Schluss",
+          "betreff": "Morgen schliesst die Aktion",
           "botschaft": "Sie waren schon da — ein Schritt fehlt noch.",
-          "text": "Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute, und Sie haben drei Monate Zeit, dem nachzugehen.",
-          "alt": "Bis morgen: drei Monate Goetheanum gratis",
+          "text": "Morgen, am 8. August, schliesst das Sommerangebot. Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute jetzt, und Sie haben drei Monate Zeit, dem nachzugehen.",
+          "alt": "Bis morgen: Ihre drei Gratis-Monate — falls Sie sie noch wollen.",
           "preheader": "Drei Monate Goetheanum, gratis und jederzeit kündbar — anmelden bis morgen, Samstag, 8. August."
         },
         "en": {
-          "betreff": "It ends tomorrow",
+          "betreff": "Tomorrow the offer closes",
           "botschaft": "You’ve already had a look — one step to go.",
-          "text": "What you looked at spoke to you for a reason — one minute, and you have three months to follow it.",
-          "alt": "Until tomorrow: 3 months of Goetheanum free",
+          "text": "Tomorrow, 8 August, the summer offer closes. What you looked at spoke to you for a reason — one minute now, and you have three months to follow it.",
+          "alt": "Until tomorrow: your three free months — if you still want them.",
           "preheader": "Three months of the Goetheanum, free, cancel anytime — sign up by tomorrow, Saturday 8 August."
         }
       }


### PR DESCRIPTION
## Was

Der **Blend**: w1/w2 bleiben die Einladung durch Gehalt; die **letzten Mails** (w3 aller drei Segmente + w3b) tragen jetzt den Kurs des Geschäftsführers — direkt, auf die Handlung, mit Dringlichkeit.

**Ton von der Redaktion verhandelt** (Direct-Response, Hüterin der Haus-Stimme, potentielle Abonnentin). Konsens: **Dringlichkeit aus dem Faktum, nicht aus dem Druck** —
- genaues Datum (Samstag, 8. August), klarer Nutzen, **ein** nächster Schritt („beginnen Sie jetzt");
- **entfernt:** die anti-dringliche Zeile „bleiben Sie nur, wenn es in Ihnen nachklingt";
- **rote Linien eingehalten:** kein „danach ist es zu spät", kein erfundener Mangel/Countdown, kein „aktivieren Sie" (Werbeton), kein Ausruf/Versal (G05);
- **Autonomie-Griff** in den Nicht-Öffner-Alt-Betreffen: „…falls Sie ihn noch wollen" (entwaffnet Reaktanz).

Die **Kleinzeile trägt weiter die Kündigungsmodell-Wahrheit** (danach läuft das Abo regulär weiter). w3 × 3 Segmente + w3b, DE + EN.

## Beispiel (Sehen w3)

- vorher: „Noch ein paar Sommertage: goetheanum.tv, drei Monate gratis — bleiben Sie nur, wenn es in Ihnen nachklingt."
- **jetzt:** „Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin sehen Sie goetheanum.tv drei Monate gratis zu Ihrem Abo — beginnen Sie jetzt, und entscheiden erst danach, ob es bleibt."

## Nicht enthalten

Die GF-Vorschläge für **w1/w2** (die reflektierte Einladung) — die bleiben bewusst Gehalt-geführt; seine Vorschläge liegen weiter offen im Register, bis er entschieden hat. Badge-Kürzung und „Archiv 2022/2023" ebenfalls offen.

## Prüfung

Gebaut, alle 20 Mails ok, AC-Prompt frisch, typo-check/ds-lint 0 Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_