### PR TITLE
Kartentool: Aquarell-Ränder schriftdünn, Schriftzug-Justage im Backend

### DIFF
--- a/apps/karten-generator/app.js
+++ b/apps/karten-generator/app.js
@@ -35,7 +35,10 @@ const MARKER_FARBEN_AQUARELL = {
   grau: "#5f6266",
   gold: "#7a5a20"
 };
-const MARKER_RAND_AQUARELL = 0.5;  // mm — Rand der weissen Scheibe
+// «So dünn wie die Schrift» (Entscheid Auftraggeber, 19.7.): der Stamm
+// der Laut-Ziffern misst 0.13 em — beim Ziffergrad 2.03 mm sind das
+// 0.26 mm. Rand und Ziffer führen damit denselben Strich.
+const MARKER_RAND_AQUARELL = 0.26;
 const TINTE = "#4e4f4a";
 // Leise Druck-Tinte für Strukturbeiwerk (Kategorie-Titel der Legende):
 // = Token --ink-print-leise (tokens.css, seit v1.6.0), gerechnet 5.07:1
@@ -118,6 +121,7 @@ const state = {
   farben: { ...PRESETS["gedeckt"] },
   basiskarte: "vektor", // Grundkarte: ‹vektor› | ‹aquarell› | ‹wiesen› (Backend «Karte»)
   aquarellDeckkraft: 100, // Deckkraft des gemalten Blatts in % (Backend-Regler)
+  schriftzuege: {},       // Aquarell-Schriftzüge: Überschreibung je Text (x, y, groesse, winkel)
   platzieren: null,    // { label, farbe } während der Platzierung (neue Marke)
   platzierenOrt: null, // Ort-id, deren Marke gerade verschoben wird
   platzierenLogo: false, // Logo wird gerade neu platziert
@@ -659,7 +663,7 @@ function pfeilMarkup(x, y, r, hex, richtung) {
   const spitze = ikonMarkup("pfeil-rechts-fett", x + dx * abstand, y + dy * abstand, 4.4, hex, winkel);
   if (!aquarellMarkerStil()) return spitze;
   // Aquarell: weisse Unterlegung (grösseres Duplikat) als Kontur zum Grund.
-  return ikonMarkup("pfeil-rechts-fett", x + dx * abstand, y + dy * abstand, 5.0, "#ffffff", winkel) + spitze;
+  return ikonMarkup("pfeil-rechts-fett", x + dx * abstand, y + dy * abstand, 4.9, "#ffffff", winkel) + spitze;
 }
 
 /* Treppen- und Lift-Badges: exakte Vektorgeometrie der Vorlage
@@ -765,7 +769,9 @@ function textBreiteMm(text, familie, groesseMm) {
 }
 
 function gebaeudeLabelMarkup() {
-  const labels = aquarellMarkerStil() ? GEBAEUDE_LABELS_AQUARELL : GEBAEUDE_LABELS;
+  const labels = aquarellMarkerStil()
+    ? GEBAEUDE_LABELS_AQUARELL.map((l) => ({ ...l, ...(state.schriftzuege[l.text] || {}) }))
+    : GEBAEUDE_LABELS;
   return labels.map((l) => {
     const drehung = l.winkel ? ` transform="rotate(${l.winkel} ${l.x} ${l.y})"` : "";
     const links = l.x - textBreiteMm(l.text, SCHRIFT_SPRACHE, l.groesse) / 2;
@@ -1539,6 +1545,17 @@ function renderOptionen() {
     document.getElementById("aquarell-deckkraft-wert").textContent = state.aquarellDeckkraft + " %";
     deckRegler.closest(".farb-reihe").style.opacity = grundModus === "vektor" ? "0.45" : "";
   }
+  const zugWahl = document.getElementById("schriftzug-wahl");
+  if (zugWahl) {
+    const basis = GEBAEUDE_LABELS_AQUARELL.find((l) => l.text === zugWahl.value)
+      || GEBAEUDE_LABELS_AQUARELL[0];
+    const zug = { ...basis, ...(state.schriftzuege[basis.text] || {}) };
+    document.getElementById("schriftzug-x").value = zug.x;
+    document.getElementById("schriftzug-y").value = zug.y;
+    document.getElementById("schriftzug-groesse").value = zug.groesse;
+    document.getElementById("schriftzug-winkel").value = zug.winkel;
+    document.querySelector(".schriftzug-justage").style.opacity = grundModus === "aquarell" ? "" : "0.45";
+  }
   const bkHinweis = document.getElementById("basiskarte-hinweis");
   if (bkHinweis) {
     bkHinweis.textContent = grundModus === "aquarell"
@@ -1585,7 +1602,8 @@ function standAlsJson() {
     titelLogo: state.titelLogo,
     preset: state.preset, farben: state.farben,
     basiskarte: state.basiskarte,
-    aquarellDeckkraft: state.aquarellDeckkraft
+    aquarellDeckkraft: state.aquarellDeckkraft,
+    schriftzuege: state.schriftzuege
   };
 }
 
@@ -1651,6 +1669,22 @@ function standAnwenden(s) {
     const deckkraft = Number(s.aquarellDeckkraft);
     state.aquarellDeckkraft = Number.isFinite(deckkraft)
       ? Math.max(10, Math.min(100, Math.round(deckkraft))) : 100;
+    state.schriftzuege = {};
+    if (s.schriftzuege && typeof s.schriftzuege === "object") {
+      GEBAEUDE_LABELS_AQUARELL.forEach((l) => {
+        const z = s.schriftzuege[l.text];
+        if (!z || typeof z !== "object") return;
+        const grenzen = { x: [0, 297], y: [0, 210], groesse: [1.5, 8], winkel: [-180, 180] };
+        const wert = {};
+        Object.keys(grenzen).forEach((feld) => {
+          const zahl = Number(z[feld]);
+          if (Number.isFinite(zahl)) {
+            wert[feld] = Math.max(grenzen[feld][0], Math.min(grenzen[feld][1], zahl));
+          }
+        });
+        if (Object.keys(wert).length) state.schriftzuege[l.text] = wert;
+      });
+    }
     state.ausschnitt = state.ausschnitt || { skala: 1, dx: 0, dy: 0 };
 }
 
@@ -1886,6 +1920,22 @@ document.getElementById("aquarell-deckkraft").addEventListener("input", (e) => {
   state.aquarellDeckkraft = Math.max(10, Math.min(100, Math.round(Number(e.target.value) || 100)));
   render();
 });
+
+document.getElementById("schriftzug-wahl").addEventListener("change", () => renderOptionen());
+[["schriftzug-x", "x", 0, 297], ["schriftzug-y", "y", 0, 210],
+ ["schriftzug-groesse", "groesse", 1.5, 8], ["schriftzug-winkel", "winkel", -180, 180]]
+  .forEach(([id, feld, min, max]) => {
+    document.getElementById(id).addEventListener("input", (e) => {
+      const wert = Number(e.target.value);
+      if (!Number.isFinite(wert)) return;
+      const text = document.getElementById("schriftzug-wahl").value;
+      state.schriftzuege[text] = {
+        ...(state.schriftzuege[text] || {}),
+        [feld]: Math.max(min, Math.min(max, wert))
+      };
+      render();
+    });
+  });
 
 document.getElementById("opt-wiese-klein").addEventListener("change", (e) => {
   state.wiesen.klein = e.target.checked;

--- a/apps/karten-generator/index.html
+++ b/apps/karten-generator/index.html
@@ -197,6 +197,14 @@
       flex: 1; min-height: var(--tap);              /* B04 */
       accent-color: var(--blue-solid);
     }
+    .schriftzug-justage select,
+    .schriftzug-justage input[type="number"] {
+      min-height: var(--tap);                       /* B04 */
+      font-size: 16px;                              /* B03: Eingaben ≥16px */
+      border: 1px solid var(--line); border-radius: var(--r-control);
+      background: var(--field-bg); color: var(--ink); padding: 0 var(--s2);
+    }
+    .schriftzug-justage input[type="number"] { width: 76px; }
     .farb-reihe input[type="color"] {
       width: 44px; height: 32px;
       border: 1px solid var(--line); border-radius: var(--r-control);
@@ -340,6 +348,27 @@
             <label for="aquarell-deckkraft">Aquarell-Deckkraft</label>
             <input id="aquarell-deckkraft" type="range" min="10" max="100" step="5" value="100" />
             <span class="hint" id="aquarell-deckkraft-wert">100 %</span>
+          </div>
+          <div class="schriftzug-justage">
+            <div class="farb-reihe">
+              <label for="schriftzug-wahl">Schriftzug auf der Malerei</label>
+              <select id="schriftzug-wahl">
+                <option value="Goetheanum">Goetheanum</option>
+                <option value="Schreinerei">Schreinerei</option>
+              </select>
+            </div>
+            <div class="farb-reihe">
+              <label for="schriftzug-x">Lage x · y in mm</label>
+              <input id="schriftzug-x" type="number" step="0.1" min="0" max="297" />
+              <input id="schriftzug-y" type="number" step="0.1" min="0" max="210" aria-label="Lage y in mm" />
+            </div>
+            <div class="farb-reihe">
+              <label for="schriftzug-groesse">Grad in mm · Winkel</label>
+              <input id="schriftzug-groesse" type="number" step="0.05" min="1.5" max="8" />
+              <input id="schriftzug-winkel" type="number" step="0.1" min="-180" max="180" aria-label="Winkel in Grad" />
+            </div>
+            <div class="hint">Wirkt nur im Aquarell-Modus; die Werte wandern
+              mit «Stand als JSON» zurück in die Vorlage.</div>
           </div>
         </div>
         <div class="hint">Standard ist die gedeckte Hauspalette; jede Rolle


### PR DESCRIPTION
Nachbesserung auf Sicht des Auftraggebers (19. Juli): «Die weissen Ränder sind zu dick … alle dünner, etwa so dünn wie die Schrift» und «Position und Grösse der Schriftzüge manuell-visuell bestimmen».

## Was geändert wurde

- **Ränder schriftdünn (0,26 mm):** Der Stamm der Laut-Ziffern wurde ausgemessen (0,13 em → 0,26 mm beim Ziffergrad 2,03 mm) — Rand und Ziffer führen jetzt denselben Strich. Gilt für die farbigen Ränder der weissen Scheiben wie für die weissen Ränder der invertierten Treppen/Lifte; die weisse Pfeil-Unterlegung folgt entsprechend (5,0 → 4,9).
- **Schriftzug-Justage im Backend** (`index.html`, Fieldset «Kartenfarben», backend-only): Auswahl Goetheanum/Schreinerei plus Felder für Lage x·y (mm), Grad (mm) und Winkel (°), mit Live-Vorschau. Wirkt nur im Aquarell-Modus (sonst abgeblendet); Überschreibungen liegen in `state.schriftzuege`, wandern durch «Stand als JSON» (mit Grenz-Validierung beim Anwenden) und damit in Export und Vorlagen-Rückfluss. Die Vektor-Schriftzüge bleiben unberührt.

## Verifikation

- Headless-E2E, 14 Zusagen grün: Vektor-/Wiesen-Modus byte-frei von Aquarell-Mustern, Rand 0,26 in Szene und Badges, Justage-Werte erscheinen live im SVG und im Stand-JSON, PDF-Export erzeugt, keine Konsolenfehler.
- Sichtvergleich der Randstärken (0,50 / 0,35 / 0,26) an Scheiben, Treppen und auf hellem Grund.

B03/B04 an den neuen Eingabefeldern eingehalten (16 px, `--tap`); Szenen-Farben bleiben Druck-Artefaktfarben (B01 unberührt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CK8rHxMDF93f9TYe5gCFsG

---
_Generated by [Claude Code](https://claude.ai/code/session_01CK8rHxMDF93f9TYe5gCFsG)_