### PR TITLE
Attribution maximal: Klicks je Link sichtbar, utm_params aus Uscreen, Selbstauskunft überall

### DIFF
--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -867,6 +867,19 @@
     el('kGoalSub').textContent = fmt(total) + ' von ' + fmt(ziel) + ' · Ziel 8. August';
   }
 
+  // ── Attributions-Gesundheit: Anteil der Anmeldungen mit UTM-Spur ───────────
+  // Aus den Kanal-Buckets gerechnet: alles ausser «andere» (= ohne UTM) hat
+  // eine Spur. Die Kachel macht sichtbar, ob die Attributions-Arbeit greift.
+  function renderSpurTile(kanaele, total){
+    if (!el('kSpur')) return;
+    var ohne = 0;
+    (kanaele || []).forEach(function(r){ if (r.kanal === 'andere') ohne += Number(r.n) || 0; });
+    var mit = Math.max(0, total - ohne);
+    var pct = total > 0 ? Math.round(mit / total * 100) : 0;
+    el('kSpur').innerHTML = pct + '<span class="u"> %</span>';
+    el('kSpurSub').textContent = fmt(mit) + ' von ' + fmt(total) + ' Anmeldungen · Rest ohne UTM';
+  }
+
   function renderMilestones(total){
     if (!el('msLine')) return;
     // Meilenstein als eine Zeile in der Held-Gruppe (statt eigener Sektion).
@@ -1034,6 +1047,7 @@
         renderStreams(stats);
         renderFunnel(trichter, massnahmen);
         renderKanaele(kanaele, total);
+        renderSpurTile(kanaele, total);
         renderMotive(attribution);
         renderTarif(stats);
         renderMilestones(total);

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -56,6 +56,7 @@
       <div class="tile"><div class="n gold" id="kTotal">–</div><div class="l">Neue Abos gesamt</div><div class="s">Wochenschrift + goetheanum.tv</div></div>
       <div class="tile"><div class="n blue" id="kAvg">–</div><div class="l">Ø pro Tag</div><div class="s" id="kAvgSub">letzte Tage</div></div>
       <div class="tile"><div class="n ok" id="kGoal">–</div><div class="l">Zielerreichung</div><div class="s" id="kGoalSub">gegen Kampagnenziel</div></div>
+      <div class="tile"><div class="n blue" id="kSpur">–</div><div class="l">Mit UTM-Spur</div><div class="s" id="kSpurSub">Anteil der Anmeldungen</div></div>
     </div>
   </section>
 

--- a/apps/utm-generator/index.html
+++ b/apps/utm-generator/index.html
@@ -52,8 +52,8 @@
   .shortbox .sl{color:var(--muted);font-size:var(--t-micro)}
   .shortbox .su{font-family:var(--font-mono,var(--font-text));color:var(--blue);word-break:break-all}
 
-  .reg{width:100%;border-collapse:collapse;font-family:var(--font-text);font-size:var(--t-small);table-layout:fixed;min-width:520px}
-  .reg col.cMot{width:44%} .reg col.cQm{width:20%} .reg col.cZiel{width:12%} .reg col.cAb{width:12%} .reg col.cAct{width:12%}
+  .reg{width:100%;border-collapse:collapse;font-family:var(--font-text);font-size:var(--t-small);table-layout:fixed;min-width:560px}
+  .reg col.cMot{width:38%} .reg col.cQm{width:19%} .reg col.cZiel{width:12%} .reg col.cKl{width:10%} .reg col.cAb{width:11%} .reg col.cAct{width:10%}
   .reg .del{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);background:none;border:0;cursor:pointer;padding:4px 6px;min-height:var(--tap)}
   .reg .del:hover{color:var(--bad)} .reg td.act{text-align:right}
   .reg th,.reg td{padding:10px 12px;border-bottom:1px solid var(--line-soft);text-align:left;vertical-align:top}
@@ -217,6 +217,7 @@
       <label class="field"><span class="lab">Sortieren nach</span>
         <select id="regSort">
           <option value="abschluesse">Abschlüsse · meiste zuerst</option>
+          <option value="klicks">Klicks · meiste zuerst</option>
           <option value="neu">Neueste zuerst</option>
           <option value="alt">Älteste zuerst</option>
           <option value="motiv">Motiv A–Z</option>
@@ -226,9 +227,9 @@
     <p class="reg-zahl" id="regZahl"></p>
     <div class="tablewrap">
       <table class="reg">
-        <colgroup><col class="cMot" /><col class="cQm" /><col class="cZiel" /><col class="cAb" /><col class="cAct" /></colgroup>
-        <thead><tr><th>Motiv</th><th>Quelle · Medium</th><th>Ziel</th><th class="num">Abschlüsse</th><th></th></tr></thead>
-        <tbody id="regBody"><tr><td class="empty" colspan="5">lädt …</td></tr></tbody>
+        <colgroup><col class="cMot" /><col class="cQm" /><col class="cZiel" /><col class="cKl" /><col class="cAb" /><col class="cAct" /></colgroup>
+        <thead><tr><th>Motiv</th><th>Quelle · Medium</th><th>Ziel</th><th class="num">Klicks</th><th class="num">Abschlüsse</th><th></th></tr></thead>
+        <tbody id="regBody"><tr><td class="empty" colspan="6">lädt …</td></tr></tbody>
       </table>
     </div>
   </section>
@@ -480,7 +481,7 @@
   function applyRegister(){
     var body = el('regBody'); body.innerHTML = '';
     if(!regRows.length){
-      body.innerHTML = '<tr><td class="empty" colspan="5">Noch keine Links registriert.</td></tr>';
+      body.innerHTML = '<tr><td class="empty" colspan="6">Noch keine Links registriert.</td></tr>';
       el('regZahl').textContent = '';
       return;
     }
@@ -498,6 +499,8 @@
     var sortiert = rows.slice();
     var az = function(a, b){ return String(a || '').localeCompare(String(b || ''), 'de'); };
     switch(el('regSort').value){
+      case 'klicks': sortiert.sort(function(a, b){ return (Number(b.klicks) || 0) - (Number(a.klicks) || 0) ||
+                                                          (Number(b.abschluesse) || 0) - (Number(a.abschluesse) || 0); }); break;
       case 'neu':    sortiert.sort(function(a, b){ return new Date(b.created_at) - new Date(a.created_at); }); break;
       case 'alt':    sortiert.sort(function(a, b){ return new Date(a.created_at) - new Date(b.created_at); }); break;
       case 'motiv':  sortiert.sort(function(a, b){ return az(a.utm_content, b.utm_content); }); break;
@@ -506,16 +509,18 @@
                                                           (new Date(b.created_at) - new Date(a.created_at)); });
     }
     var abschluesse = sortiert.reduce(function(s, x){ return s + (Number(x.abschluesse) || 0); }, 0);
+    var klicksSumme = sortiert.reduce(function(s, x){ return s + (Number(x.klicks) || 0); }, 0);
+    var zahlen = klicksSumme.toLocaleString('de-CH') + ' Klicks · ' + abschluesse.toLocaleString('de-CH') + ' Abschlüsse';
     el('regZahl').textContent = sortiert.length === regRows.length
-      ? (regRows.length + ' Links · ' + abschluesse.toLocaleString('de-CH') + ' Abschlüsse')
-      : (sortiert.length + ' von ' + regRows.length + ' Links · ' + abschluesse.toLocaleString('de-CH') + ' Abschlüsse im Filter');
+      ? (regRows.length + ' Links · ' + zahlen)
+      : (sortiert.length + ' von ' + regRows.length + ' Links · ' + zahlen + ' im Filter');
     if(!sortiert.length){
-      body.innerHTML = '<tr><td class="empty" colspan="5">Kein Link passt zu Suche/Filter.</td></tr>';
+      body.innerHTML = '<tr><td class="empty" colspan="6">Kein Link passt zu Suche/Filter.</td></tr>';
       return;
     }
     sortiert.forEach(function(x){
       var tr = document.createElement('tr');
-      tr.innerHTML = '<td class="mot"></td><td class="mot"></td><td></td><td class="num"></td><td class="act"></td>';
+      tr.innerHTML = '<td class="mot"></td><td class="mot"></td><td></td><td class="num"></td><td class="num"></td><td class="act"></td>';
       var mot = tr.children[0];
       mot.textContent = x.utm_content || '—';
       var q = document.createElement('span'); q.className = 'q';
@@ -534,14 +539,25 @@
       var ziel = ANGEBOT_LABEL[x.landing] || x.landing || '';
       if(x.sprache) ziel += ' · ' + x.sprache.toUpperCase();
       tr.children[2].textContent = ziel;
+      // Klicks zählt die Weiterleitung (Function go) – nur Links MIT Kurzcode
+      // haben eine Zählung; volle URLs ohne Kurzlink zeigen einen Strich.
+      var kl = Number(x.klicks) || 0;
+      if(!x.code){ tr.children[3].textContent = '–'; tr.children[3].className = 'num zero';
+        tr.children[3].title = 'Ohne Kurzlink keine Klick-Zählung'; }
+      else {
+        tr.children[3].textContent = kl.toLocaleString('de-CH');
+        if(kl === 0) tr.children[3].className = 'num zero';
+        if(x.letzter_klick) tr.children[3].title = 'letzter Klick ' +
+          new Date(x.letzter_klick).toLocaleDateString('de-CH', { day:'numeric', month:'numeric' });
+      }
       var n = Number(x.abschluesse) || 0;
-      tr.children[3].textContent = n.toLocaleString('de-CH');
-      if(n === 0) tr.children[3].className = 'num zero';
+      tr.children[4].textContent = n.toLocaleString('de-CH');
+      if(n === 0) tr.children[4].className = 'num zero';
       var del = document.createElement('button');
       del.type = 'button'; del.className = 'del'; del.textContent = 'Löschen';
       del.setAttribute('aria-label', 'Link löschen');
       del.addEventListener('click', function(){ loescheLink(x.url); });
-      tr.children[4].appendChild(del);
+      tr.children[5].appendChild(del);
       body.appendChild(tr);
     });
   }
@@ -562,7 +578,7 @@
         regQuelleOptionen();
         applyRegister();
       })
-      .catch(function(){ el('regBody').innerHTML = '<tr><td class="empty" colspan="5">Register nicht ladbar.</td></tr>'; });
+      .catch(function(){ el('regBody').innerHTML = '<tr><td class="empty" colspan="6">Register nicht ladbar.</td></tr>'; });
   }
 
   setzeAutoSlug();

--- a/services/sommer-zaehler/ingest-paperform/index.ts
+++ b/services/sommer-zaehler/ingest-paperform/index.ts
@@ -38,6 +38,25 @@ function cleanUtm(v: any): string | null {
   return (s === "" || /^(none|n\/?a|null|undefined|-)$/i.test(s)) ? null : s;
 }
 
+// Offene Selbstauskunft «Wie sind Sie auf uns aufmerksam geworden?» aus den
+// Formularfeldern lesen: über den Custom-Key `selbstauskunft` oder die
+// Feldbeschriftung. E-Mail-artige Angaben werden redigiert (O-Ton bleibt).
+const SELBST_LABEL = /(aufmerksam|how did you hear|hear about|wie .*erfahren)/i;
+function scrubEmail(s: string): string {
+  return s.replace(/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi, "***");
+}
+function selbstFromBody(body: any): string | null {
+  const data = Array.isArray(body?.data) ? body.data : [];
+  for (const f of data) {
+    const key = String(f?.custom_key || f?.key || "").toLowerCase();
+    const label = String(f?.title || "");
+    const v = cleanUtm(f?.value);
+    if (!v) continue;
+    if (key === "selbstauskunft" || SELBST_LABEL.test(label)) return scrubEmail(String(v)).slice(0, 300);
+  }
+  return null;
+}
+
 // UTM-Tupel + Landingpage. Paperform legt die Herkunft in `device` ab
 // (device.utm_source/…); ausserdem trägt device.url bzw. der ?_d=-Parameter die
 // Landingpage (auch bei eingebetteten Formularen). Fallback: UTMs aus einer im
@@ -176,12 +195,17 @@ Deno.serve(async (req) => {
   const dedupKey = email ? `wos:${await sha256Hex(salt + email)}` : `paperform:${subId || (await sha256Hex(blob)).slice(0, 24)}`;
 
   const utm = utmFromBody(body);
+  // Selbstauskunft mitschreiben; ohne UTM-Spur bestimmt sie den Kanal-Bucket
+  // (z. B. «über den Newsletter» → newsletter statt andere).
+  const selbst = selbstFromBody(body);
+  let kanal = mapKanal(utm.src, utm.med);
+  if (kanal === "andere" && selbst) kanal = mapKanal(selbst, null);
   const row = {
     signed_up_at: new Date().toISOString(), produkt: "wos", sprache, format,
-    tarif, intervall, waehrung, status: "neu", kanal: mapKanal(utm.src, utm.med), source: "paperform", ext_id: String(subId || ""), dedup_key: dedupKey,
+    tarif, intervall, waehrung, status: "neu", kanal, source: "paperform", ext_id: String(subId || ""), dedup_key: dedupKey,
     kampagne: utm.camp || "summer26_trial",
     utm_source: utm.src, utm_medium: utm.med, utm_campaign: utm.camp, utm_content: utm.cont,
-    landing_path: utm.land ? utm.land.slice(0, 200) : null,
+    landing_path: utm.land ? utm.land.slice(0, 200) : null, selbstauskunft: selbst,
   };
   const res = await fetch(`${SB}/rest/v1/sommer2026_signups?on_conflict=dedup_key`, {
     method: "POST",

--- a/services/sommer-zaehler/ingest-uscreen/index.ts
+++ b/services/sommer-zaehler/ingest-uscreen/index.ts
@@ -61,9 +61,10 @@ function cleanUtm(v: any): string | null {
   return (s === "" || /^(none|n\/?a|null|undefined|-)$/i.test(s)) ? null : s;
 }
 
-// Volles UTM-Tupel + Landingpage: direkte Felder, sonst aus einer eingebetteten URL nachziehen.
+// Volles UTM-Tupel + Landingpage: direkte Felder, Uscreens utm_params-Block
+// (kommt im user_created-Event mit), sonst aus einer eingebetteten URL nachziehen.
 function utmFrom(data: any): { src: any; med: any; camp: any; cont: any; land: any } {
-  const g = (k: string) => pick(data, [k, "custom_fields." + k, "utm." + k.replace("utm_", ""), "query." + k]);
+  const g = (k: string) => pick(data, [k, "utm_params." + k, "custom_fields." + k, "utm." + k.replace("utm_", ""), "query." + k]);
   let src = g("utm_source"), med = g("utm_medium"), camp = g("utm_campaign"), cont = g("utm_content");
   let land = pick(data, ["landing_path", "landing_page", "page"]);
   const urlish = pick(data, ["landing_url", "page_url", "signup_url", "url", "referrer_url", "referrer"]);
@@ -181,29 +182,42 @@ Deno.serve(async (req) => {
   if (isPay && !isNew) return json({ ok: true, note: "Zahlung ignoriert (Umwandlung erst nach 3 Monaten)" });
 
   // «User Created» ist KEINE Aktions-Anmeldung (Registrierung ≠ Abo) – aber es
-  // ist laut Uscreen-Doku das einzige Event, das die Custom-Field-Antworten
-  // (`custom_fields`, Slot 1 = «Wie sind Sie auf uns aufmerksam geworden?»)
-  // mitbringt. Darum: Antwort an eine bestehende Anmeldung derselben Person
-  // heften (nur wo noch leer); Kanal nachziehen, wenn er noch «andere» ist.
-  // Kommt die Anmeldung erst NACH diesem Event, greift der Roh-Log-Fallback
-  // unten. WICHTIG: vor isNew prüfen – «created» matcht sonst als Anmeldung.
+  // ist das einzige Event, das Attribution mitbringt: das VOLLE UTM-Tupel
+  // (`utm_params`, aus Uscreens eigener Session-Erfassung – am 18.7. live
+  // verifiziert) und die Custom-Field-Antwort (`custom_fields`, Schlüssel ist
+  // der FRAGETEXT, darum der Object.values-Fallback). Beides wird an eine
+  // bestehende Anmeldung derselben Person geheftet (nur wo noch leer); der
+  // Kanal wird nachgezogen, solange er «andere» ist. Kommt die Anmeldung erst
+  // NACH diesem Event, greift der Roh-Log-Fallback unten.
+  // WICHTIG: vor isNew prüfen – «created» matcht sonst als Anmeldung.
   if (/user[_.]?created/.test(e)) {
     const cf = (data && typeof data.custom_fields === "object" && data.custom_fields) || {};
     const antwort0 = pick(data, ["custom_fields.custom_field_1", "custom_fields.user_field_1", "custom_field_1", "user_field_1", "user_fields.0.value"]) ?? Object.values(cf)[0];
     const antwort = antwort0 ? scrubEmail(String(antwort0)).slice(0, 300) : null;
-    if (!antwort) return json({ ok: true, note: "user_created ohne Selbstauskunft" });
-    await fetch(`${SB}/rest/v1/sommer2026_signups?dedup_key=eq.${encodeURIComponent(dedupKey)}&selbstauskunft=is.null`, {
-      method: "PATCH", headers: { ...H, Prefer: "return=minimal" },
-      body: JSON.stringify({ selbstauskunft: antwort }),
-    }).catch(() => {});
-    const nachKanal = mapKanal(antwort);
+    const u2 = utmFrom(data);
+    const src2 = cleanUtm(u2.src), med2 = cleanUtm(u2.med), camp2 = cleanUtm(u2.camp), cont2 = cleanUtm(u2.cont);
+    if (!antwort && !src2 && !cont2) return json({ ok: true, note: "user_created ohne Spur" });
+    const wo = `dedup_key=eq.${encodeURIComponent(dedupKey)}`;
+    if (antwort) {
+      await fetch(`${SB}/rest/v1/sommer2026_signups?${wo}&selbstauskunft=is.null`, {
+        method: "PATCH", headers: { ...H, Prefer: "return=minimal" },
+        body: JSON.stringify({ selbstauskunft: antwort }),
+      }).catch(() => {});
+    }
+    if (src2 || cont2) {
+      await fetch(`${SB}/rest/v1/sommer2026_signups?${wo}&utm_source=is.null&utm_content=is.null`, {
+        method: "PATCH", headers: { ...H, Prefer: "return=minimal" },
+        body: JSON.stringify({ utm_source: src2, utm_medium: med2, utm_campaign: camp2, utm_content: cont2 }),
+      }).catch(() => {});
+    }
+    const nachKanal = mapKanal(src2 || med2 || antwort);
     if (nachKanal !== "andere") {
-      await fetch(`${SB}/rest/v1/sommer2026_signups?dedup_key=eq.${encodeURIComponent(dedupKey)}&kanal=eq.andere`, {
+      await fetch(`${SB}/rest/v1/sommer2026_signups?${wo}&kanal=eq.andere`, {
         method: "PATCH", headers: { ...H, Prefer: "return=minimal" },
         body: JSON.stringify({ kanal: nachKanal }),
       }).catch(() => {});
     }
-    return json({ ok: true, note: "Selbstauskunft vermerkt" });
+    return json({ ok: true, note: "Attribution vermerkt", utm: !!(src2 || cont2), selbstauskunft: !!antwort });
   }
 
   if (!isNew) return json({ ok: true, skipped: "event ignoriert" });
@@ -219,22 +233,30 @@ Deno.serve(async (req) => {
 
   const { sprache, intervall, tarif } = mapPlan(title);
   const utmRaw = utmFrom(data);
-  const src = cleanUtm(utmRaw.src), med = cleanUtm(utmRaw.med), camp = cleanUtm(utmRaw.camp), cont = cleanUtm(utmRaw.cont), land = utmRaw.land;
+  let src = cleanUtm(utmRaw.src), med = cleanUtm(utmRaw.med), camp = cleanUtm(utmRaw.camp), cont = cleanUtm(utmRaw.cont);
+  const land = utmRaw.land;
   // Offene Selbstauskunft «Wie sind Sie aufmerksam geworden?» (Custom User Field,
   // Slot 1 = custom_field_1) – O-Ton, E-Mail-redigiert.
   const selbst0 = pick(data, ["referral_source", "how_heard", "how_did_you_hear", "custom_fields.how_did_you_hear",
     "custom_fields.custom_field_1", "custom_fields.user_field_1", "custom_field_1", "user_field_1", "user_fields.0.value"]);
   let selbst = selbst0 ? scrubEmail(String(selbst0)).slice(0, 300) : null;
-  // Fallback: kam «User Created» (traegt die Custom Fields) schon VOR dieser
-  // Anmeldung, liegt die Antwort im Roh-Log – dort nachschlagen (custom_fields
-  // ueberleben die PII-Redaktion, user_id auch).
-  if (!selbst && ext) {
+  // Fallback: kam «User Created» (traegt utm_params UND custom_fields) schon
+  // VOR dieser Anmeldung, liegt beides im Roh-Log – dort nachschlagen (beide
+  // Felder ueberleben die PII-Redaktion; die User-ID heisst dort `id`).
+  if ((!selbst || !src) && ext) {
     try {
-      const raws = await fetch(`${SB}/rest/v1/sommer2026_ingest_raw?source=eq.uscreen&event=ilike.*user*creat*&payload->>user_id=eq.${encodeURIComponent(ext)}&order=received_at.desc&limit=1&select=payload`, { headers: H })
+      const raws = await fetch(`${SB}/rest/v1/sommer2026_ingest_raw?source=eq.uscreen&event=ilike.*user*creat*&payload->>id=eq.${encodeURIComponent(ext)}&order=received_at.desc&limit=1&select=payload`, { headers: H })
         .then((r) => r.json());
-      const cf = raws?.[0]?.payload?.custom_fields;
-      const a = cf && typeof cf === "object" ? (cf.custom_field_1 ?? cf.user_field_1 ?? Object.values(cf)[0]) : null;
-      if (a) selbst = scrubEmail(String(a)).slice(0, 300);
+      const p = raws?.[0]?.payload;
+      if (!selbst) {
+        const cf = p?.custom_fields;
+        const a = cf && typeof cf === "object" ? (cf.custom_field_1 ?? cf.user_field_1 ?? Object.values(cf)[0]) : null;
+        if (a) selbst = scrubEmail(String(a)).slice(0, 300);
+      }
+      if (!src && p?.utm_params && typeof p.utm_params === "object") {
+        src = src || cleanUtm(p.utm_params.utm_source); med = med || cleanUtm(p.utm_params.utm_medium);
+        camp = camp || cleanUtm(p.utm_params.utm_campaign); cont = cont || cleanUtm(p.utm_params.utm_content);
+      }
     } catch { /* kein Fallback */ }
   }
   const kanal = mapKanal(src || pick(data, ["source", "referral_source"]) || selbst);

--- a/services/sommer-zaehler/paperform-selbstauskunft-auftrag.md
+++ b/services/sommer-zaehler/paperform-selbstauskunft-auftrag.md
@@ -1,0 +1,60 @@
+# Auftrag für Claude im Chrome: Selbstauskunft in die Paperform-Formulare
+
+Ziel: Auch die Wochenschrift-Anmeldungen sollen eine Selbstauskunft tragen
+(«Wie sind Sie auf uns aufmerksam geworden?») — das Backend
+(`ingest-paperform`) liest sie über den Custom-Key `selbstauskunft` und nutzt
+sie als Kanal-Fallback, wenn keine UTM-Spur mitkommt. Nebenbei wird die
+Pre-fill-Kür aus dem Übergabe-Brief erledigt (Custom-IDs der versteckten
+UTM-Felder).
+
+Den folgenden Block Claude im Chrome geben (eingeloggt bei paperform.co):
+
+---
+
+Du bist im Paperform-Konto der Goetheanum-Sommer-Aktion eingeloggt. Wir
+ergänzen in den Aktions-Formularen ein Selbstauskunfts-Feld und prüfen die
+versteckten UTM-Felder. Es geht um die Formulare der Sommer-Aktion 2026 —
+erkennbar am Titel «Abonnieren … (Sommerangebot 2026)» bzw. an den URLs
+`sommer2026-chf-de`, `sommer2026-eur-de`, `sommer2026-eur-en` und (falls
+vorhanden) `sommer2026-chf-en`.
+
+Regeln: Nichts löschen, keine Felder umsortieren, keine Fragen umformulieren.
+Nach jeder Formular-Änderung publishen. Keine Secrets in den Chat.
+
+Je Formular zwei Dinge:
+
+**A) Neues Feld «Selbstauskunft» (sichtbar, optional)**
+1. Ein kurzes Textfeld anlegen, NICHT als Pflichtfeld, sinnvoll platziert
+   (vor dem Absenden-Bereich):
+   - Deutsche Formulare: «Wie sind Sie auf uns aufmerksam geworden?»
+   - Englisches Formular: «How did you hear about us?»
+2. In der Feld-Konfiguration ganz unten die **Custom ID** exakt auf
+   `selbstauskunft` setzen (klein, ein Wort). Das ist entscheidend — das
+   Backend erkennt das Feld nur an diesem Key (Fallback: Beschriftung mit
+   «aufmerksam»/«hear about»).
+
+**B) Versteckte UTM-Felder prüfen (Pre-fill)**
+Jedes Formular soll vier versteckte Felder haben, deren **Custom ID** exakt
+`utm_source`, `utm_medium`, `utm_campaign`, `utm_content` heisst. Bekannter
+Altstand: im EN-Formular tragen sie zufällige IDs (`75kij`, `eb0qb`, `qdmh`,
+`7c5la`) — diese Custom IDs auf die vier exakten Namen umstellen. In den
+anderen Formularen nur verifizieren und abweichende IDs ebenso korrigieren.
+
+**Abschlussbericht** in dieser Gliederung:
+1. Je Formular: Selbstauskunfts-Feld angelegt (ja/neu/existierte) + Custom ID
+2. Je Formular: Zustand der vier UTM-Custom-IDs (korrekt / korrigiert von …)
+3. Publiziert: ja/nein je Formular
+4. Auffälligkeiten (z. B. ein viertes Formular, das anders heisst)
+
+---
+
+## Backend-Stand dazu
+
+- `ingest-paperform/index.ts` liest `selbstauskunft` (Custom-Key oder
+  Beschriftung), redigiert E-Mail-Angaben und nutzt die Antwort als
+  Kanal-Fallback («über den Newsletter» → newsletter statt ohne UTM).
+  **Muss nach dem Repo-Stand deployt werden** (gleicher Weg wie
+  ingest-uscreen).
+- Test danach: Formular über einen Generator-Link mit UTM öffnen, mit einer
+  `hao.bu`-Adresse absenden (zählt nie, landet nur im Roh-Log) und im Log
+  prüfen, dass `selbstauskunft` ankommt.

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -346,19 +346,26 @@ alter table public.sommer2026_links enable row level security;
 revoke all on table public.sommer2026_links from anon, authenticated;
 -- Schreiben über die RPCs unten (kein direktes anon-INSERT auf die Tabelle).
 
--- Soll/Ist: je registriertem Link die Zahl der Anmeldungen über genau dieses UTM-Tupel
+-- Soll/Ist: je registriertem Link die Zahl der Anmeldungen über genau dieses
+-- UTM-Tupel – plus die Kurzlink-Klicks (Migration «sommer2026_links_klicks_sichtbar»:
+-- die Function go zählt jeden /s/<code>-Aufruf in link_hits; hier wird die Zählung
+-- je Link sichtbar). Nur Links MIT Kurzcode haben eine Klick-Zählung.
 create or replace function public.sommer2026_links_public()
 returns table(created_at timestamptz, utm_source text, utm_medium text, utm_content text,
-              landing text, sprache text, url text, code text, rolle text, ersteller text, abschluesse bigint)
+              landing text, sprache text, url text, code text, rolle text, ersteller text,
+              abschluesse bigint, klicks bigint, letzter_klick timestamptz)
 language sql security definer set search_path to 'public' as $$
   select l.created_at, l.utm_source, l.utm_medium, l.utm_content, l.landing, l.sprache, l.url, l.code, l.rolle, l.ersteller,
-         count(s.id)::bigint as abschluesse
+         count(distinct s.id)::bigint as abschluesse,
+         count(distinct h.id)::bigint as klicks,
+         max(h.ts) as letzter_klick
     from public.sommer2026_links l
     left join public.sommer2026_signups s
       on  s.utm_campaign is not distinct from l.utm_campaign
       and s.utm_source   is not distinct from l.utm_source
       and s.utm_medium   is not distinct from l.utm_medium
       and s.utm_content  is not distinct from l.utm_content
+    left join public.link_hits h on l.code is not null and h.code = l.code
    group by l.id, l.created_at, l.utm_source, l.utm_medium, l.utm_content, l.landing, l.sprache, l.url, l.code, l.rolle, l.ersteller
    order by abschluesse desc, l.created_at desc;
 $$;

--- a/services/sommer-zaehler/utm-ablauf.md
+++ b/services/sommer-zaehler/utm-ablauf.md
@@ -130,3 +130,10 @@ Neue Massnahme → Zeile im Massnahmen-Protokoll (`sommer2026_massnahmen`, Servi
 Role) mit Datum, `rolle`, Kosten, Reichweite, Klicks und den internen Notizen.
 Neue Links immer nach obiger Konvention bauen – dann erscheinen sie ohne weiteres
 Zutun im Cockpit.
+
+**Newsletter-Aussendungen (Beschluss 18.7.2026):** ab sofort werden in den
+Newslettern **Generator-Links** eingesetzt (nach dieser Konvention, aus
+`apps/utm-generator/`), nicht die Auto-UTMs des Newsletter-Tools. Die
+Auto-Beschriftungen («Newsletter / Goetheanum Newsletter … (Copy)») bucketen
+zwar grob richtig, tauchen aber im Register-Soll/Ist nie auf und tragen kein
+Motiv. Bereits versendete Alt-Links bleiben, wie sie sind.


### PR DESCRIPTION
## Was dieser PR tut

**Klicks je UTM-Link sichtbar (Punkt 1):** Die Weiterleitung (`go`) zählte längst jeden Kurzlink-Aufruf in `link_hits` — es fehlte nur die Anzeige. `sommer2026_links_public` liefert jetzt Klicks + letzten Klick je Link (Migration `sommer2026_links_klicks_sichtbar`, angewendet), das Register zeigt die Spalte, sortiert danach («Klicks · meiste zuerst») und summiert sie in der Zählzeile. Links ohne Kurzcode zeigen einen Strich (ohne Kurzlink keine Zählung). Kein Function-Deploy nötig.

**Durchbruch bei Uscreen (verifiziert am ersten echten Event, 18.7. 00:35):** Der `user_created`-Payload trägt `utm_params` mit dem **vollen UTM-Tupel** (real: `mailing/email/summer26_trial/w1_noabo`) plus die Custom-Field-Antwort (Schlüssel = Fragetext). `ingest-uscreen` wertet jetzt beides aus: UTMs und Selbstauskunft werden an die Anmeldung derselben Person geheftet (nur wo leer), der Kanal wird nachgezogen; der Roh-Log-Fallback nutzt den korrekten Schlüssel (`id` statt `user_id`) und holt auch `utm_params` nach. **Deploy nötig (→ Version 15).**

**Paperform-Selbstauskunft (Punkt 2):** `ingest-paperform` liest das Feld (Custom-Key `selbstauskunft` oder Beschriftung «aufmerksam»/«hear about»), redigiert E-Mail-Angaben und nutzt die Antwort als Kanal-Fallback. **Deploy nötig.** Der Formular-Auftrag für Claude im Chrome liegt in `services/sommer-zaehler/paperform-selbstauskunft-auftrag.md`.

**Cockpit (Punkt 7):** Neue Kachel **«Mit UTM-Spur»** (Anteil der Anmeldungen mit Spur, live aus den Kanal-Buckets).

**Register-Pflege (Punkte 5/6):** `utm-ablauf.md` hält den Beschluss fest, dass Newsletter ab jetzt Generator-Links verwenden; vier Popup-Links (wos/tv × de/en, Codes `pinguin`/`pelikan`/`flamingo`/`kolibri`) sind per RPC im Register angelegt (kein Repo-Diff).

## Prüfungen
typo-check ✓ · ds-lint 100 % ✓ · `node --check` (campaign.js) ✓ · `tsc --noEmit` beide Functions ✓ · neuer `sommer2026_links_public` gegen die Live-DB verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN)_