### PR TITLE
Aktivitäten: Titel-Atem sanfter – kleiner Hub, langsamer Zug

### DIFF
--- a/apps/sommer-zaehler/aktivitaeten.html
+++ b/apps/sommer-zaehler/aktivitaeten.html
@@ -153,13 +153,15 @@
   const apply = () => {
     if (tween){ tween.kill(); tween = null; }
     if (reduce.matches){ gsap.set(L, { clearProps: "fontWeight" }); return; } // Satzgewicht (Deutlich) ruht
-    gsap.set(L, { fontWeight: 344 });
+    // Sanfter Atem: kleiner Hub um das eigene Satzgewicht (Klar 440 ↔ Deutlich 580),
+    // langsamer Zug – ein voller Atemzug dauert so rund 3,6 Sekunden.
+    gsap.set(L, { fontWeight: 440 });
     tween = gsap.to(L, {
-      fontWeight: 527,
-      duration: 0.6,
+      fontWeight: 580,
+      duration: 1.8,
       ease: "sine.inOut",
       yoyo: true, repeat: -1,
-      stagger: { each: 0.04, from: "center" }
+      stagger: { each: 0.06, from: "center" }
     });
   };
   reduce.addEventListener?.("change", apply);


### PR DESCRIPTION
Nachjustierung zu #466: der Atem des Kampagnen-Titels ‹Aktivitäten› wird sanfter und weicher.

- **Kleinerer Hub:** statt wght 344↔527 neu **Klar (440) ↔ Deutlich (580)** – der Titel schwingt um sein eigenes Satzgewicht, statt darunter zu pumpen.
- **Langsamer Zug:** 1,8 s je Halbzug statt 0,6 s – ein voller Atemzug dauert rund 3,6 Sekunden.
- **Weicherer Versatz:** Stagger 0,06 s von der Mitte (statt 0,04 s).

Im Browser verifiziert (Chromium headless): Gewichte wandern ruhig zwischen 440 und 580, keine Konsolen-Fehler; bei `prefers-reduced-motion` steht der Titel weiterhin still (WCAG 2.3.3).

Prüfmaschinen lokal grün: typo-check ✓, ds-lint Score 100 % ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ui9zSzwgtoDYJNHajeJaX

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ui9zSzwgtoDYJNHajeJaX)_