### PR TITLE
Uscreen-Ingestion: Selbstauskunft über das Event «User Created» einsammeln

### DIFF
--- a/services/sommer-zaehler/ingest-uscreen/index.ts
+++ b/services/sommer-zaehler/ingest-uscreen/index.ts
@@ -180,6 +180,32 @@ Deno.serve(async (req) => {
   // 3-Monats-Frist bestimmt (separater Schritt im Oktober).
   if (isPay && !isNew) return json({ ok: true, note: "Zahlung ignoriert (Umwandlung erst nach 3 Monaten)" });
 
+  // «User Created» ist KEINE Aktions-Anmeldung (Registrierung ≠ Abo) – aber es
+  // ist laut Uscreen-Doku das einzige Event, das die Custom-Field-Antworten
+  // (`custom_fields`, Slot 1 = «Wie sind Sie auf uns aufmerksam geworden?»)
+  // mitbringt. Darum: Antwort an eine bestehende Anmeldung derselben Person
+  // heften (nur wo noch leer); Kanal nachziehen, wenn er noch «andere» ist.
+  // Kommt die Anmeldung erst NACH diesem Event, greift der Roh-Log-Fallback
+  // unten. WICHTIG: vor isNew prüfen – «created» matcht sonst als Anmeldung.
+  if (/user[_.]?created/.test(e)) {
+    const cf = (data && typeof data.custom_fields === "object" && data.custom_fields) || {};
+    const antwort0 = pick(data, ["custom_fields.custom_field_1", "custom_fields.user_field_1", "custom_field_1", "user_field_1", "user_fields.0.value"]) ?? Object.values(cf)[0];
+    const antwort = antwort0 ? scrubEmail(String(antwort0)).slice(0, 300) : null;
+    if (!antwort) return json({ ok: true, note: "user_created ohne Selbstauskunft" });
+    await fetch(`${SB}/rest/v1/sommer2026_signups?dedup_key=eq.${encodeURIComponent(dedupKey)}&selbstauskunft=is.null`, {
+      method: "PATCH", headers: { ...H, Prefer: "return=minimal" },
+      body: JSON.stringify({ selbstauskunft: antwort }),
+    }).catch(() => {});
+    const nachKanal = mapKanal(antwort);
+    if (nachKanal !== "andere") {
+      await fetch(`${SB}/rest/v1/sommer2026_signups?dedup_key=eq.${encodeURIComponent(dedupKey)}&kanal=eq.andere`, {
+        method: "PATCH", headers: { ...H, Prefer: "return=minimal" },
+        body: JSON.stringify({ kanal: nachKanal }),
+      }).catch(() => {});
+    }
+    return json({ ok: true, note: "Selbstauskunft vermerkt" });
+  }
+
   if (!isNew) return json({ ok: true, skipped: "event ignoriert" });
 
   // Aktion = jede Neuanmeldung im Aktionszeitraum (aktion_start begrenzt es zeitlich).
@@ -194,10 +220,24 @@ Deno.serve(async (req) => {
   const { sprache, intervall, tarif } = mapPlan(title);
   const utmRaw = utmFrom(data);
   const src = cleanUtm(utmRaw.src), med = cleanUtm(utmRaw.med), camp = cleanUtm(utmRaw.camp), cont = cleanUtm(utmRaw.cont), land = utmRaw.land;
-  // Offene Selbstauskunft «Wie sind Sie aufmerksam geworden?» (Custom User Field) – O-Ton, E-Mail-redigiert.
-  const selbst0 = pick(data, ["referral_source", "how_heard", "how_did_you_hear", "custom_fields.how_did_you_hear", "user_field_1", "user_fields.0.value"]);
-  const selbst = selbst0 ? scrubEmail(String(selbst0)).slice(0, 300) : null;
-  const kanal = mapKanal(src || pick(data, ["source", "referral_source"]) || selbst0);
+  // Offene Selbstauskunft «Wie sind Sie aufmerksam geworden?» (Custom User Field,
+  // Slot 1 = custom_field_1) – O-Ton, E-Mail-redigiert.
+  const selbst0 = pick(data, ["referral_source", "how_heard", "how_did_you_hear", "custom_fields.how_did_you_hear",
+    "custom_fields.custom_field_1", "custom_fields.user_field_1", "custom_field_1", "user_field_1", "user_fields.0.value"]);
+  let selbst = selbst0 ? scrubEmail(String(selbst0)).slice(0, 300) : null;
+  // Fallback: kam «User Created» (traegt die Custom Fields) schon VOR dieser
+  // Anmeldung, liegt die Antwort im Roh-Log – dort nachschlagen (custom_fields
+  // ueberleben die PII-Redaktion, user_id auch).
+  if (!selbst && ext) {
+    try {
+      const raws = await fetch(`${SB}/rest/v1/sommer2026_ingest_raw?source=eq.uscreen&event=ilike.*user*creat*&payload->>user_id=eq.${encodeURIComponent(ext)}&order=received_at.desc&limit=1&select=payload`, { headers: H })
+        .then((r) => r.json());
+      const cf = raws?.[0]?.payload?.custom_fields;
+      const a = cf && typeof cf === "object" ? (cf.custom_field_1 ?? cf.user_field_1 ?? Object.values(cf)[0]) : null;
+      if (a) selbst = scrubEmail(String(a)).slice(0, 300);
+    } catch { /* kein Fallback */ }
+  }
+  const kanal = mapKanal(src || pick(data, ["source", "referral_source"]) || selbst);
   const when = pick(data, ["created_at", "subscribed_at", "started_at", "date"]) || new Date().toISOString();
 
   // Aktions-Grenze: Anmeldungen vor dem Start (Nachmittag 3. Juli) zählen nicht.

--- a/services/sommer-zaehler/uscreen-attribution-auftrag.md
+++ b/services/sommer-zaehler/uscreen-attribution-auftrag.md
@@ -82,6 +82,43 @@ Gib mir am Ende einen kompakten Bericht in genau dieser Gliederung:
 
 ---
 
+## Ergebnis des ersten Durchlaufs (17.7.2026, Claude im Chrome)
+
+- **Custom-Feld angelegt:** Slot «User Field 1» trägt jetzt «Wie sind Sie auf
+  uns aufmerksam geworden?» (Key im Datenmodell: `custom_field_1` /
+  `user_field_1`; Uscreen kennt nur drei feste, immer optionale Text-Slots).
+- **Webhook-Payload nicht erweiterbar** (nur URL + ein Event je Endpunkt).
+  Unser Endpunkt hört auf: Recurring Payment Successful, Order Paid, Access
+  canceled, Subscription Assigned. **Es fehlt «User Created»** – laut
+  Uscreen-Doku das einzige Event, das die Custom-Field-Antworten
+  (`custom_fields`) mitliefert. → Follow-up unten.
+- **API:** Unter «Developers» gibt es nur den Publishable-Key (Headless,
+  «no scopes») – für Server-Lookups ungeeignet. Der eigentliche Admin-Key
+  (`X-Store-Token`) liegt laut Doku auf der **API-Keys-Seite unter Admin
+  Users** und ist teils Plus-Plan-gebunden. Mit dem User-Created-Event wird
+  die API für die Selbstauskunft aber voraussichtlich gar nicht gebraucht.
+- **Tracking (Weg B):** Kein GA4/Meta verbunden; der **Post-purchase-Slot**
+  (Settings → Snippets, läuft ~10 s nach Checkout) ist frei bis auf ein
+  X/Twitter-Event – dort könnte clientseitiges Konversions-Tracking ergänzt
+  werden, falls nötig.
+
+### Follow-up-Auftrag für Claude im Chrome (kurz)
+
+> Im Uscreen-Admin von goetheanum.tv: Öffne Settings → Webhooks. Lege einen
+> zusätzlichen Webhook auf **dieselbe URL wie der bestehende
+> `…supabase.co/functions/v1/ingest-uscreen`-Endpunkt** an (URL inklusive des
+> `?key=…`-Teils vom bestehenden Eintrag übernehmen, nicht in den Chat
+> schreiben), mit Event **«User Created»**. Nichts löschen, bestehende
+> Einträge unverändert lassen. Danach: Sieh unter Settings → Admin Users
+> nach, ob es dort eine API-Keys-Seite gibt (Admin-API, `X-Store-Token`) und
+> berichte nur, ob sie existiert und ob ein Key angelegt werden kann – keinen
+> Key-Wert in den Chat.
+
+Die Ingestion verarbeitet «User Created» bereits: Sie legt daraus **kein**
+Abo an, sondern heftet die Selbstauskunft an die Anmeldung derselben Person
+(nur wo noch leer) und zieht den Kanal nach, wenn er noch «andere» ist;
+kommt die Anmeldung später, greift der Roh-Log-Fallback.
+
 ## Was danach bei uns passiert (Backend-Seite)
 
 - Die Ingestion (`ingest-uscreen/index.ts`) liest die Custom-Field-Antwort


### PR DESCRIPTION
## Was dieser PR tut

Setzt die Erkenntnisse aus dem Claude-Chrome-Durchlauf im Uscreen-Admin und der Uscreen-Doku um: Der Webhook-Payload ist **nicht erweiterbar**, aber das Event **«User Created»** trägt als einziges die Custom-Field-Antworten (`custom_fields`, Slot 1 = «Wie sind Sie auf uns aufmerksam geworden?»).

**`ingest-uscreen/index.ts`:**
- Eigener Handler für `user_created` — **vor** der `isNew`-Prüfung, weil «created» sonst fälschlich als Neuanmeldung zählte (jede Registrierung würde ein Abo anlegen). Das Event erzeugt **keinen** Signup, sondern heftet die Selbstauskunft an die Anmeldung derselben Person (PATCH über `dedup_key`, nur wo `selbstauskunft` noch leer ist) und zieht den `kanal` nach, wenn er noch `andere` ist.
- Fallback für die umgekehrte Reihenfolge: Kommt die Anmeldung **nach** dem User-Created-Event, schlägt die Function die Antwort im Roh-Log nach (`custom_fields` und `user_id` überleben die PII-Redaktion).
- Die Selbstauskunfts-Pfade kennen zusätzlich `custom_field_1`/`user_field_1` (die realen Uscreen-Slot-Keys).

**`uscreen-attribution-auftrag.md`:** Ergebnis des ersten Durchlaufs dokumentiert (Custom-Feld angelegt, Payload fix, nur Publishable-Key unter «Developers», Post-purchase-Slot als Weg B) plus kompakter Follow-up-Auftrag für Claude im Chrome: Webhook **«User Created»** auf unseren Endpunkt legen und die Admin-API-Keys-Seite unter *Admin Users* prüfen.

**Deployment-Hinweis:** Die Function ist damit auf `main` zwei Versionen vor dem deployten Stand (`waehrung: "eur"` + dieser PR); das Deployment läuft über die frische Session mit dem Schlüsselbund-Token und schippt beides zusammen.

## Prüfungen
`tsc --noEmit` (ohne Deno-Imports) ✓, typo-check ✓, ds-lint ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN)_