### PR TITLE
Werkzeug-Abo: Updates aller Werkzeuge abonnieren — alle oder nur die relevanten

### DIFF
--- a/abo.html
+++ b/abo.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
+<title>Werkzeug-Abo · Goetheanum</title>
+<meta name="description" content="Bescheid bekommen, wenn ein Werkzeug neu ist oder besser funktioniert – alle oder nur die persönlich relevanten." />
+<link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
+
+<!-- Das Fundament – eine Quelle der Wahrheit. NICHT kopieren, EINBINDEN. RELATIV, nie absolut. -->
+<link rel="stylesheet" href="design-system/tokens.css" />
+<link rel="stylesheet" href="design-system/base.css" />
+<link rel="stylesheet" href="design-system/nav.css" />
+
+<style>
+  .hero{padding-block:clamp(40px,7vw,72px) var(--s8)}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);line-height:1.05;letter-spacing:-.01em;max-width:18ch}
+  .hero .lede{margin-top:var(--s6);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:58ch}
+
+  /* Auswahl-Liste: Fingerziele ≥44px (B04), Lese-Grotesk für Label (Schrift-Grenze) */
+  .gruppe{margin-top:var(--s6)}
+  .gruppe h3{font-family:var(--font);font-weight:var(--w-deutlich);font-size:var(--t-body);margin:0 0 var(--s2)}
+  .wahl{display:grid;gap:2px}
+  .wahl label{display:flex;align-items:center;gap:var(--s3);min-height:var(--tap);padding:var(--s2) var(--s3);
+    border-radius:8px;cursor:pointer;font-family:var(--font-text);font-size:var(--t-body);color:var(--ink)}
+  .wahl label:hover{background:var(--field-bg)}
+  .wahl input{width:20px;height:20px;accent-color:var(--blue);flex:none}
+  .wahl label.aus{color:var(--muted)}
+  .honig{position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden}
+  .meldung{display:none;margin-top:var(--s6);padding:var(--s4) var(--s5);border-radius:10px;
+    background:var(--field-bg);border:1px solid var(--line);font-family:var(--font-text);font-size:var(--t-body)}
+  .meldung.zeigen{display:block}
+</style>
+</head>
+<body>
+
+<script src="design-system/nav.js" data-root="./" data-variant="werkzeug"></script>
+
+<main class="wrap">
+
+  <section class="hero">
+    <span class="kicker">Werkzeuge · Neuerungen</span>
+    <h1>Das Werkzeug-Abo</h1>
+    <p class="lede">Bescheid bekommen, wenn ein Werkzeug neu ist oder besser funktioniert –
+      etwa wenn sich bei den Schriften eine Neuinstallation lohnt. Alle Werkzeuge
+      oder nur die, mit denen du arbeitest. Jede Mail trägt die Abmeldung mit einem Klick.</p>
+  </section>
+
+  <section>
+    <div class="shead">
+      <h2>Anmelden</h2>
+      <p>E-Mail eintragen, Auswahl treffen, bestätigen – fertig. Schon angemeldet?
+        Einfach mit neuer Auswahl erneut absenden, sie wird übernommen.</p>
+    </div>
+
+    <div id="meldung-gesendet" class="meldung">Fast geschafft: Bitte den Posteingang öffnen
+      und die Anmeldung bestätigen. Nichts erhalten? Spam-Ordner prüfen oder erneut absenden.</div>
+    <div id="meldung-bestaetigt" class="meldung">Das Abo ist bestätigt – du bekommst ab jetzt
+      Bescheid, wenn etwas Neues kommt.</div>
+    <div id="meldung-beendet" class="meldung">Das Abo ist beendet. Danke fürs Dabeisein –
+      die Tür bleibt offen.</div>
+    <div id="meldung-fehler" class="meldung">Das hat nicht geklappt – der Link ist verbraucht
+      oder unvollständig. Einfach unten neu anmelden.</div>
+
+    <form id="abo" class="card soft" style="display:grid;gap:var(--s4);max-width:620px">
+      <label class="field">
+        <span class="lab">E-Mail</span>
+        <input type="email" name="email" required autocomplete="email" placeholder="vorname.name@goetheanum.ch" />
+      </label>
+
+      <label class="honig" aria-hidden="true" tabindex="-1">
+        <span class="lab">Website</span>
+        <input type="text" name="website" autocomplete="off" />
+      </label>
+
+      <div class="wahl" style="margin-top:var(--s2)">
+        <label><input type="checkbox" id="alle" checked />
+          <span><strong>Alle Werkzeuge</strong> – alles Neue, eine Auswahl ist nicht nötig</span></label>
+      </div>
+
+      <div id="gruppen" hidden></div>
+
+      <div style="display:flex;gap:var(--s2);flex-wrap:wrap;align-items:center">
+        <button class="btn primary" type="submit">Abo bestellen</button>
+        <span style="font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)">
+          Double-Opt-in – erst der Klick in der Mail schaltet das Abo scharf.</span>
+      </div>
+    </form>
+
+    <p class="lese" style="margin-top:var(--s6);line-height:1.5;font-size:var(--t-small);color:var(--muted);max-width:62ch">
+      Die Adresse dient allein diesem Versand und wandert nirgendwohin sonst.
+      Abmelden geht in jeder Mail mit einem Klick – ohne Rückfrage, ohne Umweg.</p>
+  </section>
+
+</main>
+
+<footer class="ds-footer">
+  <div class="wrap frow">
+    <span><strong>Goetheanum</strong> · Hausgrafik</span>
+    <span><a href="design-system/">Design-System</a></span>
+  </div>
+</footer>
+
+<script>
+const ABO_URL = 'https://dagcsnfrlbpxcmdimnrw.supabase.co/functions/v1/werkzeug-abo?aktion=anmelden';
+// Öffentlicher (publishable) Schlüssel — kein Geheimnis, nur die Eintrittskarte ans Funktions-Tor.
+const ANON = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRhZ2NzbmZybGJweGNtZGltbnJ3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzYwMTAyNzYsImV4cCI6MjA5MTU4NjI3Nn0.sp-Cl-6ua0xR90oJ4lP1-vvB5orAd-zsAWRyQhPy9KM';
+const OFFEN = new Set(['live', 'beta']);   // nur öffentlich Nutzbares anbieten
+
+async function bauen() {
+  const t = await (await fetch('tools.json')).json();
+  const je = new Map();
+  for (const w of t.tools) {
+    if (!OFFEN.has(w.status) || w.slug === 'abo') continue;   // sich selbst nicht anbieten
+    if (!je.has(w.cat)) je.set(w.cat, []);
+    je.get(w.cat).push(w);
+  }
+  const wurzel = document.getElementById('gruppen');
+  for (const kat of t.categories) {
+    const liste = je.get(kat.id);
+    if (!liste || !liste.length) continue;
+    const g = document.createElement('div');
+    g.className = 'gruppe';
+    const h = document.createElement('h3');
+    h.textContent = kat.title;
+    g.appendChild(h);
+    const w = document.createElement('div');
+    w.className = 'wahl';
+    for (const werk of liste) {
+      const label = document.createElement('label');
+      const box = document.createElement('input');
+      box.type = 'checkbox'; box.value = werk.slug;
+      label.appendChild(box);
+      label.appendChild(document.createTextNode(werk.title));
+      w.appendChild(label);
+    }
+    g.appendChild(w);
+    wurzel.appendChild(g);
+  }
+}
+
+const alle = document.getElementById('alle');
+const gruppen = document.getElementById('gruppen');
+alle.addEventListener('change', () => { gruppen.hidden = alle.checked; });
+
+function zeige(id) {
+  document.querySelectorAll('.meldung').forEach((m) => m.classList.remove('zeigen'));
+  const m = document.getElementById('meldung-' + id);
+  if (m) { m.classList.add('zeigen'); m.scrollIntoView({ block: 'nearest' }); }
+}
+const anker = location.hash.replace('#', '');
+if (['bestaetigt', 'beendet', 'fehler'].includes(anker)) zeige(anker);
+
+document.getElementById('abo').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const f = e.target;
+  const auswahl = alle.checked ? []
+    : [...gruppen.querySelectorAll('input:checked')].map((b) => b.value);
+  try {
+    await fetch(ABO_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + ANON, 'apikey': ANON },
+      body: JSON.stringify({ email: f.email.value, auswahl, website: f.website.value }),
+    });
+  } catch (_) { /* Antwort ist bewusst immer gleich */ }
+  zeige('gesendet');
+  f.email.value = '';
+});
+
+bauen();
+</script>
+
+</body>
+</html>

--- a/schriften.html
+++ b/schriften.html
@@ -308,6 +308,7 @@ body{ font-family:"Goetheanum", system-ui, sans-serif; }
       <b style="color:var(--ink);font-weight:400">Installieren:</b> ältere Goetheanum-Schriften zuerst entfernen
       (<a href="https://support.apple.com/de-de/guide/font-book/fntb2bcb512d/mac">Anleitung von Apple</a>; Windows: Einstellungen → Personalisierung → Schriftarten),
       dann Datei doppelklicken → ‹Installieren› (macOS Schriftsammlung / Windows Rechtsklick) und das Programm neu starten.
+      <b style="color:var(--ink);font-weight:400">Auf dem Laufenden bleiben:</b> das <a href="abo.html">Werkzeug-Abo</a> meldet, wenn eine neue Fassung eine Neuinstallation lohnt.
       <b style="color:var(--ink);font-weight:400">Nicht installierbar:</b> WOFF/WOFF2 sind Web-Dateien (nur <code>@font-face</code>); der Variable Font ist fürs Web/Design, nicht fürs Office.
     </p>
   </div></section>

--- a/services/werkzeug-abo/README.md
+++ b/services/werkzeug-abo/README.md
@@ -1,0 +1,60 @@
+# werkzeug-abo — Update-Abo der Werkzeuge
+
+Wer mag, abonniert auf [`abo.html`](../../abo.html) Neuerungen der Werkzeuge —
+alle oder nur die persönlich relevanten (Auswahl nach `tools.json`-Slugs,
+leere Auswahl = alles). Double-Opt-in, Ein-Klick-Abmeldung, Honeypot, kein
+Nutzer-Enumerieren — dasselbe Muster wie der [Seelenkalender-Versand](../seelenkalender/).
+
+Abgrenzung zur [Werkzeugpost](../werkzeugpost/): die Werkzeugpost ist die
+redigierte Monats-Mail an alle Mitarbeitenden (Versand von Hand aus dem
+Postfach); das Abo ist der freiwillige, feinkörnige Update-Kanal dazwischen
+(«Schrift-Fassung neu — Neuinstallation lohnt sich»).
+
+## Wege (`?aktion=`)
+
+| Aktion | Methode | Eingabe | Wirkung |
+|--------|---------|---------|---------|
+| `anmelden` | POST | `{email, auswahl?: string[], website?}` | Double-Opt-in-Mail; Wieder-Anmelden aktualisiert nur die Auswahl |
+| `bestaetigen` | GET | `?t=<token>` | Status `aktiv`, Umleitung auf die Seite |
+| `ende` | GET | `?t=<token>` | Status `beendet` (1 Klick) |
+| `versand` | POST | `?key=<versand_key>` + `{betreff, inhalt_html, werkzeuge?: string[]\|"alle", test?: email}` | Mail an alle Aktiven, deren Auswahl die Werkzeuge berührt; `test` schickt nur an diese Adresse |
+
+Versand-Beispiel (Schlüssel steht in `werkzeugabo_config.versand_key`):
+
+```bash
+curl -X POST "https://dagcsnfrlbpxcmdimnrw.supabase.co/functions/v1/werkzeug-abo?aktion=versand&key=…" \
+  -H "Content-Type: application/json" \
+  -d '{"betreff":"Schriften 3.0 — Neuinstallation lohnt sich",
+       "inhalt_html":"<p>…</p>",
+       "werkzeuge":["schriften","powerpoint"],
+       "test":"philipp.tok@goetheanum.ch"}'
+```
+
+## Speicher (Supabase, Projekt `dagcsnfrlbpxcmdimnrw`)
+
+- `werkzeugabo_abo` — email, email_hash (Salt in Config), auswahl (jsonb),
+  status `angemeldet|aktiv|beendet`, token, Zeitstempel
+- `werkzeugabo_versand` — Protokoll je Aussendung
+- `werkzeugabo_config` — `resend_api_key`, `absender`, `hash_salt`,
+  `versand_key`, `seite_url`. RLS an, keine Policies → nur die Service-Role
+  (Edge Function) kommt heran. **Schlüssel liegen nie im Repo.**
+
+## Einmalige Handgriffe (Dashboard, nur der Auftraggeber)
+
+1. **Verify JWT ausschalten** (Edge Functions → werkzeug-abo → Details):
+   sonst weist das Funktions-Tor die Bestätigungs-/Abmelde-Links aus den
+   Mails ab (nackte Browser-GETs ohne Header). Der Seelenkalender läuft
+   genauso. Die Abo-Seite selbst schickt den Publishable Key mit und
+   funktioniert in beiden Stellungen.
+2. **Resend-Schlüssel setzen** — er fehlt derzeit auch beim Seelenkalender
+   (Wert leer), Mails gehen also noch nicht hinaus:
+   `update werkzeugabo_config set value='re_…' where key='resend_api_key';`
+   Dazu den `absender` auf eine verifizierte Domain heben (derzeit
+   Resend-Sandbox `onboarding@resend.dev`), z. B.
+   `Werkzeuge – Das Goetheanum <post@werkzeuge.goetheanum.ch>`.
+
+## Deploy
+
+Quelle hier im Repo; deployt wird die Datei
+[`werkzeug-abo/index.ts`](./werkzeug-abo/index.ts) als Edge Function
+`werkzeug-abo` (per MCP oder `supabase functions deploy --no-verify-jwt werkzeug-abo`).

--- a/services/werkzeug-abo/werkzeug-abo/index.ts
+++ b/services/werkzeug-abo/werkzeug-abo/index.ts
@@ -1,0 +1,216 @@
+// =============================================================================
+// werkzeug-abo · Supabase Edge Function
+// Das Update-Abo der Werkzeuge: wer mag, wählt die persönlich relevanten
+// Werkzeuge und bekommt eine Mail, wenn dort etwas neu ist oder besser
+// funktioniert (z. B. eine neue Schrift-Fassung, die eine Neuinstallation
+// lohnt). Leere Auswahl = alle Werkzeuge.
+//
+// Vier Wege über ?aktion= :
+//   anmelden    POST {email, auswahl?: string[], website?}  → Double-Opt-in-Mail
+//               (Wieder-Anmelden mit neuer Auswahl aktualisiert nur die Auswahl,
+//                ohne zweite Mail — Antwort immer gleich, kein Enumerieren.)
+//   bestaetigen GET  ?t=<token>                             → Status aktiv
+//   ende        GET  ?t=<token>                             → Status beendet (1 Klick)
+//   versand     POST ?key=<versand_key>
+//               {betreff, inhalt_html, werkzeuge?: string[]|"alle", test?: email}
+//               → an alle Aktiven, deren Auswahl die Werkzeuge berührt
+//                 (leere Auswahl = alles abonniert); test = nur an diese Adresse.
+//
+// Versand über Resend (API-Key in werkzeugabo_config, nie im Repo).
+// Grundsätze wie beim Seelenkalender: Honeypot «website», Zweckbindung,
+// Ein-Klick-Abmeldung, List-Unsubscribe-Header, kein Nutzer-Enumerieren.
+// =============================================================================
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+const SB = Deno.env.get("SUPABASE_URL")!;
+const KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const H = { "Content-Type": "application/json", apikey: KEY, Authorization: `Bearer ${KEY}` };
+const FUNKTION_URL = `${SB}/functions/v1/werkzeug-abo`;
+
+const EMAIL_RE = /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/i;
+const SLUG_RE = /^[a-z0-9-]{1,50}$/;
+
+async function sha256Hex(s: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(s));
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+function tokenNeu(): string {
+  const b = new Uint8Array(24); crypto.getRandomValues(b);
+  return [...b].map((x) => x.toString(16).padStart(2, "0")).join("");
+}
+
+async function config(): Promise<Record<string, string>> {
+  const r = await fetch(`${SB}/rest/v1/werkzeugabo_config?select=key,value`, { headers: H });
+  const rows = await r.json();
+  const c: Record<string, string> = {};
+  for (const row of rows) c[row.key] = row.value;
+  return c;
+}
+
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+function mailHtml(inhalt: string, fussHtml: string): string {
+  return `<!doctype html><html lang="de"><body style="margin:0;padding:0;background:#faf8f4">
+  <div style="max-width:560px;margin:0 auto;padding:32px 20px;font-family:Georgia,'Times New Roman',serif;color:#23272b;font-size:17px;line-height:1.65">
+  ${inhalt}
+  <hr style="border:none;border-top:1px solid #d9d4c9;margin:32px 0 16px">
+  <p style="font-size:13px;color:#6b7177;line-height:1.6">${fussHtml}</p>
+  </div></body></html>`;
+}
+
+async function resendBatch(cfg: Record<string, string>, mails: unknown[]): Promise<number> {
+  let fehler = 0;
+  for (let i = 0; i < mails.length; i += 100) {
+    const teil = mails.slice(i, i + 100);
+    const r = await fetch("https://api.resend.com/emails/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${cfg.resend_api_key}` },
+      body: JSON.stringify(teil),
+    });
+    if (!r.ok) { fehler += teil.length; console.error("resend", r.status, await r.text()); }
+    if (i + 100 < mails.length) await new Promise((res) => setTimeout(res, 600));
+  }
+  return fehler;
+}
+
+// --- Aktionen ----------------------------------------------------------------
+async function anmelden(req: Request, cfg: Record<string, string>): Promise<Response> {
+  const ok = new Response(JSON.stringify({ ok: true }), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } });
+  let body: Record<string, unknown> = {};
+  try { body = await req.json(); } catch { return ok; }
+  const email = String(body.email ?? "").trim().toLowerCase();
+  const honeypot = String(body.website ?? "");
+  if (honeypot !== "" || !EMAIL_RE.test(email) || email.length > 200) return ok; // still, kein Enumerieren
+  const roh = Array.isArray(body.auswahl) ? body.auswahl : [];
+  const auswahl = roh.filter((s) => typeof s === "string" && SLUG_RE.test(s)).slice(0, 100);
+  const hash = await sha256Hex(cfg.hash_salt + email);
+
+  const vr = await fetch(`${SB}/rest/v1/werkzeugabo_abo?email_hash=eq.${hash}&select=status,token`, { headers: H });
+  const rows: { status: string; token: string }[] = vr.ok ? await vr.json() : [];
+
+  if (rows[0]?.status === "aktiv") {
+    // schon dabei — nur die Auswahl übernehmen, keine zweite Mail
+    await fetch(`${SB}/rest/v1/werkzeugabo_abo?email_hash=eq.${hash}`, {
+      method: "PATCH", headers: H, body: JSON.stringify({ auswahl }),
+    });
+    return ok;
+  }
+
+  const token = tokenNeu();
+  if (rows.length) {
+    await fetch(`${SB}/rest/v1/werkzeugabo_abo?email_hash=eq.${hash}`, {
+      method: "PATCH", headers: H,
+      body: JSON.stringify({ auswahl, status: "angemeldet", token, beendet_am: null }),
+    });
+  } else {
+    const ins = await fetch(`${SB}/rest/v1/werkzeugabo_abo`, {
+      method: "POST", headers: H,
+      body: JSON.stringify([{ email, email_hash: hash, auswahl, status: "angemeldet", token }]),
+    });
+    if (!ins.ok) { console.error("insert", ins.status, await ins.text()); return ok; }
+  }
+
+  const bestaetigen = `${FUNKTION_URL}?aktion=bestaetigen&t=${token}`;
+  const anzahl = auswahl.length;
+  const was = anzahl === 0 ? "alle Werkzeuge" : (anzahl === 1 ? "ein ausgewähltes Werkzeug" : `${anzahl} ausgewählte Werkzeuge`);
+  const inhalt = `
+    <p style="color:#8a6728;font-size:14px;letter-spacing:.04em;margin:0 0 8px">Werkzeuge – Das Goetheanum</p>
+    <p style="font-size:20px;margin:0 0 16px"><strong>Nur noch ein Schritt.</strong></p>
+    <p>Damit dich Neuerungen der Goetheanum-Werkzeuge erreichen (${was}), bestätige bitte deine Anmeldung:</p>
+    <p style="margin:24px 0"><a href="${bestaetigen}" style="background:#0061a9;color:#ffffff;text-decoration:none;padding:12px 22px;border-radius:8px;display:inline-block">Anmeldung bestätigen</a></p>
+    <p>Kein Wunsch von dir? Dann lass diese Nachricht einfach unbeantwortet — es geschieht nichts weiter.</p>`;
+  const fuss = `Du erhältst diese Nachricht, weil diese Adresse auf werkzeuge.goetheanum.ch/abo eingetragen wurde.`;
+  const fehler = await resendBatch(cfg, [{
+    from: cfg.absender, to: [email],
+    subject: "Bitte bestätigen: das Werkzeug-Abo",
+    html: mailHtml(inhalt, fuss),
+  }]);
+  if (fehler) console.error("bestaetigungs-mail fehlgeschlagen");
+  return ok;
+}
+
+async function statusPerToken(t: string, neu: "aktiv" | "beendet", cfg: Record<string, string>): Promise<Response> {
+  const ziel = cfg.seite_url || "https://werkzeuge.goetheanum.ch/abo.html";
+  if (!/^[0-9a-f]{48}$/.test(t)) return Response.redirect(ziel + "#fehler", 303);
+  const patch: Record<string, unknown> = { status: neu };
+  if (neu === "aktiv") patch.bestaetigt_am = new Date().toISOString();
+  else patch.beendet_am = new Date().toISOString();
+  const r = await fetch(`${SB}/rest/v1/werkzeugabo_abo?token=eq.${t}`, {
+    method: "PATCH", headers: { ...H, Prefer: "return=representation" }, body: JSON.stringify(patch),
+  });
+  const rows = r.ok ? await r.json() : [];
+  const anker = rows.length ? (neu === "aktiv" ? "#bestaetigt" : "#beendet") : "#fehler";
+  return Response.redirect(ziel + anker, 303);
+}
+
+async function versand(req: Request, url: URL, cfg: Record<string, string>): Promise<Response> {
+  if (!cfg.versand_key || url.searchParams.get("key") !== cfg.versand_key) {
+    return new Response("nein", { status: 403 });
+  }
+  if (!cfg.resend_api_key) return new Response(JSON.stringify({ ok: false, grund: "resend_api_key fehlt" }), { status: 200 });
+
+  let body: Record<string, unknown> = {};
+  try { body = await req.json(); } catch { /* leer */ }
+  const betreff = String(body.betreff ?? "").trim();
+  const inhaltHtml = String(body.inhalt_html ?? "").trim();
+  if (!betreff || !inhaltHtml) {
+    return new Response(JSON.stringify({ ok: false, grund: "betreff und inhalt_html noetig" }), { status: 200 });
+  }
+  const roh = Array.isArray(body.werkzeuge) ? body.werkzeuge : "alle";
+  const werkzeuge = roh === "alle" ? "alle" : (roh as unknown[]).filter((s) => typeof s === "string" && SLUG_RE.test(s as string)) as string[];
+  const test = typeof body.test === "string" && EMAIL_RE.test(body.test) ? body.test : null;
+
+  const ar = await fetch(`${SB}/rest/v1/werkzeugabo_abo?status=eq.aktiv&select=email,token,auswahl`, { headers: H });
+  const alle: { email: string; token: string; auswahl: string[] }[] = await ar.json();
+  const passt = (a: { auswahl: string[] }) =>
+    werkzeuge === "alle" || !Array.isArray(a.auswahl) || a.auswahl.length === 0 ||
+    (werkzeuge as string[]).some((w) => a.auswahl.includes(w));
+  const abos = test ? [{ email: test, token: "test".padEnd(48, "0"), auswahl: [] }] : alle.filter(passt);
+
+  const mails = abos.map((a) => {
+    const ende = `${FUNKTION_URL}?aktion=ende&t=${a.token}`;
+    const seite = cfg.seite_url || "https://werkzeuge.goetheanum.ch/abo.html";
+    const inhalt = `
+      <p style="color:#8a6728;font-size:14px;letter-spacing:.04em;margin:0 0 8px">Werkzeuge – Das Goetheanum</p>
+      ${inhaltHtml}`;
+    const fuss = `Neuerungen der Goetheanum-Werkzeuge, nach deiner Auswahl.
+      <a href="${seite}" style="color:#6b7177">Auswahl ändern</a> ·
+      <a href="${ende}" style="color:#6b7177">Abmelden mit einem Klick</a> — ohne Rückfrage, ohne Umweg.`;
+    return {
+      from: cfg.absender, to: [a.email],
+      subject: betreff,
+      html: mailHtml(inhalt, fuss),
+      headers: { "List-Unsubscribe": `<${ende}>`, "List-Unsubscribe-Post": "List-Unsubscribe=One-Click" },
+    };
+  });
+
+  const fehler = abos.length ? await resendBatch(cfg, mails) : 0;
+  if (!test) {
+    await fetch(`${SB}/rest/v1/werkzeugabo_versand`, {
+      method: "POST", headers: H,
+      body: JSON.stringify([{ betreff, werkzeuge: werkzeuge === "alle" ? [] : werkzeuge, empfaenger: abos.length - fehler, fehler }]),
+    });
+  }
+  return new Response(JSON.stringify({ ok: true, test: !!test, empfaenger: abos.length, fehler }), { status: 200 });
+}
+
+// --- Router --------------------------------------------------------------------
+Deno.serve(async (req: Request) => {
+  const url = new URL(req.url);
+  const aktion = url.searchParams.get("aktion") ?? "";
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Headers": "content-type" } });
+  }
+  const cfg = await config();
+  try {
+    if (aktion === "anmelden" && req.method === "POST") return await anmelden(req, cfg);
+    if (aktion === "bestaetigen") return await statusPerToken(url.searchParams.get("t") ?? "", "aktiv", cfg);
+    if (aktion === "ende") return await statusPerToken(url.searchParams.get("t") ?? "", "beendet", cfg);
+    if (aktion === "versand" && req.method === "POST") return await versand(req, url, cfg);
+  } catch (e) {
+    console.error("werkzeug-abo", aktion, e);
+    return new Response("fehler", { status: 500 });
+  }
+  return new Response("unbekannte aktion", { status: 404 });
+});

--- a/tools.json
+++ b/tools.json
@@ -148,8 +148,19 @@
       "tag": "Anwendungen",
       "title": "PowerPoint-Vorlagen",
       "href": "powerpoint.html",
-      "desc": "Präsentationsvorlage (A4) im Hausbild mit eingebetteten Schriften – plus die TrueType-Schriften fürs Office zum Installieren.",
+      "desc": "Präsentationsvorlage (A4) im Hausbild – acht Layouts, plus die TrueType-Schriften fürs Office zum Installieren.",
       "such": "PowerPoint Präsentation Folien PPT Vorlage Keynote"
+    },
+    {
+      "slug": "abo",
+      "cat": "anwendung",
+      "status": "live",
+      "tag": "Anwendungen",
+      "title": "Werkzeug-Abo",
+      "short": "Abo",
+      "href": "abo.html",
+      "desc": "Bescheid bekommen, wenn ein Werkzeug neu ist oder besser funktioniert – alle oder nur die persönlich relevanten.",
+      "such": "Abo Newsletter Updates Neuerungen Benachrichtigung Mail"
     },
     {
       "slug": "logo-generator",


### PR DESCRIPTION
## Worum es geht

Neuer Update-Kanal: Wer die Werkzeuge nutzt, kann sich auf **abo.html** eintragen und bekommt eine Mail, wenn ein Werkzeug neu ist oder besser funktioniert (etwa: neue Schrift-Fassung, Neuinstallation lohnt sich) — wahlweise für **alle Werkzeuge oder nur die persönlich ausgewählten**. Abgrenzung zur geplanten Werkzeugpost (redigierte Monats-Mail an alle): das Abo ist der freiwillige, feinkörnige Kanal dazwischen.

## Was sich ändert

**Seite `abo.html`** (aus `design-system/starter.html`): E-Mail-Feld, Schalter «Alle Werkzeuge», Auswahl je Werkzeug gruppiert nach den tools.json-Kategorien (nur live/beta, ohne sich selbst), Honeypot, Status-Meldungen über Anker (#bestaetigt/#beendet/#fehler). Fingerziele ≥44px (B04), Labels in der Lese-Grotesk, Grössen und Farben allein über Tokens (B01/B03/B05). Eintrag in `tools.json` → erscheint im Hub; `schriften.html` verweist aufs Abo.

**Service `services/werkzeug-abo/`** (Supabase Edge Function, Muster = Seelenkalender-Versand):
- `anmelden` POST — Double-Opt-in; Wieder-Anmelden mit neuer Auswahl aktualisiert nur die Auswahl (Antwort immer gleich, kein Nutzer-Enumerieren)
- `bestaetigen` / `ende` GET — Ein-Klick, Umleitung mit Anker
- `versand` POST `?key=` — `{betreff, inhalt_html, werkzeuge[]|"alle", test?}`; Empfänger nach Auswahl-Schnittmenge (leere Auswahl = alles abonniert), List-Unsubscribe-Header, Protokoll je Aussendung

Deployt auf Projekt `dagcsnfrlbpxcmdimnrw`; Tabellen `werkzeugabo_abo/versand/config` mit RLS ohne Policies (nur Service-Role). **Schlüssel liegen nie im Repo.** Nebenbei: veraltete Einbettungs-Behauptung in der PowerPoint-Beschreibung (tools.json) korrigiert.

## Test / Prüfung
- Lebenszyklus live gegen die deployte Function getestet: Honeypot und ungültige Adresse erzeugen keine Zeile; angemeldet → bestätigt (aktiv) → Auswahl-Update im aktiven Zustand → beendet; kaputter Token → #fehler. Ungültige Slugs werden gefiltert. Testdaten geräumt.
- Render-Check der Seite (Chromium, mit geladener Werkzeug-Liste) ✓ · `typo-check` 0 Fehler · `ds-lint` Score 100 %.

## Offene Handgriffe (nur Auftraggeber, dokumentiert in `services/werkzeug-abo/README.md`)
1. **Verify JWT ausschalten** (Dashboard → Edge Functions → werkzeug-abo) — sonst weist das Funktions-Tor die Bestätigungs-/Abmelde-Links aus den Mails ab. Der Seelenkalender läuft genauso.
2. **Resend-API-Schlüssel setzen + Absender-Domain verifizieren** — der Schlüssel fehlt derzeit auch beim Seelenkalender (Wert leer, Absender noch Resend-Sandbox), Mails gehen bis dahin nicht hinaus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8B4TqbvJgPUpAYAxwyvHU

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8B4TqbvJgPUpAYAxwyvHU)_