### PR TITLE
sortierer-commit: Konfig aus DB-Tabelle statt Env-Secrets

### DIFF
--- a/SECRETS.md
+++ b/SECRETS.md
@@ -75,21 +75,39 @@ statt sie zu exportieren. Dahinter steht die Edge Function
 `dagcsnfrlbpxcmdimnrw`). Sie schreibt **ausschliesslich** das Feld
 `reihenfolge` in die `tools.json` — winzige Wirkfläche, per Git rückholbar.
 
-Zum Scharfschalten zweierlei, **im Supabase-Projekt** (nie hier eintragen):
+**Konfiguration liegt in der Tabelle `public.sortierer_config`** (Hausmuster wie
+`seelenkalender_config`: `key`/`value`, RLS ohne Policies → nur Service-Role).
+Die Funktion liest sie mit der automatisch injizierten Service-Role — **es sind
+keine Env-Secrets zu setzen**. Zwei Zeilen zählen:
 
-1. **Deploy:** Function `sortierer-commit` aus obiger Quelle deployen (Connector
-   oder `supabase functions deploy sortierer-commit`).
-2. **Function-Secrets** (Dashboard → Edge Functions → Secrets, oder
-   `supabase secrets set`):
-   - `GITHUB_TOKEN` — fine-grained PAT, **nur `phtok/goeloggen`**, Contents:
-     Read+Write. (Optional `GITHUB_REPO`/`GITHUB_BRANCH`; Vorgabe
-     `phtok/goeloggen` / `main`.)
-   - `SORTIERER_SECRET` — frei gewähltes langes Passwort; dasselbe gibt die
-     Person beim ersten «Direkt speichern» im Browser ein (bleibt lokal).
+| key | Inhalt | Stand |
+|---|---|---|
+| `sortierer_secret` | App-Passwort fürs Direkt-Speichern (gesetzt) | ✅ gesetzt |
+| `github_token` | Fine-grained PAT, **nur `phtok/goeloggen`**, Contents R+W | ⬜ von Hand eintragen |
 
-Bis beide Secrets gesetzt sind, antwortet die Funktion bewusst mit 500
-«nicht konfiguriert»; solange bleibt **«Exportieren»** der Weg (Datei
-herunterladen und committen).
+Zwei Handgriffe bleiben (genaue Links — die Oberflächen sind sonst mühsam):
+
+1. **PAT erzeugen:** <https://github.com/settings/personal-access-tokens/new>
+   → *Resource owner* `phtok` · *Repository access* → **Only select repositories**
+   → `phtok/goeloggen` · *Permissions* → *Repository permissions* →
+   **Contents: Read and write** · kurze Ablauf. Token kopieren.
+2. **Token eintragen** (nicht hier, direkt in die DB-Zeile):
+   SQL-Editor <https://supabase.com/dashboard/project/dagcsnfrlbpxcmdimnrw/sql/new>
+   ```sql
+   update public.sortierer_config set value = 'DEIN_PAT' where key = 'github_token';
+   ```
+   Oder Tabellen-Editor
+   <https://supabase.com/dashboard/project/dagcsnfrlbpxcmdimnrw/editor> →
+   Tabelle `sortierer_config` → Zeile `github_token` → `value` einfügen.
+3. **Deploy** (die aktuelle Fassung mit `aus` + Config-Tabelle live setzen):
+   `supabase functions deploy sortierer-commit --project-ref dagcsnfrlbpxcmdimnrw`
+   oder Dashboard
+   <https://supabase.com/dashboard/project/dagcsnfrlbpxcmdimnrw/functions>.
+
+Das App-Passwort (`sortierer_secret`) tippt die Person einmalig beim ersten
+«Direkt speichern» im Browser ein (bleibt lokal). Bis `github_token` gesetzt
+**und** die neue Fassung deployt ist, antwortet die Funktion mit 500
+«nicht konfiguriert»; solange bleibt **«Exportieren»** der Weg.
 
 ## Merksatz
 Connector, wo es einen gibt (parat + nie einsehbar + kein Recycling); Env-Key

--- a/services/kistenpflege/sortierer-commit/index.ts
+++ b/services/kistenpflege/sortierer-commit/index.ts
@@ -5,24 +5,38 @@
 // schreibt AUSSCHLIESSLICH das Feld «reihenfolge» in die tools.json auf GitHub —
 // per Contents-API, mit dem aktuellen Stand als Basis (kein Stale-Clobber).
 // Alles andere in der Datei bleibt byte-genau. Ein GitHub-Token liegt server-
-// seitig (Secret), nie im Browser. Ein Passwort (SORTIERER_SECRET) sperrt den
-// Zugang; die Wirkfläche ist bewusst winzig (nur Menü-Reihenfolge, per Git
-// jederzeit rückholbar).
+// seitig, nie im Browser. Ein Passwort sperrt den Zugang; die Wirkfläche ist
+// bewusst winzig (nur Menü-Reihenfolge, per Git jederzeit rückholbar).
 //
-// Secrets (im Supabase-Projekt setzen):
-//   GITHUB_TOKEN      Fine-grained PAT, nur dieses Repo, Contents: Read+Write
-//   GITHUB_REPO       "phtok/goeloggen" (Vorgabe, wenn leer)
-//   GITHUB_BRANCH     "main" (Vorgabe, wenn leer)
-//   SORTIERER_SECRET  frei gewähltes, langes Passwort
-// Quelle im Repo: services/kistenpflege/sortierer-commit/index.ts
+// Konfiguration liegt NICHT in Env-Secrets, sondern in der Tabelle
+// public.sortierer_config (nur Service-Role, RLS ohne Policies) — Hausmuster
+// wie seelenkalender_config. Schlüssel (Spalte key → value):
+//   sortierer_secret  frei gewähltes, langes Passwort (App-Passwort)
+//   github_token      Fine-grained PAT, nur dieses Repo, Contents: Read+Write
+//   github_repo       "phtok/goeloggen" (Vorgabe, wenn leer)
+//   github_branch     "main" (Vorgabe, wenn leer)
+// Die Funktion liest sie mit der automatisch injizierten Service-Role-Rolle
+// (SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY) — es sind KEINE eigenen Env-Secrets
+// mehr zu setzen. Quelle im Repo: services/kistenpflege/sortierer-commit/index.ts
 // =============================================================================
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 
-const TOKEN  = Deno.env.get("GITHUB_TOKEN") || "";
-const REPO   = Deno.env.get("GITHUB_REPO") || "phtok/goeloggen";
-const BRANCH = Deno.env.get("GITHUB_BRANCH") || "main";
-const SECRET = Deno.env.get("SORTIERER_SECRET") || "";
+const SB_URL = Deno.env.get("SUPABASE_URL") || "";
+const SVC    = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "";
 const PATH   = "tools.json";
+
+// Config aus public.sortierer_config lesen (nur Service-Role kommt an die Tabelle).
+async function loadConfig(): Promise<Record<string, string>> {
+  if (!SB_URL || !SVC) return {};
+  const res = await fetch(`${SB_URL}/rest/v1/sortierer_config?select=key,value`, {
+    headers: { apikey: SVC, Authorization: `Bearer ${SVC}` },
+  });
+  if (!res.ok) return {};
+  const rows = await res.json().catch(() => []) as Array<{ key: string; value: string }>;
+  const cfg: Record<string, string> = {};
+  for (const r of rows) cfg[r.key] = r.value;
+  return cfg;
+}
 
 const CORS = {
   "Access-Control-Allow-Origin": "*",
@@ -55,7 +69,13 @@ const arr = (a: string[]) => "[" + a.map((s) => JSON.stringify(s)).join(", ") + 
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") return new Response("ok", { headers: CORS });
   if (req.method !== "POST") return json(405, { error: "Nur POST." });
-  if (!TOKEN || !SECRET) return json(500, { error: "Funktion nicht konfiguriert (GITHUB_TOKEN / SORTIERER_SECRET fehlen)." });
+
+  const cfg = await loadConfig();
+  const TOKEN  = cfg.github_token || "";
+  const SECRET = cfg.sortierer_secret || "";
+  const REPO   = cfg.github_repo || "phtok/goeloggen";
+  const BRANCH = cfg.github_branch || "main";
+  if (!TOKEN || !SECRET) return json(500, { error: "Funktion nicht konfiguriert (sortierer_config: github_token / sortierer_secret fehlen)." });
 
   // Passwort-Sperre.
   if ((req.headers.get("x-sortierer-secret") || "") !== SECRET) {


### PR DESCRIPTION
Die „Alternative" aus der Diskussion: die Sortierer-Edge-Function liest ihre Konfiguration nicht mehr aus Env-Secrets, sondern aus der Tabelle `public.sortierer_config` — Hausmuster wie `seelenkalender_config` (`key`/`value`, RLS ohne Policies → nur Service-Role).

- **Kein Env-Secret mehr zu setzen:** die Funktion nutzt die automatisch injizierte Service-Role (`SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`), um `sortierer_secret` und `github_token` aus der Tabelle zu lesen.
- **DB bereits eingerichtet** (Migration `sortierer_config` auf dem Projekt angewandt): `sortierer_secret` ist gesetzt; `github_token` trägt der Betrieb in die eine Zeile ein.
- **Versionsmangel behoben:** diese Fassung trägt zugleich die `aus`-Unterstützung — sie ersetzt die noch laufende Alt-Version (die `aus` nicht kannte und Env-Secrets erwartete). Der Redeploy erfolgt betriebsseitig (im Repo-Diff nur die Quelle).
- `SECRETS.md`: Config-Tabellen-Muster + **genaue Links** für PAT-Erstellung, SQL-/Tabellen-Editor und Deploy.

Kein Frontend-Diff; `sortierer.html` sendet `aus` bereits (vorheriger PR). Keine HTML-Änderung → typo-check/ds-lint unberührt (Score 100 %).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuXR9zNWBPqTZrQTRksch1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuXR9zNWBPqTZrQTRksch1)_