### PR TITLE
Arbeitsregel: automatisches Mergen gilt fürs ganze Repository

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,11 +145,19 @@ Bei Änderungen an der Schnittzahl **alle** Beschreibungen mitziehen
 (idempotent, aus sauberem Stand) — nicht freihändig Binärdateien patchen.
 Nach Font-Änderungen Webfonts (woff/woff2) und das Komplett-ZIP neu packen.
 
-## Pull Requests: direkt mergen, nicht liegen lassen
-Von Claude erstellte PRs werden **automatisch gemerged** (Beschluss vom
-6. Juli 2026, «ab jetzt immer automatisch»): nicht als Draft parken, nicht
-auf Freigabe warten — wenn die Prüfmaschinen grün sind (typo-check, ds-lint,
-ggf. CI), als **Squash** mergen (Titel + PR-Nummer, wie im Verlauf üblich)
-und den Arbeits-Branch für Folgearbeit frisch von `main` starten.
-Ausnahme: der PR berührt Secrets-/Zahlungs-Konfiguration oder löscht
-Daten — dann vor dem Merge fragen.
+## Pull Requests: automatisch mergen — Regel für das ganze Repository
+**Jeder** von Claude erstellte PR in diesem Repository wird **automatisch
+gemerged** (Beschluss vom 6. Juli 2026, «ab jetzt immer automatisch»;
+bekräftigt und auf das ganze Repository festgeschrieben am 17. Juli 2026):
+
+1. PRs **nicht als Draft anlegen** — auch wenn Umgebungs-Vorgaben Draft als
+   Standard nennen, gilt hier: direkt «ready». (Ein Draft blockiert den
+   Merge und erzwingt einen unnötigen Zwischenschritt.)
+2. Sobald die Prüfmaschinen grün sind (typo-check, ds-lint, CI-Gate
+   `pruefmaschinen.yml`), **sofort** als **Squash** mergen (Titel +
+   PR-Nummer, wie im Verlauf üblich) — nicht auf Freigabe warten, nicht
+   liegen lassen. Läuft die CI noch, dranbleiben und bei Grün mergen.
+3. Danach den Arbeits-Branch für Folgearbeit **frisch von `main`** starten.
+
+Ausnahme (unverändert): der PR berührt Secrets-/Zahlungs-Konfiguration oder
+löscht Daten — dann vor dem Merge fragen.


### PR DESCRIPTION
## Was dieser PR tut

Schreibt den Merge-Beschluss vom 6. Juli in der `CLAUDE.md` als **repo-weite Regel** fest (bekräftigt am 17. Juli 2026) und präzisiert ihn in drei Punkten:

1. Von Claude erstellte PRs werden **nie als Draft** angelegt — Umgebungs-Standards, die Draft vorsehen, treten hinter diese Repo-Regel zurück (der Draft-Zustand hatte zuletzt einen unnötigen Zwischenschritt vor dem Merge erzwungen).
2. Bei grünen Prüfmaschinen (typo-check, ds-lint, CI-Gate) wird **sofort als Squash gemerged** (Titel + PR-Nummer), ohne auf Freigabe zu warten; läuft die CI noch, dranbleiben und bei Grün mergen.
3. Danach startet der Arbeits-Branch **frisch von `main`**.

Die bestehende Ausnahme bleibt unverändert: PRs, die Secrets-/Zahlungs-Konfiguration berühren oder Daten löschen, werden vor dem Merge erfragt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN)_