### PR TITLE
Cockpit: vermutete Herkunft für Anmeldungen ohne UTM-Spur

### DIFF
--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -219,6 +219,9 @@
     padding:2px 10px;margin-right:8px;white-space:nowrap}
   .ev-kanal.ev-ohne{color:var(--muted);background:var(--soft)}
   .ev-spur{color:var(--muted);font-size:var(--t-micro);overflow-wrap:anywhere}
+  /* Vermutete Herkunft: klar abgesetzt (gepunktete Kante), damit Indiz nie wie Messung liest. */
+  .ev-vermutet{display:block;color:var(--muted);font-size:var(--t-micro);margin-top:3px;
+    padding-left:var(--s3);border-left:2px dotted var(--line);overflow-wrap:anywhere}
   @media (max-width:560px){ .ev-row{grid-template-columns:48px 1fr} .ev-her{grid-column:2} }
 
   /* Aktionsseiten als Buttons – Fingerziele statt klebender Textlinks (B04, DS02) */

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -1010,6 +1010,15 @@
           var wo = document.createElement('span'); wo.className = 'ev-spur';
           wo.textContent = r.landing_path ? ('via ' + r.landing_path) : ('via ' + (r.source === 'uscreen' ? 'goetheanum.tv-Checkout' : r.source));
           her.appendChild(wo);
+          // «Vermutete Herkunft»: zeitlich nächster Kurzlink-Klick vor dem
+          // Abschluss (aus dem RPC) – Indiz, keine Messung, darum eigene,
+          // klar abgesetzte Beschriftung. Die harte Attribution bleibt leer.
+          if (r.vermutet_code){
+            var vm = document.createElement('span'); vm.className = 'ev-vermutet';
+            vm.textContent = 'vermutet: ' + [r.vermutet_source, r.vermutet_content].filter(Boolean).join(' · ') +
+              ' — Klick auf /s/' + r.vermutet_code + ' ' + fmt(r.vermutet_min) + ' Min. davor';
+            her.appendChild(vm);
+          }
         }
         row.appendChild(zeit); row.appendChild(was); row.appendChild(her);
         list.appendChild(row);
@@ -1018,7 +1027,8 @@
       host.appendChild(det);
     });
     var note = document.createElement('div'); note.className = 'fnote';
-    note.textContent = 'Zeiten auf die Stunde gerundet, keine Personendaten. «ohne UTM» = Anmeldung kam ohne UTM-Parameter an – so heisst sie auch in der Wirkung.';
+    note.textContent = 'Zeiten auf die Stunde gerundet, keine Personendaten. «ohne UTM» = Anmeldung kam ohne UTM-Parameter an – so heisst sie auch in der Wirkung. ' +
+      '«vermutet» = der zeitlich nächste Kurzlink-Klick (bis 90 Minuten davor) auf einen passenden Kampagnen-Link – ein Indiz, keine Messung; gezählt wird es nirgends.';
     host.appendChild(note);
   }
 

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -304,18 +304,37 @@ grant execute on function public.sommer2026_attribution()       to anon, authent
 grant execute on function public.sommer2026_massnahmen_public() to anon, authenticated;
 grant execute on function public.sommer2026_trichter()          to anon, authenticated;
 
--- Ereignis-Protokoll (Migration «sommer2026_ereignisse»): die einzelnen
--- Anmeldungen der letzten 14 Tage fürs Cockpit («Was ist heute passiert?») –
--- stundengenau gerundet (keine Minuten-Fingerprints), ohne jede Personenspalte.
+-- Ereignis-Protokoll (Migration «sommer2026_ereignisse», erweitert um
+-- «sommer2026_ereignisse_vermutung»): die einzelnen Anmeldungen der letzten
+-- 14 Tage fürs Cockpit («Was ist heute passiert?») – stundengenau gerundet
+-- (keine Minuten-Fingerprints), ohne jede Personenspalte. Für Anmeldungen
+-- OHNE UTM-Spur wird zusätzlich die «vermutete Herkunft» mitgeliefert: der
+-- zeitlich nächste Kurzlink-Klick auf einen zum Produkt passenden Link
+-- innerhalb von 90 Minuten davor. Indiz, keine Messung – die harte
+-- Attribution (kanal/utm_*) bleibt unberührt.
 create or replace function public.sommer2026_ereignisse()
 returns table(stunde timestamptz, produkt text, sprache text, format text, tarif text, intervall text,
-              kanal text, utm_source text, utm_medium text, utm_content text, landing_path text, source text)
+              kanal text, utm_source text, utm_medium text, utm_content text, landing_path text, source text,
+              vermutet_source text, vermutet_content text, vermutet_code text, vermutet_min int)
 language sql security definer set search_path to 'public' as $$
-  select date_trunc('hour', signed_up_at) as stunde, produkt, sprache, format, tarif, intervall,
-         kanal, utm_source, utm_medium, utm_content, landing_path, source
-    from public.sommer2026_signups
-   where signed_up_at >= now() - interval '14 days'
-   order by signed_up_at desc
+  select date_trunc('hour', s.signed_up_at) as stunde, s.produkt, s.sprache, s.format, s.tarif, s.intervall,
+         s.kanal, s.utm_source, s.utm_medium, s.utm_content, s.landing_path, s.source,
+         v.utm_source, v.utm_content, v.code, v.minuten
+    from public.sommer2026_signups s
+    left join lateral (
+      select l.utm_source, l.utm_content, l.code,
+             (extract(epoch from (s.signed_up_at - h.ts)) / 60)::int as minuten
+        from public.link_hits h
+        join public.sommer2026_links l on l.code = h.code
+       where s.utm_source is null and s.utm_content is null
+         and h.ts between s.signed_up_at - interval '90 minutes' and s.signed_up_at
+         and ((s.produkt = 'gtv' and l.landing in ('tv','gtv','uebersicht'))
+           or (s.produkt = 'wos' and l.landing in ('wos','uebersicht')))
+       order by h.ts desc
+       limit 1
+    ) v on true
+   where s.signed_up_at >= now() - interval '14 days'
+   order by s.signed_up_at desc
    limit 400;
 $$;
 grant execute on function public.sommer2026_ereignisse() to anon, authenticated;


### PR DESCRIPTION
## Was dieser PR tut

Für Anmeldungen **ohne** UTM-Spur liefert der RPC `sommer2026_ereignisse` jetzt eine **vermutete Herkunft** mit: den zeitlich nächsten Kurzlink-Klick (bis 90 Minuten vor dem Abschluss) auf einen zum Produkt passenden Kampagnen-Link (Migration `sommer2026_ereignisse_vermutung`, angewendet; goetheanum.tv-Abschlüsse matchen gegen TV-/Übersichts-Links, Wochenschrift gegen WoS-/Übersichts-Links).

Die Ereignisliste im Cockpit beschriftet das klar abgesetzt — eigene Zeile mit gepunkteter Kante: «vermutet: meta-anzeige · story_statisch — Klick auf /s/elster-2 12 Min. davor». Die Fussnote sagt ausdrücklich: **Indiz, keine Messung** — die harte Attribution (`kanal`/`utm_*`) bleibt unberührt, und die Vermutung wird in keiner Zahl mitgezählt.

Hintergrund: Von den herkunftslosen goetheanum.tv-Abschlüssen ab dem 10. Juli hat die Mehrheit einen plausiblen Vorgänger-Klick (auffällig oft die Meta-Anzeigen und die TV-Weekly-Newsletter-Links) — diese Information war bislang unsichtbar.

## Prüfungen
typo-check ✓ · ds-lint ✓ · `node --check` ✓ · RPC gegen die Live-DB verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN)_