### PR TITLE
Kampagne: echte Preise je Währung, «ohne UTM» statt «Andere», Uscreen-Auftrag

### DIFF
--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -19,14 +19,28 @@
       'wos.en.digital': 120,
       'gtv.de': 250, 'gtv.en': 180
     },
-    // Anzeige-Währung aller Geldbeträge (Kosten, CPA, Folgejahr-Umsatz).
-    // Gezahlt wird real in EUR UND CHF (Paperform-Formulare je Währung) – bis
-    // je Währung echte Preise hinterlegt sind, gilt EINE Rechenwährung.
+    // Anzeige-Währung aller Geldbeträge (Kosten, CPA, Summenzeile Folgejahr-Umsatz).
     waehrung: 'CHF',
-    // Beispielpreise (Vollpreis der wiederkehrenden Zahlung, in CONFIG.waehrung) – bitte ersetzen.
+    // Umrechnung EUR→CHF – nur für die Summenzeile (EUR-Umsatz in die
+    // CHF-Gesamtsumme einrechnen). Bei Kursbewegung hier nachführen.
+    eurChf: 0.93,
+    // ECHTE Preise (Stand 17.7.2026): Wochenschrift aus den vier Kampagnen-
+    // Formularen (Paperform, CHF/EUR × Papier&Online/Online), goetheanum.tv aus
+    // dem Uscreen-Store (rechnet ausschliesslich in EUR: 14.90/Monat, 149/Jahr).
+    // «Ermässigt» ist im Shop KEIN eigener Preis, sondern läuft über Coupons
+    // (20/30/50 %) – ermässigte Zeilen rechnen darum zum Standardpreis (Fallback).
+    // Das Förderabo der Wochenschrift (Papier 249 CHF/239 EUR, Online 199/189
+    // im Jahr) führt das Backend nicht als Tarif – es zählt als Standard.
     preise: {
-      wos: { standard:{monatlich:14.9, jaehrlich:149}, ermaessigt:{monatlich:7.9, jaehrlich:79} },
-      gtv: { standard:{monatlich:12,   jaehrlich:120}, ermaessigt:{monatlich:8,   jaehrlich:80} }
+      chf: {
+        wos: { papier:  { standard:{monatlich:14.9, jaehrlich:149} },
+               digital: { standard:{monatlich:10.9, jaehrlich:109} } }
+      },
+      eur: {
+        wos: { papier:  { standard:{monatlich:13.9, jaehrlich:139} },
+               digital: { standard:{monatlich:9.9,  jaehrlich:99} } },
+        gtv: { stream:  { standard:{monatlich:14.9, jaehrlich:149} } }
+      }
     },
     // Herkunftswege (Attribution) mit Hauptaufgabe – nicht jeder Kanal verkauft.
     // Social stiftet Aufmerksamkeit, der Newsletter Beziehung, das Mailing die
@@ -38,7 +52,7 @@
       { key:'popup',      label:'Popup',          rolle:'Entscheidung' },
       { key:'website',    label:'Website direkt', rolle:'Orientierung' },
       { key:'empfehlung', label:'Empfehlung',     rolle:'Vertrauen' },
-      { key:'andere',     label:'Andere',         rolle:'' }
+      { key:'andere',     label:'ohne UTM',       rolle:'' }
     ],
     // Kosten der Aktion (in CONFIG.waehrung) – stehen auf 0, echte Zahlen werden erfragt.
     zahlenProvisorisch: true,      // blendet den Hinweis auf Beispielwerte ein
@@ -155,15 +169,15 @@
       row.querySelector('.track > span').style.width = Math.max(3, Math.round(x.n / max * 100)) + '%';
       host.appendChild(row);
     });
-    // «Andere» einordnen: kein eigener Kanal, sondern Anmeldungen OHNE UTM-Spur.
+    // «ohne UTM» einordnen: kein eigener Kanal, sondern Anmeldungen ohne UTM-Spur.
     // Hauptquellen: goetheanum.tv (der Uscreen-Webhook trägt keine UTM-Felder mit)
     // und direkte Landingpage-/Formular-Aufrufe ohne Parameter.
     var ohneSpur = byKanal['andere'] || 0;
     if (ohneSpur > 0){
       var note = document.createElement('div'); note.className = 'fnote';
-      note.textContent = '«Andere» heisst: ohne UTM-Spur angekommen (' + fmt(ohneSpur) +
-        ' Anmeldungen). Der goetheanum.tv-Checkout liefert technisch keine UTMs in den Webhook – ' +
-        'diese Abos landen immer hier; dazu direkte Aufrufe von Landingpage oder Formular. ' +
+      note.textContent = '«ohne UTM» = ' + fmt(ohneSpur) + ' Anmeldungen, die ohne UTM-Parameter ankamen. ' +
+        'Der goetheanum.tv-Checkout liefert technisch keine UTMs in den Webhook – diese Abos landen immer hier; ' +
+        'dazu direkte Aufrufe von Landingpage oder Formular. ' +
         'Die Einzel-Ereignisse stehen unter Momentum → «Was ist passiert?».';
       host.appendChild(note);
     }
@@ -726,7 +740,8 @@
     posten.forEach(function(k){ var b = Number(k.betrag) || 0; summe += b; jeKat[k.kategorie] = (jeKat[k.kategorie] || 0) + b; });
     el('costTotal').textContent = geld(summe);
     el('costCpa').textContent   = (summe > 0 && total > 0) ? geld(summe / total) : '–';
-    el('costRoi').textContent   = summe > 0 ? (revenue / summe).toFixed(1) + '×' : '–';
+    var revChf = revenue && revenue.chfGesamt || 0;
+    el('costRoi').textContent   = summe > 0 ? (revChf / summe).toFixed(1) + '×' : '–';
 
     var body = el('costBody'); body.innerHTML = '';
     Object.keys(KAT_LABEL).forEach(function(kat){
@@ -815,17 +830,28 @@
   }
 
   // ── Umsatz-Projektion (Folgejahr) ──────────────────────────────────────────
+  // Rechnet je Zahlungswährung getrennt (CHF- und EUR-Zahler zum je echten
+  // Preis) und liefert zusätzlich die CHF-Gesamtsumme (EUR über CONFIG.eurChf).
+  // goetheanum.tv rechnet ausschliesslich in EUR – Zeilen ohne Währungsangabe
+  // fallen darum auf EUR. Preis-Lookup: Währung → Produkt → Format → Tarif
+  // (ermässigt hat im Shop keinen eigenen Preis → Fallback Standard).
   function projectRevenue(rows){
-    return rows.reduce(function(sum, r){
-      var preis = ((CONFIG.preise[r.produkt] || {})[r.tarif] || {})[r.intervall];
-      if(!preis) return sum;
+    var summe = { chf: 0, eur: 0 };
+    rows.forEach(function(r){
+      var w = r.waehrung === 'chf' ? 'chf' : 'eur';
+      var jeFormat = ((CONFIG.preise[w] || {})[r.produkt] || {})[r.format] || {};
+      var jeTarif = jeFormat[r.tarif] || jeFormat.standard || {};
+      var preis = jeTarif[r.intervall];
+      if(!preis) return;
       var jahr = r.intervall === 'monatlich' ? preis * 12 : preis;
       var bleibend;
       if(r.status === 'bleibt') bleibend = Number(r.n);
       else if(r.status === 'neu' || r.status === 'laeuft-aus') bleibend = Number(r.n) * CONFIG.bleibeQuote;
       else bleibend = 0;                     // gekuendigt zählt nicht
-      return sum + bleibend * jahr;
-    }, 0);
+      summe[w] += bleibend * jahr;
+    });
+    summe.chfGesamt = summe.chf + summe.eur * CONFIG.eurChf;
+    return summe;
   }
 
   // ── Kacheln, Meilensteine ──────────────────────────────────────────────────
@@ -874,9 +900,13 @@
     card.querySelector('.txt .m').textContent = fmt(offen) + ' Entscheidungen noch offen · ' + fmt(bleibt) + ' bereits umgewandelt';
     card.querySelector('.pill').textContent = 'Projektion · Annahme ' + Math.round(CONFIG.bleibeQuote * 100) + ' % Bleibe-Quote';
 
-    el('projValue').textContent = geld(revenue);
-    el('projNote').textContent = 'Hochgerechnet: bleibende Abos zum Vollpreis über alle Tarife, bei ' +
-      Math.round(CONFIG.bleibeQuote * 100) + ' % Bleibe-Quote.';
+    el('projValue').textContent = geld(revenue.chfGesamt);
+    var teile = [];
+    if (revenue.chf > 0) teile.push('CHF ' + Math.round(revenue.chf).toLocaleString('de-CH') + ' von CHF-Zahlern');
+    if (revenue.eur > 0) teile.push('€ ' + Math.round(revenue.eur).toLocaleString('de-CH') + ' von EUR-Zahlern, umgerechnet zum Kurs ' + CONFIG.eurChf);
+    el('projNote').textContent = 'Hochgerechnet: bleibende Abos zum echten Vollpreis je Zahlungswährung' +
+      (teile.length ? ' (' + teile.join(' + ') + ')' : '') + ', bei ' +
+      Math.round(CONFIG.bleibeQuote * 100) + ' % Bleibe-Quote.';
   }
 
   // ── Momentum ───────────────────────────────────────────────────────────────
@@ -940,7 +970,7 @@
       sb.textContent = wann + ' · ' + t.datum.toLocaleDateString('de-CH', { day: 'numeric', month: 'long' });
       var sn = document.createElement('span'); sn.className = 'ev-sum';
       sn.textContent = fmt(t.rows.length) + (t.rows.length === 1 ? ' Abo' : ' Abos') +
-        ' · ' + fmt(mitSpur) + ' mit Spur · ' + fmt(t.rows.length - mitSpur) + ' ohne';
+        ' · ' + fmt(mitSpur) + ' mit UTM · ' + fmt(t.rows.length - mitSpur) + ' ohne';
       sum.appendChild(sb); sum.appendChild(sn); det.appendChild(sum);
       var list = document.createElement('div'); list.className = 'ev-list';
       t.rows.forEach(function(r){
@@ -962,7 +992,7 @@
           her.appendChild(spur);
         } else {
           var ob = document.createElement('span'); ob.className = 'ev-kanal ev-ohne';
-          ob.textContent = 'ohne Spur';
+          ob.textContent = 'ohne UTM';
           her.appendChild(ob);
           var wo = document.createElement('span'); wo.className = 'ev-spur';
           wo.textContent = r.landing_path ? ('via ' + r.landing_path) : ('via ' + (r.source === 'uscreen' ? 'goetheanum.tv-Checkout' : r.source));
@@ -975,7 +1005,7 @@
       host.appendChild(det);
     });
     var note = document.createElement('div'); note.className = 'fnote';
-    note.textContent = 'Zeiten auf die Stunde gerundet, keine Personendaten. «Ohne Spur» = Anmeldung kam ohne UTM-Parameter an (zählt in der Wirkung als «Andere»).';
+    note.textContent = 'Zeiten auf die Stunde gerundet, keine Personendaten. «ohne UTM» = Anmeldung kam ohne UTM-Parameter an – so heisst sie auch in der Wirkung.';
     host.appendChild(note);
   }
 

--- a/services/sommer-zaehler/README.md
+++ b/services/sommer-zaehler/README.md
@@ -46,10 +46,12 @@ Sie aufmerksam geworden?», E-Mail-redigiert). So bleibt sichtbar, welches
 welcher Kanal. Die Ingestion (Paperform / Uscreen) schreibt das mit; der
 `kanal`-Bucket wird daraus abgeleitet. Die **Kosten** liegen (wie Preise und
 Zielmarken) im `CONFIG`-Block der Seite; daraus rechnet das Cockpit Kosten je Abo
-(CPA) und den Rückfluss je eingesetztem Franken. Alle Geldbeträge zeigt das
-Cockpit in **einer** Anzeige-Währung (`CONFIG.waehrung`, aktuell CHF); gezahlt
-wird real in EUR und CHF (`waehrung` je Anmeldung) – echte Preise je Währung
-stehen noch aus.
+(CPA) und den Rückfluss je eingesetztem Franken. Der Folgejahr-Umsatz rechnet
+je **Zahlungswährung** getrennt (`waehrung` je Anmeldung; goetheanum.tv
+rechnet ausschliesslich in EUR) mit den **echten Preisen** aus den
+Kampagnen-Formularen bzw. dem Uscreen-Store (`CONFIG.preise`, Stand
+17.7.2026); die EUR-Summe fliesst über `CONFIG.eurChf` in die
+CHF-Gesamtsumme ein.
 
 ## Wirkungskette und Aktivitäten-Protokoll
 

--- a/services/sommer-zaehler/ingest-uscreen/index.ts
+++ b/services/sommer-zaehler/ingest-uscreen/index.ts
@@ -207,6 +207,8 @@ Deno.serve(async (req) => {
 
   const row = {
     signed_up_at: when, produkt: "gtv", sprache, format: "stream",
+    // Der Store rechnet ausschliesslich in EUR (Uscreen-Währung des Shops).
+    waehrung: "eur",
     tarif, intervall, status: "neu", kanal, source: "uscreen", ext_id: ext, dedup_key: dedupKey,
     kampagne: (camp ? String(camp) : "summer26_trial"),
     utm_source: src ? String(src) : null, utm_medium: med ? String(med) : null,

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -45,13 +45,16 @@ alter table public.sommer2026_signups enable row level security;
 -- Bewusst KEINE anon-Policy: RLS an + keine Policy = Rohzeilen zu.
 revoke all on table public.sommer2026_signups from anon, authenticated;
 
--- 1) Breakdown je Dimension (Ströme, Tarife, Bleibe-Zustand)
+-- 1) Breakdown je Dimension (Ströme, Tarife, Bleibe-Zustand, Zahlungswährung)
+-- (Migration «sommer2026_stats_waehrung»: waehrung ergänzt, damit der
+-- Folgejahr-Umsatz je Zahlungswährung zum echten Preis rechnet; gtv-Zeilen
+-- ohne Angabe wurden auf 'eur' nachgezogen – der Uscreen-Store rechnet in EUR.)
 create or replace function public.sommer2026_stats()
-returns table(produkt text, sprache text, format text, tarif text, intervall text, status text, n bigint)
+returns table(produkt text, sprache text, format text, tarif text, intervall text, status text, waehrung text, n bigint)
 language sql security definer set search_path to 'public' as $$
-  select produkt, sprache, format, tarif, intervall, status, count(*)::bigint as n
+  select produkt, sprache, format, tarif, intervall, status, waehrung, count(*)::bigint as n
     from public.sommer2026_signups
-   group by produkt, sprache, format, tarif, intervall, status;
+   group by produkt, sprache, format, tarif, intervall, status, waehrung;
 $$;
 
 -- 2) Momentum: Anmeldungen je Tag und Produkt

--- a/services/sommer-zaehler/uscreen-attribution-auftrag.md
+++ b/services/sommer-zaehler/uscreen-attribution-auftrag.md
@@ -1,0 +1,94 @@
+# Auftrag für Claude im Chrome: Uscreen-Attribution einrichten (goetheanum.tv)
+
+Dieser Prompt ist für **Claude in Chrome** gedacht, eingeloggt im
+**Uscreen-Admin von goetheanum.tv**. Er stammt aus der Attributions-Analyse vom
+17.7.2026: Der Uscreen-Webhook liefert nur `event`, `subscription_id`,
+`subscription_title`, `transaction_id` und User-Felder — **keine UTM-Parameter,
+keinen Referrer, keine Custom-Field-Antworten**. Darum landen alle
+goetheanum.tv-Abos im Cockpit unter «ohne UTM».
+
+Den folgenden Block vollständig kopieren und Claude im Chrome geben:
+
+---
+
+Du bist im Uscreen-Admin-Backend von goetheanum.tv eingeloggt und hilfst mir,
+die Herkunfts-Attribution unserer Abo-Anmeldungen einzurichten. Kontext: Wir
+fahren die Sommer-Aktion «3 Monate gratis» (bis 8. August) und messen die
+Anmeldungen in einem eigenen Cockpit. Unser Webhook-Empfänger bekommt von
+Uscreen aktuell nur `event`, `subscription_id`, `subscription_title`,
+`transaction_id` und die User-Felder — keine UTM-Parameter, keinen Referrer
+und keine Antworten aus Custom-Feldern. Dadurch ist bei allen
+goetheanum.tv-Abos unsichtbar, welche Massnahme sie ausgelöst hat.
+
+Regeln für diesen Auftrag:
+- Nichts löschen und keine bestehenden Einstellungen abschalten. Nur
+  hinzufügen, prüfen und dokumentieren.
+- Keine Aktionen, die Mails an Kundinnen oder Kunden auslösen.
+- Geheimnisse (Webhook-URLs mit `?key=…`, API-Tokens) nie in den Chat
+  schreiben und nicht in Screenshots zeigen — nur bestätigen, DASS sie
+  existieren, und den Fundort nennen.
+- Wenn eine Einstellung nicht existiert oder anders heisst als unten
+  beschrieben, nicht improvisieren: notieren, wie der Bereich wirklich heisst,
+  und im Abschlussbericht melden.
+
+Arbeite diese fünf Schritte der Reihe nach ab:
+
+**Schritt 1 — Custom-Feld «Wie sind Sie auf uns aufmerksam geworden?»**
+Öffne die Einstellungen für Nutzerfelder (Settings → Custom Fields bzw.
+User Fields, je nach Oberfläche). Prüfe, ob ein Feld wie «Wie sind Sie auf
+uns aufmerksam geworden?» existiert. Falls nein: lege es an, als bei der
+Registrierung sichtbares, optionales Textfeld (kein Pflichtfeld — es darf
+keine Anmeldung verhindern). Notiere den exakten internen Feld-Key/Namen,
+den Uscreen dem Feld gibt — wir brauchen ihn wortgenau für unser Mapping.
+
+**Schritt 2 — Webhook-Konfiguration prüfen**
+Öffne Settings → Webhooks (bzw. Integrations → Webhooks). Dokumentiere,
+welche Webhook-Endpunkte eingetragen sind (nur Host nennen, den `?key=`-Teil
+weglassen) und welche Events aktiviert sind. Wir erwarten mindestens:
+Subscription created/assigned, Subscription canceled und ein Zahlungs-Event
+(order paid / payment succeeded). Prüfe ausserdem, ob es irgendwo eine Option
+gibt, den Payload zu erweitern (Custom Fields, UTM/Referrer, Marketing-Daten
+mitsenden). Falls ja: aktiviere sie und dokumentiere genau, welche Felder
+dazukommen. Falls nein: ausdrücklich notieren, dass der Payload nicht
+erweiterbar ist.
+
+**Schritt 3 — Admin-API-Zugang für die Anreicherung**
+Öffne Settings → API (Uscreen-API). Prüfe, ob ein API-Token existiert oder
+erzeugt werden kann — wenn wählbar, mit Nur-Lese-Rechten. Erzeuge das Token,
+schreibe es aber NICHT in den Chat: sag mir nur, wo es liegt, damit ich es
+selbst kopieren und sicher hinterlegen kann. Hintergrund: Wenn der Webhook
+keine Custom-Field-Antworten mitliefert, kann unser Backend sie nach jeder
+Anmeldung per API nachschlagen (User → Custom Fields) — dafür brauchen wir
+dieses Token. Notiere auch, ob die API pro User die Custom-Field-Antworten
+und Marketing-/Herkunftsdaten hergibt (in der API-Doku nachsehen, die im
+Admin verlinkt ist).
+
+**Schritt 4 — Tracking-Möglichkeiten des Storefronts**
+Sieh in Settings → Tracking (bzw. Marketing/Integrations) nach: Gibt es
+Felder für Google Analytics 4, Meta Pixel oder eigene Tracking-Snippets im
+Checkout? Dokumentiere, was vorhanden und was davon bereits ausgefüllt ist
+(IDs nur mit den letzten 4 Zeichen). Das ist unser Weg B: Wenn Uscreen die
+UTMs nie an den Webhook gibt, können wir die Konversion clientseitig im
+Checkout messen.
+
+**Schritt 5 — Abschlussbericht**
+Gib mir am Ende einen kompakten Bericht in genau dieser Gliederung:
+1. Custom-Feld: existierte schon? / neu angelegt? — exakter Feld-Key
+2. Webhooks: Endpunkte (ohne Key) + aktivierte Events + erweiterbar ja/nein
+3. API: Token vorhanden/erzeugt (Fundort, nicht der Wert) + was die API je
+   User an Herkunftsdaten hergibt
+4. Tracking: welche Snippet-/Analytics-Felder es gibt und was belegt ist
+5. Auffälligkeiten oder Abweichungen von den Beschreibungen oben
+
+---
+
+## Was danach bei uns passiert (Backend-Seite)
+
+- Die Ingestion (`ingest-uscreen/index.ts`) liest die Custom-Field-Antwort
+  bereits aus mehreren möglichen Payload-Pfaden (`custom_fields.…`,
+  `user_fields.0.value` …) und schreibt sie als `selbstauskunft` mit — sobald
+  Uscreen sie liefert, greift das Mapping ohne weiteres Zutun.
+- Kommt sie nur per API: Anreicherungs-Schritt bauen (API-Token in
+  `sommer2026_config`, Nachschlag je neuer Anmeldung).
+- Test-Anmeldungen mit einer `hao.bu`-Adresse zählen nie als Abo, werden aber
+  roh geloggt — damit lässt sich die Kette gefahrlos verifizieren.


### PR DESCRIPTION
## Was dieser PR tut

**Echte Preise (Beschluss: «alle Preise sind online zu finden»):** `CONFIG.preise` trägt jetzt die realen Preise, Stand 17.7.2026 — Wochenschrift aus den vier Kampagnen-Formularen (CHF: Papier&Online 14.90/Monat · 149/Jahr, Online 10.90/109; EUR: 13.90/139 bzw. 9.90/99; Ermässigung läuft im Shop über Coupons 20/30/50 %, das Förderabo ist dokumentiert, aber kein Backend-Tarif), goetheanum.tv aus dem Uscreen-Store, der ausschliesslich in EUR rechnet (14.90/Monat, 149/Jahr — verifiziert über Store-Währung und real abgebuchte Beträge in den Webhook-Logs).

**Währungsgetrennte Projektion:** `projectRevenue` rechnet CHF- und EUR-Zahler getrennt zum je echten Preis (Lookup Währung → Produkt → Format → Tarif) und weist die EUR-Summe über `CONFIG.eurChf` (0.93, anpassbar) in der CHF-Gesamtsumme aus; die Aufteilung steht in der Notiz unter dem Betrag. Dafür liefert der RPC `sommer2026_stats` neu die Spalte `waehrung` (Migration `sommer2026_stats_waehrung`, angewendet; bestehende gtv-Zeilen auf `eur` nachgezogen). Die Uscreen-Ingestion setzt `waehrung: "eur"` künftig direkt — **Hinweis:** das Function-Deployment brauchte eine Freigabe, die in der Session nicht erteilt werden konnte; die Code-Änderung liegt in `services/sommer-zaehler/ingest-uscreen/index.ts` und muss noch deployt werden (bis dahin greift der EUR-Fallback in der Projektion).

**Umbenennung:** Die Wirkungs-Kategorie heisst überall **«ohne UTM»** statt «Andere» — in den Kanal-Balken, im Hinweistext und in der Ereignisliste («mit UTM / ohne»). Der Aktivitäten-Kanal «Anderes» (echte Kanal-Kategorie) bleibt unberührt.

**Neu:** `services/sommer-zaehler/uscreen-attribution-auftrag.md` — vollständiger, kopierfertiger Prompt für Claude im Chrome, um im Uscreen-Admin das Custom-Feld «Wie sind Sie auf uns aufmerksam geworden?», die Webhook-Events, einen API-Token für die Anreicherung und die Tracking-Optionen des Storefronts zu prüfen bzw. anzulegen.

## Regeln
G25 (Ziffern tabellarisch), B02/B03 unverändert eingehalten, DS02 (nur Tokens). Prüfmaschinen: typo-check ✓, ds-lint ✓; `node --check` auf campaign.js ✓; neuer `sommer2026_stats` gegen die Live-DB verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN)_