### PR TITLE
Fix: geschlossenes WYSIWYG-Overlay sauber ausblenden

### DIFF
--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -103,7 +103,9 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 .mhd-edit{min-height:var(--tap);margin-left:8px;background:transparent;border:1px solid var(--paper);border-radius:999px;color:var(--paper);padding:2px 10px;font:inherit;font-size:var(--t-micro);cursor:pointer}
 .mhd-edit:hover{background:var(--paper);color:var(--ink)}
 /* WYSIWYG-Overlay: Vollfenster, dünner Balken, Mail zentriert und direkt editierbar. */
-.wyz{border:0;padding:0;margin:0;width:100vw;max-width:100vw;height:100vh;max-height:100vh;inset:0;background:var(--paper);color:var(--ink);overflow:hidden;display:flex;flex-direction:column}
+.wyz{border:0;padding:0;margin:0;width:100vw;max-width:100vw;height:100vh;max-height:100vh;inset:0;background:var(--paper);color:var(--ink);overflow:hidden}
+.wyz:not([open]){display:none}  /* geschlossen = unsichtbar (nicht vom eigenen display überschreiben) */
+.wyz[open]{display:flex;flex-direction:column}
 .wyz::backdrop{background:rgba(20,24,28,.55)} /* # ds-ok Scrim, kein Theme */
 .wyz-bar{flex:0 0 auto;display:flex;align-items:center;gap:var(--s3);min-height:var(--tap);padding:2px var(--s3);background:var(--ink);color:var(--paper)}
 .wyz-label{font-family:var(--font-text);font-size:var(--t-micro);color:var(--paper);opacity:.85}
@@ -140,7 +142,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 14.07.2026, 8.51 Uhr · <code>b0f37b2</code></p>
+  <p class="subline">Stand dieses Builds: 14.07.2026, 9.23 Uhr · <code>28717dd</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>

--- a/services/mailing-sommer2026/build_editor.py
+++ b/services/mailing-sommer2026/build_editor.py
@@ -464,7 +464,9 @@ body.nurmails .flds,body.nurmails .shared-sec{{display:none}}
 .mhd-edit{{min-height:var(--tap);margin-left:8px;background:transparent;border:1px solid var(--paper);border-radius:999px;color:var(--paper);padding:2px 10px;font:inherit;font-size:var(--t-micro);cursor:pointer}}
 .mhd-edit:hover{{background:var(--paper);color:var(--ink)}}
 /* WYSIWYG-Overlay: Vollfenster, dünner Balken, Mail zentriert und direkt editierbar. */
-.wyz{{border:0;padding:0;margin:0;width:100vw;max-width:100vw;height:100vh;max-height:100vh;inset:0;background:var(--paper);color:var(--ink);overflow:hidden;display:flex;flex-direction:column}}
+.wyz{{border:0;padding:0;margin:0;width:100vw;max-width:100vw;height:100vh;max-height:100vh;inset:0;background:var(--paper);color:var(--ink);overflow:hidden}}
+.wyz:not([open]){{display:none}}  /* geschlossen = unsichtbar (nicht vom eigenen display überschreiben) */
+.wyz[open]{{display:flex;flex-direction:column}}
 .wyz::backdrop{{background:rgba(20,24,28,.55)}} /* # ds-ok Scrim, kein Theme */
 .wyz-bar{{flex:0 0 auto;display:flex;align-items:center;gap:var(--s3);min-height:var(--tap);padding:2px var(--s3);background:var(--ink);color:var(--paper)}}
 .wyz-label{{font-family:var(--font-text);font-size:var(--t-micro);color:var(--paper);opacity:.85}}


### PR DESCRIPTION
Beim Laden der Editor-Seite war schon **vor** dem Öffnen einer Mail ein Teil des Overlays sichtbar (die Blätter-Pfeile und ein leerer Kasten), der Seitenelemente verdeckte.

**Ursache:** `.wyz{display:flex}` überschrieb die Browser-UA-Regel `dialog:not([open]){display:none}`, die einen geschlossenen `<dialog>` ausblendet.

**Fix:** `display:flex` nur noch unter `.wyz[open]`; geschlossen explizit `display:none`. Im Chromium geprüft: geschlossen `display:none` (Pfeile unsichtbar), beim Öffnen `flex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_