### PR TITLE
Gestaltungsprinzipien: Entwurf der Prinzipien-Mittelschicht (P1–P6)

### DIFF
--- a/docs/gestaltungsprinzipien-entwurf.md
+++ b/docs/gestaltungsprinzipien-entwurf.md
@@ -1,0 +1,210 @@
+# Gestaltungsprinzipien – Entwurf zur Entscheidung
+
+Stand: 19. Juli 2026 · Status: **Entwurf, vom Auftraggeber zu ratifizieren.**
+Anlass: der Befund ‹wir sammeln allerlei, vieles wirkt kleinteilig›. Dieses
+Blatt schlägt die fehlende Mittelschicht vor – wenige tragende Prinzipien
+zwischen der Strategie (Purpose, Onliness) und den vielen Einzelregeln
+(G01–G28, B01–B05, DS01–DS09). Beschlossen wird hier nichts.
+
+---
+
+## 1 · Befund: warum es kleinteilig wirkt
+
+Das System hat eine **Spitze** (das Strategieblatt: Purpose, Onliness, Werte)
+und einen breiten **Unterbau** (Tokens, Rollen, Regelwerk, Vertrag, Ledger,
+Prüfmaschinen). Was fehlt, ist die **Mitte**: eine Handvoll Prinzipien, aus
+denen sich jede Regel herleitet und an denen sich jede neue Frage beantworten
+lässt, **bevor** sie eine neue Regel erzeugt.
+
+Die Folgen des fehlenden Mittelbaus sind genau die beobachteten:
+
+- **Regeln sagen was, nicht warum.** G05 verbietet Versal-Hervorhebung, G17
+  Kunst-Kapitälchen, G23 Versalsatz im Lesetext – drei Regeln, ein Grund. Wer
+  den Grund nicht kennt, muss drei Regeln lernen; wer ihn kennt, braucht keine.
+- **Jede neue Frage wird als Einzellösung beantwortet** und landet als
+  weiterer Eintrag im Regelwerk oder Ledger. Das Regelwerk wächst schneller
+  als das Verständnis.
+- **Der Charakter ist implizit da** – er steckt erkennbar in G03
+  (Weglassen), im Credo (‹Diese Regeln verhindern den Fehler. Den guten Satz
+  macht der Mensch.›), in der Stimm-Metapher der Schnitte – aber er ist
+  nirgends auf einer Seite ausgesprochen. Was nicht ausgesprochen ist, kann
+  eine breite Mitarbeitendenschaft weder denken noch weitergeben.
+
+## 2 · Vorbilder – und was genau von ihnen zu lernen ist
+
+- **Karl Gerstner, ‹Programme entwerfen› (1964).** Die direkteste Antwort auf
+  ‹tausend Einzellösungen›: nicht Lösungen für Aufgaben entwerfen, sondern
+  **Programme für Lösungen**. Eine Aufgabe wird nicht einzeln gelöst, sondern
+  als Fall eines Programms – genau das leisten Tokens, Rollen und der Atem
+  schon technisch; Gerstner liefert die Denkfigur dazu.
+- **Dieter Rams / Braun.** Zehn Prinzipien, jedes ein wertender Satz (‹Gutes
+  Design ist so wenig Design wie möglich›). Lehre: Prinzipien sind **wenige,
+  merkbare, wertende Sätze** – keine Checklisten. Und: sie sind über Jahrzehnte
+  stabil, während Produkte und Regeln wechseln.
+- **Otl Aicher (Lufthansa, München 72, ERCO).** Gestaltung als **Haltung**,
+  nicht als Stil: aus wenigen Entscheiden (eine Schrift, ein Raster, eine
+  Bildsprache) ist alles ableitbar, vom Ticket bis zum Leitsystem. Lehre: der
+  Charakter sitzt in den Entscheiden, nicht in den Artefakten.
+- **Christopher Alexander, ‹A Pattern Language›.** Muster **erzeugen**
+  Lösungen, statt sie aufzuzählen; jede konkrete Lösung kann ihr Muster
+  nennen. Das ist die gesuchte **Nachvollziehbarkeit aus der
+  Gesamtperspektive**: von jeder Einzellösung führt ein benannter Weg zurück.
+- **GOV.UK Design Principles.** Der Beweis, dass Prinzipien für eine sehr
+  breite, gestalterisch ungeschulte Mitarbeitendenschaft formulierbar sind:
+  zehn Verb-Sätze (‹Do less› · ‹Do the hard work to make it simple›), jeder
+  mit Beispielen, öffentlich, zitierfähig in jeder Diskussion.
+- **Massimo Vignelli, ‹The Vignelli Canon›.** Disziplin der wenigen Mittel
+  (eine Handvoll Schriften genügt für alles) – die Rechtfertigung dafür, dass
+  Enge kein Mangel ist, sondern die Quelle der Wiedererkennbarkeit.
+- **Handwerk des Prinzipien-Schreibens** (u. a. Jared Spool): ein Prinzip
+  taugt nur, wenn man **mit ihm Nein sagen kann** und wenn sein **Gegenteil
+  vertretbar** wäre. ‹Wir gestalten einfach, schön und nützlich› ist keines –
+  niemand vertritt das Gegenteil. ‹Weglassen› ist eines – das Gegenteil
+  (‹mehr Auszeichnung hilft der Orientierung›) ist eine echte Position, die
+  andere Häuser leben.
+
+## 3 · Was den Charakter tatsächlich ausmacht – sechs Prinzipien (Vorschlag)
+
+Der Vorschlag erfindet nichts Neues, er **spricht aus, was im Bestand schon
+konsequent gelebt wird**. Voran ein Charaktersatz, der alles trägt:
+
+> **Das Goetheanum spricht – es dekoriert nicht.**
+> Ruhig, deutlich, würdig; mit wenigen Mitteln, für alle, aus einer Quelle.
+
+### P1 · Eine Stimme
+
+Die Schrift ist eine **Sprechweise**, kein Stil-Baukasten: Klar trägt, Laut
+betont, Leise antwortet. Betont wird mit Ton (Laut), nie mit Tricks
+(Unterstreichen, Versalien, Sperren). Eine Familie trägt alles; wo sie an
+ihre Grenze kommt, übernimmt genau **eine** benannte Zweitstimme (Source
+Sans 3 für Funktion und Daten) – als Entscheid, nicht je Seite.
+*Daraus folgen:* S01, G01, G02, G04, G05, G23, die Schrift-Grenze.
+
+### P2 · Weglassen
+
+Was entfallen kann, entfällt – Auszeichnung, Schmuck, Beiwerk, Text. Das Menü
+koordiniert, es erklärt nicht; der Normalfall trägt kein Zeichen; ein
+Beta-Hinweis an einem Ort statt zwölf Pillen. Weglassen ist keine Askese,
+sondern der Grund, warum das Wenige wirkt.
+*Daraus folgen:* G03, G17 (kein Schmuck), die Utility-Lücke (für Falsches
+gibt es kein Werkzeug), der Dramaturgie-Leitsatz (ein Hero, eine
+Primärhandlung).
+
+### P3 · Für alle gebaut
+
+Zugänglichkeit ist Ausgangspunkt, nicht Prüfpunkt – und sie wird **gerechnet,
+nicht geschätzt** (Kontraste, Grade, Ziele). Nichts Lesbares unter 14 px,
+Weiss auf Farbflächen, Fingerziele 44 px. Wer das Haus vertritt, schliesst
+niemanden aus.
+*Daraus folgen:* B01–B05, G28, die Mobil-Baseline.
+
+### P4 · Ehrlich
+
+Nichts vortäuschen: keine Kunst-Kapitälchen, keine vorgetäuschten
+Mediävalziffern, CMYK nur als ausgewiesener Richtwert, Status ehrlich
+(live · beta · Entwurf), Schätzungen als Lesart markiert, nie als Messung.
+Auch die Werkzeuge selbst sind ehrlich: sie zeigen, was sie können, und
+verschweigen nicht, was aussteht.
+*Daraus folgen:* G17, G25 (nicht vortäuschen), die Farben-Seite
+(‹ehrlich statt erfunden›), die Wirkungs-Lesarten.
+
+### P5 · Aus einer Quelle
+
+Einbinden statt kopieren: eine Änderung gilt überall oder sie gilt nicht.
+Tokens, eine Org-Datenwurzel, eine Logo-Engine, ein Manifest. Was an einer
+Seite verbessert wird, fliesst ins Fundament zurück (der Atem) – eine
+Verbesserung am Rand ist erst fertig, wenn sie überall gilt.
+*Daraus folgen:* DS01, DS02, DS07, DS09, die Aufnahme-Schleife, der Ledger.
+
+### P6 · Die Maschine verhindert den Fehler, der Mensch macht die Gestalt
+
+Eindeutiges wird automatisiert, Mehrdeutiges vorgeschlagen, Gestaltung bleibt
+beim Menschen. Die Maschine schlägt vor, der Mensch **ratifiziert** – und die
+Ratifizierung wird Teil des Codes (`# ds-ok`, Ledger). Konformität entsteht
+durch Konstruktion, nicht durch Kontrolle.
+*Daraus folgen:* G26, die gesamte Konformitäts-Engine, der Bau-Workflow
+(Starter statt Nullpunkt).
+
+**Gegenprobe (Nein-sagen-Test).** Jedes der sechs verbietet real Erwünschtes:
+P1 verbietet die ‹lebendige› Mischtypografie, P2 das gut gemeinte
+Erklär-Beiwerk, P3 die elegante 12-px-Marginalie, P4 die geschönte Zahl,
+P5 die schnelle lokale Kopie, P6 sowohl den handgeprüften Wildwuchs als auch
+die Maschine, die Gestaltung erzwingt. Und jedes Gegenteil ist eine
+vertretbare Position, die andere Häuser einnehmen – die Prinzipien sind also
+Entscheidungen, keine Platitüden.
+
+## 4 · Prinzipiell arbeiten – die Herleitungskette
+
+Damit Einzellösungen aus der Gesamtperspektive nachvollziehbar werden, wird
+die vorhandene Vier-Schichten-Architektur um die fehlende Ebene ergänzt und
+**jede Ebene beruft sich ausdrücklich auf die darüber**:
+
+```
+Charaktersatz            (1 Satz – ändert sich nie)
+  └─ Prinzipien P1–P6    (ändern sich fast nie; dieses Blatt)
+       └─ Regeln G/B/DS  (ändern sich selten; jede nennt ihr Prinzip)
+            └─ Tokens & Rollen   (ändern sich im Atem-Rhythmus)
+                 └─ Werkzeuge & Seiten   (ändern sich laufend)
+```
+
+Konkrete Mechanik (kleine Eingriffe, grosse Wirkung):
+
+1. **Jede Regel bekommt einen Prinzip-Anker.** In
+   `goetheanum-typo-tokens.json` (`$regeln`) und `contract.json` je ein Feld
+   `prinzip: "P1"…"P6"`. Eine Regel, die sich keinem Prinzip zuordnen lässt,
+   ist ein Befund: entweder fehlt ein Prinzip (dann hier nachtragen) oder die
+   Regel ist entbehrlich (P2 auf das Regelwerk selbst angewandt).
+2. **Ledger-Einträge nennen das Prinzip**, nicht nur die Regel: *was · warum ·
+   Wirkung · Prinzip*. Damit liest sich der Beschluss-Ledger als
+   fortlaufender Beweis, dass das System aus sich selbst heraus wächst.
+3. **Neue Fragen zuerst ans Prinzip stellen.** Der Weg ist: Prinzip befragen →
+   reicht meist → sonst Regel ableiten (mit Anker) → zuletzt Token/Rolle.
+   Eine Lösung, die keinen Anker findet, ist per Definition ein
+   Atem-Entscheid für den Auftraggeber – nicht eine stille Einzellösung.
+4. **Die Prüfmaschinen sprechen mit.** `ds-lint` und `typo-check` können in
+   der Meldung den Prinzip-Anker mitgeben (‹DS02 · P5 Aus einer Quelle›) –
+   aus einer Fehlermeldung wird ein Lehrsatz.
+5. **Der Widerspruchsfall bleibt beim Menschen.** Wo Regel und Schrift (oder
+   zwei Prinzipien) kollidieren, wird gemeldet und entschieden, nicht
+   eigenmächtig umgeschrieben – jetzt aber mit dem Prinzip als Massstab der
+   Entscheidung.
+
+## 5 · Formulierbar für die breite Mitarbeitendenschaft
+
+Zwei Fassungen desselben Inhalts, nach Publikum getrennt:
+
+- **Werkstatt-Fassung** – dieses Blatt: mit Regel-IDs, Herleitungskette,
+  Gegenproben. Für alle, die am System bauen.
+- **Haus-Fassung** – eine Seite, sechs Sätze, je ein Bildpaar ‹so nicht /
+  so›. Ohne eine einzige Regel-ID, ohne Fachwort. Als Abschnitt im
+  Schaufenster (`design-system/index.html`) und als druckbares Blatt.
+  Sprachregel dafür: Verben, Hausdeutsch, keine Platitüden – jeder Satz muss
+  den Nein-sagen-Test bestehen.
+
+Dabei die wichtigste Entlastung nicht vergessen: **die Mitarbeitendenschaft
+begegnet den Prinzipien vor allem verkörpert, nicht als Text** – das ist das
+Onliness-Versprechen. Wer die Werkzeuge benutzt, arbeitet prinzipiengetreu,
+ohne ein Prinzip gelesen zu haben. Die Haus-Fassung beantwortet nur die
+Frage, die Werkzeuge offen lassen: *Warum ist das so?* – in sechs Sätzen,
+die man sich merken und weitersagen kann.
+
+## 6 · Offene Fragen zur Entscheidung
+
+1. **Der Charaktersatz:** trägt ‹Das Goetheanum spricht – es dekoriert
+   nicht›? Oder soll er näher an Purpose/Würde formuliert sein?
+2. **Sechs Prinzipien:** richtige Zahl, richtiger Schnitt? (Kandidat für
+   Zusammenlegung: P4 Ehrlich und P6 teilen die Wurzel ‹nichts vortäuschen›.)
+3. **Die offene Charakterfrage:** Das System, wie es steht, ist still,
+   schweizerisch, zurückhaltend – der Bau, den es vertritt, ist plastisch,
+   organisch, expressiv. Ist die Stille der gewollte Charakter (die Bühne
+   gehört dem Haus, die Grafik dient) – oder fehlt dem System eine benannte
+   warme/organische Dimension? Die Welt ‹warm› und der Spielraum-Entwurf
+   (Dialekte, Dramaturgie-Budget) sind erste Antworten; hier braucht es
+   einen Grundsatz-Entscheid, kein weiteres Experiment.
+4. **Verankerung:** `prinzip`-Feld in `$regeln`/`contract.json` einführen und
+   die Prüfmaschinen-Meldungen erweitern (Abschnitt 4) – ja/nein?
+5. **Ort der Haus-Fassung:** Schaufenster-Abschnitt, eigene Seite
+   (`prinzipien.html`), oder beides (Seite speist Abschnitt)?
+
+Nach Ratifizierung wird dieses Blatt zur Quelle: Haus-Fassung bauen,
+Prinzip-Anker eintragen, Ledger-Schema erweitern – je als eigener Schritt.


### PR DESCRIPTION
Neues Entscheidungsblatt `docs/gestaltungsprinzipien-entwurf.md` — Antwort auf den Befund ‹vieles wirkt kleinteilig›:

- **Befund:** zwischen Strategie-Spitze (Purpose/Onliness) und den ~40 Einzelregeln (G/B/DS) fehlt die Mittelschicht — wenige Prinzipien, aus denen sich Regeln herleiten.
- **Vorbilder** mit je einer konkreten Lehre: Gerstner (Programme statt Lösungen), Rams (wenige wertende Sätze), Aicher (Haltung), Alexander (Muster erzeugen Lösungen), GOV.UK (formulierbar für Breite), Vignelli (Disziplin der wenigen Mittel).
- **Sechs Prinzipien P1–P6**, aus dem Bestand ausgesprochen (nicht erfunden), je mit Regel-Ankern und Nein-sagen-Gegenprobe; dazu ein Charaktersatz-Vorschlag.
- **Herleitungskette** Charakter → Prinzipien → Regeln → Tokens/Rollen → Werkzeuge, mit kleiner Mechanik (`prinzip`-Feld, Ledger-Schema, Prüfmaschinen-Meldungen).
- **Zwei Fassungen** (Werkstatt / Haus) für die breite Mitarbeitendenschaft.
- **Offene Fragen** zur Ratifizierung, inkl. der Grundsatzfrage still ↔ organisch.

Status im Dokument: Entwurf, vom Auftraggeber zu ratifizieren. Regelwerk, Tokens und Vertrag bleiben unangetastet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuXR9zNWBPqTZrQTRksch1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuXR9zNWBPqTZrQTRksch1)_