### PR TITLE
Aktivitäten: Titel atmet auf der Gewichtsachse

### DIFF
--- a/apps/sommer-zaehler/aktivitaeten.html
+++ b/apps/sommer-zaehler/aktivitaeten.html
@@ -123,5 +123,48 @@
 </footer>
 
 <script src="campaign.js"></script>
+
+<!-- Titel-Atem (Erprobung aus ‹Bewegte Schrift›): der Titel atmet auf der
+     Gewichtsachse der Hausschrift – animierte Betonung mit Laut/Leise (G05),
+     nur in der Zeit. Hausschrift: font-family:var(--font-display); die Achse
+     ist wght (190–725), font-weight (numerisch) steuert wght direkt – kein
+     font-variation-settings nötig. Bewegung immer gegen prefers-reduced-motion
+     absichern (WCAG 2.3.3): dann ruht der Titel im gesetzten Gewicht. -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
+<script>
+(() => {
+  "use strict";
+  const el = document.querySelector(".lead-title");
+  if (!el || !window.gsap) return;             // ohne Motor (CDN blockiert) steht der Titel ruhig
+
+  // Wort in Zeichen zerlegen – Vorlesbarkeit sichert das aria-label am Titel.
+  const text = el.textContent.trim();
+  el.setAttribute("aria-label", text);
+  el.textContent = "";
+  [...text].forEach(ch => {
+    const s = document.createElement("span");
+    s.className = "ltr"; s.textContent = ch; s.setAttribute("aria-hidden", "true");
+    el.appendChild(s);
+  });
+  const L = [...el.querySelectorAll(".ltr")];   // Wort in Zeichen zerlegt
+
+  const reduce = matchMedia("(prefers-reduced-motion: reduce)");
+  let tween = null;
+  const apply = () => {
+    if (tween){ tween.kill(); tween = null; }
+    if (reduce.matches){ gsap.set(L, { clearProps: "fontWeight" }); return; } // Satzgewicht (Deutlich) ruht
+    gsap.set(L, { fontWeight: 344 });
+    tween = gsap.to(L, {
+      fontWeight: 527,
+      duration: 0.6,
+      ease: "sine.inOut",
+      yoyo: true, repeat: -1,
+      stagger: { each: 0.04, from: "center" }
+    });
+  };
+  reduce.addEventListener?.("change", apply);
+  apply();
+})();
+</script>
 </body>
 </html>

--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -10,6 +10,8 @@
   .lead{padding:clamp(28px,6vw,52px) 0 var(--s6)}
   .lead .status{margin-left:8px}
   .lead-title{font-family:var(--font-display);font-weight:var(--w-deutlich);color:var(--gold-ink);font-size:clamp(32px,7vw,58px);line-height:1.02;letter-spacing:-.01em;margin:8px 0 0;max-width:18ch}
+  /* Titel-Atem (Aktivitäten): Zeichen einzeln ansprechbar, nur das Gewicht bewegt sich. */
+  .lead-title .ltr{display:inline-block;will-change:font-weight}
   .heroline{display:flex;flex-wrap:wrap;align-items:flex-end;gap:clamp(16px,5vw,48px);margin-top:var(--s8)}
   .figure{display:flex;flex-direction:column}
   .figure .big{font-family:var(--font-display);font-weight:var(--w-strong);


### PR DESCRIPTION
Der Kampagnen-Titel ‹Aktivitäten› (`apps/sommer-zaehler/aktivitaeten.html`) bekommt den Atem-Effekt aus der Erprobung ‹Bewegte Schrift›: das Wort atmet auf der Gewichtsachse der Hausschrift zwischen wght 344 und 527 (0,6 s, sine.inOut, yoyo, Stagger 0,04 von der Mitte) – animierte Betonung mit Laut/Leise (G05), nur das Gewicht bewegt sich.

**Absicherungen:**
- `prefers-reduced-motion` (WCAG 2.3.3): Bewegung schaltet sich ab, der Titel ruht im Satzgewicht (Deutlich); Wechsel zur Laufzeit wird mitverfolgt.
- Ohne GSAP-Motor (CDN blockiert) bleibt der Titel unverändert stehen.
- Vorlesbarkeit: `aria-label` am Titel, die Einzelzeichen-Spans sind `aria-hidden`.

**Dateien:**
- `apps/sommer-zaehler/aktivitaeten.html` – GSAP-Motor (gleiche CDN-Quelle wie `apps/bewegte-schrift/`) + Zeichen-Split + Atem-Tween
- `apps/sommer-zaehler/campaign.css` – `.lead-title .ltr` (inline-block, will-change)

Prüfmaschinen lokal grün: typo-check ✓, ds-lint Score 100 % ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ui9zSzwgtoDYJNHajeJaX

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ui9zSzwgtoDYJNHajeJaX)_