### PR TITLE
Kampagne: Register durchsuchbar, Cockpit zeigt die einzelnen Abos, Geld in CHF

### DIFF
--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -196,6 +196,31 @@
   .zb-form .span3{grid-column:1 / -1}
   @media (max-width:640px){ .zb-form .grid{grid-template-columns:1fr} }
 
+  /* Ereignis-Protokoll: je Tag aufklappbar (heute offen), Zeilen = einzelne Abos.
+     Daten-Schrift Source (B03 ≥15), Ziffern tabellarisch (G25), nur Tokens (DS02). */
+  .ev-day{border-bottom:1px solid var(--line-soft)}
+  .ev-day>summary{cursor:pointer;list-style:none;display:flex;flex-wrap:wrap;gap:var(--s2) var(--s4);
+    align-items:baseline;justify-content:space-between;min-height:var(--tap);padding:10px 0;
+    font-family:var(--font-text);font-size:var(--t-small)}
+  .ev-day>summary::-webkit-details-marker{display:none}
+  .ev-day>summary:focus-visible{outline:2px solid var(--blue);outline-offset:2px}
+  .ev-day>summary b{color:var(--ink);font-weight:600}
+  .ev-day .ev-sum{color:var(--muted);font-variant-numeric:tabular-nums}
+  .ev-list{padding-bottom:var(--s4)}
+  .ev-row{display:grid;grid-template-columns:56px 1.1fr 1.4fr;gap:var(--s2) var(--s4);
+    padding:7px 0;border-top:1px solid var(--line-soft);
+    font-family:var(--font-text);font-size:var(--t-small);align-items:baseline}
+  .ev-zeit{color:var(--muted);font-variant-numeric:tabular-nums;white-space:nowrap}
+  .ev-was{color:var(--ink)}
+  .ev-meta{display:block;color:var(--muted);font-size:var(--t-micro);margin-top:2px}
+  .ev-her{min-width:0}
+  .ev-kanal{display:inline-block;font-size:var(--t-micro);font-weight:600;color:var(--gold-ink);
+    background:color-mix(in srgb,var(--gold) 15%,transparent);border-radius:var(--r-pill);
+    padding:2px 10px;margin-right:8px;white-space:nowrap}
+  .ev-kanal.ev-ohne{color:var(--muted);background:var(--soft)}
+  .ev-spur{color:var(--muted);font-size:var(--t-micro);overflow-wrap:anywhere}
+  @media (max-width:560px){ .ev-row{grid-template-columns:48px 1fr} .ev-her{grid-column:2} }
+
   /* Aktionsseiten als Buttons – Fingerziele statt klebender Textlinks (B04, DS02) */
   .landing{display:flex;flex-wrap:wrap;gap:var(--s2) var(--s3);align-items:center;font-family:var(--font-text);font-size:var(--t-small);margin-bottom:var(--s4)}
   .landing .meta{margin-right:var(--s2)}

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -19,7 +19,11 @@
       'wos.en.digital': 120,
       'gtv.de': 250, 'gtv.en': 180
     },
-    // Beispielpreise (Vollpreis der wiederkehrenden Zahlung, Euro) – bitte ersetzen.
+    // Anzeige-Währung aller Geldbeträge (Kosten, CPA, Folgejahr-Umsatz).
+    // Gezahlt wird real in EUR UND CHF (Paperform-Formulare je Währung) – bis
+    // je Währung echte Preise hinterlegt sind, gilt EINE Rechenwährung.
+    waehrung: 'CHF',
+    // Beispielpreise (Vollpreis der wiederkehrenden Zahlung, in CONFIG.waehrung) – bitte ersetzen.
     preise: {
       wos: { standard:{monatlich:14.9, jaehrlich:149}, ermaessigt:{monatlich:7.9, jaehrlich:79} },
       gtv: { standard:{monatlich:12,   jaehrlich:120}, ermaessigt:{monatlich:8,   jaehrlich:80} }
@@ -36,7 +40,7 @@
       { key:'empfehlung', label:'Empfehlung',     rolle:'Vertrauen' },
       { key:'andere',     label:'Andere',         rolle:'' }
     ],
-    // Kosten der Aktion (Euro) – stehen auf 0, echte Zahlen werden erfragt.
+    // Kosten der Aktion (in CONFIG.waehrung) – stehen auf 0, echte Zahlen werden erfragt.
     zahlenProvisorisch: true,      // blendet den Hinweis auf Beispielwerte ein
     // Externe Quelle der Social-Media-Zahlen (Reichweite/Klicks je Kanal).
     // Metricool gibt die Zahlen nur im geschützten Dashboard aus – ein Live-Abgriff
@@ -61,7 +65,7 @@
   ];
 
   function fmt(n){ return (Number(n)||0).toLocaleString('de-CH'); }
-  function eur(n){ return '€ ' + Math.round(Number(n)||0).toLocaleString('de-CH'); }
+  function geld(n){ return CONFIG.waehrung + ' ' + Math.round(Number(n)||0).toLocaleString('de-CH'); }
   function el(id){ return document.getElementById(id); }
   function dmy(d){ return d.toLocaleDateString('de-CH',{day:'numeric',month:'long'}); }
 
@@ -151,6 +155,18 @@
       row.querySelector('.track > span').style.width = Math.max(3, Math.round(x.n / max * 100)) + '%';
       host.appendChild(row);
     });
+    // «Andere» einordnen: kein eigener Kanal, sondern Anmeldungen OHNE UTM-Spur.
+    // Hauptquellen: goetheanum.tv (der Uscreen-Webhook trägt keine UTM-Felder mit)
+    // und direkte Landingpage-/Formular-Aufrufe ohne Parameter.
+    var ohneSpur = byKanal['andere'] || 0;
+    if (ohneSpur > 0){
+      var note = document.createElement('div'); note.className = 'fnote';
+      note.textContent = '«Andere» heisst: ohne UTM-Spur angekommen (' + fmt(ohneSpur) +
+        ' Anmeldungen). Der goetheanum.tv-Checkout liefert technisch keine UTMs in den Webhook – ' +
+        'diese Abos landen immer hier; dazu direkte Aufrufe von Landingpage oder Formular. ' +
+        'Die Einzel-Ereignisse stehen unter Momentum → «Was ist passiert?».';
+      host.appendChild(note);
+    }
   }
 
   // ── Wirkungskette: Reichweite → Klicks → Abschlüsse → Geblieben ─────────────
@@ -499,7 +515,7 @@
       tr.children[1].textContent = (r.massnahme || '') + (r.ersteller ? ' · ' + r.ersteller : '');
       if (r.notiz){ var nn = document.createElement('span'); nn.className = 'mnote'; nn.textContent = r.notiz; tr.children[1].appendChild(nn); }
       tr.children[2].textContent = kanal;
-      tr.children[3].textContent = (r.kosten != null) ? eur(r.kosten) : '–';
+      tr.children[3].textContent = (r.kosten != null) ? geld(r.kosten) : '–';
       tr.children[4].textContent = (r.reichweite != null) ? fmt(r.reichweite) : '–';
       tr.children[5].textContent = (r.klicks != null) ? fmt(r.klicks) : '–';
       var edit = document.createElement('button');
@@ -708,8 +724,8 @@
     posten = posten || [];
     var jeKat = {}; var summe = 0;
     posten.forEach(function(k){ var b = Number(k.betrag) || 0; summe += b; jeKat[k.kategorie] = (jeKat[k.kategorie] || 0) + b; });
-    el('costTotal').textContent = eur(summe);
-    el('costCpa').textContent   = (summe > 0 && total > 0) ? eur(summe / total) : '–';
+    el('costTotal').textContent = geld(summe);
+    el('costCpa').textContent   = (summe > 0 && total > 0) ? geld(summe / total) : '–';
     el('costRoi').textContent   = summe > 0 ? (revenue / summe).toFixed(1) + '×' : '–';
 
     var body = el('costBody'); body.innerHTML = '';
@@ -718,12 +734,12 @@
       var tr = document.createElement('tr');
       tr.innerHTML = '<td></td><td class="num"></td>';
       tr.children[0].textContent = KAT_LABEL[kat];
-      tr.children[1].textContent = eur(jeKat[kat] || 0);
+      tr.children[1].textContent = geld(jeKat[kat] || 0);
       body.appendChild(tr);
     });
     var foot = el('costFoot');
     foot.innerHTML = '<tr><td>Summe</td><td class="num"></td></tr>';
-    foot.querySelector('tr').children[1].textContent = eur(summe);
+    foot.querySelector('tr').children[1].textContent = geld(summe);
 
     var pb = el('kostenPostenBody'); pb.innerHTML = '';
     if (!posten.length){
@@ -735,7 +751,7 @@
         tr.children[0].textContent = k.tag ? new Date(k.tag + 'T00:00:00').toLocaleDateString('de-CH', { day:'numeric', month:'numeric' }) : '–';
         tr.children[1].textContent = (k.posten || '') + (k.ersteller ? ' · ' + k.ersteller : '');
         tr.children[2].textContent = KAT_LABEL[k.kategorie] || k.kategorie || '';
-        tr.children[3].textContent = eur(k.betrag);
+        tr.children[3].textContent = geld(k.betrag);
         pb.appendChild(tr);
       });
     }
@@ -858,7 +874,7 @@
     card.querySelector('.txt .m').textContent = fmt(offen) + ' Entscheidungen noch offen · ' + fmt(bleibt) + ' bereits umgewandelt';
     card.querySelector('.pill').textContent = 'Projektion · Annahme ' + Math.round(CONFIG.bleibeQuote * 100) + ' % Bleibe-Quote';
 
-    el('projValue').textContent = eur(revenue);
+    el('projValue').textContent = geld(revenue);
     el('projNote').textContent = 'Hochgerechnet: bleibende Abos zum Vollpreis über alle Tarife, bei ' +
       Math.round(CONFIG.bleibeQuote * 100) + ' % Bleibe-Quote.';
   }
@@ -887,10 +903,91 @@
     return { avg: Math.round(sum / recent.length), days: recent.length };
   }
 
+  // ── Ereignis-Protokoll: die einzelnen Abos («Was ist passiert?») ────────────
+  // RPC sommer2026_ereignisse: Einzel-Anmeldungen der letzten 14 Tage, stunden-
+  // genau gerundet, ohne Personendaten. Beantwortet «woher kamen heute welche
+  // Abos?» – je Tag aufklappbar, heute offen. Abos ohne UTM-Spur sind markiert.
+  function evProduktLabel(r){
+    if (r.produkt === 'gtv') return 'goetheanum.tv · ' + (r.sprache === 'en' ? 'EN' : 'DE');
+    return 'Wochenschrift · ' + (r.sprache === 'en' ? 'EN' : 'DE') + ' · ' + (r.format === 'papier' ? 'Papier' : 'Digital');
+  }
+  function renderEreignisse(rows){
+    var host = el('evList'); if (!host) return;
+    host.innerHTML = '';
+    if (!rows || !rows.length){
+      host.innerHTML = '<div class="empty">Noch keine Anmeldungen in den letzten 14 Tagen.</div>';
+      return;
+    }
+    var heute = new Date(); heute.setHours(0, 0, 0, 0);
+    var gestern = new Date(heute); gestern.setDate(gestern.getDate() - 1);
+    var tage = {}, folge = [];
+    rows.forEach(function(r){
+      var d = new Date(r.stunde);
+      var k = d.getFullYear() + '-' + (d.getMonth() + 1) + '-' + d.getDate();
+      if (!tage[k]){ tage[k] = { datum: new Date(d.getFullYear(), d.getMonth(), d.getDate()), rows: [] }; folge.push(k); }
+      tage[k].rows.push(r);
+    });
+    folge.forEach(function(k){
+      var t = tage[k];
+      var mitSpur = t.rows.filter(function(r){ return r.utm_source || r.utm_content; }).length;
+      var det = document.createElement('details'); det.className = 'ev-day';
+      if (t.datum.getTime() === heute.getTime()) det.open = true;
+      var wann = t.datum.getTime() === heute.getTime() ? 'Heute'
+               : t.datum.getTime() === gestern.getTime() ? 'Gestern'
+               : t.datum.toLocaleDateString('de-CH', { weekday: 'long' });
+      var sum = document.createElement('summary');
+      var sb = document.createElement('b');
+      sb.textContent = wann + ' · ' + t.datum.toLocaleDateString('de-CH', { day: 'numeric', month: 'long' });
+      var sn = document.createElement('span'); sn.className = 'ev-sum';
+      sn.textContent = fmt(t.rows.length) + (t.rows.length === 1 ? ' Abo' : ' Abos') +
+        ' · ' + fmt(mitSpur) + ' mit Spur · ' + fmt(t.rows.length - mitSpur) + ' ohne';
+      sum.appendChild(sb); sum.appendChild(sn); det.appendChild(sum);
+      var list = document.createElement('div'); list.className = 'ev-list';
+      t.rows.forEach(function(r){
+        var row = document.createElement('div'); row.className = 'ev-row';
+        var zeit = document.createElement('span'); zeit.className = 'ev-zeit';
+        zeit.textContent = new Date(r.stunde).toLocaleTimeString('de-CH', { hour: '2-digit', minute: '2-digit' });
+        var was = document.createElement('span'); was.className = 'ev-was';
+        was.textContent = evProduktLabel(r);
+        var wm = document.createElement('span'); wm.className = 'ev-meta';
+        wm.textContent = (r.tarif === 'ermaessigt' ? 'Ermässigt' : 'Standard') + ' · ' + (r.intervall === 'monatlich' ? 'monatlich' : 'jährlich');
+        was.appendChild(wm);
+        var her = document.createElement('span'); her.className = 'ev-her';
+        if (r.utm_source || r.utm_content){
+          var kb = document.createElement('span'); kb.className = 'ev-kanal';
+          kb.textContent = KANAL_LABEL[r.kanal] || r.kanal;
+          her.appendChild(kb);
+          var spur = document.createElement('span'); spur.className = 'ev-spur';
+          spur.textContent = [r.utm_source, r.utm_medium, r.utm_content].filter(Boolean).join(' · ');
+          her.appendChild(spur);
+        } else {
+          var ob = document.createElement('span'); ob.className = 'ev-kanal ev-ohne';
+          ob.textContent = 'ohne Spur';
+          her.appendChild(ob);
+          var wo = document.createElement('span'); wo.className = 'ev-spur';
+          wo.textContent = r.landing_path ? ('via ' + r.landing_path) : ('via ' + (r.source === 'uscreen' ? 'goetheanum.tv-Checkout' : r.source));
+          her.appendChild(wo);
+        }
+        row.appendChild(zeit); row.appendChild(was); row.appendChild(her);
+        list.appendChild(row);
+      });
+      det.appendChild(list);
+      host.appendChild(det);
+    });
+    var note = document.createElement('div'); note.className = 'fnote';
+    note.textContent = 'Zeiten auf die Stunde gerundet, keine Personendaten. «Ohne Spur» = Anmeldung kam ohne UTM-Parameter an (zählt in der Wirkung als «Andere»).';
+    host.appendChild(note);
+  }
+
   // ── Laden ──────────────────────────────────────────────────────────────────
   function load(){
     renderDeadline();
     renderQuelleSocial();
+    // Ereignis-Protokoll separat laden: fällt der RPC aus, bleibt der Rest des
+    // Cockpits vollständig – nur die Liste meldet sich als nicht ladbar.
+    if (el('evList')) rpc('sommer2026_ereignisse')
+      .then(renderEreignisse)
+      .catch(function(){ el('evList').innerHTML = '<div class="err">nicht ladbar</div>'; });
     if(CONFIG.zahlenProvisorisch && el('provisorisch')){
       el('provisorisch').textContent = 'Zielmarken, Preise und die Bleibe-Quote sind vorläufig hinterlegt – sobald die echten Werte gesetzt sind, rechnet das Cockpit unverändert weiter.';
     }

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -84,6 +84,10 @@
   <section>
     <div class="shead"><h2>Momentum</h2><p>Neue Abos je Tag – hier wird sichtbar, wann ein Aufruf, ein Newsletter oder ein Beitrag Wirkung zeigt.</p></div>
     <div class="spark" id="spark"><div class="empty">lädt …</div></div>
+    <details class="zb-form" open>
+      <summary>Was ist passiert? – die einzelnen Abos mit Herkunft</summary>
+      <div id="evList" style="margin-top:var(--s4)"><div class="empty">lädt …</div></div>
+    </details>
   </section>
 
 

--- a/apps/sommer-zaehler/kosten.html
+++ b/apps/sommer-zaehler/kosten.html
@@ -34,7 +34,7 @@
     <div class="tiles">
       <div class="tile"><div class="n gold" id="costTotal">–</div><div class="l">Kosten gesamt</div><div class="s" id="costSub">Stunden, Social Media, Druck & Versand, Infrastruktur</div></div>
       <div class="tile"><div class="n blue" id="costCpa">–</div><div class="l">Kosten je Abo</div><div class="s">sobald Kosten erfasst</div></div>
-      <div class="tile"><div class="n ok" id="costRoi">–</div><div class="l">Rückfluss je € Kosten</div><div class="s">projizierter Folgejahr-Umsatz</div></div>
+      <div class="tile"><div class="n ok" id="costRoi">–</div><div class="l">Rückfluss je eingesetztem Franken</div><div class="s">projizierter Folgejahr-Umsatz</div></div>
     </div>
     <div class="tablewrap" style="margin-top:var(--s5)">
       <table class="tarif">
@@ -68,7 +68,7 @@
             </select>
           </label>
           <label class="field">
-            <span class="lab">Betrag in Euro</span>
+            <span class="lab">Betrag in Franken</span>
             <input type="number" id="kfBetrag" min="0" step="0.01" placeholder="0.00" />
           </label>
           <label class="field span3">

--- a/apps/utm-generator/index.html
+++ b/apps/utm-generator/index.html
@@ -64,7 +64,11 @@
   .reg .zero{color:var(--muted)}
   .tablewrap{overflow-x:auto;margin-top:var(--s4)}
   .empty{font-family:var(--font-text);color:var(--muted);font-size:var(--t-small)}
+  /* Register-Werkzeuge: Suche, Filter, Sortierung – Felder aus base.css, nur Raster hier. */
+  .reg-tools{display:grid;grid-template-columns:2fr 1fr 1fr 1.4fr;gap:var(--s3);margin-top:var(--s4)}
+  .reg-zahl{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);margin:var(--s3) 0 0;font-variant-numeric:tabular-nums}
 
+  @media (max-width:720px){ .reg-tools{grid-template-columns:1fr 1fr} }
   @media (max-width:640px){
     .grid{grid-template-columns:1fr}
     .out{grid-template-columns:1fr}
@@ -196,6 +200,30 @@
       <h2>Registrierte Links</h2>
       <p>Soll und Ist: jeder gebaute Link mit der Zahl der Anmeldungen, die tatsächlich über ihn kamen. <q>0</q> heisst: lief, brachte (noch) nichts.</p>
     </div>
+    <!-- Werkzeuge über der Liste: Suche, zwei Filter, Sortierung – die Liste
+         bleibt vollständig geladen, gefiltert wird im Browser. -->
+    <div class="reg-tools">
+      <label class="field"><span class="lab">Suche</span>
+        <input id="regSuche" type="search" placeholder="Motiv, Quelle, Tiername, URL …" autocomplete="off" /></label>
+      <label class="field"><span class="lab">Quelle</span>
+        <select id="regQuelle"><option value="">alle</option></select></label>
+      <label class="field"><span class="lab">Ziel</span>
+        <select id="regZiel">
+          <option value="">alle</option>
+          <option value="uebersicht">Übersicht</option>
+          <option value="wos">Wochenschrift</option>
+          <option value="tv">goetheanum.tv</option>
+        </select></label>
+      <label class="field"><span class="lab">Sortieren nach</span>
+        <select id="regSort">
+          <option value="abschluesse">Abschlüsse · meiste zuerst</option>
+          <option value="neu">Neueste zuerst</option>
+          <option value="alt">Älteste zuerst</option>
+          <option value="motiv">Motiv A–Z</option>
+          <option value="quelle">Quelle A–Z</option>
+        </select></label>
+    </div>
+    <p class="reg-zahl" id="regZahl"></p>
     <div class="tablewrap">
       <table class="reg">
         <colgroup><col class="cMot" /><col class="cQm" /><col class="cZiel" /><col class="cAb" /><col class="cAct" /></colgroup>
@@ -433,41 +461,106 @@
       .catch(function(){ say('Löschen nicht erreichbar.', true); });
   }
 
+  // Register: einmal laden, dann im Browser suchen, filtern, sortieren.
+  var regRows = [];
+
+  function regQuelleOptionen(){
+    // Quellen-Filter aus den tatsächlich vorhandenen utm_source-Werten füllen;
+    // die aktuelle Auswahl übersteht das Neuladen.
+    var sel = el('regQuelle'), aktuell = sel.value;
+    var quellen = {};
+    regRows.forEach(function(x){ if(x.utm_source) quellen[x.utm_source] = true; });
+    sel.innerHTML = '<option value="">alle</option>';
+    Object.keys(quellen).sort().forEach(function(s){
+      var o = document.createElement('option'); o.value = s; o.textContent = s; sel.appendChild(o);
+    });
+    if(quellen[aktuell]) sel.value = aktuell;
+  }
+
+  function applyRegister(){
+    var body = el('regBody'); body.innerHTML = '';
+    if(!regRows.length){
+      body.innerHTML = '<tr><td class="empty" colspan="5">Noch keine Links registriert.</td></tr>';
+      el('regZahl').textContent = '';
+      return;
+    }
+    var suche = (el('regSuche').value || '').trim().toLowerCase();
+    var fQuelle = el('regQuelle').value, fZiel = el('regZiel').value;
+    var rows = regRows.filter(function(x){
+      if(fQuelle && x.utm_source !== fQuelle) return false;
+      if(fZiel && x.landing !== fZiel) return false;
+      if(!suche) return true;
+      var heu = [x.utm_content, x.utm_source, x.utm_medium, x.code, x.url,
+                 x.ersteller, ANGEBOT_LABEL[x.landing] || x.landing, x.sprache]
+        .filter(Boolean).join(' ').toLowerCase();
+      return heu.indexOf(suche) !== -1;
+    });
+    var sortiert = rows.slice();
+    var az = function(a, b){ return String(a || '').localeCompare(String(b || ''), 'de'); };
+    switch(el('regSort').value){
+      case 'neu':    sortiert.sort(function(a, b){ return new Date(b.created_at) - new Date(a.created_at); }); break;
+      case 'alt':    sortiert.sort(function(a, b){ return new Date(a.created_at) - new Date(b.created_at); }); break;
+      case 'motiv':  sortiert.sort(function(a, b){ return az(a.utm_content, b.utm_content); }); break;
+      case 'quelle': sortiert.sort(function(a, b){ return az(a.utm_source, b.utm_source) || az(a.utm_medium, b.utm_medium); }); break;
+      default:       sortiert.sort(function(a, b){ return (Number(b.abschluesse) || 0) - (Number(a.abschluesse) || 0) ||
+                                                          (new Date(b.created_at) - new Date(a.created_at)); });
+    }
+    var abschluesse = sortiert.reduce(function(s, x){ return s + (Number(x.abschluesse) || 0); }, 0);
+    el('regZahl').textContent = sortiert.length === regRows.length
+      ? (regRows.length + ' Links · ' + abschluesse.toLocaleString('de-CH') + ' Abschlüsse')
+      : (sortiert.length + ' von ' + regRows.length + ' Links · ' + abschluesse.toLocaleString('de-CH') + ' Abschlüsse im Filter');
+    if(!sortiert.length){
+      body.innerHTML = '<tr><td class="empty" colspan="5">Kein Link passt zu Suche/Filter.</td></tr>';
+      return;
+    }
+    sortiert.forEach(function(x){
+      var tr = document.createElement('tr');
+      tr.innerHTML = '<td class="mot"></td><td class="mot"></td><td></td><td class="num"></td><td class="act"></td>';
+      var mot = tr.children[0];
+      mot.textContent = x.utm_content || '—';
+      var q = document.createElement('span'); q.className = 'q';
+      // Kurzlink zeigen (aufgeräumt für die Veröffentlichung), Titel = volle URL.
+      if(x.code){ var a = document.createElement('a'); a.href = SHORTBASE + x.code;
+        a.target = '_blank'; a.rel = 'noopener'; a.textContent = SHORTBASE + x.code;
+        a.title = x.url; q.appendChild(a); }
+      else { q.textContent = x.url; }
+      mot.appendChild(q);
+      tr.children[1].textContent = [x.utm_source, x.utm_medium].filter(Boolean).join(' · ');
+      // Unterzeile: wann angelegt, von wem – macht die Sortierung nach Datum lesbar.
+      var meta = document.createElement('span'); meta.className = 'q';
+      var wann = x.created_at ? new Date(x.created_at).toLocaleDateString('de-CH', { day:'numeric', month:'numeric' }) : '';
+      meta.textContent = [wann && ('angelegt ' + wann), x.ersteller].filter(Boolean).join(' · ');
+      if(meta.textContent) tr.children[1].appendChild(meta);
+      var ziel = ANGEBOT_LABEL[x.landing] || x.landing || '';
+      if(x.sprache) ziel += ' · ' + x.sprache.toUpperCase();
+      tr.children[2].textContent = ziel;
+      var n = Number(x.abschluesse) || 0;
+      tr.children[3].textContent = n.toLocaleString('de-CH');
+      if(n === 0) tr.children[3].className = 'num zero';
+      var del = document.createElement('button');
+      del.type = 'button'; del.className = 'del'; del.textContent = 'Löschen';
+      del.setAttribute('aria-label', 'Link löschen');
+      del.addEventListener('click', function(){ loescheLink(x.url); });
+      tr.children[4].appendChild(del);
+      body.appendChild(tr);
+    });
+  }
+
+  ['regSuche','regQuelle','regZiel','regSort'].forEach(function(id){
+    el(id).addEventListener('input', applyRegister);
+    el(id).addEventListener('change', applyRegister);
+  });
+
   function loadRegister(){
     fetch(SB + '/rest/v1/rpc/sommer2026_links_public', {
       method:'POST', headers:{ 'Content-Type':'application/json', 'apikey':KEY, 'Authorization':'Bearer ' + KEY }, body:'{}'
     }).then(function(r){ if(!r.ok) throw new Error(r.status); return r.json(); })
       .then(function(rows){
-        var body = el('regBody'); body.innerHTML = '';
-        usedCodes = {}; (rows || []).forEach(function(x){ if(x.code) usedCodes[x.code] = true; });
+        regRows = rows || [];
+        usedCodes = {}; regRows.forEach(function(x){ if(x.code) usedCodes[x.code] = true; });
         if(slugWarAutomatisch || !el('slug').value || usedCodes[slugCode(el('slug').value)]) setzeAutoSlug();
-        if(!rows || !rows.length){ body.innerHTML = '<tr><td class="empty" colspan="5">Noch keine Links registriert.</td></tr>'; return; }
-        rows.forEach(function(x){
-          var tr = document.createElement('tr');
-          tr.innerHTML = '<td class="mot"></td><td></td><td></td><td class="num"></td><td class="act"></td>';
-          var mot = tr.children[0];
-          mot.textContent = x.utm_content || '—';
-          var q = document.createElement('span'); q.className = 'q';
-          // Kurzlink zeigen (aufgeräumt für die Veröffentlichung), Titel = volle URL.
-          if(x.code){ var a = document.createElement('a'); a.href = SHORTBASE + x.code;
-            a.target = '_blank'; a.rel = 'noopener'; a.textContent = SHORTBASE + x.code;
-            a.title = x.url; q.appendChild(a); }
-          else { q.textContent = x.url; }
-          mot.appendChild(q);
-          tr.children[1].textContent = [x.utm_source, x.utm_medium].filter(Boolean).join(' · ');
-          var ziel = ANGEBOT_LABEL[x.landing] || x.landing || '';
-          if(x.sprache) ziel += ' · ' + x.sprache.toUpperCase();
-          tr.children[2].textContent = ziel;
-          var n = Number(x.abschluesse) || 0;
-          tr.children[3].textContent = n.toLocaleString('de-CH');
-          if(n === 0) tr.children[3].className = 'num zero';
-          var del = document.createElement('button');
-          del.type = 'button'; del.className = 'del'; del.textContent = 'Löschen';
-          del.setAttribute('aria-label', 'Link löschen');
-          del.addEventListener('click', function(){ loescheLink(x.url); });
-          tr.children[4].appendChild(del);
-          body.appendChild(tr);
-        });
+        regQuelleOptionen();
+        applyRegister();
       })
       .catch(function(){ el('regBody').innerHTML = '<tr><td class="empty" colspan="5">Register nicht ladbar.</td></tr>'; });
   }

--- a/services/sommer-zaehler/README.md
+++ b/services/sommer-zaehler/README.md
@@ -31,7 +31,9 @@ RPCs (für `anon` per Publishable-Key aufrufbar, wie in `statistik.html`):
 `sommer2026_kohorten` (der 3-Monats-Moment), `sommer2026_kanaele` (Attribution
 je Herkunftsweg), `sommer2026_attribution` (feiner: je UTM-Motiv),
 `sommer2026_trichter` (Wirkungskette Sichtbarkeit→Bindung),
-`sommer2026_massnahmen_public` (Massnahmen-Protokoll, kuratiert).
+`sommer2026_massnahmen_public` (Massnahmen-Protokoll, kuratiert),
+`sommer2026_ereignisse` (Einzel-Anmeldungen der letzten 14 Tage für «Was ist
+passiert?» – stundengenau gerundet, ohne jede Personenspalte).
 
 ## Attribution (Woher) und Kosten
 
@@ -44,7 +46,10 @@ Sie aufmerksam geworden?», E-Mail-redigiert). So bleibt sichtbar, welches
 welcher Kanal. Die Ingestion (Paperform / Uscreen) schreibt das mit; der
 `kanal`-Bucket wird daraus abgeleitet. Die **Kosten** liegen (wie Preise und
 Zielmarken) im `CONFIG`-Block der Seite; daraus rechnet das Cockpit Kosten je Abo
-(CPA) und den Rückfluss je € Kosten.
+(CPA) und den Rückfluss je eingesetztem Franken. Alle Geldbeträge zeigt das
+Cockpit in **einer** Anzeige-Währung (`CONFIG.waehrung`, aktuell CHF); gezahlt
+wird real in EUR und CHF (`waehrung` je Anmeldung) – echte Preise je Währung
+stehen noch aus.
 
 ## Wirkungskette und Aktivitäten-Protokoll
 

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -301,6 +301,22 @@ grant execute on function public.sommer2026_attribution()       to anon, authent
 grant execute on function public.sommer2026_massnahmen_public() to anon, authenticated;
 grant execute on function public.sommer2026_trichter()          to anon, authenticated;
 
+-- Ereignis-Protokoll (Migration «sommer2026_ereignisse»): die einzelnen
+-- Anmeldungen der letzten 14 Tage fürs Cockpit («Was ist heute passiert?») –
+-- stundengenau gerundet (keine Minuten-Fingerprints), ohne jede Personenspalte.
+create or replace function public.sommer2026_ereignisse()
+returns table(stunde timestamptz, produkt text, sprache text, format text, tarif text, intervall text,
+              kanal text, utm_source text, utm_medium text, utm_content text, landing_path text, source text)
+language sql security definer set search_path to 'public' as $$
+  select date_trunc('hour', signed_up_at) as stunde, produkt, sprache, format, tarif, intervall,
+         kanal, utm_source, utm_medium, utm_content, landing_path, source
+    from public.sommer2026_signups
+   where signed_up_at >= now() - interval '14 days'
+   order by signed_up_at desc
+   limit 400;
+$$;
+grant execute on function public.sommer2026_ereignisse() to anon, authenticated;
+
 -- =============================================================================
 -- Link-Register (Migration «sommer2026_links_register»)
 -- Erzeugte UTM-Links (aus apps/utm-generator/) sammeln → Soll/Ist im Cockpit.


### PR DESCRIPTION
## Was dieser PR tut

**UTM-Register (`apps/utm-generator/`):** Über der Liste stehen jetzt Suche (Motiv, Quelle, Tiername, URL, Kürzel), Filter nach Quelle und Ziel sowie eine Sortierung (Abschlüsse, Neueste/Älteste, Motiv A–Z, Quelle A–Z). Eine Zählzeile nennt Treffer und Abschlüsse im Filter; die Quelle-·-Medium-Zelle trägt neu Anlagedatum und Kürzel als Unterzeile.

**Cockpit (`apps/sommer-zaehler/`):** Unter Momentum gibt es das aufklappbare Ereignis-Protokoll «Was ist passiert?» – je Tag eine Zeile-für-Zeile-Liste der einzelnen Abos (Stunde, Strom, Tarif/Intervall, Kanal und UTM-Spur bzw. «ohne Spur» mit Herkunftsweg). Heute ist offen, ältere Tage zugeklappt. Gespeist vom neuen Aggregat-RPC `sommer2026_ereignisse` (letzte 14 Tage, stundengenau gerundet, keine Personenspalten – Migration ist auf dem Werkzeug-Supabase angewendet, `schema.sql` dokumentiert sie).

**Wirkung:** Ein Hinweis unter den Kanal-Balken ordnet «Andere» ein: das ist kein Kanal, sondern «ohne UTM-Spur angekommen» – vor allem der goetheanum.tv-Checkout, dessen Uscreen-Webhook technisch keine UTM-Felder mitliefert.

**Währung:** Alle Geldbeträge (Kosten, CPA, Folgejahr-Umsatz) laufen über `CONFIG.waehrung` (aktuell `CHF`) statt über hart verdrahtetes `€ `; Beschriftungen in `kosten.html` entsprechend («Betrag in Franken», «Rückfluss je eingesetztem Franken»). Gezahlt wird real in EUR **und** CHF – echte Preise je Währung stehen noch aus und sind im README als offen markiert.

## Regeln
G25 (Ziffern tabellarisch), B03/B04 (Mindestgrössen, Fingerziele ≥44px), DS02 (nur Token-Farben/-Grössen). Prüfmaschinen: typo-check ✓, ds-lint 100 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN)_