### PR TITLE
Wirkung: Kurzlink-Klicks im Trichter, Lesart-Tabelle im Cockpit

### DIFF
--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -284,7 +284,7 @@
       host.appendChild(box);
     }
     var note = document.createElement('div'); note.className = 'fnote';
-    note.textContent = 'Reichweite und Klicks kommen aus den Aktivitäten – je Eintrag erfassen (auch später über Bearbeiten). Abschlüsse und Geblieben zählt das Cockpit live aus den Anmeldungen.';
+    note.textContent = 'Reichweite kommt aus den Aktivitäten (je Eintrag erfassen). Klicks = erfasste Aktivitäts-Klicks plus die automatisch gezählten Kurzlink-Klicks aller Kampagnen-Links; dieselben Klicks nicht zusätzlich von Hand eintragen, sonst zählen sie doppelt. Abschlüsse und Geblieben zählt das Cockpit live aus den Anmeldungen.';
     host.appendChild(note);
   }
 

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -102,6 +102,22 @@
     <div class="panel" style="margin-top:var(--s5)">
       <div class="funnel" id="funnel"><div class="empty">lädt …</div></div>
     </div>
+    <details class="zb-form">
+      <summary>Lesart: die Abos ohne UTM eingeordnet – Schätzung, Stand 18. Juli</summary>
+      <div class="tablewrap" style="margin-top:var(--s4)">
+        <table class="tarif">
+          <thead><tr><th>Aktivität</th><th class="num">gemessen</th><th class="num">≈ geschätzt dazu</th><th class="num">≈ gesamt</th></tr></thead>
+          <tbody>
+            <tr><td>Mailing (Mail-Welle 1)</td><td class="num">34</td><td class="num">≈21</td><td class="num">≈55</td></tr>
+            <tr><td>Haus-Newsletter (Sommerfestivals, AWW, TV-Weekly)</td><td class="num">6</td><td class="num">≈20</td><td class="num">≈26</td></tr>
+            <tr><td>Organik und Bestand (Suche, Haus-Seiten, Storefront)</td><td class="num">7</td><td class="num">≈23</td><td class="num">≈30</td></tr>
+            <tr><td>Social Media</td><td class="num">8</td><td class="num">≈5</td><td class="num">≈13</td></tr>
+            <tr><td>Print und Festival</td><td class="num">0</td><td class="num">≈0–2</td><td class="num">≈0–2</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="provisorisch">Die Spalte «gemessen» sind harte UTM-Zuordnungen. «≈ geschätzt» ist eine <b>Lesart</b> der Abos ohne Spur (±30 %), gestützt auf vier belegte Anker: die Klick-Tageskurven des ActiveCampaign-Newsletters, die Kurzlink-Klicks, das Konto-Alter der goetheanum.tv-Abonnenten (31 der dunklen TV-Abos sind Bestandskonten von vor der Aktion) und die Referrer aus dem Uscreen-Export. Nichts davon steht in der Datenbank – die Messwerte bleiben unangetastet. Herleitung: <code>docs/wirkungs-lesart-18-07.md</code> im Werkzeug-Repo.</p>
+    </details>
     <div id="quelleSocial" style="margin-top:var(--s5)"></div>
   </section>
 

--- a/docs/wirkungs-lesart-18-07.md
+++ b/docs/wirkungs-lesart-18-07.md
@@ -1,0 +1,84 @@
+# Wirkungs-Lesart der Sommer-Aktion — Stand 18. Juli 2026
+
+Dieses Dokument ordnet die Anmeldungen **ohne UTM-Spur** («ohne UTM» im
+Cockpit) den Aktivitäten der Kampagne zu. Es ist eine **Lesart, keine
+Messung**: Alle mit ≈ markierten Zahlen sind Schätzungen (±30 %). Die
+Datenbank bleibt unangetastet — dort stehen nur harte Zuordnungen. Die
+Kompaktfassung steht im Cockpit unter Wirkung → «Lesart».
+
+Grundlage am Stichtag: **84 Anmeldungen ohne UTM** von insgesamt ~139
+(52 goetheanum.tv · 28 Wochenschrift/Paperform · 4 Zoho/Verlag).
+
+## Die vier belegten Anker
+
+1. **AC-Klick-Tageskurven:** Der einzige Newsletter der Frühphase
+   («Goetheanum Newsletter Juli-August 2026», 4.7., 6'999 Empfänger) hatte
+   113 einmalige Klicks auf die Aktions-Links (70 WoS, 43 TV) mit Peak am
+   4.–5.7. und dünnem Nachlauf bis 17.7. — deckungsgleich mit den dunklen
+   Anmeldungen dieser Tage.
+2. **Kurzlink-Klicks (link_hits):** je Link automatisch gezählt; u. a.
+   Meta-Anzeige EN 199, TV-Weekly-Links (`otter-2` 30, `biber-4` 12),
+   Instagram-Story (`spinne` 31). Die Inserat-QRs (`otter`, `biber`):
+   **null** Scans.
+3. **Konto-Alter (Uscreen-User-IDs sind fortlaufend):** 31 der 52 dunklen
+   TV-Abos gehören zu Konten, die **vor** der Aktion angelegt wurden —
+   Bestandsnutzer, keine Neuzugänge über Landingpages.
+4. **Referrer aus dem Uscreen-People-Export:** Suche (google/ecosia/
+   duckduckgo), Haus-Ökosystem (studium.goetheanum.ch, medsektion,
+   dasgoetheanum.com), vereinzelt facebook.
+
+## Zuordnung im Einzelnen
+
+### goetheanum.tv — Alt-Konten (31, Segment hart belegt)
+
+| Aktivität | ≈Anteil | Beleg |
+|---|---|---|
+| Mail-Welle 1 (17.7.) | ≈16 | 29 der dunklen TV-Abos liegen am 17./18.7. — Zeitprofil identisch mit den 34 hart zugeordneten der Welle; Empfänger = Bestandskontakte |
+| TV-Weekly-Newsletter (14./16.7.) | ≈5 | 42 Kurzlink-Klicks, «vermutet»-Treffer |
+| Storefront-Banner («3 Monate Probezeit») | ≈7 | Bestandsnutzer sehen das Angebot beim normalen Besuch |
+| AC-Newsletter-Nachlauf (5.–8.7.) | ≈3 | AC-Tageskurve |
+
+### goetheanum.tv — Aktions-Konten ohne Spur (21)
+
+| Aktivität | ≈Anteil | Beleg |
+|---|---|---|
+| AC-Newsletter «Sommerfestivals» (4.7.) | ≈7 | 43 TV-Klicks, Peak deckungsgleich mit den 10 dunklen Anmeldungen 4.–5.7. |
+| Hinweis-Newsletter AWW (3.7., 12'948) | ≈3 | die 4 Anmeldungen am Aktionsstart-Tag, vor dem AC-Versand |
+| Instagram-Stories/Reels (10.–14.7.) | ≈3 | «vermutet»-Korrelation, Social-Referrer im Export |
+| Organik (Suche + Haus-Ökosystem) | ≈8 | Referrer-Beleg |
+
+### Wochenschrift — Paperform ohne Spur (28)
+
+| Aktivität | ≈Anteil | Beleg |
+|---|---|---|
+| AC-Newsletter «Sommerfestivals» | ≈8 | 70 WS-Klicks, Peak 4.–6.7. = die dunklen Tage 5.–8.7.; NL-Links waren nackt, Prefill damals löchrig (Zufalls-Keys) |
+| Mail-Welle 1 (17.–18.7.) | ≈5 | Zeitspitze; 12 der 28 kamen übers inzwischen geschlossene No-JS-Leck direkt aufs Formular |
+| EN-Leserschaft (Weekly/geteilte Links) | ≈4 | 12 EN-Fälle, bevor EN-Links registriert waren |
+| Organik/Abtippen/Weiterleiten | ≈11 | Rest; getippte URLs tragen nie Parameter |
+
+### Zoho/Verlag (4)
+
+Direktbestellungen der Startwoche — Auslöser wahrscheinlich das
+Newsletter-Umfeld (≈3), Rest unbekannt.
+
+## Kampagnenweite Rangfolge (gemessen + geschätzt)
+
+| Rang | Aktivität | gemessen | ≈dazu | ≈gesamt |
+|---|---|---|---|---|
+| 1 | Mailing (Mail-Welle 1) | 34 | ≈21 | **≈55** |
+| 2 | Organik/Bestand | 7 | ≈23 | ≈30 |
+| 3 | Haus-Newsletter gesamt | 6 | ≈20 | ≈26 |
+| 4 | Social Media | 8 | ≈5 | ≈13 |
+| 5 | Print/Festival | 0 | ≈0–2 | ≈0–2 |
+
+Drei Sätze dazu: **Das Mailing trägt die Aktion** — eine Welle, gut ein
+Drittel aller Abos. **Die Haus-Newsletter sind stark unterzählt**, weil sie
+in der löchrigen Frühphase liefen. **Print/Festival hat bislang nichts
+Messbares beigetragen** (null QR-Scans) — der ehrlichste Einzelbefund.
+
+## Pflege
+
+Die Lesart ist datiert und wird nicht automatisch nachgeführt. Bei einer
+neuen Auswertung: Kopie mit neuem Datum anlegen, Cockpit-Tabelle
+nachziehen. Seit dem 18.7. entsteht kein neuer dunkler Bestand mehr —
+künftige Auswertungen brauchen immer weniger Schätzung.

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -285,13 +285,21 @@ revoke all on table public.sommer2026_multi_kontakte from anon, authenticated;
 -- Volltext siehe Migration «sommer2026_multiplikatoren».
 
 -- Wirkungstrichter: Sichtbarkeit → Aktivierung → Wirkung → Bindung
+-- (Migration «sommer2026_trichter_kurzlink_klicks»: die Stufe «Klicks» =
+-- von Hand erfasste Aktivitäts-Klicks PLUS die automatisch gezählten
+-- Kurzlink-Klicks der Kampagnen-Links aus link_hits. Doppelzählung möglich,
+-- wenn dieselben Klicks zusätzlich von Hand erfasst werden – die Fussnote
+-- im Cockpit weist die Zusammensetzung aus.)
 create or replace function public.sommer2026_trichter()
 returns table(stufe text, wert bigint, ord int)
 language sql security definer set search_path to 'public' as $$
   select * from (
     select 'sichtbarkeit'::text as stufe, coalesce(sum(reichweite),0)::bigint as wert, 1 as ord from public.sommer2026_massnahmen
     union all
-    select 'aktivierung', coalesce(sum(klicks),0)::bigint, 2 from public.sommer2026_massnahmen
+    select 'aktivierung',
+           (select coalesce(sum(klicks),0) from public.sommer2026_massnahmen)::bigint
+         + (select count(*) from public.link_hits h join public.sommer2026_links l on l.code = h.code)::bigint,
+           2
     union all
     select 'wirkung', count(*)::bigint, 3 from public.sommer2026_signups
     union all


### PR DESCRIPTION
## Was dieser PR tut

**Fehlende Klicks im Trichter:** Die Stufe «Klicks» der Wirkungskette zählte nur die von Hand erfassten Aktivitäts-Klicks (113). Jetzt zählen die automatisch erfassten Kurzlink-Klicks aller Kampagnen-Links dazu (Migration `sommer2026_trichter_kurzlink_klicks`, angewendet) — aktuell **779 statt 113**. Die Fussnote erklärt die Zusammensetzung und warnt davor, dieselben Klicks zusätzlich von Hand einzutragen.

**Lesart im Cockpit:** Unter «Wirkung» gibt es die aufklappbare Tabelle **«Lesart: die Abos ohne UTM eingeordnet — Schätzung, Stand 18. Juli»**: je Aktivität die gemessene Zahl und der geschätzte Anteil aus den Abos ohne Spur, klar getrennt (≈, ±30 %). Gestützt auf vier belegte Anker: AC-Klick-Tageskurven, Kurzlink-Klicks, Konto-Alter der goetheanum.tv-Abonnenten (31 der dunklen TV-Abos sind Bestandskonten von vor der Aktion) und die Referrer aus dem Uscreen-Export. Die vollständige Herleitung liegt datiert in `docs/wirkungs-lesart-18-07.md`; die Messwerte in der Datenbank bleiben unangetastet.

## Regeln
G25 (Ziffern tabellarisch), DS02 (nur Tokens); Schätzung ist durchgängig als Lesart beschriftet und nie mit Messung vermischt. Prüfmaschinen: typo-check ✓, ds-lint 100 %; Trichter-RPC gegen die Live-DB verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUKnMhCZ9mzynev9K4zBsN)_