### PR TITLE
Lesen: GF-Fassung optimiert (DE) + EN-Übersetzung, Beweis-Band linksbündig

### DIFF
--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -141,7 +141,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 14.07.2026, 10.53 Uhr · <code>cadea09</code></p>
+  <p class="subline">Stand dieses Builds: 14.07.2026, 12.35 Uhr · <code>dfc8892</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -167,7 +167,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cpanel" hidden><ul class="clist" data-cl="shared#wortmarke"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#wortmarke')">senden</button></div></div></div><div class="fld" data-key="shared#badge"><div class="fh" onclick="toggle(this)"><span class="lbl">Badge</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="shared#badge">0</span></button></div>
-<div class="val"><span style="color:#A95278">Sommerangebot 2026</span> / <span style="color:#A95278">Summer offer 2026 · 3 months free</span> — HTML-Text, normal statt fett (G05) <!-- # ds-ok Mail-DNA, kein Theme --></div>
+<div class="val"><span style="color:#A95278">Sommerangebot 2026</span> / <span style="color:#A95278">Summer offer 2026</span> — HTML-Text, normal statt fett (G05) <!-- # ds-ok Mail-DNA, kein Theme --></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="shared#badge"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#badge')">senden</button></div></div></div><div class="fld" data-key="shared#beweisband"><div class="fh" onclick="toggle(this)"><span class="lbl">Beweis-Band</span>
 <button class="cbtn" type="button">💬 <span class="cc" data-cc="shared#beweisband">0</span></button></div>
@@ -188,13 +188,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'shared#footer')">senden</button></div></div></div></div></section>
 <section class="segment"><h2>Lesen · Die Wochenschrift — nurtv</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W1 · DE<button class="mhd-edit" type="button" onclick="openEditor('lesen_w1_de')">✎ Bearbeiten</button><a href="mails/mail_lesen_w1_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Ihr freier Zugang zur Wochenzeitschrift Das Goetheanum</div><div class="ib-a">Drei Monate freien Zugang für alle, die gerne in Ruhe auf Papier oder online lesen.</div></div>
+  <div class="inbox"><div class="ib-b">Ihr freier Zugang zur Wochenschrift Das Goetheanum</div><div class="ib-a">Drei Monate freien Zugang für alle, die gerne in Ruhe auf Papier oder online lesen.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Ihr freier Zugang zur Wochenzeitschrift Das Goetheanum</title>
+  <title>Ihr freier Zugang zur Wochenschrift Das Goetheanum</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -299,7 +299,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
   <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Drei Monate freien Zugang für alle, die gerne in Ruhe auf Papier oder online lesen.</div>
-  <div aria-label=&quot;Ihr freier Zugang zur Wochenzeitschrift Das Goetheanum&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div aria-label=&quot;Ihr freier Zugang zur Wochenschrift Das Goetheanum&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
@@ -416,7 +416,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w1_de#text&quot;>Ergänzend zu dem, was Sie auf goetheanum.tv sehen können, erweitert die Wochenzeitschrift ‹Das Goetheanum› den Horizont – auf Papier oder online – und beleuchtet brisante Themen. Sie erhalten auch drei Monate lang uneingeschränkten Zugriff auf das gesamte Archiv seit 2022.</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w1_de#text&quot;>Die Wochenschrift ‹Das Goetheanum› erweitert den Horizont – auf Papier oder online – und beleuchtet brisante Themen. Sie erhalten drei Monate lang uneingeschränkten Zugriff auf das gesamte Archiv seit 2022.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -464,8 +464,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -488,15 +488,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_de#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Ihr freier Zugang zur Wochenzeitschrift Das Goetheanum</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Drei Monate freien Zugang für alle, die gerne in Ruhe auf Papier oder online lesen.</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Drei freie Monate für Sie</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Ergänzend zu dem, was Sie auf goetheanum.tv sehen können, erweitert die Wochenzeitschrift ‹Das Goetheanum› den Horizont – auf Papier oder online – und beleuchtet brisante Themen. Sie erhalten auch drei Monate lang uneingeschränkten Zugriff auf das gesamte Archiv seit 2022.</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_de#text')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Ihr freier Zugang zur Wochenschrift Das Goetheanum</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Drei Monate freien Zugang für alle, die gerne in Ruhe auf Papier oder online lesen.</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Drei freie Monate für Sie</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Die Wochenschrift ‹Das Goetheanum› erweitert den Horizont – auf Papier oder online – und beleuchtet brisante Themen. Sie erhalten drei Monate lang uneingeschränkten Zugriff auf das gesamte Archiv seit 2022.</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_de#text')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
   <div class="mhd">W1 · EN<button class="mhd-edit" type="button" onclick="openEditor('lesen_w1_en')">✎ Bearbeiten</button><a href="mails/mail_lesen_w1_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Thinking that reaches beyond the week — 3 months free</div><div class="ib-a">«What if life came from the stars?» and the whole archive — new each week. Until 8 August.</div></div>
+  <div class="inbox"><div class="ib-b">Your free access to the weekly Das Goetheanum</div><div class="ib-a">Three months of free access — for anyone who likes to read in peace, on paper or online.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Thinking that reaches beyond the week — 3 months free</title>
+  <title>Your free access to the weekly Das Goetheanum</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -600,8 +600,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>«What if life came from the stars?» and the whole archive — new each week. Until 8 August.</div>
-  <div aria-label=&quot;Thinking that reaches beyond the week — 3 months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of free access — for anyone who likes to read in peace, on paper or online.</div>
+  <div aria-label=&quot;Your free access to the weekly Das Goetheanum&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
@@ -706,19 +706,19 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026 · 3 months free</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w1_en#botschaft&quot;>Reading that keeps working in&#160;you.</div>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w1_en#botschaft&quot;>Three free months for&#160;you</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w1_en#text&quot;>Alongside what you watch on goetheanum.tv, the weekly thinks on — in black and white, new each week: «Envisioning peace», «What if life came from the stars?», «Biography work as a path to the self». Plus the whole archive since 2022, which stays open with your subscription. Not what the authors know, but how they search.</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w1_en#text&quot;>The weekly ‹Das Goetheanum› broadens your horizon – on paper or online – and takes on pressing questions. You receive three months of unlimited access to the entire archive since 2022.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -766,8 +766,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -790,15 +790,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w1_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w1_en#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Thinking that reaches beyond the week — 3 months free</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">«What if life came from the stars?» and the whole archive — new each week. Until 8 August.</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Reading that keeps working in you.</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Alongside what you watch on goetheanum.tv, the weekly thinks on — in black and white, new each week: «Envisioning peace», «What if life came from the stars?», «Biography work as a path to the self». Plus the whole archive since 2022, which stays open with your subscription. Not what the authors know, but how they search.</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_en#text')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Your free access to the weekly Das Goetheanum</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Three months of free access — for anyone who likes to read in peace, on paper or online.</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Three free months for you</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">The weekly ‹Das Goetheanum› broadens your horizon – on paper or online – and takes on pressing questions. You receive three months of unlimited access to the entire archive since 2022.</textarea><button type="button" onclick="vorschlag(this,'lesen_w1_en#text')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W2 · DE<button class="mhd-edit" type="button" onclick="openEditor('lesen_w2_de')">✎ Bearbeiten</button><a href="mails/mail_lesen_w2_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Haben Sie bereits daran gedacht, Ihren kostenlosen Zugang zu aktivieren?</div><div class="ib-a">Der kostenlose Zugang für drei Monate ist ein Angebot, das nur bis zum 8. August gilt.</div></div>
+  <div class="inbox"><div class="ib-b">Ihr kostenloser Zugang – noch bis zum 8. August</div><div class="ib-a">Der kostenlose Zugang für drei Monate ist ein Angebot, das nur bis zum 8. August gilt.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Haben Sie bereits daran gedacht, Ihren kostenlosen Zugang zu aktivieren?</title>
+  <title>Ihr kostenloser Zugang – noch bis zum 8. August</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -903,7 +903,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
   <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Der kostenlose Zugang für drei Monate ist ein Angebot, das nur bis zum 8. August gilt.</div>
-  <div aria-label=&quot;Haben Sie bereits daran gedacht, Ihren kostenlosen Zugang zu aktivieren?&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div aria-label=&quot;Ihr kostenloser Zugang – noch bis zum 8. August&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
@@ -1014,13 +1014,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w2_de#botschaft&quot;>Haben Sie nicht vergessen, Ihren kostenlosen Zugang zu&#160;aktivieren?</div>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w2_de#botschaft&quot;>Ihr kostenloser Zugang steht noch&#160;bereit</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w2_de#text&quot;>Das Angebot gilt bis zum 8. August und erlaubt Ihnen, die Wochenschrift Das Goetheanum drei Monate lang kostenlos zu testen. Zögern Sie nicht, es jetzt zu aktivieren.</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w2_de#text&quot;>Das Angebot gilt bis zum 8. August und erlaubt Ihnen, die Wochenschrift ‹Das Goetheanum› drei Monate lang kostenlos zu testen. Jetzt freischalten.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -1068,8 +1068,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -1092,15 +1092,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_de#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Haben Sie bereits daran gedacht, Ihren kostenlosen Zugang zu aktivieren?</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Der kostenlose Zugang für drei Monate ist ein Angebot, das nur bis zum 8. August gilt.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Haben Sie nicht vergessen, Ihren kostenlosen Zugang zu aktivieren?</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Das Angebot gilt bis zum 8. August und erlaubt Ihnen, die Wochenschrift Das Goetheanum drei Monate lang kostenlos zu testen. Zögern Sie nicht, es jetzt zu aktivieren.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_de#text')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Ihr kostenloser Zugang – noch bis zum 8. August</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Der kostenlose Zugang für drei Monate ist ein Angebot, das nur bis zum 8. August gilt.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Ihr kostenloser Zugang steht noch bereit</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Das Angebot gilt bis zum 8. August und erlaubt Ihnen, die Wochenschrift ‹Das Goetheanum› drei Monate lang kostenlos zu testen. Jetzt freischalten.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_de#text')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
   <div class="mhd">W2 · EN<button class="mhd-edit" type="button" onclick="openEditor('lesen_w2_en')">✎ Bearbeiten</button><a href="mails/mail_lesen_w2_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Three months of reading — then you decide.</div><div class="ib-a">Until 8 August: three months of the weekly, free with your subscription — it goes where you go.</div></div>
+  <div class="inbox"><div class="ib-b">Your free access — still open until 8 August</div><div class="ib-a">Free access for three months — an offer that runs only until 8 August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Three months of reading — then you decide.</title>
+  <title>Your free access — still open until 8 August</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -1204,8 +1204,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Until 8 August: three months of the weekly, free with your subscription — it goes where you go.</div>
-  <div aria-label=&quot;Three months of reading — then you decide.&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Free access for three months — an offer that runs only until 8 August.</div>
+  <div aria-label=&quot;Your free access — still open until 8 August&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
@@ -1310,19 +1310,19 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026 · 3 months free</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w2_en#botschaft&quot;>A summer beyond your own&#160;horizon.</div>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w2_en#botschaft&quot;>Your free access is still&#160;waiting</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w2_en#text&quot;>Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark.</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w2_en#text&quot;>The offer runs until 8 August and lets you try the weekly ‹Das Goetheanum› free for three months. Unlock it now.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -1370,8 +1370,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -1394,15 +1394,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w2_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Three months of reading — then you decide.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Until 8 August: three months of the weekly, free with your subscription — it goes where you go.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">A summer beyond your own horizon.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#text')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Your free access — still open until 8 August</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Free access for three months — an offer that runs only until 8 August.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Your free access is still waiting</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">The offer runs until 8 August and lets you try the weekly ‹Das Goetheanum› free for three months. Unlock it now.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#text')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3 · DE<button class="mhd-edit" type="button" onclick="openEditor('lesen_w3_de')">✎ Bearbeiten</button><a href="mails/mail_lesen_w3_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Letzte Erinnerung: Nur noch wenig Zeit, um Ihren kostenlosen Zugang zu aktivieren.</div><div class="ib-a">Das Ausnahmeangebot von drei kostenlosen Monaten läuft bald aus – Sie haben heute noch Zeit, es zu aktivieren.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen.</div></div>
+  <div class="inbox"><div class="ib-b">Letzte Erinnerung: nur noch bis Samstag, 8. August</div><div class="ib-a">Das Ausnahmeangebot von drei kostenlosen Monaten läuft am Samstag, 8. August, aus.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Letzte Erinnerung: Nur noch wenig Zeit, um Ihren kostenlosen Zugang zu aktivieren.</title>
+  <title>Letzte Erinnerung: nur noch bis Samstag, 8. August</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -1506,8 +1506,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Das Ausnahmeangebot von drei kostenlosen Monaten läuft bald aus – Sie haben heute noch Zeit, es zu aktivieren.</div>
-  <div aria-label=&quot;Letzte Erinnerung: Nur noch wenig Zeit, um Ihren kostenlosen Zugang zu aktivieren.&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Das Ausnahmeangebot von drei kostenlosen Monaten läuft am Samstag, 8. August, aus.</div>
+  <div aria-label=&quot;Letzte Erinnerung: nur noch bis Samstag, 8. August&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
@@ -1618,13 +1618,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w3_de#botschaft&quot;>Falls Sie vergessen haben: Es bleiben noch ein paar Stunden, um es zu&#160;aktivieren.</div>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w3_de#botschaft&quot;>Nur noch bis Samstag, 8.&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w3_de#text&quot;>Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift Das Goetheanum – auf Papier und/oder online – erhalten, in wenigen Stunden endet. Sie können es noch aktivieren – tun Sie es jetzt. Danach ist es zu spät.</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w3_de#text&quot;>Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift ‹Das Goetheanum› – auf Papier und/oder online – erhalten, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -1667,8 +1667,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -1691,15 +1691,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Letzte Erinnerung: Nur noch wenig Zeit, um Ihren kostenlosen Zugang zu aktivieren.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Das Ausnahmeangebot von drei kostenlosen Monaten läuft bald aus – Sie haben heute noch Zeit, es zu aktivieren.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Falls Sie vergessen haben: Es bleiben noch ein paar Stunden, um es zu aktivieren.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift Das Goetheanum – auf Papier und/oder online – erhalten, in wenigen Stunden endet. Sie können es noch aktivieren – tun Sie es jetzt. Danach ist es zu spät.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#alt')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Letzte Erinnerung: nur noch bis Samstag, 8. August</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Das Ausnahmeangebot von drei kostenlosen Monaten läuft am Samstag, 8. August, aus.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Nur noch bis Samstag, 8. August</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift ‹Das Goetheanum› – auf Papier und/oder online – erhalten, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#alt')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3 · EN<button class="mhd-edit" type="button" onclick="openEditor('lesen_w3_en')">✎ Bearbeiten</button><a href="mails/mail_lesen_w3_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Until Saturday: three months of the weekly, free — then the offer closes</div><div class="ib-a">Three months of the weekly, free — only until Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> On Saturday your free trial of the weekly ends — if you still want it.</div></div>
+  <div class="inbox"><div class="ib-b">Last reminder: only until Saturday, 8 August</div><div class="ib-a">The exceptional offer of three free months ends on Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> On Saturday your free trial of the weekly ends — if you still want it.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Until Saturday: three months of the weekly, free — then the offer closes</title>
+  <title>Last reminder: only until Saturday, 8 August</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -1803,8 +1803,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of the weekly, free — only until Saturday, 8 August.</div>
-  <div aria-label=&quot;Until Saturday: three months of the weekly, free — then the offer closes&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>The exceptional offer of three free months ends on Saturday, 8 August.</div>
+  <div aria-label=&quot;Last reminder: only until Saturday, 8 August&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
@@ -1909,19 +1909,19 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026 · 3 months free</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w3_en#botschaft&quot;>On Saturday the door&#160;closes.</div>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w3_en#botschaft&quot;>Only until Saturday, 8&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w3_en#text&quot;>On Saturday, 8 August, the summer offer ends. Until then, read the weekly free for three months with your subscription — begin now, and decide only afterwards whether it stays.</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w3_en#text&quot;>A reminder that the summer offer — three months of free access to the weekly ‹Das Goetheanum›, on paper and/or online — ends on Saturday, 8 August. Until then, you can unlock it.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -1964,8 +1964,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -1988,7 +1988,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Until Saturday: three months of the weekly, free — then the offer closes</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Three months of the weekly, free — only until Saturday, 8 August.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">On Saturday the door closes.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">On Saturday, 8 August, the summer offer ends. Until then, read the weekly free for three months with your subscription — begin now, and decide only afterwards whether it stays.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">On Saturday your free trial of the weekly ends — if you still want it.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#alt')">vorschlagen</button></label></details></div></div></div></div></section><section class="segment"><h2>Sehen · goetheanum.tv — nurws</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Last reminder: only until Saturday, 8 August</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">The exceptional offer of three free months ends on Saturday, 8 August.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Only until Saturday, 8 August</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">A reminder that the summer offer — three months of free access to the weekly ‹Das Goetheanum›, on paper and/or online — ends on Saturday, 8 August. Until then, you can unlock it.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">On Saturday your free trial of the weekly ends — if you still want it.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#alt')">vorschlagen</button></label></details></div></div></div></div></section><section class="segment"><h2>Sehen · goetheanum.tv — nurws</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W1 · DE<button class="mhd-edit" type="button" onclick="openEditor('sehen_w1_de')">✎ Bearbeiten</button><a href="mails/mail_sehen_w1_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
   <div class="inbox"><div class="ib-b">Sehen, wie Menschen laut denken — 3 Monate gratis</div><div class="ib-a">«Kann man Glück lernen?» und über 800 weitere Beiträge — nah am Goetheanum, wohin der Sommer Sie trägt.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
@@ -2266,8 +2266,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -2508,7 +2508,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026 · 3 months free</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -2568,8 +2568,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -2870,8 +2870,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -3112,7 +3112,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026 · 3 months free</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -3172,8 +3172,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -3469,8 +3469,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -3711,7 +3711,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026 · 3 months free</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -3766,8 +3766,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -4066,8 +4066,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -4308,7 +4308,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026 · 3 months free</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -4366,8 +4366,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -4666,8 +4666,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -4908,7 +4908,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026 · 3 months free</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -4966,8 +4966,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -5261,8 +5261,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -5503,7 +5503,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026 · 3 months free</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -5556,8 +5556,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -5851,8 +5851,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -6093,7 +6093,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                   <tbody>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026 · 3 months free</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -6146,8 +6146,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                 <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
                   <tbody>
                     <tr>
-                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -6184,7 +6184,7 @@ const SB_URL="https://dagcsnfrlbpxcmdimnrw.supabase.co", SB_KEY="sb_publishable_
 const REST=SB_URL+"/rest/v1/"+TAB, RPC=SB_URL+"/rest/v1/rpc/sommer2026_comment_erledigt";
 const HDR={"apikey":SB_KEY,"Authorization":"Bearer "+SB_KEY,"Content-Type":"application/json"};
 let COMMENTS={}, SHOW_DONE=false;
-const MAILDATA={"lesen_w1_de": {"label": "nurtv · lesen · w1 · DE", "fields": {"betreff": "Ihr freier Zugang zur Wochenzeitschrift Das Goetheanum", "preheader": "Drei Monate freien Zugang für alle, die gerne in Ruhe auf Papier oder online lesen.", "botschaft": "Drei freie Monate für Sie", "text": "Ergänzend zu dem, was Sie auf goetheanum.tv sehen können, erweitert die Wochenzeitschrift ‹Das Goetheanum› den Horizont – auf Papier oder online – und beleuchtet brisante Themen. Sie erhalten auch drei Monate lang uneingeschränkten Zugriff auf das gesamte Archiv seit 2022."}, "cta": {"editable": true, "ziel": "wos", "label": "Mehr erfahren →"}}, "lesen_w1_en": {"label": "nurtv · lesen · w1 · EN", "fields": {"betreff": "Thinking that reaches beyond the week — 3 months free", "preheader": "«What if life came from the stars?» and the whole archive — new each week. Until 8 August.", "botschaft": "Reading that keeps working in you.", "text": "Alongside what you watch on goetheanum.tv, the weekly thinks on — in black and white, new each week: «Envisioning peace», «What if life came from the stars?», «Biography work as a path to the self». Plus the whole archive since 2022, which stays open with your subscription. Not what the authors know, but how they search."}, "cta": {"editable": true, "ziel": "wos", "label": "Learn more →"}}, "lesen_w2_de": {"label": "nurtv · lesen · w2 · DE", "fields": {"betreff": "Haben Sie bereits daran gedacht, Ihren kostenlosen Zugang zu aktivieren?", "preheader": "Der kostenlose Zugang für drei Monate ist ein Angebot, das nur bis zum 8. August gilt.", "botschaft": "Haben Sie nicht vergessen, Ihren kostenlosen Zugang zu aktivieren?", "text": "Das Angebot gilt bis zum 8. August und erlaubt Ihnen, die Wochenschrift Das Goetheanum drei Monate lang kostenlos zu testen. Zögern Sie nicht, es jetzt zu aktivieren."}, "cta": {"editable": true, "ziel": "wos", "label": "Mehr erfahren →"}}, "lesen_w2_en": {"label": "nurtv · lesen · w2 · EN", "fields": {"betreff": "Three months of reading — then you decide.", "preheader": "Until 8 August: three months of the weekly, free with your subscription — it goes where you go.", "botschaft": "A summer beyond your own horizon.", "text": "Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark."}, "cta": {"editable": true, "ziel": "wos", "label": "Learn more →"}}, "lesen_w3_de": {"label": "nurtv · lesen · w3 · DE", "fields": {"betreff": "Letzte Erinnerung: Nur noch wenig Zeit, um Ihren kostenlosen Zugang zu aktivieren.", "preheader": "Das Ausnahmeangebot von drei kostenlosen Monaten läuft bald aus – Sie haben heute noch Zeit, es zu aktivieren.", "botschaft": "Falls Sie vergessen haben: Es bleiben noch ein paar Stunden, um es zu aktivieren.", "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift Das Goetheanum – auf Papier und/oder online – erhalten, in wenigen Stunden endet. Sie können es noch aktivieren – tun Sie es jetzt. Danach ist es zu spät.", "alt": "Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen."}, "cta": {"editable": true, "ziel": "wos", "label": "Mehr erfahren →"}}, "lesen_w3_en": {"label": "nurtv · lesen · w3 · EN", "fields": {"betreff": "Until Saturday: three months of the weekly, free — then the offer closes", "preheader": "Three months of the weekly, free — only until Saturday, 8 August.", "botschaft": "On Saturday the door closes.", "text": "On Saturday, 8 August, the summer offer ends. Until then, read the weekly free for three months with your subscription — begin now, and decide only afterwards whether it stays.", "alt": "On Saturday your free trial of the weekly ends — if you still want it."}, "cta": {"editable": true, "ziel": "wos", "label": "Learn more →"}}, "sehen_w1_de": {"label": "nurws · sehen · w1 · DE", "fields": {"betreff": "Sehen, wie Menschen laut denken — 3 Monate gratis", "preheader": "«Kann man Glück lernen?» und über 800 weitere Beiträge — nah am Goetheanum, wohin der Sommer Sie trägt.", "botschaft": "So nah am Goetheanum, wo immer Sie sind.", "text": "Ergänzend zu den Artikeln, die Sie jede Woche lesen, steht Ihnen die ganze Mediathek offen — über 800 Beiträge, wöchentlich neu: «Dieser Krieg muss enden. Jetzt.», «Kann man Glück lernen?», dazu die Reihe, in der die Sahara ergrünt. Vorträge, Reportagen und Aufführungen, die Sie ganz nah ans Leben am Goetheanum bringen — selbst aus grosser Entfernung."}, "cta": {"editable": true, "ziel": "gtv", "label": "Mehr erfahren →"}}, "sehen_w1_en": {"label": "nurws · sehen · w1 · EN", "fields": {"betreff": "Watch people think out loud — 3 months free", "preheader": "«Can we learn to be happy?» and over 800 more — close to the Goetheanum, wherever summer takes you.", "botschaft": "Close to the Goetheanum, wherever you are.", "text": "Alongside the articles you read each week, the whole media library is open to you — over 800 pieces, new every week: «This war must end. Now.», «Can we learn to be happy?», and the series «Greening the Desert», in which the Sahara turns green. Lectures, reportage and performances that bring you close to life at the Goetheanum — even from a great distance."}, "cta": {"editable": true, "ziel": "gtv", "label": "Learn more →"}}, "sehen_w2_de": {"label": "nurws · sehen · w2 · DE", "fields": {"betreff": "Ihr Sommer hat noch Abende frei", "preheader": "goetheanum.tv drei Monate gratis zu Ihrem Abo — Abende, die nachwirken. Bis 8. August.", "botschaft": "Setzen Sie sich dazu.", "text": "Ein Abend auf goetheanum.tv ist ein Abend in Gesellschaft von Menschen, die ihr Leben lang an einer Frage gearbeitet haben — und die laut denken, statt fertige Antworten vorzutragen. Noch bis 8. August drei Monate gratis zu Ihrem Abo."}, "cta": {"editable": true, "ziel": "gtv", "label": "Mehr erfahren →"}}, "sehen_w2_en": {"label": "nurws · sehen · w2 · EN", "fields": {"betreff": "Your summer still has evenings free", "preheader": "goetheanum.tv, three months free with your subscription — evenings that linger. By 8 August.", "botschaft": "Pull up a chair.", "text": "An evening on goetheanum.tv is an evening in the company of people who have worked on a question all their lives — thinking out loud rather than reciting finished answers. Until 8 August: three months free with your subscription."}, "cta": {"editable": true, "ziel": "gtv", "label": "Learn more →"}}, "sehen_w3_de": {"label": "nurws · sehen · w3 · DE", "fields": {"betreff": "Bis Samstag: drei Monate goetheanum.tv gratis — dann schliesst die Aktion", "preheader": "Eine Minute genügt: drei Monate goetheanum.tv gratis — bis Samstag, 8. August.", "botschaft": "Am Samstag schliesst die Aktion.", "text": "Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin sehen Sie goetheanum.tv drei Monate gratis zu Ihrem Abo — beginnen Sie jetzt, und entscheiden erst danach, ob es bleibt.", "alt": "Am Samstag endet Ihr Gratis-Test von goetheanum.tv — falls Sie ihn noch wollen."}, "cta": {"editable": true, "ziel": "gtv", "label": "Mehr erfahren →"}}, "sehen_w3_en": {"label": "nurws · sehen · w3 · EN", "fields": {"betreff": "Until Saturday: three months of goetheanum.tv, free — then the offer closes", "preheader": "One minute is enough: three months of goetheanum.tv, free — until Saturday, 8 August.", "botschaft": "On Saturday the offer closes.", "text": "On Saturday, 8 August, the summer offer ends. Until then, watch goetheanum.tv free for three months with your subscription — begin now, and decide only afterwards whether it stays.", "alt": "On Saturday your free trial of goetheanum.tv ends — if you still want it."}, "cta": {"editable": true, "ziel": "gtv", "label": "Learn more →"}}, "beides_w1_de": {"label": "noabo · beides · w1 · DE", "fields": {"betreff": "Ein Sommer mit dem Goetheanum — 3 Monate gratis", "preheader": "Lesen oder schauen — oder beides: drei Monate kostenlos, bis 8. August.", "botschaft": "Zwei Fenster auf, den ganzen Sommer.", "text": "Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie in der Wochenschrift Menschen, die einer Frage ihr Leben gewidmet haben, und sehen Sie auf goetheanum.tv zu, wie sie laut denken — drei Monate kostenlos, danach läuft das Abo regulär weiter, jederzeit kündbar."}, "cta": {"editable": false}}, "beides_w1_en": {"label": "noabo · beides · w1 · EN", "fields": {"betreff": "A summer with the Goetheanum — 3 months free", "preheader": "Read the weekly, watch goetheanum.tv — or both: three months free. Until 8 August.", "botschaft": "Two windows open, all summer long.", "text": "Get to know the Goetheanum from both sides this summer: in the weekly, read people who have given their lives to a question; on goetheanum.tv, watch them think out loud — three months free, then the subscription continues at the regular price, cancel anytime."}, "cta": {"editable": false}}, "beides_w2_de": {"label": "noabo · beides · w2 · DE", "fields": {"betreff": "Lesen, sehen — oder gleich beides", "preheader": "Wochenschrift und goetheanum.tv, drei Monate kostenlos — Stoff zum Weiterdenken. Bis 8. August.", "botschaft": "Denken in guter Gesellschaft.", "text": "Ein Essay am Morgen, ein Vortrag am Abend — und dazwischen merken Sie, wie die eigenen Gedanken weiter reichen als sonst. Drei Monate kostenlos, anmelden bis 8. August."}, "cta": {"editable": false}}, "beides_w2_en": {"label": "noabo · beides · w2 · EN", "fields": {"betreff": "Read, watch — or simply both", "preheader": "The weekly and goetheanum.tv, three months free — food for thought all summer. By 8 August.", "botschaft": "Thinking in good company.", "text": "An essay in the morning, a lecture in the evening — and in between you notice your own thoughts reaching further than usual. Three months free, sign up by 8 August."}, "cta": {"editable": false}}, "beides_w3_de": {"label": "noabo · beides · w3 · DE", "fields": {"betreff": "Bis Samstag: drei Monate Goetheanum gratis — dann schliesst die Aktion", "preheader": "Drei Monate lesen oder schauen, gratis — nur noch bis Samstag, 8. August.", "botschaft": "Bis Samstag — lesen, sehen oder beides.", "text": "Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin lesen und/oder sehen Sie das Goetheanum drei Monate gratis — beginnen Sie jetzt, und entscheiden erst danach, ob es weitergeht.", "alt": "Am Samstag endet Ihr Gratis-Test — falls Sie ihn noch wollen."}, "cta": {"editable": false}}, "beides_w3_en": {"label": "noabo · beides · w3 · EN", "fields": {"betreff": "Until Saturday: three months of the Goetheanum, free — then the offer closes", "preheader": "Three months of reading or watching, free — only until Saturday, 8 August.", "botschaft": "Until Saturday — read, watch or both.", "text": "On Saturday, 8 August, the summer offer ends. Until then, read and/or watch the Goetheanum free for three months — begin now, and decide only afterwards whether it continues.", "alt": "On Saturday your free trial ends — if you still want it."}, "cta": {"editable": false}}, "beides_w3b_de": {"label": "noabo · beides · w3b · DE", "fields": {"betreff": "Morgen schliesst die Aktion", "preheader": "Drei Monate Goetheanum, gratis und jederzeit kündbar — anmelden bis morgen, Samstag, 8. August.", "botschaft": "Sie waren schon da — ein Schritt fehlt noch.", "text": "Morgen, am 8. August, schliesst das Sommerangebot. Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute jetzt, und Sie haben drei Monate Zeit, dem nachzugehen."}, "cta": {"editable": false}}, "beides_w3b_en": {"label": "noabo · beides · w3b · EN", "fields": {"betreff": "Tomorrow the offer closes", "preheader": "Three months of the Goetheanum, free, cancel anytime — sign up by tomorrow, Saturday 8 August.", "botschaft": "You’ve already had a look — one step to go.", "text": "Tomorrow, 8 August, the summer offer closes. What you looked at spoke to you for a reason — one minute now, and you have three months to follow it."}, "cta": {"editable": false}}};
+const MAILDATA={"lesen_w1_de": {"label": "nurtv · lesen · w1 · DE", "fields": {"betreff": "Ihr freier Zugang zur Wochenschrift Das Goetheanum", "preheader": "Drei Monate freien Zugang für alle, die gerne in Ruhe auf Papier oder online lesen.", "botschaft": "Drei freie Monate für Sie", "text": "Die Wochenschrift ‹Das Goetheanum› erweitert den Horizont – auf Papier oder online – und beleuchtet brisante Themen. Sie erhalten drei Monate lang uneingeschränkten Zugriff auf das gesamte Archiv seit 2022."}, "cta": {"editable": true, "ziel": "wos", "label": "Mehr erfahren →"}}, "lesen_w1_en": {"label": "nurtv · lesen · w1 · EN", "fields": {"betreff": "Your free access to the weekly Das Goetheanum", "preheader": "Three months of free access — for anyone who likes to read in peace, on paper or online.", "botschaft": "Three free months for you", "text": "The weekly ‹Das Goetheanum› broadens your horizon – on paper or online – and takes on pressing questions. You receive three months of unlimited access to the entire archive since 2022."}, "cta": {"editable": true, "ziel": "wos", "label": "Learn more →"}}, "lesen_w2_de": {"label": "nurtv · lesen · w2 · DE", "fields": {"betreff": "Ihr kostenloser Zugang – noch bis zum 8. August", "preheader": "Der kostenlose Zugang für drei Monate ist ein Angebot, das nur bis zum 8. August gilt.", "botschaft": "Ihr kostenloser Zugang steht noch bereit", "text": "Das Angebot gilt bis zum 8. August und erlaubt Ihnen, die Wochenschrift ‹Das Goetheanum› drei Monate lang kostenlos zu testen. Jetzt freischalten."}, "cta": {"editable": true, "ziel": "wos", "label": "Mehr erfahren →"}}, "lesen_w2_en": {"label": "nurtv · lesen · w2 · EN", "fields": {"betreff": "Your free access — still open until 8 August", "preheader": "Free access for three months — an offer that runs only until 8 August.", "botschaft": "Your free access is still waiting", "text": "The offer runs until 8 August and lets you try the weekly ‹Das Goetheanum› free for three months. Unlock it now."}, "cta": {"editable": true, "ziel": "wos", "label": "Learn more →"}}, "lesen_w3_de": {"label": "nurtv · lesen · w3 · DE", "fields": {"betreff": "Letzte Erinnerung: nur noch bis Samstag, 8. August", "preheader": "Das Ausnahmeangebot von drei kostenlosen Monaten läuft am Samstag, 8. August, aus.", "botschaft": "Nur noch bis Samstag, 8. August", "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift ‹Das Goetheanum› – auf Papier und/oder online – erhalten, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.", "alt": "Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen."}, "cta": {"editable": true, "ziel": "wos", "label": "Mehr erfahren →"}}, "lesen_w3_en": {"label": "nurtv · lesen · w3 · EN", "fields": {"betreff": "Last reminder: only until Saturday, 8 August", "preheader": "The exceptional offer of three free months ends on Saturday, 8 August.", "botschaft": "Only until Saturday, 8 August", "text": "A reminder that the summer offer — three months of free access to the weekly ‹Das Goetheanum›, on paper and/or online — ends on Saturday, 8 August. Until then, you can unlock it.", "alt": "On Saturday your free trial of the weekly ends — if you still want it."}, "cta": {"editable": true, "ziel": "wos", "label": "Learn more →"}}, "sehen_w1_de": {"label": "nurws · sehen · w1 · DE", "fields": {"betreff": "Sehen, wie Menschen laut denken — 3 Monate gratis", "preheader": "«Kann man Glück lernen?» und über 800 weitere Beiträge — nah am Goetheanum, wohin der Sommer Sie trägt.", "botschaft": "So nah am Goetheanum, wo immer Sie sind.", "text": "Ergänzend zu den Artikeln, die Sie jede Woche lesen, steht Ihnen die ganze Mediathek offen — über 800 Beiträge, wöchentlich neu: «Dieser Krieg muss enden. Jetzt.», «Kann man Glück lernen?», dazu die Reihe, in der die Sahara ergrünt. Vorträge, Reportagen und Aufführungen, die Sie ganz nah ans Leben am Goetheanum bringen — selbst aus grosser Entfernung."}, "cta": {"editable": true, "ziel": "gtv", "label": "Mehr erfahren →"}}, "sehen_w1_en": {"label": "nurws · sehen · w1 · EN", "fields": {"betreff": "Watch people think out loud — 3 months free", "preheader": "«Can we learn to be happy?» and over 800 more — close to the Goetheanum, wherever summer takes you.", "botschaft": "Close to the Goetheanum, wherever you are.", "text": "Alongside the articles you read each week, the whole media library is open to you — over 800 pieces, new every week: «This war must end. Now.», «Can we learn to be happy?», and the series «Greening the Desert», in which the Sahara turns green. Lectures, reportage and performances that bring you close to life at the Goetheanum — even from a great distance."}, "cta": {"editable": true, "ziel": "gtv", "label": "Learn more →"}}, "sehen_w2_de": {"label": "nurws · sehen · w2 · DE", "fields": {"betreff": "Ihr Sommer hat noch Abende frei", "preheader": "goetheanum.tv drei Monate gratis zu Ihrem Abo — Abende, die nachwirken. Bis 8. August.", "botschaft": "Setzen Sie sich dazu.", "text": "Ein Abend auf goetheanum.tv ist ein Abend in Gesellschaft von Menschen, die ihr Leben lang an einer Frage gearbeitet haben — und die laut denken, statt fertige Antworten vorzutragen. Noch bis 8. August drei Monate gratis zu Ihrem Abo."}, "cta": {"editable": true, "ziel": "gtv", "label": "Mehr erfahren →"}}, "sehen_w2_en": {"label": "nurws · sehen · w2 · EN", "fields": {"betreff": "Your summer still has evenings free", "preheader": "goetheanum.tv, three months free with your subscription — evenings that linger. By 8 August.", "botschaft": "Pull up a chair.", "text": "An evening on goetheanum.tv is an evening in the company of people who have worked on a question all their lives — thinking out loud rather than reciting finished answers. Until 8 August: three months free with your subscription."}, "cta": {"editable": true, "ziel": "gtv", "label": "Learn more →"}}, "sehen_w3_de": {"label": "nurws · sehen · w3 · DE", "fields": {"betreff": "Bis Samstag: drei Monate goetheanum.tv gratis — dann schliesst die Aktion", "preheader": "Eine Minute genügt: drei Monate goetheanum.tv gratis — bis Samstag, 8. August.", "botschaft": "Am Samstag schliesst die Aktion.", "text": "Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin sehen Sie goetheanum.tv drei Monate gratis zu Ihrem Abo — beginnen Sie jetzt, und entscheiden erst danach, ob es bleibt.", "alt": "Am Samstag endet Ihr Gratis-Test von goetheanum.tv — falls Sie ihn noch wollen."}, "cta": {"editable": true, "ziel": "gtv", "label": "Mehr erfahren →"}}, "sehen_w3_en": {"label": "nurws · sehen · w3 · EN", "fields": {"betreff": "Until Saturday: three months of goetheanum.tv, free — then the offer closes", "preheader": "One minute is enough: three months of goetheanum.tv, free — until Saturday, 8 August.", "botschaft": "On Saturday the offer closes.", "text": "On Saturday, 8 August, the summer offer ends. Until then, watch goetheanum.tv free for three months with your subscription — begin now, and decide only afterwards whether it stays.", "alt": "On Saturday your free trial of goetheanum.tv ends — if you still want it."}, "cta": {"editable": true, "ziel": "gtv", "label": "Learn more →"}}, "beides_w1_de": {"label": "noabo · beides · w1 · DE", "fields": {"betreff": "Ein Sommer mit dem Goetheanum — 3 Monate gratis", "preheader": "Lesen oder schauen — oder beides: drei Monate kostenlos, bis 8. August.", "botschaft": "Zwei Fenster auf, den ganzen Sommer.", "text": "Lernen Sie das Goetheanum diesen Sommer von beiden Seiten kennen: Lesen Sie in der Wochenschrift Menschen, die einer Frage ihr Leben gewidmet haben, und sehen Sie auf goetheanum.tv zu, wie sie laut denken — drei Monate kostenlos, danach läuft das Abo regulär weiter, jederzeit kündbar."}, "cta": {"editable": false}}, "beides_w1_en": {"label": "noabo · beides · w1 · EN", "fields": {"betreff": "A summer with the Goetheanum — 3 months free", "preheader": "Read the weekly, watch goetheanum.tv — or both: three months free. Until 8 August.", "botschaft": "Two windows open, all summer long.", "text": "Get to know the Goetheanum from both sides this summer: in the weekly, read people who have given their lives to a question; on goetheanum.tv, watch them think out loud — three months free, then the subscription continues at the regular price, cancel anytime."}, "cta": {"editable": false}}, "beides_w2_de": {"label": "noabo · beides · w2 · DE", "fields": {"betreff": "Lesen, sehen — oder gleich beides", "preheader": "Wochenschrift und goetheanum.tv, drei Monate kostenlos — Stoff zum Weiterdenken. Bis 8. August.", "botschaft": "Denken in guter Gesellschaft.", "text": "Ein Essay am Morgen, ein Vortrag am Abend — und dazwischen merken Sie, wie die eigenen Gedanken weiter reichen als sonst. Drei Monate kostenlos, anmelden bis 8. August."}, "cta": {"editable": false}}, "beides_w2_en": {"label": "noabo · beides · w2 · EN", "fields": {"betreff": "Read, watch — or simply both", "preheader": "The weekly and goetheanum.tv, three months free — food for thought all summer. By 8 August.", "botschaft": "Thinking in good company.", "text": "An essay in the morning, a lecture in the evening — and in between you notice your own thoughts reaching further than usual. Three months free, sign up by 8 August."}, "cta": {"editable": false}}, "beides_w3_de": {"label": "noabo · beides · w3 · DE", "fields": {"betreff": "Bis Samstag: drei Monate Goetheanum gratis — dann schliesst die Aktion", "preheader": "Drei Monate lesen oder schauen, gratis — nur noch bis Samstag, 8. August.", "botschaft": "Bis Samstag — lesen, sehen oder beides.", "text": "Am Samstag, dem 8. August, endet das Sommerangebot. Bis dahin lesen und/oder sehen Sie das Goetheanum drei Monate gratis — beginnen Sie jetzt, und entscheiden erst danach, ob es weitergeht.", "alt": "Am Samstag endet Ihr Gratis-Test — falls Sie ihn noch wollen."}, "cta": {"editable": false}}, "beides_w3_en": {"label": "noabo · beides · w3 · EN", "fields": {"betreff": "Until Saturday: three months of the Goetheanum, free — then the offer closes", "preheader": "Three months of reading or watching, free — only until Saturday, 8 August.", "botschaft": "Until Saturday — read, watch or both.", "text": "On Saturday, 8 August, the summer offer ends. Until then, read and/or watch the Goetheanum free for three months — begin now, and decide only afterwards whether it continues.", "alt": "On Saturday your free trial ends — if you still want it."}, "cta": {"editable": false}}, "beides_w3b_de": {"label": "noabo · beides · w3b · DE", "fields": {"betreff": "Morgen schliesst die Aktion", "preheader": "Drei Monate Goetheanum, gratis und jederzeit kündbar — anmelden bis morgen, Samstag, 8. August.", "botschaft": "Sie waren schon da — ein Schritt fehlt noch.", "text": "Morgen, am 8. August, schliesst das Sommerangebot. Was Sie sich angeschaut haben, hat Sie aus einem Grund angesprochen — eine Minute jetzt, und Sie haben drei Monate Zeit, dem nachzugehen."}, "cta": {"editable": false}}, "beides_w3b_en": {"label": "noabo · beides · w3b · EN", "fields": {"betreff": "Tomorrow the offer closes", "preheader": "Three months of the Goetheanum, free, cancel anytime — sign up by tomorrow, Saturday 8 August.", "botschaft": "You’ve already had a look — one step to go.", "text": "Tomorrow, 8 August, the summer offer closes. What you looked at spoke to you for a reason — one minute now, and you have three months to follow it."}, "cta": {"editable": false}}};
 const NAVBASES=["lesen_w1_de", "lesen_w1_en", "lesen_w2_de", "lesen_w2_en", "lesen_w3_de", "lesen_w3_en", "sehen_w1_de", "sehen_w1_en", "sehen_w2_de", "sehen_w2_en", "sehen_w3_de", "sehen_w3_en", "beides_w1_de", "beides_w1_en", "beides_w2_de", "beides_w2_en", "beides_w3_de", "beides_w3_en", "beides_w3b_de", "beides_w3b_en"];
 let PENDING={}, SUBMITTED={}, CUR=null, UILANG='de';
 const st=t=>document.getElementById('status').textContent=t;

--- a/apps/mail-editor/mails/mail_beides_w1_de.html
+++ b/apps/mail-editor/mails/mail_beides_w1_de.html
@@ -271,8 +271,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w1_en.html
+++ b/apps/mail-editor/mails/mail_beides_w1_en.html
@@ -213,7 +213,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026 · 3 months free</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -271,8 +271,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_de.html
+++ b/apps/mail-editor/mails/mail_beides_w2_de.html
@@ -271,8 +271,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w2_en.html
+++ b/apps/mail-editor/mails/mail_beides_w2_en.html
@@ -213,7 +213,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026 · 3 months free</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -271,8 +271,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3_de.html
@@ -266,8 +266,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3_en.html
@@ -213,7 +213,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026 · 3 months free</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -266,8 +266,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_de.html
@@ -266,8 +266,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_beides_w3b_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_en.html
@@ -213,7 +213,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026 · 3 months free</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -266,8 +266,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w1_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Ihr freier Zugang zur Wochenzeitschrift Das Goetheanum</title>
+  <title>Ihr freier Zugang zur Wochenschrift Das Goetheanum</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -108,7 +108,7 @@
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Drei Monate freien Zugang für alle, die gerne in Ruhe auf Papier oder online lesen.</div>
-  <div aria-label="Ihr freier Zugang zur Wochenzeitschrift Das Goetheanum" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div aria-label="Ihr freier Zugang zur Wochenschrift Das Goetheanum" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -225,7 +225,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w1_de#text">Ergänzend zu dem, was Sie auf goetheanum.tv sehen können, erweitert die Wochenzeitschrift ‹Das Goetheanum› den Horizont – auf Papier oder online – und beleuchtet brisante Themen. Sie erhalten auch drei Monate lang uneingeschränkten Zugriff auf das gesamte Archiv seit 2022.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w1_de#text">Die Wochenschrift ‹Das Goetheanum› erweitert den Horizont – auf Papier oder online – und beleuchtet brisante Themen. Sie erhalten drei Monate lang uneingeschränkten Zugriff auf das gesamte Archiv seit 2022.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -273,8 +273,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w1_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w1_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Thinking that reaches beyond the week — 3 months free</title>
+  <title>Your free access to the weekly Das Goetheanum</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">«What if life came from the stars?» and the whole archive — new each week. Until 8 August.</div>
-  <div aria-label="Thinking that reaches beyond the week — 3 months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of free access — for anyone who likes to read in peace, on paper or online.</div>
+  <div aria-label="Your free access to the weekly Das Goetheanum" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -213,19 +213,19 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026 · 3 months free</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="lesen_w1_en#botschaft">Reading that keeps working in&#160;you.</div>
+                          <div style="text-wrap:balance" data-edit="lesen_w1_en#botschaft">Three free months for&#160;you</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w1_en#text">Alongside what you watch on goetheanum.tv, the weekly thinks on — in black and white, new each week: «Envisioning peace», «What if life came from the stars?», «Biography work as a path to the self». Plus the whole archive since 2022, which stays open with your subscription. Not what the authors know, but how they search.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w1_en#text">The weekly ‹Das Goetheanum› broadens your horizon – on paper or online – and takes on pressing questions. You receive three months of unlimited access to the entire archive since 2022.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -273,8 +273,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Haben Sie bereits daran gedacht, Ihren kostenlosen Zugang zu aktivieren?</title>
+  <title>Ihr kostenloser Zugang – noch bis zum 8. August</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -108,7 +108,7 @@
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Der kostenlose Zugang für drei Monate ist ein Angebot, das nur bis zum 8. August gilt.</div>
-  <div aria-label="Haben Sie bereits daran gedacht, Ihren kostenlosen Zugang zu aktivieren?" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div aria-label="Ihr kostenloser Zugang – noch bis zum 8. August" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -219,13 +219,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="lesen_w2_de#botschaft">Haben Sie nicht vergessen, Ihren kostenlosen Zugang zu&#160;aktivieren?</div>
+                          <div style="text-wrap:balance" data-edit="lesen_w2_de#botschaft">Ihr kostenloser Zugang steht noch&#160;bereit</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w2_de#text">Das Angebot gilt bis zum 8. August und erlaubt Ihnen, die Wochenschrift Das Goetheanum drei Monate lang kostenlos zu testen. Zögern Sie nicht, es jetzt zu aktivieren.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w2_de#text">Das Angebot gilt bis zum 8. August und erlaubt Ihnen, die Wochenschrift ‹Das Goetheanum› drei Monate lang kostenlos zu testen. Jetzt freischalten.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -273,8 +273,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w2_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w2_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Three months of reading — then you decide.</title>
+  <title>Your free access — still open until 8 August</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Until 8 August: three months of the weekly, free with your subscription — it goes where you go.</div>
-  <div aria-label="Three months of reading — then you decide." aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Free access for three months — an offer that runs only until 8 August.</div>
+  <div aria-label="Your free access — still open until 8 August" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -213,19 +213,19 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026 · 3 months free</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="lesen_w2_en#botschaft">A summer beyond your own&#160;horizon.</div>
+                          <div style="text-wrap:balance" data-edit="lesen_w2_en#botschaft">Your free access is still&#160;waiting</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w2_en#text">Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w2_en#text">The offer runs until 8 August and lets you try the weekly ‹Das Goetheanum› free for three months. Unlock it now.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -273,8 +273,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Letzte Erinnerung: Nur noch wenig Zeit, um Ihren kostenlosen Zugang zu aktivieren.</title>
+  <title>Letzte Erinnerung: nur noch bis Samstag, 8. August</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Das Ausnahmeangebot von drei kostenlosen Monaten läuft bald aus – Sie haben heute noch Zeit, es zu aktivieren.</div>
-  <div aria-label="Letzte Erinnerung: Nur noch wenig Zeit, um Ihren kostenlosen Zugang zu aktivieren." aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Das Ausnahmeangebot von drei kostenlosen Monaten läuft am Samstag, 8. August, aus.</div>
+  <div aria-label="Letzte Erinnerung: nur noch bis Samstag, 8. August" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -219,13 +219,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="lesen_w3_de#botschaft">Falls Sie vergessen haben: Es bleiben noch ein paar Stunden, um es zu&#160;aktivieren.</div>
+                          <div style="text-wrap:balance" data-edit="lesen_w3_de#botschaft">Nur noch bis Samstag, 8.&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w3_de#text">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift Das Goetheanum – auf Papier und/oder online – erhalten, in wenigen Stunden endet. Sie können es noch aktivieren – tun Sie es jetzt. Danach ist es zu spät.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w3_de#text">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift ‹Das Goetheanum› – auf Papier und/oder online – erhalten, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -268,8 +268,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Until Saturday: three months of the weekly, free — then the offer closes</title>
+  <title>Last reminder: only until Saturday, 8 August</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of the weekly, free — only until Saturday, 8 August.</div>
-  <div aria-label="Until Saturday: three months of the weekly, free — then the offer closes" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">The exceptional offer of three free months ends on Saturday, 8 August.</div>
+  <div aria-label="Last reminder: only until Saturday, 8 August" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -213,19 +213,19 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026 · 3 months free</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="lesen_w3_en#botschaft">On Saturday the door&#160;closes.</div>
+                          <div style="text-wrap:balance" data-edit="lesen_w3_en#botschaft">Only until Saturday, 8&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w3_en#text">On Saturday, 8 August, the summer offer ends. Until then, read the weekly free for three months with your subscription — begin now, and decide only afterwards whether it stays.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w3_en#text">A reminder that the summer offer — three months of free access to the weekly ‹Das Goetheanum›, on paper and/or online — ends on Saturday, 8 August. Until then, you can unlock it.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -268,8 +268,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w1_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_de.html
@@ -273,8 +273,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w1_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w1_en.html
@@ -213,7 +213,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026 · 3 months free</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -273,8 +273,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_de.html
@@ -273,8 +273,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w2_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w2_en.html
@@ -213,7 +213,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026 · 3 months free</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -273,8 +273,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_de.html
@@ -268,8 +268,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_en.html
@@ -213,7 +213,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026 · 3 months free</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -268,8 +268,8 @@
                 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:center;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/services/mailing-sommer2026/build_editor.py
+++ b/services/mailing-sommer2026/build_editor.py
@@ -199,7 +199,7 @@ def render_mail(motiv, welle, lang, wm):
   <mj-text font-size="13px" line-height="20px" color="{MUTED}" padding="0 0 14px 0">{wrap_edit(kleinzeile(H['kleinzeile'][motiv][lang]), f"shared#kleinzeile#{motiv}#{lang}")}</mj-text>
   {ps_block(seg, welle, lang)}
 </mj-column></mj-section>
-<mj-section background-color="{WASH}" padding="16px 28px"><mj-column><mj-text font-size="14px" line-height="22px" color="{AKZENT_TIEF}" align="center" padding="0">{wrap_edit(xml(H['proof'][lang]), f"shared#beweisband#{lang}")}</mj-text></mj-column></mj-section>
+<mj-section background-color="{WASH}" padding="16px 28px"><mj-column><mj-text font-size="14px" line-height="22px" color="{AKZENT_TIEF}" align="left" padding="0">{wrap_edit(xml(H['proof'][lang]), f"shared#beweisband#{lang}")}</mj-text></mj-column></mj-section>
 </mj-body></mjml>"""
     p = subprocess.run(["mjml", "-i", "-s"], input=mjml, capture_output=True, text=True)
     if p.returncode: raise RuntimeError(p.stderr)

--- a/services/mailing-sommer2026/heroes.json
+++ b/services/mailing-sommer2026/heroes.json
@@ -178,7 +178,7 @@
   },
   "badge": {
     "de": "Sommerangebot 2026",
-    "en": "Summer offer 2026 · 3 months free"
+    "en": "Summer offer 2026"
   },
   "ps": {
     "_hinweis": "Leises Teilen-PS unter der Kleinzeile. link_wort wird in build_editor.py zum Teilen-Link auf das Angebot der jeweiligen Gruppe (nie auf ein schon bezahltes Produkt) mit eigenem utm_content w{n}_{seg}_share. wellen = nur diese Wellen tragen das PS (Frist-Mails w3/w3b ausgenommen: die letzte Erinnerung trägt einen einzigen klaren Ruf).",
@@ -222,50 +222,50 @@
     "lesen": {
       "w1": {
         "de": {
-          "betreff": "Ihr freier Zugang zur Wochenzeitschrift Das Goetheanum",
+          "betreff": "Ihr freier Zugang zur Wochenschrift Das Goetheanum",
           "botschaft": "Drei freie Monate für Sie",
-          "text": "Ergänzend zu dem, was Sie auf goetheanum.tv sehen können, erweitert die Wochenzeitschrift ‹Das Goetheanum› den Horizont – auf Papier oder online – und beleuchtet brisante Themen. Sie erhalten auch drei Monate lang uneingeschränkten Zugriff auf das gesamte Archiv seit 2022.",
+          "text": "Die Wochenschrift ‹Das Goetheanum› erweitert den Horizont – auf Papier oder online – und beleuchtet brisante Themen. Sie erhalten drei Monate lang uneingeschränkten Zugriff auf das gesamte Archiv seit 2022.",
           "alt": "Drei Monate im Freien lesen — gratis",
           "preheader": "Drei Monate freien Zugang für alle, die gerne in Ruhe auf Papier oder online lesen."
         },
         "en": {
-          "betreff": "Thinking that reaches beyond the week — 3 months free",
-          "botschaft": "Reading that keeps working in you.",
-          "text": "Alongside what you watch on goetheanum.tv, the weekly thinks on — in black and white, new each week: «Envisioning peace», «What if life came from the stars?», «Biography work as a path to the self». Plus the whole archive since 2022, which stays open with your subscription. Not what the authors know, but how they search.",
+          "betreff": "Your free access to the weekly Das Goetheanum",
+          "botschaft": "Three free months for you",
+          "text": "The weekly ‹Das Goetheanum› broadens your horizon – on paper or online – and takes on pressing questions. You receive three months of unlimited access to the entire archive since 2022.",
           "alt": "Read in the open air — three months free",
-          "preheader": "«What if life came from the stars?» and the whole archive — new each week. Until 8 August."
+          "preheader": "Three months of free access — for anyone who likes to read in peace, on paper or online."
         }
       },
       "w2": {
         "de": {
-          "betreff": "Haben Sie bereits daran gedacht, Ihren kostenlosen Zugang zu aktivieren?",
-          "botschaft": "Haben Sie nicht vergessen, Ihren kostenlosen Zugang zu aktivieren?",
-          "text": "Das Angebot gilt bis zum 8. August und erlaubt Ihnen, die Wochenschrift Das Goetheanum drei Monate lang kostenlos zu testen. Zögern Sie nicht, es jetzt zu aktivieren.",
+          "betreff": "Ihr kostenloser Zugang – noch bis zum 8. August",
+          "botschaft": "Ihr kostenloser Zugang steht noch bereit",
+          "text": "Das Angebot gilt bis zum 8. August und erlaubt Ihnen, die Wochenschrift ‹Das Goetheanum› drei Monate lang kostenlos zu testen. Jetzt freischalten.",
           "alt": "Lesestoff, der den Sommer überdauert — gratis",
           "preheader": "Der kostenlose Zugang für drei Monate ist ein Angebot, das nur bis zum 8. August gilt."
         },
         "en": {
-          "betreff": "Three months of reading — then you decide.",
-          "botschaft": "A summer beyond your own horizon.",
-          "text": "Until 8 August, read the weekly free for three months with your subscription — reading that keeps working in you after the screen goes dark.",
+          "betreff": "Your free access — still open until 8 August",
+          "botschaft": "Your free access is still waiting",
+          "text": "The offer runs until 8 August and lets you try the weekly ‹Das Goetheanum› free for three months. Unlock it now.",
           "alt": "Reading that outlasts the summer — free",
-          "preheader": "Until 8 August: three months of the weekly, free with your subscription — it goes where you go."
+          "preheader": "Free access for three months — an offer that runs only until 8 August."
         }
       },
       "w3": {
         "de": {
-          "betreff": "Letzte Erinnerung: Nur noch wenig Zeit, um Ihren kostenlosen Zugang zu aktivieren.",
-          "botschaft": "Falls Sie vergessen haben: Es bleiben noch ein paar Stunden, um es zu aktivieren.",
-          "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift Das Goetheanum – auf Papier und/oder online – erhalten, in wenigen Stunden endet. Sie können es noch aktivieren – tun Sie es jetzt. Danach ist es zu spät.",
+          "betreff": "Letzte Erinnerung: nur noch bis Samstag, 8. August",
+          "botschaft": "Nur noch bis Samstag, 8. August",
+          "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift ‹Das Goetheanum› – auf Papier und/oder online – erhalten, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.",
           "alt": "Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen.",
-          "preheader": "Das Ausnahmeangebot von drei kostenlosen Monaten läuft bald aus – Sie haben heute noch Zeit, es zu aktivieren."
+          "preheader": "Das Ausnahmeangebot von drei kostenlosen Monaten läuft am Samstag, 8. August, aus."
         },
         "en": {
-          "betreff": "Until Saturday: three months of the weekly, free — then the offer closes",
-          "botschaft": "On Saturday the door closes.",
-          "text": "On Saturday, 8 August, the summer offer ends. Until then, read the weekly free for three months with your subscription — begin now, and decide only afterwards whether it stays.",
+          "betreff": "Last reminder: only until Saturday, 8 August",
+          "botschaft": "Only until Saturday, 8 August",
+          "text": "A reminder that the summer offer — three months of free access to the weekly ‹Das Goetheanum›, on paper and/or online — ends on Saturday, 8 August. Until then, you can unlock it.",
           "alt": "On Saturday your free trial of the weekly ends — if you still want it.",
-          "preheader": "Three months of the weekly, free — only until Saturday, 8 August."
+          "preheader": "The exceptional offer of three free months ends on Saturday, 8 August."
         }
       }
     },


### PR DESCRIPTION
Den GF-Text **behalten**, nur brechende Stellen chirurgisch fixen — kein Neuwurf.

**DE (optimiert)**
- **w1:** falscher Video-Bezug raus («ergänzend zu dem, was Sie auf goetheanum.tv sehen…») — goetheanum.tv und die Wochenschrift sind **verschiedene Redaktionen**, den Bezug gibt es nicht. Rest wörtlich GF.
- **w2:** Vorwurf raus («Haben Sie vergessen…»), Betreff/Botschaft entdoppelt, Füllwort «Zögern Sie nicht» gestrichen, auf die Frist gestellt.
- **w3:** «wenige Stunden» → **Datum** (Samstag, 8. August), faktisch korrekt egal wann w3 rausgeht; Drohsatz «Danach ist es zu spät» raus.
- Titel vereinheitlicht auf «Wochenschrift»; Badge EN an DE angeglichen («Summer offer 2026»).

**EN** = Übersetzung dieser optimierten GF-Fassung (kein Eigenkonzept).

**Beweis-Band** «Stimmen und Gesichter…» jetzt **linksbündig** statt zentriert (wie der Rest der Mail).

typo-check + ds-lint grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_