### PR TITLE
REDAKTION.md als Repo-Werkzeug + CLAUDE.md finaler Takt

### DIFF
--- a/services/mailing-sommer2026/CLAUDE.md
+++ b/services/mailing-sommer2026/CLAUDE.md
@@ -11,6 +11,10 @@ echte Sommer-Lifestyle-Motive. **Schrift-Beschluss 11.7. (Vorschlag 1):** Headli
 System-Stack; Fazeta bleibt der WS-Landingpage vorbehalten. Die Mail ist **Artefakt** (Kampagnen-DNA),
 das Editor-Chrome läuft auf dem Haus-Design-System.
 
+## Redaktion (erweiterter Tisch)
+Rollen, Spielregeln und Aufruf («Redaktion auf X schauen lassen») stehen in
+**REDAKTION.md** — parallele Rollen-Agenten, Ergebnisse werden vorgelegt.
+
 ## Drehbuch für die nächste Kampagne
 Die übertragbaren Lehren (Reihenfolge, Messkette, Fünfer-Tisch, AC-Muster, eingefrorenes
 Detailwissen) stehen in **docs/kampagnen-drehbuch.md** — dort beginnt die nächste Kampagne.
@@ -38,7 +42,9 @@ HTML-Text in der Mail-Grundschrift — beide so beschlossen im Gegenlesen (Komme
 - **lesen** → Segment `nurtv` (Cross-sell WS): w1 garten · w2 abendlicht · w3 see
 - **sehen** → Segment `nurws` (Cross-sell TV): w1 pergola · w2 licht · w3 feuer
 - **beides** → Segment `noabo` (kein Abo): w1 abendlicht · w2 vor-dem-bau · w3 picknick · w3b picknick
-- **w3b jetzt für ALLE Gruppen** (Samstag-Frist-Mail, Entscheid 14.7.): lesen/sehen erhielten w3b (Bild = w3). Termine: w1 16.7., w2 30.7., w3 Fr 7.8. 18 Uhr («morgen»), w3b Sa 8.8. 10 Uhr («heute»). w3 = Öffner-Split (Alt-Betreff), w3b = an alle Nicht-Konvertierten.
+- **Finaler Takt (Entscheide 14./15.7.):** w1 Do 16.7. 9.30 · w2 Do 30.7. 9.30 · w3 Fr 7.8. **18 Uhr** (Rahmen «morgen», Öffner-Split: Nicht-Öffner nur Alt-Betreff, Predictive AUS) · **w3b Sa 8.8. 10 Uhr** (Frist-Tag, Rahmen «heute», **nur an Öffner von w1/w2/w3** — Nicht-Öffner bekommen max. 3 Mails; Predictive AUS). Frist = Sa 8.8. **Mitternacht** (bestätigt). w3b gibt es in ALLEN Gruppen; 24 Mails, 6 Automatisierungen (Gruppe×Sprache).
+- **Bilder w3b/W2 (15.7.):** beides wechselt Wos/TV/Wos/TV (W2 tv-haengematte, W4 tv-terrasse); sehen W4 = pergola. `gtv-feuer/licht.jpg` sind Mini-Auflösung (680px) — NICHT als Hero verwenden. Kein Motiv zeigt Heft+TV zusammen (müsste neu entstehen).
+- **Register:** w3b_nurtv/w3b_nurws (de+en) sind im Live-Register; `python3 links.py --sql` erzeugt idempotentes Register-SQL für künftige Wellen.
 Auswahl (bestätigt): lesen=garten · sehen=pergola · beides=abendlicht. Motive in `assets/motive/` (8 JPGs).
 Betreff-Alternativen (`wellen.*.alt`) = Munition für AC-Split (Nicht-Öffner).
 

--- a/services/mailing-sommer2026/REDAKTION.md
+++ b/services/mailing-sommer2026/REDAKTION.md
@@ -1,0 +1,46 @@
+# Die Redaktion (erweiterter Tisch) — parat im Repo
+
+Die «Redaktion» ist kein Programm, sondern eine **Arbeitsweise**: mehrere
+unabhängige Rollen-Agenten schauen parallel auf denselben Gegenstand und
+liefern priorisierte, konkrete Kritik. Jede Claude-Code-Session kann sie
+einberufen — dieses Dokument ist die Einladung samt Rollen und Spielregeln.
+
+## Aufrufen
+In einer Session sagen: **«Redaktion auf X schauen lassen»** (oder «an den
+Tisch geben»). Die Session startet dann pro Rolle einen parallelen Agenten
+mit dem jeweiligen Rollen-Prompt unten, sammelt die Ergebnisse und verdichtet
+sie. Ergebnisse werden **vorgelegt**, nicht ungefragt eingebaut.
+
+## Die Rollen (je nach Frage 2–5 auswählen)
+1. **Endredaktion / Schlagzeilen** — Schärfe, Redundanz, Rhythmus, Wortwahl
+   der sichtbaren Zeilen (Betreff/Anriss/Headline); Vorher→Nachher-Vorschläge.
+2. **Blattmacher / Strategie** — trägt der Bogen? Eskalation über Wert statt
+   Druck; was gehört in die Mail, was auf die Landingpage.
+3. **Leser-Anwalt** — skeptische Empfänger-Perspektive («wo lösche ich
+   genervt?», «was will ich wissen, das nicht dasteht?»).
+4. **EN-Endredaktion** — native englische Fassung, idiomatisch, nie
+   wörtlich übersetzt; hält die Hausregeln.
+5. Nach Bedarf: Statistiker (virtuelle A/B-Panels, Persona-Tests),
+   Marketing-Blick, potentielle Abonnentin.
+
+## Spielregeln (in jeden Rollen-Prompt aufnehmen)
+- **Ohne Sentimentalität**, als wäre es ein neues Projekt.
+- **Hausregeln:** kein «!», keine Versalien/Unterstreichung als Betonung,
+  «…»/‹…› als Anführung, ss statt ß, Datum «8. August»; G05/G16/G22.
+- **Ehrlichkeit vor Wirkung:** goetheanum.tv und die Wochenschrift sind
+  **verschiedene Redaktionen** — keine erfundenen Bezüge («ergänzend zu dem,
+  was Sie sehen…» war falsch). Kündigungsmodell: nach 3 Gratismonaten läuft
+  das Abo regulär weiter — nichts darf «für immer gratis» suggerieren.
+- **Frist-Sprache aufs Datum ankern** (nie «Stunden», wenn der Versandtag
+  das nicht deckt); kein Vorwurfs-Rahmen («haben Sie vergessen?»), keine
+  Drohsprache («danach ist es zu spät»).
+- Ergebnisse **priorisiert** (wertvollstes zuerst), konkret, mit
+  Vorher→Nachher. Bei Richtungsfragen: die gesetzte Richtung nicht
+  umwerfen, innerhalb kritisieren.
+
+## Historie (Kurz)
+Der Tisch hat in dieser Kampagne u. a. geliefert: die Betreff-Anker aus
+echten Titeln, die Kritik an «ersten/geschenkt», die drei grossen Fixes der
+GF-Fassung (Datum statt Stunden, kein Vorwurf, konkreter Haken) und die
+EN-Fassungen. Entscheide trifft Philipp; der GF-Kurs (Aktivierung) ist die
+gesetzte Richtung.


### PR DESCRIPTION
Doku-PR (kein Code, keine Mails):

- **REDAKTION.md** — der «erweiterte Tisch» als dauerhaftes Repo-Werkzeug: Rollen (Endredaktion, Blattmacher, Leser-Anwalt, EN-Endredaktion …), Spielregeln (Hausregeln, Ehrlichkeit TV≠WS, Datum-Anker) und Aufruf («Redaktion auf X schauen lassen»). Jede neue Session kann den Tisch damit einberufen.
- **CLAUDE.md** — finaler Takt (16.7. / 30.7. / Fr 7.8. 18 Uhr / Sa 8.8. 10 Uhr, Frist Mitternacht), w3b-Öffner-Gate, Bild-Verteilung, Register-Stand, Verweis auf REDAKTION.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M37fR47HiSBPa5uWtWDAqr)_