### PR TITLE
Zeitband: Chips kompakt, Antippen klappt die Felder auf

### DIFF
--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -146,15 +146,26 @@
   .zb thead .wk th.heute{color:var(--gold-ink);border-bottom:2px solid var(--gold)}
   .zb .kz{white-space:nowrap;color:var(--ink);font-weight:600;background:var(--soft)}
   .zb td{min-width:104px}
+  /* Chip kompakt: Punkt · Tag · Titel in EINER Zeile (Übersicht) – Antippen
+     klappt die Felder auf (.zb-det). Zustand .open + aria-expanded aus campaign.js. */
   .zb-chip{display:block;margin:2px 0;padding:4px 8px;border:1px solid var(--line);border-radius:var(--r-control);
     background:var(--field-bg);color:var(--ink);font-size:var(--t-micro);line-height:1.35;overflow-wrap:anywhere}
   .zb-chip.clickable{cursor:pointer}
   .zb-chip.clickable:hover{border-color:var(--gold);background:var(--soft)}
   .zb-chip.clickable:focus-visible{outline:2px solid var(--blue);outline-offset:1px}
   .zb-chip.has-note{border-left:3px solid var(--gold)}
-  .zb-chip .zt{color:var(--muted);font-variant-numeric:tabular-nums;margin-right:5px}
-  .zb-chip .zr{display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:5px;vertical-align:baseline;background:var(--blue)}
-  .zb-chip .zn{display:block;margin-top:3px;color:var(--muted);font-style:normal}
+  .zb-chip .zk{display:flex;align-items:baseline;gap:5px;min-width:0}
+  .zb-chip .zt{color:var(--muted);font-variant-numeric:tabular-nums}
+  .zb-chip .zr{display:inline-block;flex:none;width:8px;height:8px;border-radius:50%;align-self:center;background:var(--blue)}
+  .zb-chip .zm{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .zb-chip.open .zm{white-space:normal;overflow:visible}
+  .zb-chip .zb-det{display:none}
+  .zb-chip.open .zb-det{display:block;margin-top:4px;padding-top:4px;border-top:1px solid var(--line-soft)}
+  .zb-chip .zd{display:flex;justify-content:space-between;gap:8px;padding:2px 0}
+  .zb-chip .zd .zdl{color:var(--muted);flex:none}
+  .zb-chip .zd .zdv{font-variant-numeric:tabular-nums;text-align:right;overflow-wrap:anywhere}
+  .zb-edit{font-family:var(--font-text);font-size:var(--t-micro);color:var(--blue);background:none;border:0;cursor:pointer;padding:6px 0;margin-top:2px;min-height:var(--tap)}
+  .zb-edit:hover{color:var(--gold-ink)}
   .mnote{display:block;margin-top:2px;color:var(--muted);font-size:var(--t-micro);line-height:1.4}
   .zb-legende{display:flex;flex-wrap:wrap;gap:var(--s2) var(--s4);margin-top:var(--s3);font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted)}
   /* Multiplikatoren: Status-Wortlabel, Verlaufszeile, Mini-Maske (DS02, G25) */

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -330,9 +330,11 @@
   }
   function zbTag(d){ return d.getDate() + '.' + (d.getMonth() + 1) + '.'; }
 
-  // Zeitband-Chips sind anklickbar → laden die Aktivität in die Bearbeiten-Maske.
+  // Zeitband-Chips sind kompakt (Punkt · Tag · Titel einzeilig) – Antippen klappt
+  // die Felder auf (Kürzel, Reichweite, Klicks, Kosten, Notiz + Bearbeiten-Knopf).
   // Delegation über die Tabelle; die Zeilen-Zuordnung liegt in zbById (je Render neu).
-  var zbById = {}, zbWired = false;
+  // zbOffen merkt sich aufgeklappte Chips über die 60-Sekunden-Neu-Renderings hinweg.
+  var zbById = {}, zbWired = false, zbOffen = {};
 
   function renderZeitband(rows){
     if (!el('zeitband')) return;
@@ -380,21 +382,36 @@
           var d = new Date(m.tag + 'T00:00:00');
           if (d < von || d > bis) return;
           var det = [];
-          if (m.ersteller) det.push('Kürzel ' + m.ersteller);
-          if (m.reichweite) det.push('Reichweite ' + Number(m.reichweite).toLocaleString('de-CH'));
-          if (m.klicks) det.push('Klicks ' + Number(m.klicks).toLocaleString('de-CH'));
-          if (m.kosten) det.push('Kosten ' + Number(m.kosten).toLocaleString('de-CH'));
-          if (m.notiz) det.push('Notiz: ' + m.notiz);
+          if (m.ersteller) det.push(['Kürzel', m.ersteller]);
+          if (m.reichweite) det.push(['Reichweite', Number(m.reichweite).toLocaleString('de-CH')]);
+          if (m.klicks) det.push(['Klicks', Number(m.klicks).toLocaleString('de-CH')]);
+          if (m.kosten) det.push(['Kosten', Number(m.kosten).toLocaleString('de-CH')]);
+          if (m.notiz) det.push(['Notiz', m.notiz]);
           zbById[m.id] = m;
+          var istOffen = !!zbOffen[m.id];
           var span = document.createElement('span');
-          span.className = 'zb-chip clickable' + (m.notiz ? ' has-note' : '');
+          span.className = 'zb-chip clickable' + (istOffen ? ' open' : '') + (m.notiz ? ' has-note' : '');
           span.setAttribute('data-mid', m.id);
           span.setAttribute('role', 'button');
           span.setAttribute('tabindex', '0');
-          span.title = m.massnahme + ' – ' + det.filter(Boolean).join(' · ') + ' · anklicken zum Bearbeiten';
-          span.innerHTML = '<span class="zr"></span><span class="zt">' + zbTag(d) + '</span>';
-          span.appendChild(document.createTextNode(m.massnahme));
-          if (m.notiz){ var zn = document.createElement('span'); zn.className = 'zn'; zn.textContent = m.notiz; span.appendChild(zn); }
+          span.setAttribute('aria-expanded', istOffen ? 'true' : 'false');
+          span.title = m.massnahme + (det.length ? ' – ' + det.map(function(p){ return p[0] + ' ' + p[1]; }).join(' · ') : '') + ' · antippen zum Ausklappen';
+          var kopf = document.createElement('span'); kopf.className = 'zk';
+          kopf.innerHTML = '<span class="zr"></span><span class="zt">' + zbTag(d) + '</span>';
+          var zm = document.createElement('span'); zm.className = 'zm'; zm.textContent = m.massnahme;
+          kopf.appendChild(zm);
+          span.appendChild(kopf);
+          var box = document.createElement('span'); box.className = 'zb-det';
+          det.forEach(function(p){
+            var zd = document.createElement('span'); zd.className = 'zd';
+            var l = document.createElement('span'); l.className = 'zdl'; l.textContent = p[0];
+            var v = document.createElement('span'); v.className = 'zdv'; v.textContent = p[1];
+            zd.appendChild(l); zd.appendChild(v); box.appendChild(zd);
+          });
+          var eb = document.createElement('button'); eb.type = 'button'; eb.className = 'zb-edit';
+          eb.setAttribute('data-mid', m.id); eb.textContent = 'Bearbeiten';
+          box.appendChild(eb);
+          span.appendChild(box);
           chips += span.outerHTML;
         });
         zeile += '<td>' + chips + '</td>';
@@ -403,14 +420,30 @@
     });
 
     tbl.innerHTML = '<thead>' + h1 + h2 + '</thead><tbody>' + body + '</tbody>';
-    // Delegierter Klick/Tastatur: Chip → Aktivität in die Bearbeiten-Maske laden.
+    // Delegierter Klick/Tastatur: Chip klappt die Felder auf/zu, der Bearbeiten-Knopf
+    // im aufgeklappten Chip lädt die Aktivität in die Maske.
     if (!zbWired){
       zbWired = true;
-      var oeffne = function(t){ var c = t && t.closest && t.closest('.zb-chip[data-mid]'); if (!c) return false; var m = zbById[c.getAttribute('data-mid')]; if (m) massnahmeBearbeiten(m); return !!m; };
-      tbl.addEventListener('click', function(e){ oeffne(e.target); });
-      tbl.addEventListener('keydown', function(e){ if (e.key === 'Enter' || e.key === ' '){ if (oeffne(e.target)) e.preventDefault(); } });
+      var kippe = function(c){
+        var offen = c.classList.toggle('open');
+        c.setAttribute('aria-expanded', offen ? 'true' : 'false');
+        var id = c.getAttribute('data-mid');
+        if (offen) zbOffen[id] = true; else delete zbOffen[id];
+      };
+      tbl.addEventListener('click', function(e){
+        var b = e.target.closest && e.target.closest('.zb-edit[data-mid]');
+        if (b){ var m = zbById[b.getAttribute('data-mid')]; if (m) massnahmeBearbeiten(m); return; }
+        var c = e.target.closest && e.target.closest('.zb-chip[data-mid]');
+        if (c) kippe(c);
+      });
+      tbl.addEventListener('keydown', function(e){
+        if (e.key !== 'Enter' && e.key !== ' ') return;
+        if (e.target.closest && e.target.closest('.zb-edit')) return; // Knopf reagiert selbst
+        var c = e.target.closest && e.target.closest('.zb-chip[data-mid]');
+        if (c){ e.preventDefault(); kippe(c); }
+      });
     }
-    el('zbLegende').innerHTML = '<span>Zeilen = Kanal, Spalten = Woche. Jeder Punkt eine Aktivität – anklicken zum Bearbeiten; Reichweite, Klicks, Kosten und Notiz beim Überfahren.</span>';
+    el('zbLegende').innerHTML = '<span>Zeilen = Kanal, Spalten = Woche. Jeder Punkt eine Aktivität – antippen klappt Reichweite, Klicks, Kosten und Notiz auf; Bearbeiten dort.</span>';
   }
 
   // Eintragen/Bearbeiten: offener Schreibweg (Muster Link-Register),


### PR DESCRIPTION
## Anliegen

In der Übersicht der Aktivitäten (Zeitband der Sommer-Aktion) ging die Übersicht verloren: jeder Chip zeigte Datum, vollen Titel und die Notiz. Wunsch: weniger Details, beim Antippen sollen die Felder ausklappen.

## Umsetzung

- **Chip kompakt:** nur noch Punkt · Tag · Titel in **einer** Zeile; lange Titel laufen in eine Ellipse. Die Notiz erscheint nicht mehr im Chip (die Gold-Kante bleibt als Hinweis, dass eine da ist).
- **Antippen klappt auf:** Kürzel, Reichweite, Klicks, Kosten und Notiz erscheinen als Label/Wert-Felder unter dem Kopf; der volle Titel bricht dann um. Nochmaliges Antippen klappt zu.
- **Bearbeiten** sitzt jetzt als Knopf im aufgeklappten Chip (vorher öffnete jeder Klick sofort die Maske) und lädt wie bisher die Bearbeiten-Maske. Fingerziel mit `--tap` (B04).
- **Robust:** aufgeklappte Chips überleben das 60-Sekunden-Neu-Rendern (`zbOffen`); Tastatur (Enter/Leertaste) und `aria-expanded` sind verdrahtet; Hover-Tooltip mit den Details bleibt für den Desktop.
- Regeln: G03 (Entbehrliches weggelassen), B04 (Fingerziel), DS02 (nur Tokens). `ds-lint`: 100 %.

## Geprüft

Playwright gegen die Seite mit Fixture-Daten: Chips rendern kompakt ohne Notiz, Antippen setzt `aria-expanded` und zeigt die Felder, Bearbeiten-Knopf öffnet die befüllte Maske, zweites Antippen klappt zu, Enter per Tastatur funktioniert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vxd99TMDS8cJ1ZJRdLRQod

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vxd99TMDS8cJ1ZJRdLRQod)_