### PR TITLE
SessionStart-Hook: frische Claude-Code-Sessions sofort startklar

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# =============================================================================
+# SessionStart-Hook · Goetheanum-Werkzeuge
+# -----------------------------------------------------------------------------
+# Macht jede frische Claude-Code-Session sofort startklar – vor allem im Web
+# (claude.ai/code), wo das Repo frisch geklont ist:
+#
+#   · Aktiviert den Prüf-Hook (git core.hooksPath tools/hooks). Danach laufen
+#     tools/typo-check.py (Sprache) UND tools/ds-lint.py (Gestalt) bei JEDEM
+#     Commit – genau wie CLAUDE.md verlangt. Diese Einstellung wohnt je
+#     Arbeitskopie und wird NICHT mitversioniert, muss also je Session gesetzt
+#     werden.
+#
+# Keine Installationen nötig: die Prüfmaschinen sind reines python3
+# (Standardbibliothek). Der Schritt ist idempotent und harmlos – auch lokal.
+# =============================================================================
+set -euo pipefail
+cd "${CLAUDE_PROJECT_DIR:-.}"
+
+# 1) Hausregeln beim Commit erzwingen.
+git config core.hooksPath tools/hooks
+chmod +x tools/hooks/pre-commit 2>/dev/null || true
+
+# 2) Kurzer Selbsttest – laufen die Prüfmaschinen? (informativ, nie blockierend)
+if command -v python3 >/dev/null 2>&1; then
+  echo "Goetheanum-Werkzeuge bereit: Prüf-Hook aktiv – typo-check + ds-lint prüfen jeden Commit. Neue Seiten aus design-system/starter.html bauen, Eintrag in tools.json."
+else
+  echo "Hinweis: python3 nicht gefunden – die Prüfmaschinen (typo-check/ds-lint) können nicht laufen; bitte python3 bereitstellen."
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Worum es geht

Damit **jemand mit Claude Code** (vor allem im Web, `claude.ai/code`) ohne Handgriffe an den Werkzeugen mitarbeiten kann. Ein SessionStart-Hook macht jede frische Session sofort hausregel-treu.

## Was er tut
- Aktiviert beim Session-Start den **Prüf-Hook** (`git config core.hooksPath tools/hooks`) → `typo-check` (Sprache) **und** `ds-lint` (Gestalt) laufen bei **jedem Commit**, wie `CLAUDE.md` verlangt. Diese Einstellung wohnt je Arbeitskopie und wird nicht mitversioniert — im Web ist der Klon frisch, also muss sie je Session gesetzt werden.
- Kurzer Selbsttest, dass `python3` (die Prüfmaschinen) da ist.
- **Keine Installationen** — die Checker sind reines `python3` (Standardbibliothek). Idempotent, harmlos auch lokal.

## Dateien
- `.claude/hooks/session-start.sh` — der Hook.
- `.claude/settings.json` — Registrierung (SessionStart).

## Validierung
- `settings.json` valides JSON.
- Hook aus dem Nichts getestet: `hooksPath` war ungesetzt → nach dem Hook `tools/hooks`. ✅
- `ds-lint` und `typo-check` laufen sauber auf einer Beispielseite (0 Fehler). ✅
- Läuft **synchron** (garantiert, dass der Prüf-Hook steht, bevor die Session arbeitet; minimal langsamerer Start — auf Wunsch async).

## Wirkung
Nach dem Merge in `main` nutzen alle künftigen Sessions den Hook. „Jemand mit Claude Code" ist dann nur noch: Repo-Zugriff → `claude.ai/code` öffnen → lossagen. Die Prüfmaschinen fangen alles Nicht-Konforme ab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScwvEZRvmy3SGmwqq11N6v

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScwvEZRvmy3SGmwqq11N6v)_