### PR TITLE
WYSIWYG mobil: Mail-Höhe robust nachmessen (nicht mehr nach Hero abgeschnitten)

### DIFF
--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -147,7 +147,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 14.07.2026, 13.03 Uhr · <code>67b69ba</code></p>
+  <p class="subline">Stand dieses Builds: 14.07.2026, 13.14 Uhr · <code>ab1df38</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -6342,7 +6342,10 @@ function applyPending(doc){
  Object.keys(merged).forEach(key=>{const feld=feldOf(key);
    doc.querySelectorAll('[data-edit="'+key+'"]').forEach(n=>writeCE(n,feld,merged[key]));});
 }
-function autosizeIframe(f){ try{const d=f.contentDocument; if(d&&d.body) f.style.height=d.body.scrollHeight+'px';}catch(e){} }
+function autosizeIframe(f){ try{const d=f.contentDocument; if(d&&d.body){
+  const h=Math.max(d.body.scrollHeight,d.body.offsetHeight,d.documentElement.scrollHeight,d.documentElement.offsetHeight);
+  if(h>0) f.style.height=h+'px';
+}}catch(e){} }
 function onCE(e){
  const node=e.target.closest&&e.target.closest('[data-edit]'); if(!node) return;
  const key=node.getAttribute('data-edit'), feld=feldOf(key);
@@ -6388,9 +6391,11 @@ function openEditor(base){
    doc.addEventListener('input',onCE); doc.addEventListener('keydown',ceKeydown);
    doc.addEventListener('click',ev=>{if(ev.target.closest('a')&&ev.target.closest('[data-edit]'))ev.preventDefault();});
    applyPending(doc); autosizeIframe(frame);
-   // Höhe nachziehen, sobald Bilder/Schrift nachladen (scrollHeight wächst danach).
+   // Höhe robust nachziehen: Bilder laden auf Mobil verzögert (4G), iOS meldet
+   // ResizeObserver/‹load› unzuverlässig — darum zusätzlich mehrfach nachmessen.
    try{new frame.contentWindow.ResizeObserver(()=>autosizeIframe(frame)).observe(doc.body);}catch(e){}
-   doc.querySelectorAll('img').forEach(im=>im.addEventListener('load',()=>autosizeIframe(frame)));
+   doc.querySelectorAll('img').forEach(im=>{ if(im.complete) return; im.addEventListener('load',()=>autosizeIframe(frame)); im.addEventListener('error',()=>autosizeIframe(frame)); });
+   [120,400,900,1800,3000,5000,8000].forEach(ms=>setTimeout(()=>autosizeIframe(frame),ms));
  };
  frame.onload=setup; frame.srcdoc=src?src.srcdoc:'';
  // Nicht auf das load-Event warten (Bilder können es verzögern): aufsetzen, sobald der Body da ist.
@@ -6410,6 +6415,7 @@ async function saveAll(){
 }
 function closeEditor(){ document.getElementById('wyz').close(); }
 document.getElementById('wyz').addEventListener('close',()=>{document.getElementById('wyz-frame').removeAttribute('srcdoc');});
+window.addEventListener('resize',()=>{ if(document.getElementById('wyz').open) autosizeIframe(document.getElementById('wyz-frame')); });
 document.getElementById('wyz').addEventListener('keydown',e=>{
  if((e.metaKey||e.ctrlKey)&&(e.key==='s'||e.key==='S')){e.preventDefault();saveAll();return;}
  if(e.key!=='ArrowLeft'&&e.key!=='ArrowRight') return;

--- a/services/mailing-sommer2026/build_editor.py
+++ b/services/mailing-sommer2026/build_editor.py
@@ -695,7 +695,10 @@ function applyPending(doc){{
  Object.keys(merged).forEach(key=>{{const feld=feldOf(key);
    doc.querySelectorAll('[data-edit="'+key+'"]').forEach(n=>writeCE(n,feld,merged[key]));}});
 }}
-function autosizeIframe(f){{ try{{const d=f.contentDocument; if(d&&d.body) f.style.height=d.body.scrollHeight+'px';}}catch(e){{}} }}
+function autosizeIframe(f){{ try{{const d=f.contentDocument; if(d&&d.body){{
+  const h=Math.max(d.body.scrollHeight,d.body.offsetHeight,d.documentElement.scrollHeight,d.documentElement.offsetHeight);
+  if(h>0) f.style.height=h+'px';
+}}}}catch(e){{}} }}
 function onCE(e){{
  const node=e.target.closest&&e.target.closest('[data-edit]'); if(!node) return;
  const key=node.getAttribute('data-edit'), feld=feldOf(key);
@@ -741,9 +744,11 @@ function openEditor(base){{
    doc.addEventListener('input',onCE); doc.addEventListener('keydown',ceKeydown);
    doc.addEventListener('click',ev=>{{if(ev.target.closest('a')&&ev.target.closest('[data-edit]'))ev.preventDefault();}});
    applyPending(doc); autosizeIframe(frame);
-   // Höhe nachziehen, sobald Bilder/Schrift nachladen (scrollHeight wächst danach).
+   // Höhe robust nachziehen: Bilder laden auf Mobil verzögert (4G), iOS meldet
+   // ResizeObserver/‹load› unzuverlässig — darum zusätzlich mehrfach nachmessen.
    try{{new frame.contentWindow.ResizeObserver(()=>autosizeIframe(frame)).observe(doc.body);}}catch(e){{}}
-   doc.querySelectorAll('img').forEach(im=>im.addEventListener('load',()=>autosizeIframe(frame)));
+   doc.querySelectorAll('img').forEach(im=>{{ if(im.complete) return; im.addEventListener('load',()=>autosizeIframe(frame)); im.addEventListener('error',()=>autosizeIframe(frame)); }});
+   [120,400,900,1800,3000,5000,8000].forEach(ms=>setTimeout(()=>autosizeIframe(frame),ms));
  }};
  frame.onload=setup; frame.srcdoc=src?src.srcdoc:'';
  // Nicht auf das load-Event warten (Bilder können es verzögern): aufsetzen, sobald der Body da ist.
@@ -763,6 +768,7 @@ async function saveAll(){{
 }}
 function closeEditor(){{ document.getElementById('wyz').close(); }}
 document.getElementById('wyz').addEventListener('close',()=>{{document.getElementById('wyz-frame').removeAttribute('srcdoc');}});
+window.addEventListener('resize',()=>{{ if(document.getElementById('wyz').open) autosizeIframe(document.getElementById('wyz-frame')); }});
 document.getElementById('wyz').addEventListener('keydown',e=>{{
  if((e.metaKey||e.ctrlKey)&&(e.key==='s'||e.key==='S')){{e.preventDefault();saveAll();return;}}
  if(e.key!=='ArrowLeft'&&e.key!=='ArrowRight') return;


### PR DESCRIPTION
Auf dem Handy (iOS/4G) brach die Mail im Overlay **direkt nach dem Hero-Bild** ab; darunter nur die dunkle Fläche (Dark-Mode-Bühne). Ursache: die Auto-Höhe des iframes wurde **einmal zu früh** gemessen (Hero noch nicht geladen) und wuchs danach nicht nach — iOS meldet `ResizeObserver`/`load` unzuverlässig. Die Mail rendert bereits in **korrekter Breite** (Hero full-width im Screenshot), es war rein die Höhenmessung.

- `autosizeIframe` misst jetzt `max(body/documentElement · scrollHeight/offsetHeight)`.
- Nach dem Laden **mehrfach nachmessen** (120 ms … 8 s) + auf `img` `load`/`error` + auf `window` `resize`/Drehen → die Höhe konvergiert sicher auf die volle Mail.

Im Chromium-Mobil-Viewport (verzögerte Bilder) geprüft: Höhe folgt `body.scrollHeight`. Da mir kein echtes iOS-Safari zur Verfügung steht, bitte am Gerät gegenprüfen. typo-check + ds-lint grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_