### PR TITLE
S26: Samstag-Frist-Mail (w3b) für alle Gruppen + neuer Takt + AC-Prompt

### DIFF
--- a/apps/mail-editor/index.html
+++ b/apps/mail-editor/index.html
@@ -147,7 +147,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
   <span class="kicker">Sommer-Aktion 2026</span>
   <h1>Mail-Editor</h1>
   <p class="lede" style="max-width:var(--measure)">Alle Wellen-Mails der drei Segmente zum Gegenlesen — je Feld kommentierbar, Kommentare landen im Werkzeug-Backend. Korrigiert wird in <code>heroes.json</code>, dann wird neu gebaut.</p>
-  <p class="subline">Stand dieses Builds: 14.07.2026, 13.20 Uhr · <code>088b04d</code></p>
+  <p class="subline">Stand dieses Builds: 14.07.2026, 22.38 Uhr · <code>187cf85</code></p>
   <div class="controls">
     <span class="lab">Sprache</span>
     <button id="b-de" class="pill on" onclick="setLang('de')">Deutsch</button>
@@ -1402,13 +1402,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w2_en#gesamt')">senden</button></div></div></div>
   <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Your free access — still open until 8 August</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Free access for three months — an offer that runs only until 8 August.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Your free access is still waiting</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">The offer runs until 8 August and lets you try the weekly ‹Das Goetheanum› free for three months. Unlock it now.</textarea><button type="button" onclick="vorschlag(this,'lesen_w2_en#text')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3 · DE<button class="mhd-edit" type="button" onclick="openEditor('lesen_w3_de')">✎ Bearbeiten</button><a href="mails/mail_lesen_w3_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Letzte Erinnerung: nur noch bis Samstag, 8. August</div><div class="ib-a">Das Ausnahmeangebot von drei kostenlosen Monaten läuft am Samstag, 8. August, aus.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen.</div></div>
+  <div class="inbox"><div class="ib-b">Nur noch bis morgen, Samstag: drei Monate gratis lesen</div><div class="ib-a">Das Angebot für drei kostenlose Monate ‹Das Goetheanum› läuft morgen, am Samstag, 8. August, aus.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Bis morgen: drei Monate gratis lesen — jetzt starten</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Letzte Erinnerung: nur noch bis Samstag, 8. August</title>
+  <title>Nur noch bis morgen, Samstag: drei Monate gratis lesen</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -1512,8 +1512,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Das Ausnahmeangebot von drei kostenlosen Monaten läuft am Samstag, 8. August, aus.</div>
-  <div aria-label=&quot;Letzte Erinnerung: nur noch bis Samstag, 8. August&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Das Angebot für drei kostenlose Monate ‹Das Goetheanum› läuft morgen, am Samstag, 8. August, aus.</div>
+  <div aria-label=&quot;Nur noch bis morgen, Samstag: drei Monate gratis lesen&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
@@ -1624,13 +1624,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w3_de#botschaft&quot;>Nur noch bis Samstag, 8.&#160;August</div>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w3_de#botschaft&quot;>Nur noch bis morgen, 8.&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w3_de#text&quot;>Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift ‹Das Goetheanum› – auf Papier und/oder online – erhalten, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w3_de#text&quot;>Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift ‹Das Goetheanum› – auf Papier oder online – erhalten, morgen, am Samstag, 8. August, endet. Jetzt freischalten.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -1697,15 +1697,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_de#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Letzte Erinnerung: nur noch bis Samstag, 8. August</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Das Ausnahmeangebot von drei kostenlosen Monaten läuft am Samstag, 8. August, aus.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Nur noch bis Samstag, 8. August</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift ‹Das Goetheanum› – auf Papier und/oder online – erhalten, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#alt')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Nur noch bis morgen, Samstag: drei Monate gratis lesen</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Das Angebot für drei kostenlose Monate ‹Das Goetheanum› läuft morgen, am Samstag, 8. August, aus.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Nur noch bis morgen, 8. August</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift ‹Das Goetheanum› – auf Papier oder online – erhalten, morgen, am Samstag, 8. August, endet. Jetzt freischalten.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Bis morgen: drei Monate gratis lesen — jetzt starten</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_de#alt')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3 · EN<button class="mhd-edit" type="button" onclick="openEditor('lesen_w3_en')">✎ Bearbeiten</button><a href="mails/mail_lesen_w3_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Last reminder: only until Saturday, 8 August</div><div class="ib-a">The exceptional offer of three free months ends on Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> On Saturday your free trial of the weekly ends — if you still want it.</div></div>
+  <div class="inbox"><div class="ib-b">Only until tomorrow, Saturday: three months free</div><div class="ib-a">The offer of three free months of ‹Das Goetheanum› ends tomorrow, Saturday 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Until tomorrow: three months of free reading — start now</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Last reminder: only until Saturday, 8 August</title>
+  <title>Only until tomorrow, Saturday: three months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -1809,8 +1809,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>The exceptional offer of three free months ends on Saturday, 8 August.</div>
-  <div aria-label=&quot;Last reminder: only until Saturday, 8 August&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>The offer of three free months of ‹Das Goetheanum› ends tomorrow, Saturday 8 August.</div>
+  <div aria-label=&quot;Only until tomorrow, Saturday: three months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
@@ -1921,13 +1921,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w3_en#botschaft&quot;>Only until Saturday, 8&#160;August</div>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w3_en#botschaft&quot;>Only until tomorrow, 8&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w3_en#text&quot;>A reminder that the summer offer — three months of free access to the weekly ‹Das Goetheanum›, on paper and/or online — ends on Saturday, 8 August. Until then, you can unlock it.</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w3_en#text&quot;>A reminder that the summer offer — three months of free access to the weekly ‹Das Goetheanum›, on paper or online — ends tomorrow, Saturday 8 August. Unlock it now.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -1994,7 +1994,601 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3_en#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Last reminder: only until Saturday, 8 August</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">The exceptional offer of three free months ends on Saturday, 8 August.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Only until Saturday, 8 August</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">A reminder that the summer offer — three months of free access to the weekly ‹Das Goetheanum›, on paper and/or online — ends on Saturday, 8 August. Until then, you can unlock it.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">On Saturday your free trial of the weekly ends — if you still want it.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#alt')">vorschlagen</button></label></details></div></div></div></div></section><section class="segment"><h2>Sehen · goetheanum.tv — nurws</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Only until tomorrow, Saturday: three months free</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">The offer of three free months of ‹Das Goetheanum› ends tomorrow, Saturday 8 August.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Only until tomorrow, 8 August</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">A reminder that the summer offer — three months of free access to the weekly ‹Das Goetheanum›, on paper or online — ends tomorrow, Saturday 8 August. Unlock it now.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Until tomorrow: three months of free reading — start now</textarea><button type="button" onclick="vorschlag(this,'lesen_w3_en#alt')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
+  <div class="mhd">W3B · DE<button class="mhd-edit" type="button" onclick="openEditor('lesen_w3b_de')">✎ Bearbeiten</button><a href="mails/mail_lesen_w3b_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Heute läuft das Angebot aus — drei Monate gratis lesen</div><div class="ib-a">Nur noch heute, Samstag, 8. August: drei Monate ‹Das Goetheanum› gratis.</div></div>
+  <iframe srcdoc="<!-- FILE: undefined -->
+<!doctype html>
+<html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
+
+<head>
+  <title>Heute läuft das Angebot aus — drei Monate gratis lesen</title>
+  <!--[if !mso]><!-->
+  <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
+  <!--<![endif]-->
+  <meta http-equiv=&quot;Content-Type&quot; content=&quot;text/html; charset=UTF-8&quot;>
+  <meta name=&quot;viewport&quot; content=&quot;width=device-width, initial-scale=1&quot;>
+  <style type=&quot;text/css&quot;>
+    #outlook a {
+      padding: 0;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
+
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+  </style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type=&quot;text/css&quot;>
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+  <style type=&quot;text/css&quot;>
+    @media only screen and (min-width:480px) {
+      .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+    }
+  </style>
+  <style media=&quot;screen and (min-width:480px)&quot;>
+    .moz-text-html .mj-column-per-100 {
+      width: 100% !important;
+      max-width: 100%;
+    }
+  </style>
+  <style type=&quot;text/css&quot;>
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile {
+        width: 100% !important;
+      }
+
+      td.mj-full-width-mobile {
+        width: auto !important;
+      }
+    }
+  </style>
+  <style type=&quot;text/css&quot;>
+    @font-face {
+      font-family: 'Goetheanum';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.7-Deutlich.woff2') format('woff2');
+      font-weight: 700;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
+  </style>
+</head>
+
+<body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Nur noch heute, Samstag, 8. August: drei Monate ‹Das Goetheanum› gratis.</div>
+  <div aria-label=&quot;Heute läuft das Angebot aus — drei Monate gratis lesen&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+    <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:6px 28px 0 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;right&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:18px;text-align:right;color:#6E6E6E;&quot;><a href=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3b_de.html&quot; style=&quot;color:#6E6E6E;text-decoration:underline;&quot;>Im Browser lesen</a></div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:18px 28px 14px 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:collapse;border-spacing:0px;&quot;>
+                          <tbody>
+                            <tr>
+                              <td style=&quot;width:119px;&quot;>
+                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:0;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:600px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:collapse;border-spacing:0px;&quot; class=&quot;mj-full-width-mobile&quot;>
+                          <tbody>
+                            <tr>
+                              <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
+                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Am See lesen&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_see.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:24px 28px 0 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#de&quot;>Sommerangebot 2026</span></div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w3b_de#botschaft&quot;>Nur noch heute, 8.&#160;August</div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w3b_de#text&quot;>Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie die Wochenschrift ‹Das Goetheanum› drei Monate lang kostenlos lesen. Jetzt freischalten.</span></div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
+                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:separate;line-height:100%;&quot;>
+                          <tbody>
+                            <tr>
+                              <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
+                                <a href=&quot;https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurtv&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;>
+                                  <span data-edit=&quot;lesen_w3b_de#cta&quot;>Mehr erfahren →</span>
+                                </a>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;><span data-edit=&quot;shared#kleinzeile#lesen#de&quot;>Drei Monate kostenlos, danach läuft das Abo regulär weiter&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</span></div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFF4F8&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFF4F8;background-color:#FFF4F8;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFF4F8;background-color:#FFF4F8;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:16px 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+  </div>
+</body>
+
+</html>
+" loading="lazy" title="Vorschau lesen_w3b_de"></iframe>
+  <div class="flds"><div class="fld" data-key="lesen_w3b_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
+<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3b_de#gesamt">0</span></button></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
+<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3b_de#gesamt"></ul>
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3b_de#gesamt')">senden</button></div></div></div>
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Heute läuft das Angebot aus — drei Monate gratis lesen</textarea><button type="button" onclick="vorschlag(this,'lesen_w3b_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Nur noch heute, Samstag, 8. August: drei Monate ‹Das Goetheanum› gratis.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3b_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Nur noch heute, 8. August</textarea><button type="button" onclick="vorschlag(this,'lesen_w3b_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie die Wochenschrift ‹Das Goetheanum› drei Monate lang kostenlos lesen. Jetzt freischalten.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3b_de#text')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
+  <div class="mhd">W3B · EN<button class="mhd-edit" type="button" onclick="openEditor('lesen_w3b_en')">✎ Bearbeiten</button><a href="mails/mail_lesen_w3b_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">The offer closes today — three months of free reading</div><div class="ib-a">Only today, Saturday 8 August: three months of ‹Das Goetheanum› free.</div></div>
+  <iframe srcdoc="<!-- FILE: undefined -->
+<!doctype html>
+<html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
+
+<head>
+  <title>The offer closes today — three months of free reading</title>
+  <!--[if !mso]><!-->
+  <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
+  <!--<![endif]-->
+  <meta http-equiv=&quot;Content-Type&quot; content=&quot;text/html; charset=UTF-8&quot;>
+  <meta name=&quot;viewport&quot; content=&quot;width=device-width, initial-scale=1&quot;>
+  <style type=&quot;text/css&quot;>
+    #outlook a {
+      padding: 0;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
+
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+  </style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type=&quot;text/css&quot;>
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+  <style type=&quot;text/css&quot;>
+    @media only screen and (min-width:480px) {
+      .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+    }
+  </style>
+  <style media=&quot;screen and (min-width:480px)&quot;>
+    .moz-text-html .mj-column-per-100 {
+      width: 100% !important;
+      max-width: 100%;
+    }
+  </style>
+  <style type=&quot;text/css&quot;>
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile {
+        width: 100% !important;
+      }
+
+      td.mj-full-width-mobile {
+        width: auto !important;
+      }
+    }
+  </style>
+  <style type=&quot;text/css&quot;>
+    @font-face {
+      font-family: 'Goetheanum';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.7-Deutlich.woff2') format('woff2');
+      font-weight: 700;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
+  </style>
+</head>
+
+<body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Only today, Saturday 8 August: three months of ‹Das Goetheanum› free.</div>
+  <div aria-label=&quot;The offer closes today — three months of free reading&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+    <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:6px 28px 0 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;right&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:18px;text-align:right;color:#6E6E6E;&quot;><a href=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3b_en.html&quot; style=&quot;color:#6E6E6E;text-decoration:underline;&quot;>Read in browser</a></div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:18px 28px 14px 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:collapse;border-spacing:0px;&quot;>
+                          <tbody>
+                            <tr>
+                              <td style=&quot;width:119px;&quot;>
+                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:0;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:600px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:collapse;border-spacing:0px;&quot; class=&quot;mj-full-width-mobile&quot;>
+                          <tbody>
+                            <tr>
+                              <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
+                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurtv&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Am See lesen&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_see.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:24px 28px 0 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026</span></div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;lesen_w3b_en#botschaft&quot;>Only today, 8&#160;August</div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;lesen_w3b_en#text&quot;>Today, Saturday 8 August, the summer offer closes. Until then you can read the weekly ‹Das Goetheanum› free for three months. Unlock it now.</span></div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
+                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:separate;line-height:100%;&quot;>
+                          <tbody>
+                            <tr>
+                              <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
+                                <a href=&quot;https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurtv&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;>
+                                  <span data-edit=&quot;lesen_w3b_en#cta&quot;>Learn more →</span>
+                                </a>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;><span data-edit=&quot;shared#kleinzeile#lesen#en&quot;>Three months free, then the subscription continues at the regular price&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</span></div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFF4F8&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFF4F8;background-color:#FFF4F8;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFF4F8;background-color:#FFF4F8;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:16px 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+  </div>
+</body>
+
+</html>
+" loading="lazy" title="Vorschau lesen_w3b_en"></iframe>
+  <div class="flds"><div class="fld" data-key="lesen_w3b_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
+<button class="cbtn" type="button">💬 <span class="cc" data-cc="lesen_w3b_en#gesamt">0</span></button></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
+<div class="cpanel" hidden><ul class="clist" data-cl="lesen_w3b_en#gesamt"></ul>
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'lesen_w3b_en#gesamt')">senden</button></div></div></div>
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">The offer closes today — three months of free reading</textarea><button type="button" onclick="vorschlag(this,'lesen_w3b_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Only today, Saturday 8 August: three months of ‹Das Goetheanum› free.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3b_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Only today, 8 August</textarea><button type="button" onclick="vorschlag(this,'lesen_w3b_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Today, Saturday 8 August, the summer offer closes. Until then you can read the weekly ‹Das Goetheanum› free for three months. Unlock it now.</textarea><button type="button" onclick="vorschlag(this,'lesen_w3b_en#text')">vorschlagen</button></label></details></div></div></div></div></section><section class="segment"><h2>Sehen · goetheanum.tv — nurws</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W1 · DE<button class="mhd-edit" type="button" onclick="openEditor('sehen_w1_de')">✎ Bearbeiten</button><a href="mails/mail_sehen_w1_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
   <div class="inbox"><div class="ib-b">Ihr freier Zugang zu goetheanum.tv</div><div class="ib-a">Drei Monate die ganze Mediathek — über 800 Beiträge, wöchentlich neu.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
@@ -3204,13 +3798,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w2_en#gesamt')">senden</button></div></div></div>
   <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Your free access — still open until 8 August</textarea><button type="button" onclick="vorschlag(this,'sehen_w2_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Three months of goetheanum.tv – the offer runs only until 8 August.</textarea><button type="button" onclick="vorschlag(this,'sehen_w2_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Your free access is still waiting</textarea><button type="button" onclick="vorschlag(this,'sehen_w2_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">The offer runs until 8 August and lets you try goetheanum.tv free for three months. Unlock it now.</textarea><button type="button" onclick="vorschlag(this,'sehen_w2_en#text')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3 · DE<button class="mhd-edit" type="button" onclick="openEditor('sehen_w3_de')">✎ Bearbeiten</button><a href="mails/mail_sehen_w3_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Letzte Erinnerung: nur noch bis Samstag, 8. August</div><div class="ib-a">Das Angebot für drei kostenlose Monate goetheanum.tv läuft am Samstag, 8. August, aus.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Am Samstag endet Ihr Gratis-Test von goetheanum.tv — falls Sie ihn noch wollen.</div></div>
+  <div class="inbox"><div class="ib-b">Nur noch bis morgen, Samstag: drei Monate goetheanum.tv gratis</div><div class="ib-a">Das Angebot für drei kostenlose Monate goetheanum.tv läuft morgen, am Samstag, 8. August, aus.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Bis morgen: drei Monate goetheanum.tv gratis — jetzt starten</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Letzte Erinnerung: nur noch bis Samstag, 8. August</title>
+  <title>Nur noch bis morgen, Samstag: drei Monate goetheanum.tv gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -3314,8 +3908,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Das Angebot für drei kostenlose Monate goetheanum.tv läuft am Samstag, 8. August, aus.</div>
-  <div aria-label=&quot;Letzte Erinnerung: nur noch bis Samstag, 8. August&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Das Angebot für drei kostenlose Monate goetheanum.tv läuft morgen, am Samstag, 8. August, aus.</div>
+  <div aria-label=&quot;Nur noch bis morgen, Samstag: drei Monate goetheanum.tv gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
@@ -3426,13 +4020,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;sehen_w3_de#botschaft&quot;>Nur noch bis Samstag, 8.&#160;August</div>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;sehen_w3_de#botschaft&quot;>Nur noch bis morgen, 8.&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;sehen_w3_de#text&quot;>Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zu goetheanum.tv erhalten, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;sehen_w3_de#text&quot;>Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zu goetheanum.tv erhalten, morgen, am Samstag, 8. August, endet. Jetzt freischalten.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -3499,15 +4093,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_de#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Letzte Erinnerung: nur noch bis Samstag, 8. August</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Das Angebot für drei kostenlose Monate goetheanum.tv läuft am Samstag, 8. August, aus.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Nur noch bis Samstag, 8. August</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zu goetheanum.tv erhalten, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Am Samstag endet Ihr Gratis-Test von goetheanum.tv — falls Sie ihn noch wollen.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#alt')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Nur noch bis morgen, Samstag: drei Monate goetheanum.tv gratis</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Das Angebot für drei kostenlose Monate goetheanum.tv läuft morgen, am Samstag, 8. August, aus.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Nur noch bis morgen, 8. August</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zu goetheanum.tv erhalten, morgen, am Samstag, 8. August, endet. Jetzt freischalten.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Bis morgen: drei Monate goetheanum.tv gratis — jetzt starten</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_de#alt')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3 · EN<button class="mhd-edit" type="button" onclick="openEditor('sehen_w3_en')">✎ Bearbeiten</button><a href="mails/mail_sehen_w3_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Last reminder: only until Saturday, 8 August</div><div class="ib-a">The offer of three free months of goetheanum.tv ends on Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> On Saturday your free trial of goetheanum.tv ends — if you still want it.</div></div>
+  <div class="inbox"><div class="ib-b">Only until tomorrow, Saturday: three months of goetheanum.tv</div><div class="ib-a">The offer of three free months of goetheanum.tv ends tomorrow, Saturday 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Until tomorrow: three months of goetheanum.tv free — start now</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Last reminder: only until Saturday, 8 August</title>
+  <title>Only until tomorrow, Saturday: three months of goetheanum.tv</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -3611,8 +4205,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>The offer of three free months of goetheanum.tv ends on Saturday, 8 August.</div>
-  <div aria-label=&quot;Last reminder: only until Saturday, 8 August&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>The offer of three free months of goetheanum.tv ends tomorrow, Saturday 8 August.</div>
+  <div aria-label=&quot;Only until tomorrow, Saturday: three months of goetheanum.tv&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
@@ -3723,13 +4317,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;sehen_w3_en#botschaft&quot;>Only until Saturday, 8&#160;August</div>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;sehen_w3_en#botschaft&quot;>Only until tomorrow, 8&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;sehen_w3_en#text&quot;>A reminder that the summer offer — three months of free access to goetheanum.tv — ends on Saturday, 8 August. Until then, you can unlock it.</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;sehen_w3_en#text&quot;>A reminder that the summer offer — three months of free access to goetheanum.tv — ends tomorrow, Saturday 8 August. Unlock it now.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -3796,7 +4390,601 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3_en#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Last reminder: only until Saturday, 8 August</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">The offer of three free months of goetheanum.tv ends on Saturday, 8 August.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Only until Saturday, 8 August</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">A reminder that the summer offer — three months of free access to goetheanum.tv — ends on Saturday, 8 August. Until then, you can unlock it.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">On Saturday your free trial of goetheanum.tv ends — if you still want it.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#alt')">vorschlagen</button></label></details></div></div></div></div></section><section class="segment"><h2>Beides · Das ganze Goetheanum — noabo</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Only until tomorrow, Saturday: three months of goetheanum.tv</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">The offer of three free months of goetheanum.tv ends tomorrow, Saturday 8 August.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Only until tomorrow, 8 August</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">A reminder that the summer offer — three months of free access to goetheanum.tv — ends tomorrow, Saturday 8 August. Unlock it now.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Until tomorrow: three months of goetheanum.tv free — start now</textarea><button type="button" onclick="vorschlag(this,'sehen_w3_en#alt')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
+  <div class="mhd">W3B · DE<button class="mhd-edit" type="button" onclick="openEditor('sehen_w3b_de')">✎ Bearbeiten</button><a href="mails/mail_sehen_w3b_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">Heute läuft das Angebot aus — drei Monate goetheanum.tv gratis</div><div class="ib-a">Nur noch heute, Samstag, 8. August: drei Monate goetheanum.tv gratis.</div></div>
+  <iframe srcdoc="<!-- FILE: undefined -->
+<!doctype html>
+<html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
+
+<head>
+  <title>Heute läuft das Angebot aus — drei Monate goetheanum.tv gratis</title>
+  <!--[if !mso]><!-->
+  <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
+  <!--<![endif]-->
+  <meta http-equiv=&quot;Content-Type&quot; content=&quot;text/html; charset=UTF-8&quot;>
+  <meta name=&quot;viewport&quot; content=&quot;width=device-width, initial-scale=1&quot;>
+  <style type=&quot;text/css&quot;>
+    #outlook a {
+      padding: 0;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
+
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+  </style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type=&quot;text/css&quot;>
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+  <style type=&quot;text/css&quot;>
+    @media only screen and (min-width:480px) {
+      .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+    }
+  </style>
+  <style media=&quot;screen and (min-width:480px)&quot;>
+    .moz-text-html .mj-column-per-100 {
+      width: 100% !important;
+      max-width: 100%;
+    }
+  </style>
+  <style type=&quot;text/css&quot;>
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile {
+        width: 100% !important;
+      }
+
+      td.mj-full-width-mobile {
+        width: auto !important;
+      }
+    }
+  </style>
+  <style type=&quot;text/css&quot;>
+    @font-face {
+      font-family: 'Goetheanum';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.7-Deutlich.woff2') format('woff2');
+      font-weight: 700;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
+  </style>
+</head>
+
+<body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Nur noch heute, Samstag, 8. August: drei Monate goetheanum.tv gratis.</div>
+  <div aria-label=&quot;Heute läuft das Angebot aus — drei Monate goetheanum.tv gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+    <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:6px 28px 0 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;right&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:18px;text-align:right;color:#6E6E6E;&quot;><a href=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3b_de.html&quot; style=&quot;color:#6E6E6E;text-decoration:underline;&quot;>Im Browser lesen</a></div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:18px 28px 14px 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:collapse;border-spacing:0px;&quot;>
+                          <tbody>
+                            <tr>
+                              <td style=&quot;width:119px;&quot;>
+                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:0;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:600px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:collapse;border-spacing:0px;&quot; class=&quot;mj-full-width-mobile&quot;>
+                          <tbody>
+                            <tr>
+                              <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
+                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;goetheanum.tv in der Hängematte am See&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_haengematte.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:24px 28px 0 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#de&quot;>Sommerangebot 2026</span></div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;sehen_w3b_de#botschaft&quot;>Nur noch heute, 8.&#160;August</div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;sehen_w3b_de#text&quot;>Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie goetheanum.tv drei Monate lang kostenlos sehen. Jetzt freischalten.</span></div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
+                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:separate;line-height:100%;&quot;>
+                          <tbody>
+                            <tr>
+                              <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
+                                <a href=&quot;https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;>
+                                  <span data-edit=&quot;sehen_w3b_de#cta&quot;>Mehr erfahren →</span>
+                                </a>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;><span data-edit=&quot;shared#kleinzeile#sehen#de&quot;>Drei Monate kostenlos, danach läuft das Abo regulär weiter&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</span></div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFF4F8&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFF4F8;background-color:#FFF4F8;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFF4F8;background-color:#FFF4F8;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:16px 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#de&quot;>Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+  </div>
+</body>
+
+</html>
+" loading="lazy" title="Vorschau sehen_w3b_de"></iframe>
+  <div class="flds"><div class="fld" data-key="sehen_w3b_de#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
+<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3b_de#gesamt">0</span></button></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
+<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3b_de#gesamt"></ul>
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3b_de#gesamt')">senden</button></div></div></div>
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Heute läuft das Angebot aus — drei Monate goetheanum.tv gratis</textarea><button type="button" onclick="vorschlag(this,'sehen_w3b_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Nur noch heute, Samstag, 8. August: drei Monate goetheanum.tv gratis.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3b_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Nur noch heute, 8. August</textarea><button type="button" onclick="vorschlag(this,'sehen_w3b_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie goetheanum.tv drei Monate lang kostenlos sehen. Jetzt freischalten.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3b_de#text')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
+  <div class="mhd">W3B · EN<button class="mhd-edit" type="button" onclick="openEditor('sehen_w3b_en')">✎ Bearbeiten</button><a href="mails/mail_sehen_w3b_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
+  <div class="inbox"><div class="ib-b">The offer closes today — three months of goetheanum.tv</div><div class="ib-a">Only today, Saturday 8 August: three months of goetheanum.tv free.</div></div>
+  <iframe srcdoc="<!-- FILE: undefined -->
+<!doctype html>
+<html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
+
+<head>
+  <title>The offer closes today — three months of goetheanum.tv</title>
+  <!--[if !mso]><!-->
+  <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
+  <!--<![endif]-->
+  <meta http-equiv=&quot;Content-Type&quot; content=&quot;text/html; charset=UTF-8&quot;>
+  <meta name=&quot;viewport&quot; content=&quot;width=device-width, initial-scale=1&quot;>
+  <style type=&quot;text/css&quot;>
+    #outlook a {
+      padding: 0;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
+
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+  </style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type=&quot;text/css&quot;>
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+  <style type=&quot;text/css&quot;>
+    @media only screen and (min-width:480px) {
+      .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+    }
+  </style>
+  <style media=&quot;screen and (min-width:480px)&quot;>
+    .moz-text-html .mj-column-per-100 {
+      width: 100% !important;
+      max-width: 100%;
+    }
+  </style>
+  <style type=&quot;text/css&quot;>
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile {
+        width: 100% !important;
+      }
+
+      td.mj-full-width-mobile {
+        width: auto !important;
+      }
+    }
+  </style>
+  <style type=&quot;text/css&quot;>
+    @font-face {
+      font-family: 'Goetheanum';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Webfonts/woff2/Goetheanum-Schrift-v2.7-Deutlich.woff2') format('woff2');
+      font-weight: 700;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    @font-face {
+      font-family: 'Source Sans 3';
+      src: url('https://werkzeuge.goetheanum.ch/assets/fonts/goetheanum/Fallback/SourceSans3-SemiBold.woff2') format('woff2');
+      font-weight: 600;
+      font-style: normal;
+    }
+  </style>
+</head>
+
+<body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Only today, Saturday 8 August: three months of goetheanum.tv free.</div>
+  <div aria-label=&quot;The offer closes today — three months of goetheanum.tv&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+    <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:6px 28px 0 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;right&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:18px;text-align:right;color:#6E6E6E;&quot;><a href=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3b_en.html&quot; style=&quot;color:#6E6E6E;text-decoration:underline;&quot;>Read in browser</a></div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:18px 28px 14px 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:collapse;border-spacing:0px;&quot;>
+                          <tbody>
+                            <tr>
+                              <td style=&quot;width:119px;&quot;>
+                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;Goetheanum&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;119&quot; height=&quot;auto&quot; />
+                                </a>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:0;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:600px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;center&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:collapse;border-spacing:0px;&quot; class=&quot;mj-full-width-mobile&quot;>
+                          <tbody>
+                            <tr>
+                              <td style=&quot;width:600px;&quot; class=&quot;mj-full-width-mobile&quot;>
+                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurws&quot; target=&quot;_blank&quot;>
+                                  <img alt=&quot;goetheanum.tv in der Hängematte am See&quot; src=&quot;https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_haengematte.jpg&quot; style=&quot;border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;&quot; width=&quot;600&quot; height=&quot;auto&quot; />
+                                </a>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFFFFF&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFFFFF;background-color:#FFFFFF;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:24px 28px 0 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 10px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;&quot;><span data-edit=&quot;shared#badge#en&quot;>Summer offer 2026</span></div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;sehen_w3b_en#botschaft&quot;>Only today, 8&#160;August</div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;sehen_w3b_en#text&quot;>Today, Saturday 8 August, the summer offer closes. Until then you can watch goetheanum.tv free for three months. Unlock it now.</span></div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
+                        <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;border-collapse:separate;line-height:100%;&quot;>
+                          <tbody>
+                            <tr>
+                              <td align=&quot;center&quot; bgcolor=&quot;#A95278&quot; role=&quot;presentation&quot; style=&quot;border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;&quot; valign=&quot;middle&quot;>
+                                <a href=&quot;https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurws&quot; style=&quot;display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;&quot; target=&quot;_blank&quot;>
+                                  <span data-edit=&quot;sehen_w3b_en#cta&quot;>Learn more →</span>
+                                </a>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;&quot;><span data-edit=&quot;shared#kleinzeile#sehen#en&quot;>Three months free, then the subscription continues at the regular price&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</span></div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#FFF4F8&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
+    <div style=&quot;background:#FFF4F8;background-color:#FFF4F8;margin:0px auto;max-width:600px;&quot;>
+      <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#FFF4F8;background-color:#FFF4F8;width:100%;&quot;>
+        <tbody>
+          <tr>
+            <td style=&quot;direction:ltr;font-size:0px;padding:16px 28px;text-align:center;&quot;>
+              <!--[if mso | IE]><table role=&quot;presentation&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot;><tr><td class=&quot;&quot; style=&quot;vertical-align:top;width:544px;&quot; ><![endif]-->
+              <div class=&quot;mj-column-per-100 mj-outlook-group-fix&quot; style=&quot;font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;&quot;>
+                <table border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;vertical-align:top;&quot; width=&quot;100%&quot;>
+                  <tbody>
+                    <tr>
+                      <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0;word-break:break-word;&quot;>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;&quot;><span data-edit=&quot;shared#beweisband#en&quot;>Voices and faces of anthroposophy today</span></div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+  </div>
+</body>
+
+</html>
+" loading="lazy" title="Vorschau sehen_w3b_en"></iframe>
+  <div class="flds"><div class="fld" data-key="sehen_w3b_en#gesamt"><div class="fh" onclick="toggle(this)"><span class="lbl">Anmerkung zur Mail</span>
+<button class="cbtn" type="button">💬 <span class="cc" data-cc="sehen_w3b_en#gesamt">0</span></button></div>
+<div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
+<div class="cpanel" hidden><ul class="clist" data-cl="sehen_w3b_en#gesamt"></ul>
+<div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'sehen_w3b_en#gesamt')">senden</button></div></div></div>
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">The offer closes today — three months of goetheanum.tv</textarea><button type="button" onclick="vorschlag(this,'sehen_w3b_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Only today, Saturday 8 August: three months of goetheanum.tv free.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3b_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Only today, 8 August</textarea><button type="button" onclick="vorschlag(this,'sehen_w3b_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Today, Saturday 8 August, the summer offer closes. Until then you can watch goetheanum.tv free for three months. Unlock it now.</textarea><button type="button" onclick="vorschlag(this,'sehen_w3b_en#text')">vorschlagen</button></label></details></div></div></div></div></section><section class="segment"><h2>Beides · Das ganze Goetheanum — noabo</h2><div class="waves"><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W1 · DE<button class="mhd-edit" type="button" onclick="openEditor('beides_w1_de')">✎ Bearbeiten</button><a href="mails/mail_beides_w1_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
   <div class="inbox"><div class="ib-b">Ihr freier Zugang zum Goetheanum – lesen und sehen</div><div class="ib-a">Wochenschrift und goetheanum.tv – drei Monate gratis, bis 8. August.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
@@ -4998,13 +6186,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w2_en#gesamt')">senden</button></div></div></div>
   <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Your free access — still open until 8 August</textarea><button type="button" onclick="vorschlag(this,'beides_w2_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">The weekly and/or goetheanum.tv, three months free – until 8 August.</textarea><button type="button" onclick="vorschlag(this,'beides_w2_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Your free access is still waiting</textarea><button type="button" onclick="vorschlag(this,'beides_w2_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">The offer runs until 8 August: try the weekly ‹Das Goetheanum› and goetheanum.tv free for three months – separately or together. Unlock it now.</textarea><button type="button" onclick="vorschlag(this,'beides_w2_en#text')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3 · DE<button class="mhd-edit" type="button" onclick="openEditor('beides_w3_de')">✎ Bearbeiten</button><a href="mails/mail_beides_w3_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Letzte Erinnerung: nur noch bis Samstag, 8. August</div><div class="ib-a">Drei Monate lesen und/oder sehen, kostenlos – am Samstag, 8. August, läuft das Angebot aus.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Am Samstag endet Ihr Gratis-Test — falls Sie ihn noch wollen.</div></div>
+  <div class="inbox"><div class="ib-b">Nur noch bis morgen, Samstag: drei Monate gratis</div><div class="ib-a">Drei Monate lesen und/oder sehen, kostenlos – morgen, am Samstag, 8. August, läuft das Angebot aus.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Bis morgen: drei Monate gratis lesen oder sehen — jetzt starten</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Letzte Erinnerung: nur noch bis Samstag, 8. August</title>
+  <title>Nur noch bis morgen, Samstag: drei Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -5108,8 +6296,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Drei Monate lesen und/oder sehen, kostenlos – am Samstag, 8. August, läuft das Angebot aus.</div>
-  <div aria-label=&quot;Letzte Erinnerung: nur noch bis Samstag, 8. August&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Drei Monate lesen und/oder sehen, kostenlos – morgen, am Samstag, 8. August, läuft das Angebot aus.</div>
+  <div aria-label=&quot;Nur noch bis morgen, Samstag: drei Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
@@ -5220,13 +6408,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;beides_w3_de#botschaft&quot;>Nur noch bis Samstag, 8.&#160;August</div>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;beides_w3_de#botschaft&quot;>Nur noch bis morgen, 8.&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;beides_w3_de#text&quot;>Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;beides_w3_de#text&quot;>Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen, morgen, am Samstag, 8. August, endet. Jetzt freischalten.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -5291,15 +6479,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_de#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Letzte Erinnerung: nur noch bis Samstag, 8. August</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Drei Monate lesen und/oder sehen, kostenlos – am Samstag, 8. August, läuft das Angebot aus.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Nur noch bis Samstag, 8. August</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Am Samstag endet Ihr Gratis-Test — falls Sie ihn noch wollen.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#alt')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Nur noch bis morgen, Samstag: drei Monate gratis</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Drei Monate lesen und/oder sehen, kostenlos – morgen, am Samstag, 8. August, läuft das Angebot aus.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Nur noch bis morgen, 8. August</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen, morgen, am Samstag, 8. August, endet. Jetzt freischalten.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Bis morgen: drei Monate gratis lesen oder sehen — jetzt starten</textarea><button type="button" onclick="vorschlag(this,'beides_w3_de#alt')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3 · EN<button class="mhd-edit" type="button" onclick="openEditor('beides_w3_en')">✎ Bearbeiten</button><a href="mails/mail_beides_w3_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Last reminder: only until Saturday, 8 August</div><div class="ib-a">Three months of reading and/or watching, free – the offer ends on Saturday, 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> On Saturday your free trial ends — if you still want it.</div></div>
+  <div class="inbox"><div class="ib-b">Only until tomorrow, Saturday: three months free</div><div class="ib-a">Three months of reading and/or watching, free – the offer ends tomorrow, Saturday 8 August.</div><div class="ib-alt"><span>Nicht-Öffner erhalten:</span> Until tomorrow: three months free to read or watch — start now</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Last reminder: only until Saturday, 8 August</title>
+  <title>Only until tomorrow, Saturday: three months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -5403,8 +6591,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of reading and/or watching, free – the offer ends on Saturday, 8 August.</div>
-  <div aria-label=&quot;Last reminder: only until Saturday, 8 August&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of reading and/or watching, free – the offer ends tomorrow, Saturday 8 August.</div>
+  <div aria-label=&quot;Only until tomorrow, Saturday: three months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
@@ -5515,13 +6703,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;beides_w3_en#botschaft&quot;>Only until Saturday, 8&#160;August</div>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;beides_w3_en#botschaft&quot;>Only until tomorrow, 8&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;beides_w3_en#text&quot;>A reminder that the summer offer — three months of free access to the Goetheanum, to read and/or watch — ends on Saturday, 8 August. Until then, you can unlock it.</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;beides_w3_en#text&quot;>A reminder that the summer offer — three months of free access to the Goetheanum, to read and/or watch — ends tomorrow, Saturday 8 August. Unlock it now.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -5586,15 +6774,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3_en#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Last reminder: only until Saturday, 8 August</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Three months of reading and/or watching, free – the offer ends on Saturday, 8 August.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Only until Saturday, 8 August</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">A reminder that the summer offer — three months of free access to the Goetheanum, to read and/or watch — ends on Saturday, 8 August. Until then, you can unlock it.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">On Saturday your free trial ends — if you still want it.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#alt')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Only until tomorrow, Saturday: three months free</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Three months of reading and/or watching, free – the offer ends tomorrow, Saturday 8 August.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Only until tomorrow, 8 August</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">A reminder that the summer offer — three months of free access to the Goetheanum, to read and/or watch — ends tomorrow, Saturday 8 August. Unlock it now.</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#text')">vorschlagen</button></label><label class="pf"><span>Alt-Betreff (Nicht-Öffner)</span><textarea rows="2">Until tomorrow: three months free to read or watch — start now</textarea><button type="button" onclick="vorschlag(this,'beides_w3_en#alt')">vorschlagen</button></label></details></div></div></div><div class="wave"><div class="mail" data-lang="de">
   <div class="mhd">W3B · DE<button class="mhd-edit" type="button" onclick="openEditor('beides_w3b_de')">✎ Bearbeiten</button><a href="mails/mail_beides_w3b_de.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">Morgen läuft das Angebot aus</div><div class="ib-a">Drei Monate Goetheanum, kostenlos – nur noch bis morgen, Samstag, 8. August.</div></div>
+  <div class="inbox"><div class="ib-b">Heute läuft das Angebot aus — drei Monate gratis</div><div class="ib-a">Nur noch heute, Samstag, 8. August: drei Monate Goetheanum gratis.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>Morgen läuft das Angebot aus</title>
+  <title>Heute läuft das Angebot aus — drei Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -5698,8 +6886,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Drei Monate Goetheanum, kostenlos – nur noch bis morgen, Samstag, 8. August.</div>
-  <div aria-label=&quot;Morgen läuft das Angebot aus&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Nur noch heute, Samstag, 8. August: drei Monate Goetheanum gratis.</div>
+  <div aria-label=&quot;Heute läuft das Angebot aus — drei Monate gratis&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
@@ -5810,13 +6998,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;beides_w3b_de#botschaft&quot;>Nur noch bis morgen, 8.&#160;August</div>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;beides_w3b_de#botschaft&quot;>Nur noch heute, 8.&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;beides_w3b_de#text&quot;>Morgen, am 8. August, endet das Sommerangebot. Bis dahin können Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen. Jetzt freischalten.</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;beides_w3b_de#text&quot;>Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen. Jetzt freischalten.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -5881,15 +7069,15 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_de#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_de#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Morgen läuft das Angebot aus</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Drei Monate Goetheanum, kostenlos – nur noch bis morgen, Samstag, 8. August.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Nur noch bis morgen, 8. August</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Morgen, am 8. August, endet das Sommerangebot. Bis dahin können Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen. Jetzt freischalten.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#text')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">Heute läuft das Angebot aus — drei Monate gratis</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Nur noch heute, Samstag, 8. August: drei Monate Goetheanum gratis.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Nur noch heute, 8. August</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen. Jetzt freischalten.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_de#text')">vorschlagen</button></label></details></div></div><div class="mail" data-lang="en">
   <div class="mhd">W3B · EN<button class="mhd-edit" type="button" onclick="openEditor('beides_w3b_en')">✎ Bearbeiten</button><a href="mails/mail_beides_w3b_en.html" title="Versand-HTML öffnen (AC-Bestückung)">HTML</a></div>
-  <div class="inbox"><div class="ib-b">The offer closes tomorrow</div><div class="ib-a">Three months of the Goetheanum, free – only until tomorrow, Saturday 8 August.</div></div>
+  <div class="inbox"><div class="ib-b">The offer closes today — three months free</div><div class="ib-a">Only today, Saturday 8 August: three months of the Goetheanum free.</div></div>
   <iframe srcdoc="<!-- FILE: undefined -->
 <!doctype html>
 <html lang=&quot;und&quot; dir=&quot;auto&quot; xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xmlns:v=&quot;urn:schemas-microsoft-com:vml&quot; xmlns:o=&quot;urn:schemas-microsoft-com:office:office&quot;>
 
 <head>
-  <title>The offer closes tomorrow</title>
+  <title>The offer closes today — three months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv=&quot;X-UA-Compatible&quot; content=&quot;IE=edge&quot;>
   <!--<![endif]-->
@@ -5993,8 +7181,8 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 </head>
 
 <body style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
-  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Three months of the Goetheanum, free – only until tomorrow, Saturday 8 August.</div>
-  <div aria-label=&quot;The offer closes tomorrow&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
+  <div style=&quot;display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;&quot;>Only today, Saturday 8 August: three months of the Goetheanum free.</div>
+  <div aria-label=&quot;The offer closes today — three months free&quot; aria-roledescription=&quot;email&quot; role=&quot;article&quot; lang=&quot;und&quot; dir=&quot;auto&quot; style=&quot;word-spacing:normal;background-color:#F6F4F2;&quot;>
     <!--[if mso | IE]><table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; class=&quot;&quot; role=&quot;presentation&quot; style=&quot;width:600px;&quot; width=&quot;600&quot; bgcolor=&quot;#F6F4F2&quot; ><tr><td style=&quot;line-height:0px;font-size:0px;mso-line-height-rule:exactly;&quot;><![endif]-->
     <div style=&quot;background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;&quot;>
       <table align=&quot;center&quot; border=&quot;0&quot; cellpadding=&quot;0&quot; cellspacing=&quot;0&quot; role=&quot;presentation&quot; style=&quot;background:#F6F4F2;background-color:#F6F4F2;width:100%;&quot;>
@@ -6105,13 +7293,13 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 14px 0;word-break:break-word;&quot;>
                         <div style=&quot;font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;&quot;>
-                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;beides_w3b_en#botschaft&quot;>Only until tomorrow, 8&#160;August</div>
+                          <div style=&quot;text-wrap:balance&quot; data-edit=&quot;beides_w3b_en#botschaft&quot;>Only today, 8&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align=&quot;left&quot; style=&quot;font-size:0px;padding:0 0 22px 0;word-break:break-word;&quot;>
-                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;beides_w3b_en#text&quot;>Tomorrow, 8 August, the summer offer closes. Until then you can read and/or watch the Goetheanum free for three months. Unlock it now.</span></div>
+                        <div style=&quot;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;&quot;><span data-edit=&quot;beides_w3b_en#text&quot;>Today, Saturday 8 August, the summer offer closes. Until then you can read and/or watch the Goetheanum free for three months. Unlock it now.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -6176,7 +7364,7 @@ body.nurmails .flds,body.nurmails .shared-sec{display:none}
 <div class="val"><i>Was auffällt — das Element einfach benennen (Betreff, Bild, Text …)</i></div>
 <div class="cpanel" hidden><ul class="clist" data-cl="beides_w3b_en#gesamt"></ul>
 <div class="cin"><button class="uebn" type="button" onclick="uebernehmen(this)" title="Feldtext übernehmen — direkt die gewünschte Fassung schreiben" aria-label="Feldtext übernehmen">✎</button><input placeholder="Kommentar oder gewünschte Fassung …"><button onclick="send(this,'beides_w3b_en#gesamt')">senden</button></div></div></div>
-  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">The offer closes tomorrow</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Three months of the Goetheanum, free – only until tomorrow, Saturday 8 August.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Only until tomorrow, 8 August</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Tomorrow, 8 August, the summer offer closes. Until then you can read and/or watch the Goetheanum free for three months. Unlock it now.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#text')">vorschlagen</button></label></details></div></div></div></div></section>
+  <details class="propose"><summary>✎ Fassung vorschlagen</summary><p class="phint">Feldtext ändern und ‹vorschlagen› — geht als Vorschlag ins Backend, der Rücklauf-Agent nimmt ihn in <code>heroes.json</code> auf.</p><label class="pf"><span>Betreff</span><textarea rows="2">The offer closes today — three months free</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#betreff')">vorschlagen</button></label><label class="pf"><span>Betreff+ (Anriss)</span><textarea rows="2">Only today, Saturday 8 August: three months of the Goetheanum free.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#preheader')">vorschlagen</button></label><label class="pf"><span>Botschaft</span><textarea rows="2">Only today, 8 August</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#botschaft')">vorschlagen</button></label><label class="pf"><span>Fliesstext</span><textarea rows="2">Today, Saturday 8 August, the summer offer closes. Until then you can read and/or watch the Goetheanum free for three months. Unlock it now.</textarea><button type="button" onclick="vorschlag(this,'beides_w3b_en#text')">vorschlagen</button></label></details></div></div></div></div></section>
 <dialog id="wyz" class="wyz"><div class="wyz-bar"><span class="wyz-label" id="wyz-label"></span><span class="wyz-msg" id="wyz-msg"></span><input class="wyz-autor" id="wyz-autor" placeholder="Kürzel" aria-label="Ihr Kürzel"><button class="wyz-save" type="button" onclick="saveAll()">Speichern</button><button class="wyz-x" type="button" onclick="closeEditor()" aria-label="Schliessen">✕</button></div><button class="wyz-nav prev" type="button" onclick="navTo(-1)" aria-label="Vorherige Mail">‹</button><button class="wyz-nav next" type="button" onclick="navTo(1)" aria-label="Nächste Mail">›</button><div class="wyz-stage"><div class="wyz-col"><div class="wyz-inbox" id="wyz-chrome"></div><iframe id="wyz-frame" class="wyz-frame" scrolling="no" title="Live-Editor"></iframe></div></div></dialog>
 </main>
 
@@ -6190,8 +7378,8 @@ const SB_URL="https://dagcsnfrlbpxcmdimnrw.supabase.co", SB_KEY="sb_publishable_
 const REST=SB_URL+"/rest/v1/"+TAB, RPC=SB_URL+"/rest/v1/rpc/sommer2026_comment_erledigt";
 const HDR={"apikey":SB_KEY,"Authorization":"Bearer "+SB_KEY,"Content-Type":"application/json"};
 let COMMENTS={}, SHOW_DONE=false;
-const MAILDATA={"lesen_w1_de": {"label": "nurtv · lesen · w1 · DE", "fields": {"betreff": "Ihr freier Zugang zur Wochenschrift Das Goetheanum", "preheader": "Drei Monate freien Zugang für alle, die gerne in Ruhe auf Papier oder online lesen.", "botschaft": "Drei freie Monate für Sie", "text": "Die Wochenschrift ‹Das Goetheanum› erweitert den Horizont – auf Papier oder online – und beleuchtet brisante Themen. Sie erhalten drei Monate lang uneingeschränkten Zugriff auf das gesamte Archiv seit 2022."}, "cta": {"editable": true, "ziel": "wos", "label": "Mehr erfahren →"}}, "lesen_w1_en": {"label": "nurtv · lesen · w1 · EN", "fields": {"betreff": "Your free access to the weekly Das Goetheanum", "preheader": "Three months of free access — for anyone who likes to read in peace, on paper or online.", "botschaft": "Three free months for you", "text": "The weekly ‹Das Goetheanum› broadens your horizon – on paper or online – and takes on pressing questions. You receive three months of unlimited access to the entire archive since 2022."}, "cta": {"editable": true, "ziel": "wos", "label": "Learn more →"}}, "lesen_w2_de": {"label": "nurtv · lesen · w2 · DE", "fields": {"betreff": "Ihr kostenloser Zugang – noch bis zum 8. August", "preheader": "Der kostenlose Zugang für drei Monate ist ein Angebot, das nur bis zum 8. August gilt.", "botschaft": "Ihr kostenloser Zugang steht noch bereit", "text": "Das Angebot gilt bis zum 8. August und erlaubt Ihnen, die Wochenschrift ‹Das Goetheanum› drei Monate lang kostenlos zu testen. Jetzt freischalten."}, "cta": {"editable": true, "ziel": "wos", "label": "Mehr erfahren →"}}, "lesen_w2_en": {"label": "nurtv · lesen · w2 · EN", "fields": {"betreff": "Your free access — still open until 8 August", "preheader": "Free access for three months — an offer that runs only until 8 August.", "botschaft": "Your free access is still waiting", "text": "The offer runs until 8 August and lets you try the weekly ‹Das Goetheanum› free for three months. Unlock it now."}, "cta": {"editable": true, "ziel": "wos", "label": "Learn more →"}}, "lesen_w3_de": {"label": "nurtv · lesen · w3 · DE", "fields": {"betreff": "Letzte Erinnerung: nur noch bis Samstag, 8. August", "preheader": "Das Ausnahmeangebot von drei kostenlosen Monaten läuft am Samstag, 8. August, aus.", "botschaft": "Nur noch bis Samstag, 8. August", "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift ‹Das Goetheanum› – auf Papier und/oder online – erhalten, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.", "alt": "Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen."}, "cta": {"editable": true, "ziel": "wos", "label": "Mehr erfahren →"}}, "lesen_w3_en": {"label": "nurtv · lesen · w3 · EN", "fields": {"betreff": "Last reminder: only until Saturday, 8 August", "preheader": "The exceptional offer of three free months ends on Saturday, 8 August.", "botschaft": "Only until Saturday, 8 August", "text": "A reminder that the summer offer — three months of free access to the weekly ‹Das Goetheanum›, on paper and/or online — ends on Saturday, 8 August. Until then, you can unlock it.", "alt": "On Saturday your free trial of the weekly ends — if you still want it."}, "cta": {"editable": true, "ziel": "wos", "label": "Learn more →"}}, "sehen_w1_de": {"label": "nurws · sehen · w1 · DE", "fields": {"betreff": "Ihr freier Zugang zu goetheanum.tv", "preheader": "Drei Monate die ganze Mediathek — über 800 Beiträge, wöchentlich neu.", "botschaft": "Drei freie Monate für Sie", "text": "goetheanum.tv öffnet Ihnen die ganze Mediathek – über 800 Beiträge, wöchentlich neu: Vorträge, Reportagen und Aufführungen, nah am Leben am Goetheanum. Sie erhalten drei Monate lang uneingeschränkten Zugriff."}, "cta": {"editable": true, "ziel": "gtv", "label": "Mehr erfahren →"}}, "sehen_w1_en": {"label": "nurws · sehen · w1 · EN", "fields": {"betreff": "Your free access to goetheanum.tv", "preheader": "Three months of the whole media library — over 800 items, new each week.", "botschaft": "Three free months for you", "text": "goetheanum.tv opens the whole media library to you – over 800 items, new each week: lectures, reportages and performances, close to life at the Goetheanum. You receive three months of unlimited access."}, "cta": {"editable": true, "ziel": "gtv", "label": "Learn more →"}}, "sehen_w2_de": {"label": "nurws · sehen · w2 · DE", "fields": {"betreff": "Ihr kostenloser Zugang – noch bis zum 8. August", "preheader": "Drei Monate goetheanum.tv – das Angebot gilt nur bis zum 8. August.", "botschaft": "Ihr kostenloser Zugang steht noch bereit", "text": "Das Angebot gilt bis zum 8. August und erlaubt Ihnen, goetheanum.tv drei Monate lang kostenlos zu testen. Jetzt freischalten."}, "cta": {"editable": true, "ziel": "gtv", "label": "Mehr erfahren →"}}, "sehen_w2_en": {"label": "nurws · sehen · w2 · EN", "fields": {"betreff": "Your free access — still open until 8 August", "preheader": "Three months of goetheanum.tv – the offer runs only until 8 August.", "botschaft": "Your free access is still waiting", "text": "The offer runs until 8 August and lets you try goetheanum.tv free for three months. Unlock it now."}, "cta": {"editable": true, "ziel": "gtv", "label": "Learn more →"}}, "sehen_w3_de": {"label": "nurws · sehen · w3 · DE", "fields": {"betreff": "Letzte Erinnerung: nur noch bis Samstag, 8. August", "preheader": "Das Angebot für drei kostenlose Monate goetheanum.tv läuft am Samstag, 8. August, aus.", "botschaft": "Nur noch bis Samstag, 8. August", "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zu goetheanum.tv erhalten, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.", "alt": "Am Samstag endet Ihr Gratis-Test von goetheanum.tv — falls Sie ihn noch wollen."}, "cta": {"editable": true, "ziel": "gtv", "label": "Mehr erfahren →"}}, "sehen_w3_en": {"label": "nurws · sehen · w3 · EN", "fields": {"betreff": "Last reminder: only until Saturday, 8 August", "preheader": "The offer of three free months of goetheanum.tv ends on Saturday, 8 August.", "botschaft": "Only until Saturday, 8 August", "text": "A reminder that the summer offer — three months of free access to goetheanum.tv — ends on Saturday, 8 August. Until then, you can unlock it.", "alt": "On Saturday your free trial of goetheanum.tv ends — if you still want it."}, "cta": {"editable": true, "ziel": "gtv", "label": "Learn more →"}}, "beides_w1_de": {"label": "noabo · beides · w1 · DE", "fields": {"betreff": "Ihr freier Zugang zum Goetheanum – lesen und sehen", "preheader": "Wochenschrift und goetheanum.tv – drei Monate gratis, bis 8. August.", "botschaft": "Drei freie Monate für Sie", "text": "Das Goetheanum gibt es in Wort und im Bild: die Wochenschrift ‹Das Goetheanum› und die Mediathek goetheanum.tv. Lernen Sie beide diesen Sommer drei Monate kostenlos kennen – einzeln oder zusammen."}, "cta": {"editable": false}}, "beides_w1_en": {"label": "noabo · beides · w1 · EN", "fields": {"betreff": "Your free access to the Goetheanum – read and watch", "preheader": "The weekly and goetheanum.tv – three months free, until 8 August.", "botschaft": "Three free months for you", "text": "The Goetheanum exists in words and in image: the weekly ‹Das Goetheanum› and the media library goetheanum.tv. Get to know both this summer, three months free – separately or together."}, "cta": {"editable": false}}, "beides_w2_de": {"label": "noabo · beides · w2 · DE", "fields": {"betreff": "Ihr kostenloser Zugang – noch bis zum 8. August", "preheader": "Wochenschrift und/oder goetheanum.tv, drei Monate kostenlos – bis 8. August.", "botschaft": "Ihr kostenloser Zugang steht noch bereit", "text": "Das Angebot gilt bis zum 8. August: die Wochenschrift ‹Das Goetheanum› und goetheanum.tv drei Monate lang kostenlos testen – einzeln oder zusammen. Jetzt freischalten."}, "cta": {"editable": false}}, "beides_w2_en": {"label": "noabo · beides · w2 · EN", "fields": {"betreff": "Your free access — still open until 8 August", "preheader": "The weekly and/or goetheanum.tv, three months free – until 8 August.", "botschaft": "Your free access is still waiting", "text": "The offer runs until 8 August: try the weekly ‹Das Goetheanum› and goetheanum.tv free for three months – separately or together. Unlock it now."}, "cta": {"editable": false}}, "beides_w3_de": {"label": "noabo · beides · w3 · DE", "fields": {"betreff": "Letzte Erinnerung: nur noch bis Samstag, 8. August", "preheader": "Drei Monate lesen und/oder sehen, kostenlos – am Samstag, 8. August, läuft das Angebot aus.", "botschaft": "Nur noch bis Samstag, 8. August", "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.", "alt": "Am Samstag endet Ihr Gratis-Test — falls Sie ihn noch wollen."}, "cta": {"editable": false}}, "beides_w3_en": {"label": "noabo · beides · w3 · EN", "fields": {"betreff": "Last reminder: only until Saturday, 8 August", "preheader": "Three months of reading and/or watching, free – the offer ends on Saturday, 8 August.", "botschaft": "Only until Saturday, 8 August", "text": "A reminder that the summer offer — three months of free access to the Goetheanum, to read and/or watch — ends on Saturday, 8 August. Until then, you can unlock it.", "alt": "On Saturday your free trial ends — if you still want it."}, "cta": {"editable": false}}, "beides_w3b_de": {"label": "noabo · beides · w3b · DE", "fields": {"betreff": "Morgen läuft das Angebot aus", "preheader": "Drei Monate Goetheanum, kostenlos – nur noch bis morgen, Samstag, 8. August.", "botschaft": "Nur noch bis morgen, 8. August", "text": "Morgen, am 8. August, endet das Sommerangebot. Bis dahin können Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen. Jetzt freischalten."}, "cta": {"editable": false}}, "beides_w3b_en": {"label": "noabo · beides · w3b · EN", "fields": {"betreff": "The offer closes tomorrow", "preheader": "Three months of the Goetheanum, free – only until tomorrow, Saturday 8 August.", "botschaft": "Only until tomorrow, 8 August", "text": "Tomorrow, 8 August, the summer offer closes. Until then you can read and/or watch the Goetheanum free for three months. Unlock it now."}, "cta": {"editable": false}}};
-const NAVBASES=["lesen_w1_de", "lesen_w1_en", "lesen_w2_de", "lesen_w2_en", "lesen_w3_de", "lesen_w3_en", "sehen_w1_de", "sehen_w1_en", "sehen_w2_de", "sehen_w2_en", "sehen_w3_de", "sehen_w3_en", "beides_w1_de", "beides_w1_en", "beides_w2_de", "beides_w2_en", "beides_w3_de", "beides_w3_en", "beides_w3b_de", "beides_w3b_en"];
+const MAILDATA={"lesen_w1_de": {"label": "nurtv · lesen · w1 · DE", "fields": {"betreff": "Ihr freier Zugang zur Wochenschrift Das Goetheanum", "preheader": "Drei Monate freien Zugang für alle, die gerne in Ruhe auf Papier oder online lesen.", "botschaft": "Drei freie Monate für Sie", "text": "Die Wochenschrift ‹Das Goetheanum› erweitert den Horizont – auf Papier oder online – und beleuchtet brisante Themen. Sie erhalten drei Monate lang uneingeschränkten Zugriff auf das gesamte Archiv seit 2022."}, "cta": {"editable": true, "ziel": "wos", "label": "Mehr erfahren →"}}, "lesen_w1_en": {"label": "nurtv · lesen · w1 · EN", "fields": {"betreff": "Your free access to the weekly Das Goetheanum", "preheader": "Three months of free access — for anyone who likes to read in peace, on paper or online.", "botschaft": "Three free months for you", "text": "The weekly ‹Das Goetheanum› broadens your horizon – on paper or online – and takes on pressing questions. You receive three months of unlimited access to the entire archive since 2022."}, "cta": {"editable": true, "ziel": "wos", "label": "Learn more →"}}, "lesen_w2_de": {"label": "nurtv · lesen · w2 · DE", "fields": {"betreff": "Ihr kostenloser Zugang – noch bis zum 8. August", "preheader": "Der kostenlose Zugang für drei Monate ist ein Angebot, das nur bis zum 8. August gilt.", "botschaft": "Ihr kostenloser Zugang steht noch bereit", "text": "Das Angebot gilt bis zum 8. August und erlaubt Ihnen, die Wochenschrift ‹Das Goetheanum› drei Monate lang kostenlos zu testen. Jetzt freischalten."}, "cta": {"editable": true, "ziel": "wos", "label": "Mehr erfahren →"}}, "lesen_w2_en": {"label": "nurtv · lesen · w2 · EN", "fields": {"betreff": "Your free access — still open until 8 August", "preheader": "Free access for three months — an offer that runs only until 8 August.", "botschaft": "Your free access is still waiting", "text": "The offer runs until 8 August and lets you try the weekly ‹Das Goetheanum› free for three months. Unlock it now."}, "cta": {"editable": true, "ziel": "wos", "label": "Learn more →"}}, "lesen_w3_de": {"label": "nurtv · lesen · w3 · DE", "fields": {"betreff": "Nur noch bis morgen, Samstag: drei Monate gratis lesen", "preheader": "Das Angebot für drei kostenlose Monate ‹Das Goetheanum› läuft morgen, am Samstag, 8. August, aus.", "botschaft": "Nur noch bis morgen, 8. August", "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift ‹Das Goetheanum› – auf Papier oder online – erhalten, morgen, am Samstag, 8. August, endet. Jetzt freischalten.", "alt": "Bis morgen: drei Monate gratis lesen — jetzt starten"}, "cta": {"editable": true, "ziel": "wos", "label": "Mehr erfahren →"}}, "lesen_w3_en": {"label": "nurtv · lesen · w3 · EN", "fields": {"betreff": "Only until tomorrow, Saturday: three months free", "preheader": "The offer of three free months of ‹Das Goetheanum› ends tomorrow, Saturday 8 August.", "botschaft": "Only until tomorrow, 8 August", "text": "A reminder that the summer offer — three months of free access to the weekly ‹Das Goetheanum›, on paper or online — ends tomorrow, Saturday 8 August. Unlock it now.", "alt": "Until tomorrow: three months of free reading — start now"}, "cta": {"editable": true, "ziel": "wos", "label": "Learn more →"}}, "lesen_w3b_de": {"label": "nurtv · lesen · w3b · DE", "fields": {"betreff": "Heute läuft das Angebot aus — drei Monate gratis lesen", "preheader": "Nur noch heute, Samstag, 8. August: drei Monate ‹Das Goetheanum› gratis.", "botschaft": "Nur noch heute, 8. August", "text": "Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie die Wochenschrift ‹Das Goetheanum› drei Monate lang kostenlos lesen. Jetzt freischalten."}, "cta": {"editable": true, "ziel": "wos", "label": "Mehr erfahren →"}}, "lesen_w3b_en": {"label": "nurtv · lesen · w3b · EN", "fields": {"betreff": "The offer closes today — three months of free reading", "preheader": "Only today, Saturday 8 August: three months of ‹Das Goetheanum› free.", "botschaft": "Only today, 8 August", "text": "Today, Saturday 8 August, the summer offer closes. Until then you can read the weekly ‹Das Goetheanum› free for three months. Unlock it now."}, "cta": {"editable": true, "ziel": "wos", "label": "Learn more →"}}, "sehen_w1_de": {"label": "nurws · sehen · w1 · DE", "fields": {"betreff": "Ihr freier Zugang zu goetheanum.tv", "preheader": "Drei Monate die ganze Mediathek — über 800 Beiträge, wöchentlich neu.", "botschaft": "Drei freie Monate für Sie", "text": "goetheanum.tv öffnet Ihnen die ganze Mediathek – über 800 Beiträge, wöchentlich neu: Vorträge, Reportagen und Aufführungen, nah am Leben am Goetheanum. Sie erhalten drei Monate lang uneingeschränkten Zugriff."}, "cta": {"editable": true, "ziel": "gtv", "label": "Mehr erfahren →"}}, "sehen_w1_en": {"label": "nurws · sehen · w1 · EN", "fields": {"betreff": "Your free access to goetheanum.tv", "preheader": "Three months of the whole media library — over 800 items, new each week.", "botschaft": "Three free months for you", "text": "goetheanum.tv opens the whole media library to you – over 800 items, new each week: lectures, reportages and performances, close to life at the Goetheanum. You receive three months of unlimited access."}, "cta": {"editable": true, "ziel": "gtv", "label": "Learn more →"}}, "sehen_w2_de": {"label": "nurws · sehen · w2 · DE", "fields": {"betreff": "Ihr kostenloser Zugang – noch bis zum 8. August", "preheader": "Drei Monate goetheanum.tv – das Angebot gilt nur bis zum 8. August.", "botschaft": "Ihr kostenloser Zugang steht noch bereit", "text": "Das Angebot gilt bis zum 8. August und erlaubt Ihnen, goetheanum.tv drei Monate lang kostenlos zu testen. Jetzt freischalten."}, "cta": {"editable": true, "ziel": "gtv", "label": "Mehr erfahren →"}}, "sehen_w2_en": {"label": "nurws · sehen · w2 · EN", "fields": {"betreff": "Your free access — still open until 8 August", "preheader": "Three months of goetheanum.tv – the offer runs only until 8 August.", "botschaft": "Your free access is still waiting", "text": "The offer runs until 8 August and lets you try goetheanum.tv free for three months. Unlock it now."}, "cta": {"editable": true, "ziel": "gtv", "label": "Learn more →"}}, "sehen_w3_de": {"label": "nurws · sehen · w3 · DE", "fields": {"betreff": "Nur noch bis morgen, Samstag: drei Monate goetheanum.tv gratis", "preheader": "Das Angebot für drei kostenlose Monate goetheanum.tv läuft morgen, am Samstag, 8. August, aus.", "botschaft": "Nur noch bis morgen, 8. August", "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zu goetheanum.tv erhalten, morgen, am Samstag, 8. August, endet. Jetzt freischalten.", "alt": "Bis morgen: drei Monate goetheanum.tv gratis — jetzt starten"}, "cta": {"editable": true, "ziel": "gtv", "label": "Mehr erfahren →"}}, "sehen_w3_en": {"label": "nurws · sehen · w3 · EN", "fields": {"betreff": "Only until tomorrow, Saturday: three months of goetheanum.tv", "preheader": "The offer of three free months of goetheanum.tv ends tomorrow, Saturday 8 August.", "botschaft": "Only until tomorrow, 8 August", "text": "A reminder that the summer offer — three months of free access to goetheanum.tv — ends tomorrow, Saturday 8 August. Unlock it now.", "alt": "Until tomorrow: three months of goetheanum.tv free — start now"}, "cta": {"editable": true, "ziel": "gtv", "label": "Learn more →"}}, "sehen_w3b_de": {"label": "nurws · sehen · w3b · DE", "fields": {"betreff": "Heute läuft das Angebot aus — drei Monate goetheanum.tv gratis", "preheader": "Nur noch heute, Samstag, 8. August: drei Monate goetheanum.tv gratis.", "botschaft": "Nur noch heute, 8. August", "text": "Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie goetheanum.tv drei Monate lang kostenlos sehen. Jetzt freischalten."}, "cta": {"editable": true, "ziel": "gtv", "label": "Mehr erfahren →"}}, "sehen_w3b_en": {"label": "nurws · sehen · w3b · EN", "fields": {"betreff": "The offer closes today — three months of goetheanum.tv", "preheader": "Only today, Saturday 8 August: three months of goetheanum.tv free.", "botschaft": "Only today, 8 August", "text": "Today, Saturday 8 August, the summer offer closes. Until then you can watch goetheanum.tv free for three months. Unlock it now."}, "cta": {"editable": true, "ziel": "gtv", "label": "Learn more →"}}, "beides_w1_de": {"label": "noabo · beides · w1 · DE", "fields": {"betreff": "Ihr freier Zugang zum Goetheanum – lesen und sehen", "preheader": "Wochenschrift und goetheanum.tv – drei Monate gratis, bis 8. August.", "botschaft": "Drei freie Monate für Sie", "text": "Das Goetheanum gibt es in Wort und im Bild: die Wochenschrift ‹Das Goetheanum› und die Mediathek goetheanum.tv. Lernen Sie beide diesen Sommer drei Monate kostenlos kennen – einzeln oder zusammen."}, "cta": {"editable": false}}, "beides_w1_en": {"label": "noabo · beides · w1 · EN", "fields": {"betreff": "Your free access to the Goetheanum – read and watch", "preheader": "The weekly and goetheanum.tv – three months free, until 8 August.", "botschaft": "Three free months for you", "text": "The Goetheanum exists in words and in image: the weekly ‹Das Goetheanum› and the media library goetheanum.tv. Get to know both this summer, three months free – separately or together."}, "cta": {"editable": false}}, "beides_w2_de": {"label": "noabo · beides · w2 · DE", "fields": {"betreff": "Ihr kostenloser Zugang – noch bis zum 8. August", "preheader": "Wochenschrift und/oder goetheanum.tv, drei Monate kostenlos – bis 8. August.", "botschaft": "Ihr kostenloser Zugang steht noch bereit", "text": "Das Angebot gilt bis zum 8. August: die Wochenschrift ‹Das Goetheanum› und goetheanum.tv drei Monate lang kostenlos testen – einzeln oder zusammen. Jetzt freischalten."}, "cta": {"editable": false}}, "beides_w2_en": {"label": "noabo · beides · w2 · EN", "fields": {"betreff": "Your free access — still open until 8 August", "preheader": "The weekly and/or goetheanum.tv, three months free – until 8 August.", "botschaft": "Your free access is still waiting", "text": "The offer runs until 8 August: try the weekly ‹Das Goetheanum› and goetheanum.tv free for three months – separately or together. Unlock it now."}, "cta": {"editable": false}}, "beides_w3_de": {"label": "noabo · beides · w3 · DE", "fields": {"betreff": "Nur noch bis morgen, Samstag: drei Monate gratis", "preheader": "Drei Monate lesen und/oder sehen, kostenlos – morgen, am Samstag, 8. August, läuft das Angebot aus.", "botschaft": "Nur noch bis morgen, 8. August", "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen, morgen, am Samstag, 8. August, endet. Jetzt freischalten.", "alt": "Bis morgen: drei Monate gratis lesen oder sehen — jetzt starten"}, "cta": {"editable": false}}, "beides_w3_en": {"label": "noabo · beides · w3 · EN", "fields": {"betreff": "Only until tomorrow, Saturday: three months free", "preheader": "Three months of reading and/or watching, free – the offer ends tomorrow, Saturday 8 August.", "botschaft": "Only until tomorrow, 8 August", "text": "A reminder that the summer offer — three months of free access to the Goetheanum, to read and/or watch — ends tomorrow, Saturday 8 August. Unlock it now.", "alt": "Until tomorrow: three months free to read or watch — start now"}, "cta": {"editable": false}}, "beides_w3b_de": {"label": "noabo · beides · w3b · DE", "fields": {"betreff": "Heute läuft das Angebot aus — drei Monate gratis", "preheader": "Nur noch heute, Samstag, 8. August: drei Monate Goetheanum gratis.", "botschaft": "Nur noch heute, 8. August", "text": "Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen. Jetzt freischalten."}, "cta": {"editable": false}}, "beides_w3b_en": {"label": "noabo · beides · w3b · EN", "fields": {"betreff": "The offer closes today — three months free", "preheader": "Only today, Saturday 8 August: three months of the Goetheanum free.", "botschaft": "Only today, 8 August", "text": "Today, Saturday 8 August, the summer offer closes. Until then you can read and/or watch the Goetheanum free for three months. Unlock it now."}, "cta": {"editable": false}}};
+const NAVBASES=["lesen_w1_de", "lesen_w1_en", "lesen_w2_de", "lesen_w2_en", "lesen_w3_de", "lesen_w3_en", "lesen_w3b_de", "lesen_w3b_en", "sehen_w1_de", "sehen_w1_en", "sehen_w2_de", "sehen_w2_en", "sehen_w3_de", "sehen_w3_en", "sehen_w3b_de", "sehen_w3b_en", "beides_w1_de", "beides_w1_en", "beides_w2_de", "beides_w2_en", "beides_w3_de", "beides_w3_en", "beides_w3b_de", "beides_w3b_en"];
 let PENDING={}, SUBMITTED={}, CUR=null, UILANG='de';
 const st=t=>document.getElementById('status').textContent=t;
 function setLang(l){UILANG=l;document.getElementById('b-de').classList.toggle('on',l=='de');document.getElementById('b-en').classList.toggle('on',l=='en');

--- a/apps/mail-editor/mails/mail_beides_w3_de.html
+++ b/apps/mail-editor/mails/mail_beides_w3_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Letzte Erinnerung: nur noch bis Samstag, 8. August</title>
+  <title>Nur noch bis morgen, Samstag: drei Monate gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Drei Monate lesen und/oder sehen, kostenlos – am Samstag, 8. August, läuft das Angebot aus.</div>
-  <div aria-label="Letzte Erinnerung: nur noch bis Samstag, 8. August" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Drei Monate lesen und/oder sehen, kostenlos – morgen, am Samstag, 8. August, läuft das Angebot aus.</div>
+  <div aria-label="Nur noch bis morgen, Samstag: drei Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -219,13 +219,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="beides_w3_de#botschaft">Nur noch bis Samstag, 8.&#160;August</div>
+                          <div style="text-wrap:balance" data-edit="beides_w3_de#botschaft">Nur noch bis morgen, 8.&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="beides_w3_de#text">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="beides_w3_de#text">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen, morgen, am Samstag, 8. August, endet. Jetzt freischalten.</span></div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_beides_w3_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Last reminder: only until Saturday, 8 August</title>
+  <title>Only until tomorrow, Saturday: three months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of reading and/or watching, free – the offer ends on Saturday, 8 August.</div>
-  <div aria-label="Last reminder: only until Saturday, 8 August" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of reading and/or watching, free – the offer ends tomorrow, Saturday 8 August.</div>
+  <div aria-label="Only until tomorrow, Saturday: three months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -219,13 +219,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="beides_w3_en#botschaft">Only until Saturday, 8&#160;August</div>
+                          <div style="text-wrap:balance" data-edit="beides_w3_en#botschaft">Only until tomorrow, 8&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="beides_w3_en#text">A reminder that the summer offer — three months of free access to the Goetheanum, to read and/or watch — ends on Saturday, 8 August. Until then, you can unlock it.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="beides_w3_en#text">A reminder that the summer offer — three months of free access to the Goetheanum, to read and/or watch — ends tomorrow, Saturday 8 August. Unlock it now.</span></div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_beides_w3b_en.html
+++ b/apps/mail-editor/mails/mail_beides_w3b_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>The offer closes tomorrow</title>
+  <title>The offer closes today — three months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Three months of the Goetheanum, free – only until tomorrow, Saturday 8 August.</div>
-  <div aria-label="The offer closes tomorrow" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Only today, Saturday 8 August: three months of the Goetheanum free.</div>
+  <div aria-label="The offer closes today — three months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -219,13 +219,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="beides_w3b_en#botschaft">Only until tomorrow, 8&#160;August</div>
+                          <div style="text-wrap:balance" data-edit="beides_w3b_en#botschaft">Only today, 8&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="beides_w3b_en#text">Tomorrow, 8 August, the summer offer closes. Until then you can read and/or watch the Goetheanum free for three months. Unlock it now.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="beides_w3b_en#text">Today, Saturday 8 August, the summer offer closes. Until then you can read and/or watch the Goetheanum free for three months. Unlock it now.</span></div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_lesen_w3_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Letzte Erinnerung: nur noch bis Samstag, 8. August</title>
+  <title>Nur noch bis morgen, Samstag: drei Monate gratis lesen</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Das Ausnahmeangebot von drei kostenlosen Monaten läuft am Samstag, 8. August, aus.</div>
-  <div aria-label="Letzte Erinnerung: nur noch bis Samstag, 8. August" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Das Angebot für drei kostenlose Monate ‹Das Goetheanum› läuft morgen, am Samstag, 8. August, aus.</div>
+  <div aria-label="Nur noch bis morgen, Samstag: drei Monate gratis lesen" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -219,13 +219,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="lesen_w3_de#botschaft">Nur noch bis Samstag, 8.&#160;August</div>
+                          <div style="text-wrap:balance" data-edit="lesen_w3_de#botschaft">Nur noch bis morgen, 8.&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w3_de#text">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift ‹Das Goetheanum› – auf Papier und/oder online – erhalten, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w3_de#text">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift ‹Das Goetheanum› – auf Papier oder online – erhalten, morgen, am Samstag, 8. August, endet. Jetzt freischalten.</span></div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_lesen_w3_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w3_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Last reminder: only until Saturday, 8 August</title>
+  <title>Only until tomorrow, Saturday: three months free</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">The exceptional offer of three free months ends on Saturday, 8 August.</div>
-  <div aria-label="Last reminder: only until Saturday, 8 August" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">The offer of three free months of ‹Das Goetheanum› ends tomorrow, Saturday 8 August.</div>
+  <div aria-label="Only until tomorrow, Saturday: three months free" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -219,13 +219,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="lesen_w3_en#botschaft">Only until Saturday, 8&#160;August</div>
+                          <div style="text-wrap:balance" data-edit="lesen_w3_en#botschaft">Only until tomorrow, 8&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w3_en#text">A reminder that the summer offer — three months of free access to the weekly ‹Das Goetheanum›, on paper and/or online — ends on Saturday, 8 August. Until then, you can unlock it.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w3_en#text">A reminder that the summer offer — three months of free access to the weekly ‹Das Goetheanum›, on paper or online — ends tomorrow, Saturday 8 August. Unlock it now.</span></div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_lesen_w3b_de.html
+++ b/apps/mail-editor/mails/mail_lesen_w3b_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Heute läuft das Angebot aus — drei Monate gratis</title>
+  <title>Heute läuft das Angebot aus — drei Monate gratis lesen</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Nur noch heute, Samstag, 8. August: drei Monate Goetheanum gratis.</div>
-  <div aria-label="Heute läuft das Angebot aus — drei Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Nur noch heute, Samstag, 8. August: drei Monate ‹Das Goetheanum› gratis.</div>
+  <div aria-label="Heute läuft das Angebot aus — drei Monate gratis lesen" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -121,7 +121,7 @@
                   <tbody>
                     <tr>
                       <td align="right" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:18px;text-align:right;color:#6E6E6E;"><a href="https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3b_de.html" style="color:#6E6E6E;text-decoration:underline;">Im Browser lesen</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:18px;text-align:right;color:#6E6E6E;"><a href="https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3b_de.html" style="color:#6E6E6E;text-decoration:underline;">Im Browser lesen</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -149,7 +149,7 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" target="_blank">
+                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurtv" target="_blank">
                                   <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
                                 </a>
                               </td>
@@ -183,8 +183,8 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" target="_blank">
-                                  <img alt="Sommer-Picknick mit dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurtv" target="_blank">
+                                  <img alt="Am See lesen" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_see.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
                                 </a>
                               </td>
                             </tr>
@@ -219,13 +219,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="beides_w3b_de#botschaft">Nur noch heute, 8.&#160;August</div>
+                          <div style="text-wrap:balance" data-edit="lesen_w3b_de#botschaft">Nur noch heute, 8.&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="beides_w3b_de#text">Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen. Jetzt freischalten.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w3b_de#text">Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie die Wochenschrift ‹Das Goetheanum› drei Monate lang kostenlos lesen. Jetzt freischalten.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -234,7 +234,9 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Mehr erfahren → </a>
+                                <a href="https://ws-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurtv" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank">
+                                  <span data-edit="lesen_w3b_de#cta">Mehr erfahren →</span>
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -243,7 +245,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;"><span data-edit="shared#kleinzeile#beides#de">Beide Angebote kombinierbar&#160;·<br />drei Monate kostenlos, danach läuft das Abo regulär weiter, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;"><span data-edit="shared#kleinzeile#lesen#de">Drei Monate kostenlos, danach läuft das Abo regulär weiter&#160;·<br />jederzeit ohne Begründung kündbar&#160;·<br />Aktion bis 8. August 2026.</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_lesen_w3b_en.html
+++ b/apps/mail-editor/mails/mail_lesen_w3b_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Heute läuft das Angebot aus — drei Monate gratis</title>
+  <title>The offer closes today — three months of free reading</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Nur noch heute, Samstag, 8. August: drei Monate Goetheanum gratis.</div>
-  <div aria-label="Heute läuft das Angebot aus — drei Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Only today, Saturday 8 August: three months of ‹Das Goetheanum› free.</div>
+  <div aria-label="The offer closes today — three months of free reading" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -121,7 +121,7 @@
                   <tbody>
                     <tr>
                       <td align="right" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:18px;text-align:right;color:#6E6E6E;"><a href="https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3b_de.html" style="color:#6E6E6E;text-decoration:underline;">Im Browser lesen</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:18px;text-align:right;color:#6E6E6E;"><a href="https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3b_en.html" style="color:#6E6E6E;text-decoration:underline;">Read in browser</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -149,7 +149,7 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" target="_blank">
+                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurtv" target="_blank">
                                   <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
                                 </a>
                               </td>
@@ -183,8 +183,8 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" target="_blank">
-                                  <img alt="Sommer-Picknick mit dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurtv" target="_blank">
+                                  <img alt="Am See lesen" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_lesen_see.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
                                 </a>
                               </td>
                             </tr>
@@ -213,19 +213,19 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#de">Sommerangebot 2026</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="beides_w3b_de#botschaft">Nur noch heute, 8.&#160;August</div>
+                          <div style="text-wrap:balance" data-edit="lesen_w3b_en#botschaft">Only today, 8&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="beides_w3b_de#text">Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen. Jetzt freischalten.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="lesen_w3b_en#text">Today, Saturday 8 August, the summer offer closes. Until then you can read the weekly ‹Das Goetheanum› free for three months. Unlock it now.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -234,7 +234,9 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Mehr erfahren → </a>
+                                <a href="https://ws-en-sommer2026.dasgoetheanum.com?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurtv" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank">
+                                  <span data-edit="lesen_w3b_en#cta">Learn more →</span>
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -243,7 +245,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;"><span data-edit="shared#kleinzeile#beides#de">Beide Angebote kombinierbar&#160;·<br />drei Monate kostenlos, danach läuft das Abo regulär weiter, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;"><span data-edit="shared#kleinzeile#lesen#en">Three months free, then the subscription continues at the regular price&#160;·<br />cancel anytime, no reason needed&#160;·<br />offer ends 8 August 2026.</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -267,7 +269,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Letzte Erinnerung: nur noch bis Samstag, 8. August</title>
+  <title>Nur noch bis morgen, Samstag: drei Monate goetheanum.tv gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Das Angebot für drei kostenlose Monate goetheanum.tv läuft am Samstag, 8. August, aus.</div>
-  <div aria-label="Letzte Erinnerung: nur noch bis Samstag, 8. August" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Das Angebot für drei kostenlose Monate goetheanum.tv läuft morgen, am Samstag, 8. August, aus.</div>
+  <div aria-label="Nur noch bis morgen, Samstag: drei Monate goetheanum.tv gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -219,13 +219,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="sehen_w3_de#botschaft">Nur noch bis Samstag, 8.&#160;August</div>
+                          <div style="text-wrap:balance" data-edit="sehen_w3_de#botschaft">Nur noch bis morgen, 8.&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="sehen_w3_de#text">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zu goetheanum.tv erhalten, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="sehen_w3_de#text">Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zu goetheanum.tv erhalten, morgen, am Samstag, 8. August, endet. Jetzt freischalten.</span></div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_sehen_w3_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w3_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Last reminder: only until Saturday, 8 August</title>
+  <title>Only until tomorrow, Saturday: three months of goetheanum.tv</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">The offer of three free months of goetheanum.tv ends on Saturday, 8 August.</div>
-  <div aria-label="Last reminder: only until Saturday, 8 August" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">The offer of three free months of goetheanum.tv ends tomorrow, Saturday 8 August.</div>
+  <div aria-label="Only until tomorrow, Saturday: three months of goetheanum.tv" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -219,13 +219,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="sehen_w3_en#botschaft">Only until Saturday, 8&#160;August</div>
+                          <div style="text-wrap:balance" data-edit="sehen_w3_en#botschaft">Only until tomorrow, 8&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="sehen_w3_en#text">A reminder that the summer offer — three months of free access to goetheanum.tv — ends on Saturday, 8 August. Until then, you can unlock it.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="sehen_w3_en#text">A reminder that the summer offer — three months of free access to goetheanum.tv — ends tomorrow, Saturday 8 August. Unlock it now.</span></div>
                       </td>
                     </tr>
                     <tr>

--- a/apps/mail-editor/mails/mail_sehen_w3b_de.html
+++ b/apps/mail-editor/mails/mail_sehen_w3b_de.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Heute läuft das Angebot aus — drei Monate gratis</title>
+  <title>Heute läuft das Angebot aus — drei Monate goetheanum.tv gratis</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Nur noch heute, Samstag, 8. August: drei Monate Goetheanum gratis.</div>
-  <div aria-label="Heute läuft das Angebot aus — drei Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Nur noch heute, Samstag, 8. August: drei Monate goetheanum.tv gratis.</div>
+  <div aria-label="Heute läuft das Angebot aus — drei Monate goetheanum.tv gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -121,7 +121,7 @@
                   <tbody>
                     <tr>
                       <td align="right" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:18px;text-align:right;color:#6E6E6E;"><a href="https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3b_de.html" style="color:#6E6E6E;text-decoration:underline;">Im Browser lesen</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:18px;text-align:right;color:#6E6E6E;"><a href="https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3b_de.html" style="color:#6E6E6E;text-decoration:underline;">Im Browser lesen</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -149,7 +149,7 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" target="_blank">
+                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurws" target="_blank">
                                   <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
                                 </a>
                               </td>
@@ -183,8 +183,8 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" target="_blank">
-                                  <img alt="Sommer-Picknick mit dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurws" target="_blank">
+                                  <img alt="goetheanum.tv in der Hängematte am See" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_haengematte.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
                                 </a>
                               </td>
                             </tr>
@@ -219,13 +219,13 @@
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="beides_w3b_de#botschaft">Nur noch heute, 8.&#160;August</div>
+                          <div style="text-wrap:balance" data-edit="sehen_w3b_de#botschaft">Nur noch heute, 8.&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="beides_w3b_de#text">Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen. Jetzt freischalten.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="sehen_w3b_de#text">Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie goetheanum.tv drei Monate lang kostenlos sehen. Jetzt freischalten.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -234,7 +234,9 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Mehr erfahren → </a>
+                                <a href="https://tv-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank">
+                                  <span data-edit="sehen_w3b_de#cta">Mehr erfahren →</span>
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -243,7 +245,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;"><span data-edit="shared#kleinzeile#beides#de">Beide Angebote kombinierbar&#160;·<br />drei Monate kostenlos, danach läuft das Abo regulär weiter, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;"><span data-edit="shared#kleinzeile#sehen#de">Drei Monate kostenlos, danach läuft das Abo regulär weiter&#160;·<br />jederzeit kündbar, ein Klick im Konto&#160;·<br />Aktion bis 8. August 2026.</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/apps/mail-editor/mails/mail_sehen_w3b_en.html
+++ b/apps/mail-editor/mails/mail_sehen_w3b_en.html
@@ -3,7 +3,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head><meta name="robots" content="noindex">
-  <title>Heute läuft das Angebot aus — drei Monate gratis</title>
+  <title>The offer closes today — three months of goetheanum.tv</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -107,8 +107,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#F6F4F2;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Nur noch heute, Samstag, 8. August: drei Monate Goetheanum gratis.</div>
-  <div aria-label="Heute läuft das Angebot aus — drei Monate gratis" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Only today, Saturday 8 August: three months of goetheanum.tv free.</div>
+  <div aria-label="The offer closes today — three months of goetheanum.tv" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F6F4F2;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F4F2" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#F6F4F2;background-color:#F6F4F2;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F4F2;background-color:#F6F4F2;width:100%;">
@@ -121,7 +121,7 @@
                   <tbody>
                     <tr>
                       <td align="right" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:18px;text-align:right;color:#6E6E6E;"><a href="https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3b_de.html" style="color:#6E6E6E;text-decoration:underline;">Im Browser lesen</a></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:18px;text-align:right;color:#6E6E6E;"><a href="https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3b_en.html" style="color:#6E6E6E;text-decoration:underline;">Read in browser</a></div>
                       </td>
                     </tr>
                   </tbody>
@@ -149,7 +149,7 @@
                           <tbody>
                             <tr>
                               <td style="width:119px;">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" target="_blank">
+                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurws" target="_blank">
                                   <img alt="Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/logo_goetheanum.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="119" height="auto" />
                                 </a>
                               </td>
@@ -183,8 +183,8 @@
                           <tbody>
                             <tr>
                               <td style="width:600px;" class="mj-full-width-mobile">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" target="_blank">
-                                  <img alt="Sommer-Picknick mit dem Goetheanum" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_beides_picknick.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurws" target="_blank">
+                                  <img alt="goetheanum.tv in der Hängematte am See" src="https://werkzeuge.goetheanum.ch/apps/mail-editor/assets/hero_sehen_haengematte.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
                                 </a>
                               </td>
                             </tr>
@@ -213,19 +213,19 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 10px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#de">Sommerangebot 2026</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;text-align:left;color:#A95278;"><span data-edit="shared#badge#en">Summer offer 2026</span></div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
                         <div style="font-family:Goetheanum,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:30px;font-weight:700;line-height:35px;text-align:left;color:#232323;">
-                          <div style="text-wrap:balance" data-edit="beides_w3b_de#botschaft">Nur noch heute, 8.&#160;August</div>
+                          <div style="text-wrap:balance" data-edit="sehen_w3b_en#botschaft">Only today, 8&#160;August</div>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 22px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="beides_w3b_de#text">Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen. Jetzt freischalten.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;text-align:left;color:#232323;"><span data-edit="sehen_w3b_en#text">Today, Saturday 8 August, the summer offer closes. Until then you can watch goetheanum.tv free for three months. Unlock it now.</span></div>
                       </td>
                     </tr>
                     <tr>
@@ -234,7 +234,9 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#A95278" role="presentation" style="border:none;border-radius:999px;cursor:auto;mso-padding-alt:15px 30px;background:#A95278;" valign="middle">
-                                <a href="https://global-sommer2026.goetheanum.online?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_noabo" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank"> Mehr erfahren → </a>
+                                <a href="https://tv-en-sommer2026.goetheanum.tv?utm_source=mailing&amp;utm_medium=email&amp;utm_campaign=summer26_trial&amp;utm_content=w3b_nurws" style="display:inline-block;background:#A95278;color:#FFFFFF;font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:15px 30px;mso-padding-alt:0px;border-radius:999px;" target="_blank">
+                                  <span data-edit="sehen_w3b_en#cta">Learn more →</span>
+                                </a>
                               </td>
                             </tr>
                           </tbody>
@@ -243,7 +245,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0 0 14px 0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;"><span data-edit="shared#kleinzeile#beides#de">Beide Angebote kombinierbar&#160;·<br />drei Monate kostenlos, danach läuft das Abo regulär weiter, jederzeit kündbar&#160;·<br />nur bis 8. August 2026.</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:20px;text-align:left;color:#6E6E6E;"><span data-edit="shared#kleinzeile#sehen#en">Three months free, then the subscription continues at the regular price&#160;·<br />cancel anytime with one click in your account&#160;·<br />offer ends 8 August 2026.</span></div>
                       </td>
                     </tr>
                   </tbody>
@@ -267,7 +269,7 @@
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#de">Stimmen und Gesichter der Anthroposophie von heute</span></div>
+                        <div style="font-family:'Source Sans 3',-apple-system,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;text-align:left;color:#8E3F62;"><span data-edit="shared#beweisband#en">Voices and faces of anthroposophy today</span></div>
                       </td>
                     </tr>
                   </tbody>

--- a/services/mailing-sommer2026/AC-AUTOMATION.md
+++ b/services/mailing-sommer2026/AC-AUTOMATION.md
@@ -8,14 +8,24 @@
 
 ---
 
-Baue in ActiveCampaign die Automatisierungen für unser Drei-Wellen-Mailing
-«Sommer-Aktion 2026» (3 Monate gratis: Wochenschrift und/oder goetheanum.tv,
-Frist Samstag, 8. August 2026). Es gibt 20 fertige, versandfähige Mails —
-je Segment die Wellen × DE/EN: NurTV 6, NurWS 6, NoAbo 8 (dort kommt der
-Mini-Reminder w3b dazu); der HTML-Quelltext jeder Mail liegt unter einer
+Baue bzw. aktualisiere in ActiveCampaign die Automatisierungen für unser
+**Vier-Wellen-Mailing** «Sommer-Aktion 2026» (3 Monate gratis: Wochenschrift
+und/oder goetheanum.tv, Frist Samstag, 8. August 2026). Es gibt **24 fertige,
+versandfähige Mails** — je Gruppe die vier Wellen × DE/EN (**w1** Ankündigung,
+**w2** Erinnerung, **w3** Vorabend-Frist «morgen», **w3b** Frist-Tag «heute»):
+Lesen 8, Sehen 8, Beides 8. Der HTML-Quelltext jeder Mail liegt unter einer
 festen URL (Tabelle unten). Orientiere dich am Stil der bestehenden
-Automatisierungen GTV26 (DE /builder/104, EN /builder/107) — aber baue neu
-nach dieser Struktur. Ändere nichts an den bestehenden Automatisierungen.
+GTV26-Automatisierungen (DE /builder/104, EN /builder/107) — je Sprache eine
+eigene Automatisierung. Ändere nichts an GTV26.
+
+**Zwei Aufträge in einem:**
+- **Gruppe Lesen (DE + EN):** die Automatisierungen bestehen bereits →
+  **aktualisieren**: die neuen Versanddaten (unten) eintragen, jede Mail frisch
+  aus ihrer URL neu einfügen (die Copy hat sich geändert), und die **neue vierte
+  Welle w3b (Samstag)** als Schritt anhängen (Conversion-Check davor, siehe unten).
+- **Gruppen Sehen und Beides (DE + EN):** **neu aufbauen** nach der Struktur unten.
+
+Macht **sechs Automatisierungen** (drei Gruppen × zwei Sprachen).
 
 ## Deine zwei Fragen, beantwortet
 
@@ -32,69 +42,53 @@ nach dieser Struktur. Ändere nichts an den bestehenden Automatisierungen.
   vermutlich «GTV Abonnent»; wie das Wochenschrift-Pendant heisst, weiss ich
   nicht sicher). Notiere mir am Ende, welche Tags du verwendet hast.
 
-## Struktur: drei Automatisierungen (nicht eine)
+## Struktur: sechs Automatisierungen (je Gruppe × Sprache)
 
-Eine je Segment — **S26 · NurTV→WS**, **S26 · NurWS→TV**, **S26 · NoAbo** —
-mit dem Sprach-Split jeweils innen. Gründe: jedes Segment hat ein eigenes
-Conversion-Ziel (anderes Abo-Tag), NoAbo hat eine Welle mehr (w3b), und das
-Reporting bleibt je Segment lesbar.
+Je Gruppe und Sprache eine eigene Automatisierung — **S26 · Lesen · DE/EN**,
+**S26 · Sehen · DE/EN**, **S26 · Beides · DE/EN** — wie bei GTV26 (getrennte
+DE/EN-Builder). Gründe: jede Gruppe hat ein eigenes Conversion-Ziel, das
+Reporting bleibt je Gruppe/Sprache lesbar, und Testversand/Go-Live lassen sich
+je Automatisierung einzeln freigeben. **Lesen DE/EN** existieren schon → nur
+aktualisieren; **Sehen/Beides DE/EN** neu bauen.
 
 ### Aufbau jeder Automatisierung
 
-1. **Start-Trigger:** Tag **«S26-Start»** wird hinzugefügt (einmaliger Lauf).
-   Der Bestand tritt NICHT über die Listen-Anmeldung ein (die feuert nur bei
-   Neuanmeldungen!), sondern indem wir das Tag per Bulk auf den Adressstamm
-   setzen — erst wenn alle drei Automatisierungen aktiv sind.
-2. **Hygiene-Filter** direkt nach dem Start: Wer in den letzten 12 Monaten
-   keine Kampagne geöffnet hat → Automatisierung beenden (Zustellbarkeit).
-3. **Segment-Weiche** (macht die drei Automatisierungen überschneidungsfrei):
-   - NurTV→WS: If/Else «hat GTV-Tag UND hat NICHT WS-Tag» — No → Ende
-   - NurWS→TV: If/Else «hat WS-Tag UND hat NICHT GTV-Tag» — No → Ende
-   - NoAbo: If/Else «hat WEDER GTV- NOCH WS-Tag» — No → Ende
-4. **Sprach-Split:** If/Else «ist in Liste ‹Special Offers›» → EN-Zweig,
-   sonst DE-Zweig. Beide Zweige sind strukturell identisch, nur mit den
-   jeweiligen Mails.
-5. **Wellen-Drip je Sprach-Zweig** (Zeiten = Schweizer Zeit):
-   - **Warten bis Di 14.07.2026, 9.30 Uhr** → Mail **w1** senden
-     (Predictive Sending: ja, wie bei GTV26).
-   - **Warten bis Do 23.07.2026, 9.30 Uhr** → **Conversion-Check**: hat der
-     Kontakt inzwischen das Ziel-Abo-Tag? Ja → Ende. Nein → Mail **w2**
-     (Predictive: ja).
-   - **Warten bis Do 06.08.2026, 9.30 Uhr** → Conversion-Check (wie oben) →
-     **Öffner-Split**: «hat w1 ODER w2 dieser Automatisierung geöffnet?»
-     - Ja → Mail **w3** mit dem **Standard-Betreff**
-     - Nein → Mail **w3** mit dem **Alt-Betreff** (identisches HTML, nur die
-       Betreffzeile anders — zwei separate E-Mail-Schritte mit derselben
-       HTML-Quelle)
-     - *Bauweg:* If/Else nutzt den Segment-Builder; das ODER geht dort als
-       «match any» über zwei «hat geöffnet»-Bedingungen (Kategorie Actions).
-       **Plan B**, falls das ODER über zwei konkrete Automation-Mails nicht
-       sauber wählbar ist: zwei verschachtelte If/Else — «hat w1 geöffnet?»
-       Ja → Standard; Nein → «hat w2 geöffnet?» Ja → Standard; Nein →
-       Alt-Betreff. Gleiches Ergebnis, ganz ohne ODER.
-     - **Predictive Sending hier AUS** (fixer Versand): Predictive streut bis
-       24 h — die letzte Erinnerung darf nicht in den Mini-Reminder- oder
-       Frist-Tag hineinrutschen.
-   - **Nur S26 · NoAbo:** **Warten bis Fr 07.08.2026, 9.30 Uhr** → Bedingung:
-     «hat in w1–w3 geklickt UND hat kein Abo-Tag» → Mail **w3b**
-     (Mini-Reminder, nur an unentschlossene Klicker; Predictive AUS).
-     Alle anderen → Ende.
-     - *Bauweg:* Bedingungsgruppe (match any) mit drei «hat Link
-       geklickt»-Bedingungen, per UND verknüpft mit «hat kein Abo-Tag»
-       (UND und ODER nie in derselben Gruppe — zweite Gruppe verwenden).
-       **Plan B:** eine kleine Hilfs-Automatisierung mit Start-Trigger
-       «klickt einen Link in einer E-Mail» (beschränkt auf die
-       S26-NoAbo-Mails), die nur das Tag **«S26-geklickt»** setzt und endet;
-       die w3b-Bedingung wird dann schlicht «hat Tag S26-geklickt UND hat
-       kein Abo-Tag».
-6. **Conversion-Ziel je Automatisierung** (als Goal-Schritt ans Ende, «Ende
-   der Automatisierung», damit Konvertierte sofort aussteigen und AC die
-   Conversion zählt):
-   - S26 · NurTV→WS: WS-Abo-Tag gesetzt
-   - S26 · NurWS→TV: GTV-Abo-Tag gesetzt
-   - S26 · NoAbo: eines der beiden Abo-Tags gesetzt — Goals nutzen denselben
-     Segment-Builder, das ODER ist also eine Bedingungsgruppe mit
-     «match any» über die zwei Tag-Bedingungen.
+1. **Start-Trigger:** Tag **«S26-Start»** (einmaliger Lauf; per Bulk auf den
+   Adressstamm, erst wenn **alle sechs** aktiv sind — die Listen-Anmeldung feuert
+   nur bei Neuanmeldungen, deshalb Bulk-Tag als Eintritt).
+2. **Hygiene-Filter:** keine Kampagne in den letzten 12 Monaten geöffnet → Ende.
+3. **Sprach-Weiche:** ist in Liste «Sonderangebote» (DE) bzw. «Special Offers»
+   (EN)? Nein → Ende. (Jede Automatisierung trägt nur EINE Sprache.)
+4. **Gruppen-Weiche** (macht die Automatisierungen überschneidungsfrei):
+   - Lesen: «hat GTV-Tag UND NICHT WS-Tag» — Nein → Ende
+   - Sehen: «hat WS-Tag UND NICHT GTV-Tag» — Nein → Ende
+   - Beides: «hat WEDER GTV- NOCH WS-Tag» — Nein → Ende
+5. **Wellen-Drip** (Zeiten = Schweizer Zeit):
+   - **Warten bis Do 16.07.2026, 9.30 Uhr** → Mail **w1** (Predictive Sending: ja).
+   - **Warten bis Do 30.07.2026, 9.30 Uhr** → **Conversion-Check** (hat der
+     Kontakt das Ziel-Abo-Tag? Ja → Ende) → Mail **w2** (Predictive: ja).
+   - **Warten bis Fr 07.08.2026, 18.00 Uhr** → Conversion-Check → **Öffner-Split**:
+     «hat w1 ODER w2 geöffnet?»
+     - Ja → **w3** mit **Standard-Betreff**
+     - Nein → **w3** mit **Alt-Betreff** (identisches HTML, nur die Betreffzeile —
+       zwei E-Mail-Schritte mit derselben HTML-Quelle)
+     - *Bauweg:* «match any» über zwei «hat geöffnet»-Bedingungen. **Plan B:**
+       zwei verschachtelte If/Else («w1 geöffnet?» → sonst «w2 geöffnet?» → sonst
+       Alt-Betreff).
+     - **Predictive AUS** (fixer Freitagabend-Versand — der Rahmen «morgen läuft
+       es aus» darf nicht in den Frist-Tag verrutschen).
+   - **Warten bis Sa 08.08.2026, 10.00 Uhr** → Conversion-Check → Mail **w3b**
+     an **alle noch nicht Konvertierten** (Standard-Betreff, Rahmen «heute läuft
+     es aus»). **Predictive AUS.**
+6. **Conversion-Ziel** (Goal am Ende, «Ende der Automatisierung», damit
+   Konvertierte sofort aussteigen und AC zählt):
+   - Lesen: WS-Abo-Tag gesetzt · Sehen: GTV-Abo-Tag gesetzt · Beides: eines der
+     beiden Abo-Tags (Bedingungsgruppe «match any» über die zwei Tag-Bedingungen).
+
+**Neu gegenüber der alten Struktur:** w3b (Samstag) geht jetzt an **alle** noch
+nicht Konvertierten **jeder** Gruppe — nicht mehr nur an NoAbo-Klicker. GF-Prinzip:
+keine Nacht zwischen letztem Ruf (Fr abend) und Frist (Sa). Die frühere
+Klick-Bedingung/Hilfsautomatisierung für w3b **entfällt** damit.
 
 ## Die Mails (HTML per URL abholen)
 
@@ -120,60 +114,72 @@ Alle Links tragen zudem
 
 | Welle | Sprache | Betreff | Alt-Betreff (nur w3-Zweig «Nicht-Öffner») | utm_content | HTML-Quelle |
 |---|---|---|---|---|---|
-| w1 | DE | Denken, das über die Woche hinausreicht — 3 Monate gratis | — | `w1_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w1_de.html |
-| w1 | EN | Thinking that reaches beyond the week — 3 months free | — | `w1_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w1_en.html |
-| w2 | DE | Drei Monate mitlesen, danach entscheiden Sie. | — | `w2_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w2_de.html |
-| w2 | EN | Three months of reading — then you decide. | — | `w2_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w2_en.html |
-| w3 | DE | Bis Samstag: drei Monate gratis lesen — dann schliesst die Aktion | Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen. | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_de.html |
-| w3 | EN | Until Saturday: three months of the weekly, free — then the offer closes | On Saturday your free trial of the weekly ends — if you still want it. | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_en.html |
+| w1 | DE | Ihr freier Zugang zur Wochenschrift Das Goetheanum | — | `w1_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w1_de.html |
+| w1 | EN | Your free access to the weekly Das Goetheanum | — | `w1_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w1_en.html |
+| w2 | DE | Ihr kostenloser Zugang – noch bis zum 8. August | — | `w2_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w2_de.html |
+| w2 | EN | Your free access — still open until 8 August | — | `w2_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w2_en.html |
+| w3 | DE | Nur noch bis morgen, Samstag: drei Monate gratis lesen | Bis morgen: drei Monate gratis lesen — jetzt starten | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_de.html |
+| w3 | EN | Only until tomorrow, Saturday: three months free | Until tomorrow: three months of free reading — start now | `w3_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3_en.html |
+| w3b | DE | Heute läuft das Angebot aus — drei Monate gratis lesen | — | `w3b_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3b_de.html |
+| w3b | EN | The offer closes today — three months of free reading | — | `w3b_nurtv` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_lesen_w3b_en.html |
 
 ### S26 · NurWS→TV (Angebot: goetheanum.tv sehen)
 
 | Welle | Sprache | Betreff | Alt-Betreff (nur w3-Zweig «Nicht-Öffner») | utm_content | HTML-Quelle |
 |---|---|---|---|---|---|
-| w1 | DE | Sehen, wie Menschen laut denken — 3 Monate gratis | — | `w1_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w1_de.html |
-| w1 | EN | Watch people think out loud — 3 months free | — | `w1_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w1_en.html |
-| w2 | DE | Ihr Sommer hat noch Abende frei | — | `w2_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w2_de.html |
-| w2 | EN | Your summer still has evenings free | — | `w2_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w2_en.html |
-| w3 | DE | Bis Samstag: drei Monate goetheanum.tv gratis — dann schliesst die Aktion | Am Samstag endet Ihr Gratis-Test von goetheanum.tv — falls Sie ihn noch wollen. | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_de.html |
-| w3 | EN | Until Saturday: three months of goetheanum.tv, free — then the offer closes | On Saturday your free trial of goetheanum.tv ends — if you still want it. | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_en.html |
+| w1 | DE | Ihr freier Zugang zu goetheanum.tv | — | `w1_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w1_de.html |
+| w1 | EN | Your free access to goetheanum.tv | — | `w1_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w1_en.html |
+| w2 | DE | Ihr kostenloser Zugang – noch bis zum 8. August | — | `w2_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w2_de.html |
+| w2 | EN | Your free access — still open until 8 August | — | `w2_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w2_en.html |
+| w3 | DE | Nur noch bis morgen, Samstag: drei Monate goetheanum.tv gratis | Bis morgen: drei Monate goetheanum.tv gratis — jetzt starten | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_de.html |
+| w3 | EN | Only until tomorrow, Saturday: three months of goetheanum.tv | Until tomorrow: three months of goetheanum.tv free — start now | `w3_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3_en.html |
+| w3b | DE | Heute läuft das Angebot aus — drei Monate goetheanum.tv gratis | — | `w3b_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3b_de.html |
+| w3b | EN | The offer closes today — three months of goetheanum.tv | — | `w3b_nurws` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_sehen_w3b_en.html |
 
 ### S26 · NoAbo (beide Angebote; jede Mail führt mit einem Button zur Übersicht)
 
 | Welle | Sprache | Betreff | Alt-Betreff (nur w3-Zweig «Nicht-Öffner») | utm_content | HTML-Quelle |
 |---|---|---|---|---|---|
-| w1 | DE | Ein Sommer mit dem Goetheanum — 3 Monate gratis | — | `w1_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w1_de.html |
-| w1 | EN | A summer with the Goetheanum — 3 months free | — | `w1_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w1_en.html |
-| w2 | DE | Lesen, sehen — oder gleich beides | — | `w2_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w2_de.html |
-| w2 | EN | Read, watch — or simply both | — | `w2_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w2_en.html |
-| w3 | DE | Bis Samstag: drei Monate Goetheanum gratis — dann schliesst die Aktion | Am Samstag endet Ihr Gratis-Test — falls Sie ihn noch wollen. | `w3_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3_de.html |
-| w3 | EN | Until Saturday: three months of the Goetheanum, free — then the offer closes | On Saturday your free trial ends — if you still want it. | `w3_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3_en.html |
-| w3b | DE | Morgen schliesst die Aktion | — | `w3b_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3b_de.html |
-| w3b | EN | Tomorrow the offer closes | — | `w3b_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3b_en.html |
+| w1 | DE | Ihr freier Zugang zum Goetheanum – lesen und sehen | — | `w1_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w1_de.html |
+| w1 | EN | Your free access to the Goetheanum – read and watch | — | `w1_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w1_en.html |
+| w2 | DE | Ihr kostenloser Zugang – noch bis zum 8. August | — | `w2_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w2_de.html |
+| w2 | EN | Your free access — still open until 8 August | — | `w2_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w2_en.html |
+| w3 | DE | Nur noch bis morgen, Samstag: drei Monate gratis | Bis morgen: drei Monate gratis lesen oder sehen — jetzt starten | `w3_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3_de.html |
+| w3 | EN | Only until tomorrow, Saturday: three months free | Until tomorrow: three months free to read or watch — start now | `w3_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3_en.html |
+| w3b | DE | Heute läuft das Angebot aus — drei Monate gratis | — | `w3b_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3b_de.html |
+| w3b | EN | The offer closes today — three months free | — | `w3b_noabo` | https://werkzeuge.goetheanum.ch/apps/mail-editor/mails/mail_beides_w3b_en.html |
 
-Macht **26 E-Mail-Schritte** insgesamt: 20 Mails, wobei die 6 w3-Mails je zweimal eingehängt werden (Standard- und Alt-Betreff, gleiches HTML).
+Macht **30 E-Mail-Schritte** insgesamt: 24 Mails, wobei die 6 w3-Mails je zweimal eingehängt werden (Standard- und Alt-Betreff, gleiches HTML).
 <!-- TABELLEN:END -->
 
 ## Bevor etwas live geht — Checkliste
 
 1. Exakte Tag-Namen (GTV-Abo, WS-Abo) und Listen-Namen verifizieren und mir
    nennen.
-2. Von jeder Mail-Vorlage einen **Testversand an philipp@saetzerei.com**:
-   Bilder laden, Betreff/Preheader stimmen, Abmeldelink funktioniert, die
-   Button-Links tragen `utm_campaign=summer26_trial` und exakt das
-   `utm_content` aus der Tabelle.
-3. Alle drei Automatisierungen **aktiv schalten, BEVOR** das Tag «S26-Start»
-   per Bulk gesetzt wird. Das Bulk-Setzen selbst NICHT ausführen — nur
-   vorbereiten und mir Bescheid geben. Zweite Voraussetzung vor dem Start:
-   der utm-Weitergabe-Fix auf der Übersichts-Landingpage muss live sein
-   (separater Zusatz-Auftrag) — vorher wäre die NoAbo-Attribution blind.
-4. Zum Insight «12,5 % Abmelderate bei GTV26 Mail 3»: Unsere w3 ist ebenfalls
-   eine Frist-Mail. Die Entschärfung ist eingebaut (w3b geht nur an Klicker,
-   Nicht-Öffner bekommen w3 nur mit anderem Betreff) — bitte keine
-   zusätzliche Dringlichkeit hineintexten und nichts am Mail-Inhalt ändern.
+2. **Testversand ALLER 24 Mails — sobald alle sechs Automatisierungen fertig
+   gebaut sind** (vor dem Aktivschalten). Schicke jede der 24 Vorlagen **je
+   einmal** an diese vier Adressen:
+   - `francisca.devries@dasgoetheanum.com`
+   - `louis.defeche@goetheanum.ch`
+   - `nicolas.prestifilippo@goetheanum.ch`
+   - `philipp@saetzerei.com`
+
+   Prüfe je Mail: Bilder laden, Betreff/Preheader stimmen, **genau EIN Footer**
+   (der AC-eigene — die HTML tragen keinen), Abmeldelink funktioniert, der
+   Button trägt `utm_campaign=summer26_trial` und exakt das `utm_content` aus
+   der Tabelle. Sind alle drei Gruppen × zwei Sprachen × vier Wellen (= 24)
+   raus, melde mir kurz «alle 24 getestet».
+3. Alle sechs Automatisierungen **aktiv schalten, BEVOR** «S26-Start» per Bulk
+   gesetzt wird. Das Bulk-Setzen selbst NICHT ausführen — nur vorbereiten und
+   mir Bescheid geben. Zweite Voraussetzung: der utm-Weitergabe-Fix auf der
+   Übersichts-Landingpage muss live sein — vorher wäre die NoAbo-Attribution
+   blind.
+4. Zum Insight «12,5 % Abmelderate bei GTV26 Mail 3»: w3 und w3b sind Frist-
+   Mails. Die Entschärfung sitzt im Text (kein Drohton, aufs Datum geankert)
+   und im Öffner-Split vor w3 (Nicht-Öffner bekommen nur einen anderen Betreff)
+   — bitte keine zusätzliche Dringlichkeit hineintexten, nichts am Inhalt ändern.
 5. Falls etwas nicht wie beschrieben machbar ist, nicht improvisieren — kurz
-   melden, was der Builder anbietet, dann entscheiden wir. Für die drei
-   bekannten Verifikationspunkte (Öffner-ODER vor w3, w3b-Klick-Bedingung,
-   NoAbo-OR-Goal) stehen die Bauwege und Plan-B-Varianten direkt bei den
-   jeweiligen Schritten in der Struktur oben. Melde mir am Ende kurz,
-   welcher Weg es jeweils geworden ist (Plan A oder B).
+   melden, was der Builder anbietet, dann entscheiden wir. Für die
+   Verifikationspunkte (Öffner-ODER vor w3, «match any»-Goal bei Beides) stehen
+   die Bauwege und Plan-B-Varianten oben. Melde am Ende, welcher Weg es jeweils
+   wurde (Plan A oder B).

--- a/services/mailing-sommer2026/CLAUDE.md
+++ b/services/mailing-sommer2026/CLAUDE.md
@@ -38,6 +38,7 @@ HTML-Text in der Mail-Grundschrift — beide so beschlossen im Gegenlesen (Komme
 - **lesen** → Segment `nurtv` (Cross-sell WS): w1 garten · w2 abendlicht · w3 see
 - **sehen** → Segment `nurws` (Cross-sell TV): w1 pergola · w2 licht · w3 feuer
 - **beides** → Segment `noabo` (kein Abo): w1 abendlicht · w2 vor-dem-bau · w3 picknick · w3b picknick
+- **w3b jetzt für ALLE Gruppen** (Samstag-Frist-Mail, Entscheid 14.7.): lesen/sehen erhielten w3b (Bild = w3). Termine: w1 16.7., w2 30.7., w3 Fr 7.8. 18 Uhr («morgen»), w3b Sa 8.8. 10 Uhr («heute»). w3 = Öffner-Split (Alt-Betreff), w3b = an alle Nicht-Konvertierten.
 Auswahl (bestätigt): lesen=garten · sehen=pergola · beides=abendlicht. Motive in `assets/motive/` (8 JPGs).
 Betreff-Alternativen (`wellen.*.alt`) = Munition für AC-Split (Nicht-Öffner).
 

--- a/services/mailing-sommer2026/config.json
+++ b/services/mailing-sommer2026/config.json
@@ -47,20 +47,21 @@
   "wellen": {
     "w1": {
       "label": "Ankündigung",
-      "versand": "2026-07-14T09:30:00+02:00"
+      "versand": "2026-07-16T09:30:00+02:00"
     },
     "w2": {
       "label": "Aktualisierung",
-      "versand": "2026-07-23T09:30:00+02:00"
+      "versand": "2026-07-30T09:30:00+02:00"
     },
     "w3": {
-      "label": "Letzte Erinnerung",
-      "versand": "2026-08-06T09:30:00+02:00"
+      "label": "Letzte Erinnerung (Vorabend)",
+      "versand": "2026-08-07T18:00:00+02:00",
+      "_hinweis": "Freitagabend, Rahmen ‹morgen läuft es aus›."
     },
     "w3b": {
-      "label": "Mini-Reminder",
-      "versand": "2026-08-07T09:30:00+02:00",
-      "nur": "klicker_ohne_anmeldung"
+      "label": "Frist-Tag (Samstag)",
+      "versand": "2026-08-08T10:00:00+02:00",
+      "_hinweis": "Samstag = Frist-Tag, Rahmen ‹heute läuft es aus›. Für ALLE Gruppen (nicht mehr nur Klicker) — GF-Prinzip: keine Nacht zwischen letztem Ruf und Frist."
     }
   },
   "segmente": {

--- a/services/mailing-sommer2026/heroes.json
+++ b/services/mailing-sommer2026/heroes.json
@@ -204,12 +204,14 @@
     "nurtv": {
       "w1": "lesen/garten",
       "w2": "lesen/abendlicht",
-      "w3": "lesen/see"
+      "w3": "lesen/see",
+      "w3b": "lesen/see"
     },
     "nurws": {
       "w1": "sehen/pergola",
       "w2": "sehen/terrasse",
-      "w3": "sehen/haengematte"
+      "w3": "sehen/haengematte",
+      "w3b": "sehen/haengematte"
     },
     "noabo": {
       "w1": "beides/abendlicht",
@@ -254,18 +256,34 @@
       },
       "w3": {
         "de": {
-          "betreff": "Letzte Erinnerung: nur noch bis Samstag, 8. August",
-          "botschaft": "Nur noch bis Samstag, 8. August",
-          "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift ‹Das Goetheanum› – auf Papier und/oder online – erhalten, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.",
-          "alt": "Am Samstag endet Ihr Gratis-Test der Wochenschrift — falls Sie ihn noch wollen.",
-          "preheader": "Das Ausnahmeangebot von drei kostenlosen Monaten läuft am Samstag, 8. August, aus."
+          "betreff": "Nur noch bis morgen, Samstag: drei Monate gratis lesen",
+          "botschaft": "Nur noch bis morgen, 8. August",
+          "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zur Wochenschrift ‹Das Goetheanum› – auf Papier oder online – erhalten, morgen, am Samstag, 8. August, endet. Jetzt freischalten.",
+          "alt": "Bis morgen: drei Monate gratis lesen — jetzt starten",
+          "preheader": "Das Angebot für drei kostenlose Monate ‹Das Goetheanum› läuft morgen, am Samstag, 8. August, aus."
         },
         "en": {
-          "betreff": "Last reminder: only until Saturday, 8 August",
-          "botschaft": "Only until Saturday, 8 August",
-          "text": "A reminder that the summer offer — three months of free access to the weekly ‹Das Goetheanum›, on paper and/or online — ends on Saturday, 8 August. Until then, you can unlock it.",
-          "alt": "On Saturday your free trial of the weekly ends — if you still want it.",
-          "preheader": "The exceptional offer of three free months ends on Saturday, 8 August."
+          "betreff": "Only until tomorrow, Saturday: three months free",
+          "botschaft": "Only until tomorrow, 8 August",
+          "text": "A reminder that the summer offer — three months of free access to the weekly ‹Das Goetheanum›, on paper or online — ends tomorrow, Saturday 8 August. Unlock it now.",
+          "alt": "Until tomorrow: three months of free reading — start now",
+          "preheader": "The offer of three free months of ‹Das Goetheanum› ends tomorrow, Saturday 8 August."
+        }
+      },
+      "w3b": {
+        "de": {
+          "betreff": "Heute läuft das Angebot aus — drei Monate gratis lesen",
+          "botschaft": "Nur noch heute, 8. August",
+          "text": "Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie die Wochenschrift ‹Das Goetheanum› drei Monate lang kostenlos lesen. Jetzt freischalten.",
+          "alt": "Heute letzter Tag: drei Monate gratis lesen — jetzt starten",
+          "preheader": "Nur noch heute, Samstag, 8. August: drei Monate ‹Das Goetheanum› gratis."
+        },
+        "en": {
+          "betreff": "The offer closes today — three months of free reading",
+          "botschaft": "Only today, 8 August",
+          "text": "Today, Saturday 8 August, the summer offer closes. Until then you can read the weekly ‹Das Goetheanum› free for three months. Unlock it now.",
+          "alt": "Last day today: three months of free reading — start now",
+          "preheader": "Only today, Saturday 8 August: three months of ‹Das Goetheanum› free."
         }
       }
     },
@@ -304,18 +322,34 @@
       },
       "w3": {
         "de": {
-          "betreff": "Letzte Erinnerung: nur noch bis Samstag, 8. August",
-          "botschaft": "Nur noch bis Samstag, 8. August",
-          "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zu goetheanum.tv erhalten, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.",
-          "alt": "Am Samstag endet Ihr Gratis-Test von goetheanum.tv — falls Sie ihn noch wollen.",
-          "preheader": "Das Angebot für drei kostenlose Monate goetheanum.tv läuft am Samstag, 8. August, aus."
+          "betreff": "Nur noch bis morgen, Samstag: drei Monate goetheanum.tv gratis",
+          "botschaft": "Nur noch bis morgen, 8. August",
+          "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie drei Monate lang kostenlosen Zugang zu goetheanum.tv erhalten, morgen, am Samstag, 8. August, endet. Jetzt freischalten.",
+          "alt": "Bis morgen: drei Monate goetheanum.tv gratis — jetzt starten",
+          "preheader": "Das Angebot für drei kostenlose Monate goetheanum.tv läuft morgen, am Samstag, 8. August, aus."
         },
         "en": {
-          "betreff": "Last reminder: only until Saturday, 8 August",
-          "botschaft": "Only until Saturday, 8 August",
-          "text": "A reminder that the summer offer — three months of free access to goetheanum.tv — ends on Saturday, 8 August. Until then, you can unlock it.",
-          "alt": "On Saturday your free trial of goetheanum.tv ends — if you still want it.",
-          "preheader": "The offer of three free months of goetheanum.tv ends on Saturday, 8 August."
+          "betreff": "Only until tomorrow, Saturday: three months of goetheanum.tv",
+          "botschaft": "Only until tomorrow, 8 August",
+          "text": "A reminder that the summer offer — three months of free access to goetheanum.tv — ends tomorrow, Saturday 8 August. Unlock it now.",
+          "alt": "Until tomorrow: three months of goetheanum.tv free — start now",
+          "preheader": "The offer of three free months of goetheanum.tv ends tomorrow, Saturday 8 August."
+        }
+      },
+      "w3b": {
+        "de": {
+          "betreff": "Heute läuft das Angebot aus — drei Monate goetheanum.tv gratis",
+          "botschaft": "Nur noch heute, 8. August",
+          "text": "Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie goetheanum.tv drei Monate lang kostenlos sehen. Jetzt freischalten.",
+          "alt": "Heute letzter Tag: drei Monate goetheanum.tv gratis — jetzt starten",
+          "preheader": "Nur noch heute, Samstag, 8. August: drei Monate goetheanum.tv gratis."
+        },
+        "en": {
+          "betreff": "The offer closes today — three months of goetheanum.tv",
+          "botschaft": "Only today, 8 August",
+          "text": "Today, Saturday 8 August, the summer offer closes. Until then you can watch goetheanum.tv free for three months. Unlock it now.",
+          "alt": "Last day today: three months of goetheanum.tv free — start now",
+          "preheader": "Only today, Saturday 8 August: three months of goetheanum.tv free."
         }
       }
     },
@@ -354,34 +388,34 @@
       },
       "w3": {
         "de": {
-          "betreff": "Letzte Erinnerung: nur noch bis Samstag, 8. August",
-          "botschaft": "Nur noch bis Samstag, 8. August",
-          "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen, am Samstag, 8. August, endet. Bis dahin können Sie es freischalten.",
-          "alt": "Am Samstag endet Ihr Gratis-Test — falls Sie ihn noch wollen.",
-          "preheader": "Drei Monate lesen und/oder sehen, kostenlos – am Samstag, 8. August, läuft das Angebot aus."
+          "betreff": "Nur noch bis morgen, Samstag: drei Monate gratis",
+          "botschaft": "Nur noch bis morgen, 8. August",
+          "text": "Wir möchten Sie daran erinnern, dass das Sommerangebot, mit dem Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen, morgen, am Samstag, 8. August, endet. Jetzt freischalten.",
+          "alt": "Bis morgen: drei Monate gratis lesen oder sehen — jetzt starten",
+          "preheader": "Drei Monate lesen und/oder sehen, kostenlos – morgen, am Samstag, 8. August, läuft das Angebot aus."
         },
         "en": {
-          "betreff": "Last reminder: only until Saturday, 8 August",
-          "botschaft": "Only until Saturday, 8 August",
-          "text": "A reminder that the summer offer — three months of free access to the Goetheanum, to read and/or watch — ends on Saturday, 8 August. Until then, you can unlock it.",
-          "alt": "On Saturday your free trial ends — if you still want it.",
-          "preheader": "Three months of reading and/or watching, free – the offer ends on Saturday, 8 August."
+          "betreff": "Only until tomorrow, Saturday: three months free",
+          "botschaft": "Only until tomorrow, 8 August",
+          "text": "A reminder that the summer offer — three months of free access to the Goetheanum, to read and/or watch — ends tomorrow, Saturday 8 August. Unlock it now.",
+          "alt": "Until tomorrow: three months free to read or watch — start now",
+          "preheader": "Three months of reading and/or watching, free – the offer ends tomorrow, Saturday 8 August."
         }
       },
       "w3b": {
         "de": {
-          "betreff": "Morgen läuft das Angebot aus",
-          "botschaft": "Nur noch bis morgen, 8. August",
-          "text": "Morgen, am 8. August, endet das Sommerangebot. Bis dahin können Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen. Jetzt freischalten.",
-          "alt": "Bis morgen: Ihre drei Gratis-Monate — falls Sie sie noch wollen.",
-          "preheader": "Drei Monate Goetheanum, kostenlos – nur noch bis morgen, Samstag, 8. August."
+          "betreff": "Heute läuft das Angebot aus — drei Monate gratis",
+          "botschaft": "Nur noch heute, 8. August",
+          "text": "Heute, am Samstag, 8. August, läuft das Sommerangebot aus. Bis dahin können Sie das Goetheanum drei Monate lang kostenlos lesen und/oder sehen. Jetzt freischalten.",
+          "alt": "Heute letzter Tag: drei Monate gratis — jetzt starten",
+          "preheader": "Nur noch heute, Samstag, 8. August: drei Monate Goetheanum gratis."
         },
         "en": {
-          "betreff": "The offer closes tomorrow",
-          "botschaft": "Only until tomorrow, 8 August",
-          "text": "Tomorrow, 8 August, the summer offer closes. Until then you can read and/or watch the Goetheanum free for three months. Unlock it now.",
-          "alt": "Until tomorrow: your three free months — if you still want them.",
-          "preheader": "Three months of the Goetheanum, free – only until tomorrow, Saturday 8 August."
+          "betreff": "The offer closes today — three months free",
+          "botschaft": "Only today, 8 August",
+          "text": "Today, Saturday 8 August, the summer offer closes. Until then you can read and/or watch the Goetheanum free for three months. Unlock it now.",
+          "alt": "Last day today: three months free — start now",
+          "preheader": "Only today, Saturday 8 August: three months of the Goetheanum free."
         }
       }
     }


### PR DESCRIPTION
Umsetzung des GF-Feedbacks (Frist-Missverständnis + ≤24h-Rhythmus) und der Termin-Entscheide.

**Neuer Takt (`config.json`):** w1 **16.7.**, w2 **30.7.**, w3 **Fr 7.8. 18 Uhr**, w3b **Sa 8.8. 10 Uhr**.
- **w3** = Vorabend, Rahmen «morgen läuft es aus» (Öffner-Split → Alt-Betreff für Nicht-Öffner).
- **w3b** = Frist-Tag Samstag, Rahmen «heute läuft es aus» — **jetzt für ALLE Gruppen** (lesen/sehen neu angelegt, Bild wie w3), an **alle Nicht-Konvertierten** statt nur NoAbo-Klicker. GF-Prinzip: keine Nacht zwischen letztem Ruf und Frist.

**Alt-Betreffe aktiv** («… jetzt starten») statt passiv («falls Sie ihn noch wollen») — behebt den GF-Fund: «*endet Ihr Gratis-Test*» las sich als «läuft von selbst aus → ich tue nichts».

**Copy:** DE optimiert, **EN frisch übersetzt und vollständig** (24 Mails, Feldabgleich ohne Lücken, EN ≠ DE).

**AC-Prompt (`AC-AUTOMATION.md`):** sechs Automatisierungen (Gruppe × Sprache), vier Wellen, neue Daten, w3b generalisiert; **Lesen = Aktualisierung**, **Sehen/Beides = Neuaufbau**; **Testversand ALLER 24 Mails** an vier Adressen, sobald alle sechs Automatisierungen fertig sind. Mail-Tabelle aus `heroes.json` regeneriert.

typo-check + ds-lint grün. 24 URLs bauen sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_