### PR TITLE
CI: Deploy-Workflow für sortierer-commit (vom Handy auslösbar)

### DIFF
--- a/.github/workflows/deploy-sortierer.yml
+++ b/.github/workflows/deploy-sortierer.yml
@@ -1,0 +1,51 @@
+# Deploy der Edge Function «sortierer-commit» — vom Handy auslösbar.
+# -----------------------------------------------------------------------------
+# Die Supabase-Weboberfläche hat keinen Deploy-Knopf; deployt wird per CLI.
+# Dieser Workflow führt die CLI in der Cloud aus: kein Rechner nötig, ein Klick
+# auf «Run workflow» (Tab Actions) genügt. Läuft ausserdem automatisch, wenn
+# sich die Funktionsquelle auf main ändert.
+#
+# Einmalig einzurichten (beides vom Handy):
+#   1. Supabase-Access-Token erzeugen:
+#      https://supabase.com/dashboard/account/tokens  → «Generate new token».
+#   2. Als GitHub-Secret hinterlegen (Name EXACT: SUPABASE_ACCESS_TOKEN):
+#      https://github.com/phtok/goeloggen/settings/secrets/actions
+#      → «New repository secret».
+# Danach: Tab «Actions» → «Deploy sortierer-commit» → «Run workflow».
+#
+# Die Funktionsquelle wohnt bei services/…; sie wird hier in das von der CLI
+# erwartete Layout (supabase/functions/<name>/index.ts) kopiert und deployt.
+# verify_jwt bleibt aus (die Funktion hat eigene Passwort-Sperre).
+name: Deploy sortierer-commit
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "services/kistenpflege/sortierer-commit/index.ts"
+      - ".github/workflows/deploy-sortierer.yml"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      PROJECT_REF: dagcsnfrlbpxcmdimnrw
+    steps:
+      - uses: actions/checkout@v4
+      - name: Supabase-CLI bereitstellen
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - name: Token prüfen
+        run: |
+          if [ -z "$SUPABASE_ACCESS_TOKEN" ]; then
+            echo "::error::Secret SUPABASE_ACCESS_TOKEN fehlt. Anleitung im Workflow-Kopf." && exit 1
+          fi
+      - name: Funktion ins CLI-Layout kopieren
+        run: |
+          mkdir -p supabase/functions/sortierer-commit
+          cp services/kistenpflege/sortierer-commit/index.ts supabase/functions/sortierer-commit/index.ts
+      - name: Deploy
+        run: supabase functions deploy sortierer-commit --project-ref "$PROJECT_REF" --no-verify-jwt


### PR DESCRIPTION
Ein GitHub-Actions-Workflow deployt die Edge Function `sortierer-commit` über die Supabase-CLI **in der Cloud** — kein Rechner nötig, ein Klick auf „Run workflow" (Tab Actions). So lässt sich der Deploy **komplett vom Handy** auslösen; der Supabase-Connector-Deploy ist in der Arbeitsumgebung blockiert.

- Läuft per **workflow_dispatch** (Knopf) und automatisch bei Änderungen an der Funktionsquelle auf `main`.
- Kopiert die Quelle (`services/kistenpflege/sortierer-commit/index.ts`) ins von der CLI erwartete Layout und deployt mit `--no-verify-jwt` (die Funktion hat ihre eigene Passwort-Sperre).
- Braucht das Repo-Secret **`SUPABASE_ACCESS_TOKEN`** (Anleitung im Workflow-Kopf); prüft dessen Vorhandensein mit klarer Fehlermeldung.

Muss auf `main` liegen, damit der „Run workflow"-Knopf erscheint (Eigenheit von `workflow_dispatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuXR9zNWBPqTZrQTRksch1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuXR9zNWBPqTZrQTRksch1)_