### PR TITLE
Cockpit aktualisiert: Ereignisliste zu beim Öffnen, Hinweistexte auf neuem Stand

### DIFF
--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -170,15 +170,17 @@
       host.appendChild(row);
     });
     // «ohne UTM» einordnen: kein eigener Kanal, sondern Anmeldungen ohne UTM-Spur.
-    // Hauptquellen: goetheanum.tv (der Uscreen-Webhook trägt keine UTM-Felder mit)
-    // und direkte Landingpage-/Formular-Aufrufe ohne Parameter.
+    // Seit 18.7. liefern beide Wege die Spur (goetheanum.tv über das
+    // user_created-Event mit utm_params, Paperform über Felder + device.utm);
+    // übrig bleiben Direktbesucher ohne Parameter und der nicht mehr
+    // rekonstruierbare Rest des Altbestands vor dem 18.7.
     var ohneSpur = byKanal['andere'] || 0;
     if (ohneSpur > 0){
       var note = document.createElement('div'); note.className = 'fnote';
-      note.textContent = '«ohne UTM» = ' + fmt(ohneSpur) + ' Anmeldungen, die ohne UTM-Parameter ankamen. ' +
-        'Der goetheanum.tv-Checkout liefert technisch keine UTMs in den Webhook – diese Abos landen immer hier; ' +
-        'dazu direkte Aufrufe von Landingpage oder Formular. ' +
-        'Die Einzel-Ereignisse stehen unter Momentum → «Was ist passiert?».';
+      note.textContent = '«ohne UTM» = ' + fmt(ohneSpur) + ' Anmeldungen, die ohne UTM-Parameter ankamen: ' +
+        'Direktbesuche ohne Link-Parameter und ein Teil des Altbestands vor dem 18. Juli ' +
+        '(seit dem 18.7. liefern Wochenschrift-Formulare UND goetheanum.tv die Spur automatisch). ' +
+        'Die Einzel-Ereignisse stehen unter Momentum → «Was ist passiert?», dort auch die vermutete Herkunft.';
       host.appendChild(note);
     }
   }

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -85,7 +85,7 @@
   <section>
     <div class="shead"><h2>Momentum</h2><p>Neue Abos je Tag – hier wird sichtbar, wann ein Aufruf, ein Newsletter oder ein Beitrag Wirkung zeigt.</p></div>
     <div class="spark" id="spark"><div class="empty">lädt …</div></div>
-    <details class="zb-form" open>
+    <details class="zb-form">
       <summary>Was ist passiert? – die einzelnen Abos mit Herkunft</summary>
       <div id="evList" style="margin-top:var(--s4)"><div class="empty">lädt …</div></div>
     </details>

--- a/services/sommer-zaehler/README.md
+++ b/services/sommer-zaehler/README.md
@@ -129,8 +129,14 @@ verfeinern.
   (Secret liegt in `sommer2026_config`, nicht im Code/Repo).
 - **In Uscreen:** Settings → Webhooks → obige URL; Events *subscription
   created / canceled* (und *payment/charge* für die Umwandlung `bleibt`).
-- **Attribution:** Settings → Custom user fields → «Wie sind Sie auf uns
-  aufmerksam geworden?»; die Function mappt die Antwort auf `kanal`.
+- **Attribution:** Das Event «User Created» liefert `utm_params` (volles
+  UTM-Tupel aus Uscreens Session-Erfassung) und die Custom-Field-Antwort
+  «Wie sind Sie auf uns aufmerksam geworden?» (Slot `custom_field_1`,
+  Schlüssel im Payload = Fragetext). Die Function heftet beides an die
+  Anmeldung derselben Person (nur wo leer) und mappt auf `kanal`;
+  Registrierungen zählen nie als Abo. Rückwirkend lässt sich dasselbe über
+  den People-CSV-Export ziehen (Filter «Created on date», enthält
+  UTM-Spalten; so am 18.7. für den Altbestand geschehen).
 - **Aktions-Isolierung:** jede Neuanmeldung (`subscription_assigned` u. ä.) im
   Aktionszeitraum zählt als `neu`. Trials hinterlegen eine Kreditkarte, darum ist
   `transaction_id` **kein** Unterscheidungsmerkmal. Verlängerungen legen nichts an

--- a/services/sommer-zaehler/uscreen-attribution-auftrag.md
+++ b/services/sommer-zaehler/uscreen-attribution-auftrag.md
@@ -1,5 +1,15 @@
 # Auftrag für Claude im Chrome: Uscreen-Attribution einrichten (goetheanum.tv)
 
+> **SCHLUSSSTAND 18.7.2026 — erledigt und übertroffen.** Das Event
+> «User Created» ist aktiv und liefert `utm_params` (volles UTM-Tupel aus
+> Uscreens Session-Erfassung) plus die Custom-Field-Antwort; die Ingestion
+> (ab v16) heftet beides automatisch an die Anmeldungen. Der Altbestand
+> 3.–18.7. wurde über den People-CSV-Export rekonstruiert (People → Filter
+> «Created on date» → Export; enthält UTM-Spalten + Referrer + User Field 1):
+> 18 Alt-Abos bekamen ihr UTM-Tupel, 23 ihren Kanal (mailer/social/website)
+> nachträglich. Ein Admin-API-Zugang existiert in diesem Konto nicht und
+> wird nicht gebraucht. Die Abschnitte unten bleiben als Verlauf stehen.
+
 Dieser Prompt ist für **Claude in Chrome** gedacht, eingeloggt im
 **Uscreen-Admin von goetheanum.tv**. Er stammt aus der Attributions-Analyse vom
 17.7.2026: Der Uscreen-Webhook liefert nur `event`, `subscription_id`,


### PR DESCRIPTION
## Was dieser PR tut

**Ereignisliste eingeklappt:** «Was ist passiert?» startet beim Öffnen der Seite zu; wer aufklappt, sieht wie bisher den heutigen Tag offen, ältere Tage zu.

**Hinweistexte auf den neuen Stand:** Der Hinweis unter «Wirkung» behauptete noch «der goetheanum.tv-Checkout liefert technisch keine UTMs» — seit dem 18.7. stimmt das nicht mehr (das Event «User Created» liefert `utm_params`, Paperform liefert über Felder + `device.utm`). «ohne UTM» wird jetzt korrekt erklärt: Direktbesuche ohne Parameter plus der nicht mehr rekonstruierbare Teil des Altbestands vor dem 18.7.

**Doku:** `uscreen-attribution-auftrag.md` trägt den Schlussstand (Event aktiv; Altbestand über den People-CSV-Export rekonstruiert — 18 Alt-Abos mit UTM-Tupel, 23 Kanal-Zuordnungen; Admin-API existiert nicht und wird nicht gebraucht). Das Service-README beschreibt die `utm_params`-Auswertung und den Export-Weg für Rückwirkendes.

## Prüfungen
typo-check ✓ · ds-lint 100 % ✓ · `node --check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN)_