### PR TITLE
Sortierer: Ausblendefunktion + Design-System vorerst aus Karten/Karussell

### DIFF
--- a/SECRETS.md
+++ b/SECRETS.md
@@ -37,6 +37,7 @@ Einmal setzen, dauerhaft wiederverwenden.
 | **ActiveCampaign** | Connector | — | — | installiert, **Auth erneuern** |
 | **GitHub** | Connector/Proxy | (`GH_TOKEN` nur für `gh`-CLI) | `repo`, `read:org` | über Proxy |
 | **Resend** | Supabase-Config-Tabelle (`seelenkalender_config`, nur Service-Role) | `resend_api_key` | nur Senden (`sending`) | per SQL-Editor setzen (`services/seelenkalender/README.md`) — **nicht** als Claude-Env nötig |
+| **Sortierer-Commit** | Supabase Edge Function | `GITHUB_TOKEN`, `SORTIERER_SECRET` | Token: **nur dieses Repo**, Contents R+W | Function-Secrets im Supabase-Projekt setzen (s. u.) |
 | *(Alternative: Brevo)* | Connector | — | — | im Verzeichnis, nicht installiert |
 
 ## Env-Variablen setzen (Web-UI)
@@ -65,6 +66,30 @@ gepflegt, **nicht** hier — deshalb ist `mcpServers` leer. Für einen
   }
 }
 ```
+
+## Sortierer «Direkt speichern» (Edge Function)
+
+Der Sortierer (`sortierer.html`) kann die Menü-Reihenfolge direkt committen,
+statt sie zu exportieren. Dahinter steht die Edge Function
+`services/kistenpflege/sortierer-commit/index.ts` (Projekt
+`dagcsnfrlbpxcmdimnrw`). Sie schreibt **ausschliesslich** das Feld
+`reihenfolge` in die `tools.json` — winzige Wirkfläche, per Git rückholbar.
+
+Zum Scharfschalten zweierlei, **im Supabase-Projekt** (nie hier eintragen):
+
+1. **Deploy:** Function `sortierer-commit` aus obiger Quelle deployen (Connector
+   oder `supabase functions deploy sortierer-commit`).
+2. **Function-Secrets** (Dashboard → Edge Functions → Secrets, oder
+   `supabase secrets set`):
+   - `GITHUB_TOKEN` — fine-grained PAT, **nur `phtok/goeloggen`**, Contents:
+     Read+Write. (Optional `GITHUB_REPO`/`GITHUB_BRANCH`; Vorgabe
+     `phtok/goeloggen` / `main`.)
+   - `SORTIERER_SECRET` — frei gewähltes langes Passwort; dasselbe gibt die
+     Person beim ersten «Direkt speichern» im Browser ein (bleibt lokal).
+
+Bis beide Secrets gesetzt sind, antwortet die Funktion bewusst mit 500
+«nicht konfiguriert»; solange bleibt **«Exportieren»** der Weg (Datei
+herunterladen und committen).
 
 ## Merksatz
 Connector, wo es einen gibt (parat + nie einsehbar + kein Recycling); Env-Key

--- a/design-system/nav.js
+++ b/design-system/nav.js
@@ -483,6 +483,8 @@
     var tools = ALL.filter(function (t) {
       return (w.cats || []).indexOf(t.cat) !== -1;
     });
+    // Auch intern in Sortierer-Reihenfolge (reihenfolge.schublade); Unbekannte ans Ende.
+    tools.sort(function (a, b) { return flatRank(a) - flatRank(b); });
     var subs = (w.sub || []).map(function (s) { return worldGroupEl(s, curCat); })
                             .filter(function (n) { return n; });
     if (!tools.length && !subs.length) return null;
@@ -504,7 +506,11 @@
     "uebersetzungen", "sektionsfarben", "typografie", "karten", "powerpoint",
     "editor", "wallpaper", "design-system"];
   var FLAT_ORDER = DEFAULT_FLAT_ORDER;
+  // Vom Sortierer ausgeblendete Schubladen-Einträge (tools.json → reihenfolge.aus.schublade):
+  // weg aus dem ÖFFENTLICHEN Menü, in der Intern-Ansicht bleiben sie sichtbar.
+  var AUS_SCHUBLADE = [];
   var PUBLIC_CATS = WORLDS.reduce(function (a, w) { return a.concat(w.cats); }, []);
+  var flatRank = function (t) { var k = FLAT_ORDER.indexOf(t.slug); return k < 0 ? 999 : k; };
 
   function renderDrawer() {
     var intern = isIntern();
@@ -519,11 +525,12 @@
 
     if (!intern) {
       // FLACH: eine priorisierte Liste aller öffentlichen Werkzeuge, keine Bereiche.
+      // Vom Sortierer Ausgeblendete bleiben hier draussen (Intern-Ansicht zeigt sie).
       var pub = ALL.filter(function (t) {
-        return PUBLIC_CATS.indexOf(t.cat) !== -1 && (t.status === "live" || t.status === "beta");
+        return PUBLIC_CATS.indexOf(t.cat) !== -1 && (t.status === "live" || t.status === "beta") &&
+               AUS_SCHUBLADE.indexOf(t.slug) === -1;
       });
-      var rank = function (t) { var k = FLAT_ORDER.indexOf(t.slug); return k < 0 ? 999 : k; };
-      pub.sort(function (a, b) { return rank(a) - rank(b); });
+      pub.sort(function (a, b) { return flatRank(a) - flatRank(b); });
       pub.forEach(function (t) { drawerBody.appendChild(linkEl(t)); });
     } else {
       // intern: nach Backstage-Welten gruppiert; Unterwelten verschachteln sich
@@ -544,6 +551,9 @@
     // sonst die eingebaute Vorgabe.
     if (m.reihenfolge && m.reihenfolge.schublade && m.reihenfolge.schublade.length) {
       FLAT_ORDER = m.reihenfolge.schublade;
+    }
+    if (m.reihenfolge && m.reihenfolge.aus && Array.isArray(m.reihenfolge.aus.schublade)) {
+      AUS_SCHUBLADE = m.reihenfolge.aus.schublade;
     }
     // Sicherheitsnetz: Manifest-Kategorien ohne Welt werden automatisch eigene
     // Backstage-Welten (Titel/Intro aus tools.json) — eine neue Kategorie im

--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
     a.innerHTML = visual(t) + '<h2>' + t.title + ' <span class="arr">›</span></h2>';
     return a;
   }
-  function buildCarousel(byslug, order){
+  function buildCarousel(byslug, order, aus){
     // Karussell-Extra (kein eigenes Werkzeug): die elf E-Mail-Gebote.
     byslug["empfehlungen"] = byslug["empfehlungen"] || {
       slug: "empfehlungen", title: "Diese Mail wird gelesen",
@@ -238,6 +238,8 @@
     // (tools.json → reihenfolge.karussell), sonst gilt die DISCOVER-Vorgabe.
     var LINES = {}; DISCOVER.forEach(function(d){ LINES[d.slug] = d.line; });
     var slugs = (order && order.length) ? order : DISCOVER.map(function(d){ return d.slug; });
+    var versteckt = aus || [];
+    slugs = slugs.filter(function(s){ return versteckt.indexOf(s) < 0; });
     var car = document.getElementById("carousel");
     var items = slugs.map(function(slug){ return { line: LINES[slug] || "", t: byslug[slug] }; })
                      .filter(function(x){ return x.t; });
@@ -313,7 +315,11 @@
     var byslug = {}; tools.forEach(function(t){ byslug[t.slug] = t; });
     // Reihenfolgen pflegt der Sortierer (tools.json → reihenfolge); sonst die Vorgaben.
     var R = man.reihenfolge || {};
-    buildCarousel(byslug, R.karussell);
+    var AUS = R.aus || {};
+    buildCarousel(byslug, R.karussell, AUS.karussell || []);
+    // Ausgeblendete Karten (Sortierer): weg von der Startseite, per Direktlink/Menü erreichbar.
+    var ausKarten = AUS.karten || [];
+    tools = tools.filter(function(t){ return ausKarten.indexOf(t.slug) < 0; });
     var kartenOrder = (R.karten && R.karten.length) ? R.karten : ORDER;
     var rank = function(t){ var k = kartenOrder.indexOf(t.slug); return k < 0 ? 999 : k; };
     tools.sort(function(a,b){ return rank(a) - rank(b); });

--- a/services/kistenpflege/sortierer-commit/index.ts
+++ b/services/kistenpflege/sortierer-commit/index.ts
@@ -97,15 +97,21 @@ Deno.serve(async (req) => {
   const clean = (a: string[]) => a.filter((s) => known.has(s));
   const neu = { schublade: clean(r.schublade), karten: clean(r.karten), karussell: clean(r.karussell) };
 
+  // Ausgeblendete je Fläche (optional, rückwärtskompatibel). Nur bekannte Slugs.
+  const a = r.aus && typeof r.aus === "object" ? r.aus : {};
+  const cleanAus = (x: unknown) => Array.isArray(x) ? clean(x.filter((s) => typeof s === "string") as string[]) : [];
+  const aus = { schublade: cleanAus(a.schublade), karussell: cleanAus(a.karussell), karten: cleanAus(a.karten) };
+
   // $hinweis aus dem Ist-Stand bewahren.
   const hm = text.match(/"\$hinweis":\s*("(?:[^"\\]|\\.)*")/);
-  const hinweis = hm ? hm[1] : JSON.stringify("Vom Sortierer gepflegte Reihenfolgen (Slugs). Startseite und Schublade lesen sie; fehlt ein Eintrag, gilt die eingebaute Vorgabe. Verlauf = Git.");
+  const hinweis = hm ? hm[1] : JSON.stringify("Vom Sortierer gepflegte Reihenfolgen (Slugs). Startseite und Schublade lesen sie; fehlt ein Eintrag, gilt die eingebaute Vorgabe. aus = je Fläche ausgeblendet (bleibt per Direktlink und in der Intern-Ansicht erreichbar). Verlauf = Git.");
   const block =
     '"reihenfolge": {\n' +
     '    "$hinweis": ' + hinweis + ',\n' +
     '    "schublade": ' + arr(neu.schublade) + ',\n' +
     '    "karten": ' + arr(neu.karten) + ',\n' +
-    '    "karussell": ' + arr(neu.karussell) + "\n" +
+    '    "karussell": ' + arr(neu.karussell) + ',\n' +
+    '    "aus": { "schublade": ' + arr(aus.schublade) + ', "karussell": ' + arr(aus.karussell) + ', "karten": ' + arr(aus.karten) + " }\n" +
     "  }";
 
   // Nur den reihenfolge-Block ersetzen (Rest byte-genau).

--- a/sortierer.html
+++ b/sortierer.html
@@ -48,6 +48,14 @@
   .zeile-ordnung{display:flex;flex-direction:column;gap:2px;flex:0 0 auto}
   .zeile-ordnung .btn{min-width:var(--tap);min-height:var(--tap);padding:0;display:grid;place-items:center}
   @media(min-width:820px){ .zeile-ordnung .btn{min-height:34px} }
+  .zeile .augen{flex:0 0 auto;min-width:var(--tap);min-height:var(--tap);padding:0;display:grid;place-items:center;font-size:17px}
+  @media(min-width:820px){ .zeile .augen{min-height:34px} }
+
+  .aus-kopf{padding:var(--s3) var(--s4) 0;color:var(--muted);font-family:var(--font-text);
+    font-size:var(--t-micro);letter-spacing:.02em}
+  .liste-aus{padding-top:var(--s2)}
+  .liste-aus .zeile{background:transparent;box-shadow:inset 0 0 0 1px var(--line);cursor:default;opacity:.8}
+  .liste-aus .zeile .wer b{font-weight:400}
 
   .hinweisbox{background:var(--field-bg);border-radius:12px;padding:var(--s4);font-size:var(--t-small);line-height:1.55;margin-top:var(--s6)}
   .hinweisbox code{font-family:var(--font-text);background:var(--paper);padding:.05em .35em;border-radius:6px}
@@ -64,7 +72,9 @@
     <span class="kicker">Kistenpflege · Sortierer</span>
     <h1>Reihenfolgen selbst ordnen</h1>
     <p class="lede">Ziehen (oder mit den Pfeilen) ordnen: die <em>Schublade</em> (öffentliches Menü),
-      das <em>Karussell</em> und die <em>Karten</em> der Startseite. Eine Quelle, ein Verlauf:
+      das <em>Karussell</em> und die <em>Karten</em> der Startseite. Mit <em>⊘</em> ein Werkzeug von
+      einer Fläche <em>ausblenden</em>, mit <em>＋</em> wieder einblenden – ausgeblendet bleibt es per
+      Direktlink und in der Intern-Ansicht erreichbar. Eine Quelle, ein Verlauf:
       <em>Exportieren</em> schreibt die <code>tools.json</code> mit dem Feld <code>reihenfolge</code>,
       die ihr committet. Startseite und Schublade lesen sie dann.</p>
   </section>
@@ -115,12 +125,13 @@
   var rohText = "";      // tools.json als Text (für formatschonenden Export)
   var quelle = null;     // tools.json geparst
   var titel = {};        // slug → Anzeigename
-  var daten = { schublade:[], karten:[], karussell:[] };
+  var daten = { schublade:[], karten:[], karussell:[] };       // sichtbar, in Reihenfolge
+  var datenAus = { schublade:[], karten:[], karussell:[] };    // ausgeblendet je Fläche
   var zieht = null;      // {key, index} beim Ziehen
 
   function esc(s){ return (s||"").replace(/[&<>"]/g, function(c){ return {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;"}[c]; }); }
   function ladeEntwurf(){ try{ var r=localStorage.getItem(LS); return r?JSON.parse(r):null; }catch(e){ return null; } }
-  function sichern(){ try{ localStorage.setItem(LS, JSON.stringify(daten)); }catch(e){} }
+  function sichern(){ try{ localStorage.setItem(LS, JSON.stringify({ daten:daten, aus:datenAus })); }catch(e){} }
 
   function laden(){
     fetch("tools.json").then(function(r){ return r.text(); }).then(function(txt){
@@ -130,20 +141,30 @@
       titel["empfehlungen"] = titel["empfehlungen"] || "Diese Mail wird gelesen";
 
       var R = quelle.reihenfolge || {};
+      var Raus = R.aus || {};
       var draft = ladeEntwurf();
+      // Rückwärtskompatibel: alter Entwurf war {schublade,…}; neuer ist {daten,aus}.
+      var dDaten = draft && (draft.daten || (draft.schublade ? draft : null));
+      var dAus = draft && draft.aus;
       ["schublade","karten","karussell"].forEach(function(k){
-        daten[k] = (draft && Array.isArray(draft[k])) ? draft[k].slice()
+        daten[k] = (dDaten && Array.isArray(dDaten[k])) ? dDaten[k].slice()
                  : (Array.isArray(R[k]) ? R[k].slice() : []);
+        datenAus[k] = (dAus && Array.isArray(dAus[k])) ? dAus[k].slice()
+                    : (Array.isArray(Raus[k]) ? Raus[k].slice() : []);
       });
       // Schublade und Karten decken genau die öffentlichen Werkzeuge ab:
       // fehlende anhängen, verschwundene entfernen (Karussell bleibt kuratiert).
+      // Bewusst Ausgeblendete (datenAus) NICHT wieder anhängen.
       var publik = (quelle.tools||[]).filter(function(t){
         return PUBLIC.indexOf(t.cat) >= 0 && (t.status === "live" || t.status === "beta");
       }).map(function(t){ return t.slug; });
       ["schublade","karten"].forEach(function(k){
-        daten[k] = daten[k].filter(function(s){ return publik.indexOf(s) >= 0; });
-        publik.forEach(function(s){ if(daten[k].indexOf(s) < 0) daten[k].push(s); });
+        daten[k] = daten[k].filter(function(s){ return publik.indexOf(s) >= 0 && datenAus[k].indexOf(s) < 0; });
+        publik.forEach(function(s){ if(daten[k].indexOf(s) < 0 && datenAus[k].indexOf(s) < 0) daten[k].push(s); });
+        datenAus[k] = datenAus[k].filter(function(s){ return publik.indexOf(s) >= 0; });
       });
+      // Karussell: ausgeblendete bleiben nur, wenn als Slug bekannt.
+      datenAus.karussell = datenAus.karussell.filter(function(s){ return !!titel[s]; });
       zeichnen();
     }).catch(function(){
       document.getElementById("spalten").innerHTML =
@@ -167,11 +188,39 @@
                    '<button class="btn" type="button" data-hoch="'+L.key+':'+i+'" '+(i===0?'disabled':'')+' aria-label="'+esc(name)+' nach oben">↑</button>'+
                    '<button class="btn" type="button" data-runter="'+L.key+':'+i+'" '+(i===daten[L.key].length-1?'disabled':'')+' aria-label="'+esc(name)+' nach unten">↓</button>'+
                  '</span>'+
+                 '<button class="btn augen" type="button" data-aus="'+L.key+':'+i+'" title="Ausblenden" aria-label="'+esc(name)+' ausblenden">⊘</button>'+
                '</li>';
       }).join("");
-      kiste.innerHTML = kopf + '<ul class="liste" data-key="'+L.key+'">'+lis+'</ul>';
+      var ausHtml = "";
+      if (datenAus[L.key].length){
+        var alis = datenAus[L.key].map(function(slug, j){
+          var name = titel[slug] || slug;
+          return '<li class="zeile aus">'+
+                   '<span class="wer"><b>'+esc(name)+'</b><small>'+esc(slug)+'</small></span>'+
+                   '<button class="btn augen" type="button" data-ein="'+L.key+':'+j+'" title="Einblenden" aria-label="'+esc(name)+' einblenden">＋</button>'+
+                 '</li>';
+        }).join("");
+        ausHtml = '<div class="aus-kopf">Ausgeblendet</div>'+
+                  '<ul class="liste liste-aus" data-key="'+L.key+'">'+alis+'</ul>';
+      }
+      kiste.innerHTML = kopf + '<ul class="liste" data-key="'+L.key+'">'+lis+'</ul>' + ausHtml;
       wrap.appendChild(kiste);
     });
+  }
+
+  // Ausblenden: aus der sichtbaren Liste in die Ausgeblendet-Zone derselben Fläche.
+  function ausblenden(key, index){
+    var s = daten[key].splice(index, 1)[0];
+    if (s == null) return;
+    if (datenAus[key].indexOf(s) < 0) datenAus[key].push(s);
+    sichern(); zeichnen();
+  }
+  // Einblenden: zurück ans Ende der sichtbaren Liste.
+  function einblenden(key, index){
+    var s = datenAus[key].splice(index, 1)[0];
+    if (s == null) return;
+    if (daten[key].indexOf(s) < 0) daten[key].push(s);
+    sichern(); zeichnen();
   }
 
   function verschiebe(key, from, to){
@@ -185,8 +234,11 @@
   // Pfeil-Knöpfe (barrierefrei, auch mobil)
   document.getElementById("spalten").addEventListener("click", function(e){
     var h = e.target.closest("[data-hoch]"), r = e.target.closest("[data-runter]");
+    var a = e.target.closest("[data-aus]"), n = e.target.closest("[data-ein]");
     if(h){ var p=h.getAttribute("data-hoch").split(":"); verschiebe(p[0], +p[1], +p[1]-1); }
     else if(r){ var q=r.getAttribute("data-runter").split(":"); verschiebe(q[0], +q[1], +q[1]+1); }
+    else if(a){ var u=a.getAttribute("data-aus").split(":"); ausblenden(u[0], +u[1]); }
+    else if(n){ var v=n.getAttribute("data-ein").split(":"); einblenden(v[0], +v[1]); }
   });
 
   // Ziehen (Drag-and-drop) – nur innerhalb derselben Liste
@@ -222,12 +274,13 @@
   function bausteinReihenfolge(){
     var arr = function(a){ return "[" + a.map(function(s){ return JSON.stringify(s); }).join(", ") + "]"; };
     var hinweis = (quelle.reihenfolge && quelle.reihenfolge.$hinweis) ||
-      "Vom Sortierer gepflegte Reihenfolgen (Slugs). Startseite und Schublade lesen sie; fehlt ein Eintrag, gilt die eingebaute Vorgabe. Verlauf = Git.";
+      "Vom Sortierer gepflegte Reihenfolgen (Slugs). Startseite und Schublade lesen sie; fehlt ein Eintrag, gilt die eingebaute Vorgabe. aus = je Fläche ausgeblendet (bleibt per Direktlink und in der Intern-Ansicht erreichbar). Verlauf = Git.";
     return '"reihenfolge": {\n' +
       '    "$hinweis": ' + JSON.stringify(hinweis) + ',\n' +
       '    "schublade": ' + arr(daten.schublade) + ',\n' +
       '    "karten": ' + arr(daten.karten) + ',\n' +
-      '    "karussell": ' + arr(daten.karussell) + '\n' +
+      '    "karussell": ' + arr(daten.karussell) + ',\n' +
+      '    "aus": { "schublade": ' + arr(datenAus.schublade) + ', "karussell": ' + arr(datenAus.karussell) + ', "karten": ' + arr(datenAus.karten) + ' }\n' +
       '  }';
   }
   function exportieren(){
@@ -236,7 +289,8 @@
       text = rohText.replace(/"reihenfolge"\s*:\s*\{[\s\S]*?\n  \}/, bausteinReihenfolge());
     } else {
       var obj = JSON.parse(JSON.stringify(quelle));
-      obj.reihenfolge = { $hinweis: (quelle.reihenfolge||{}).$hinweis || "", schublade: daten.schublade, karten: daten.karten, karussell: daten.karussell };
+      obj.reihenfolge = { $hinweis: (quelle.reihenfolge||{}).$hinweis || "", schublade: daten.schublade, karten: daten.karten, karussell: daten.karussell,
+        aus: { schublade: datenAus.schublade, karussell: datenAus.karussell, karten: datenAus.karten } };
       text = JSON.stringify(obj, null, 2);
     }
     var blob = new Blob([text], { type: "application/json" });
@@ -265,7 +319,8 @@
     fetch(FUNKTION, {
       method: "POST",
       headers: { "Content-Type": "application/json", "x-sortierer-secret": secret, "apikey": PUBKEY, "Authorization": "Bearer " + PUBKEY },
-      body: JSON.stringify({ reihenfolge: { schublade: daten.schublade, karten: daten.karten, karussell: daten.karussell } })
+      body: JSON.stringify({ reihenfolge: { schublade: daten.schublade, karten: daten.karten, karussell: daten.karussell,
+        aus: { schublade: datenAus.schublade, karussell: datenAus.karussell, karten: datenAus.karten } } })
     }).then(function (r) {
       return r.json().catch(function () { return {}; }).then(function (j) { return { ok: r.ok, code: r.status, j: j }; });
     }).then(function (res) {

--- a/tools.json
+++ b/tools.json
@@ -669,9 +669,10 @@
     }
   ],
   "reihenfolge": {
-    "$hinweis": "Vom Sortierer gepflegte Reihenfolgen (Slugs). Startseite und Schublade lesen sie; fehlt ein Eintrag, gilt die eingebaute Vorgabe. Verlauf = Git.",
+    "$hinweis": "Vom Sortierer gepflegte Reihenfolgen (Slugs). Startseite und Schublade lesen sie; fehlt ein Eintrag, gilt die eingebaute Vorgabe. aus = je Fläche ausgeblendet (bleibt per Direktlink und in der Intern-Ansicht erreichbar). Verlauf = Git.",
     "schublade": ["logo-generator", "signatur", "visitenkarten", "schriften", "icons", "qr-generator", "kurzlink", "uebersetzungen", "sektionsfarben", "typografie", "karten", "powerpoint", "wallpaper", "design-system"],
-    "karten": ["logo-generator", "signatur", "visitenkarten", "schriften", "icons", "uebersetzungen", "qr-generator", "kurzlink", "typografie", "powerpoint", "wallpaper", "karten", "sektionsfarben", "design-system"],
-    "karussell": ["signatur", "empfehlungen", "karten", "wallpaper", "powerpoint", "visitenkarten", "logo-generator", "schriften", "uebersetzungen", "icons", "sektionsfarben", "typografie", "editor", "design-system"]
+    "karten": ["logo-generator", "signatur", "visitenkarten", "schriften", "icons", "uebersetzungen", "qr-generator", "kurzlink", "typografie", "powerpoint", "wallpaper", "karten", "sektionsfarben"],
+    "karussell": ["signatur", "empfehlungen", "karten", "wallpaper", "powerpoint", "visitenkarten", "logo-generator", "schriften", "uebersetzungen", "icons", "sektionsfarben", "typografie", "editor"],
+    "aus": { "schublade": [], "karussell": ["design-system"], "karten": ["design-system"] }
   }
 }


### PR DESCRIPTION
Drei zusammenhängende Anliegen am Start-Sortierer.

**1 · Design-System vorerst weg von Startseite, bleibt im Menü**
Neues Feld `reihenfolge.aus` je Fläche (`schublade`/`karussell`/`karten`). `design-system` aus Karten + Karussell in `aus` verschoben; bleibt in der Schublade (öffentliches Menü) und per Direktlink erreichbar. Reversibel — Slug wieder einblenden genügt.

**2 · Ausblendefunktion im Sortierer**
`sortierer.html` bekommt pro Spalte eine **Ausgeblendet**-Zone: ⊘ blendet ein Werkzeug von einer Fläche aus, ＋ blendet es wieder ein. Das Auto-Auffüllen respektiert Ausgeblendete (neue Werkzeuge erscheinen weiter, bewusst Verborgene nicht). Export **und** «Direkt speichern» schreiben `aus` mit. Fingerziele ≥ `--tap`, Zonen tokenrein (B03/B04, DS-konform).

**3 · «Wo ist der Schublade-Sortierer hängen geblieben?»**
Diagnose und Fix: In `nav.js` wirkte `reihenfolge.schublade` bisher **nur** im öffentlichen Zweig; der Intern-/Backstage-Zweig (`worldGroupEl`) ignorierte die Reihenfolge. Jetzt folgt auch die Intern-Ansicht der Sortierer-Reihenfolge. Der öffentliche Zweig filtert zusätzlich `aus.schublade` (Intern zeigt weiterhin alles).

**Backend (Edge Function `sortierer-commit`)**
`index.ts` validiert/säubert `aus` optional und schreibt es in den `reihenfolge`-Block (rückwärtskompatibel). Die Funktion **läuft bereits** (Version 2) — der Redeploy dieser Fassung ist **bewusst nicht Teil dieses PR** und erfolgt separat. Bis dahin persistiert Ausblenden über «Exportieren». `SECRETS.md` dokumentiert die beiden Function-Secrets (`GITHUB_TOKEN`, `SORTIERER_SECRET`), die im Supabase-Projekt zu setzen sind.

**Verifiziert (lokal, Playwright + Prüfmaschinen):** Startseite ohne Design-System in Karten (14) und Karussell (12), Design-System weiter in der öffentlichen Schublade, kein H-Overflow; Sortierer-Zonen rendern, Hide/Show-Round-trip funktioniert; typo-check konform, ds-lint 0 Fehler (Score 100 %); `tools.json` gültig, Regex-Round-trip der Edge-Funktion gegen die neue Datei getestet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuXR9zNWBPqTZrQTRksch1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuXR9zNWBPqTZrQTRksch1)_