### PR TITLE
Cockpit: Übersicht «Aktivität → Abschlüsse» + Dunkelfeld-Lesart 22.7.

### DIFF
--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -140,6 +140,17 @@
   .motrow .mn{font-variant-numeric:tabular-nums lining-nums;color:var(--ink);font-weight:600}
   .kanal-rolle{color:var(--muted);font-size:var(--t-micro);margin-left:7px}
 
+  /* Aktivität → Abschlüsse: gemessene Live-Tabelle + Dunkelfeld-Schätzung.
+     Nur Tokens (DS02/DS07), Ziffern tabellarisch über .tarif .num (G25). */
+  .panel>.mh{font-family:var(--font-text);font-size:var(--t-small);color:var(--ink);font-weight:600;margin-bottom:var(--s3)}
+  .akt-tab .akt-q{display:block;color:var(--muted);font-size:var(--t-micro);margin-top:2px;overflow-wrap:anywhere}
+  /* Leck-Zeile: viele Klicks, kaum Abschlüsse – zurückhaltend getönt, Kante in Gold. */
+  .akt-tab tbody tr.akt-leck td{background:color-mix(in srgb,var(--gold) 12%,transparent)}
+  .akt-tab tbody tr.akt-leck td:first-child{box-shadow:inset 3px 0 0 var(--gold-ink)}
+  .akt-tab tfoot .akt-ohne td{border-top:2px solid var(--line);font-weight:600;color:var(--ink)}
+  .akt-tab tfoot .akt-ohne .akt-q{font-weight:400}
+  .motrow.qz-rest .mc{color:var(--muted)}
+
   /* Zeitband: Phasen × Wochen × Kanäle (nur Tokens, DS02; Ziffern tnum, G25).
      Festes Spaltenraster: die Wochen teilen sich die Breite gleichmässig, statt
      sich nach dem längsten Chip-Titel zu strecken – Titel laufen in die Ellipse. */

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -63,6 +63,27 @@
       label: 'Metricool · Kampagnen-Auswertung',
       url:   'https://app.metricool.com/reporting/campaigns-dashboard/public?token=eyJ6aXAiOiJERUYiLCJhbGciOiJIUzUxMiJ9.eJxVztFSgkAUgOF3ObcywhrCxh3VTLLWZmZmNU2Dy5Lgrhzg5AhN7x7jXZf_d_X_QPqdQfQOOyJsI9dNEcdWU1OoqjJjVVn4cKBICSIW8ouQ-YwFDhy2-X_QJxyAs-lk6p3B0icaiEBjU6_atpJHafY66b6sElsSM755NJORZFjGwdO8v85ewxN7vkoal4tDvWyThUrucS1fVOnFYo_Ey5u7oq770L_t5w9Wr5ualqsyrUaoWrmIdZG7lF_yYOfHb8UmnOVCd4EHDlCHejjBLDUE5zM6Ds3g9w85oFAH.cL8xJiluV4VRcqD2tsOIXKgpvI7UfN_fbvREgPpiP_r0T0JTBfS_vH2cnrq50d-kogWBjyZLE_OMINhFqo8dIw',
       takt:  'Empfehlung: wöchentlich (montags) übernehmen; in der Schlussspurt-Woche ab 3. August täglich.'
+    },
+    // Dunkelfeld-Lesart: die Anmeldungen OHNE UTM den Aktivitäten zugeordnet.
+    // DATIERTE SCHÄTZUNG (±30 %), keine Messung – die «gemessen»-Spalte im
+    // Cockpit kommt live aus attribution/kanaele, «≈ dunkel» steht hier. Bei
+    // neuer Auswertung: stand + zeilen nachziehen (Herleitung im Repo unter
+    // docs/wirkungs-lesart-<datum>.md). Summe der zeilen = Live-Gesamt, sonst
+    // stimmt die Fusszeile nicht mehr (gemessen 107 · dunkel 109 · gesamt 216
+    // am 22.7.). Sortiert nach ≈ gesamt.
+    dunkelLesart: {
+      stand: '22. Juli',
+      doc:   'docs/wirkungs-lesart-22-07.md',
+      zeilen: [
+        { akt:'Mailing · Welle 1',                              gemessen:79, dunkel:1,  gesamt:80 },
+        { akt:'Meta-Anzeige · bezahlt',                         gemessen:0,  dunkel:44, gesamt:44 },
+        { akt:'Organik · Bestand · Direkt',                     gemessen:8,  dunkel:25, gesamt:33 },
+        { akt:'Social organisch · Reels, Stories, Karussell',   gemessen:9,  dunkel:14, gesamt:23 },
+        { akt:'goetheanum.tv-Newsletter · TV-Weekly',           gemessen:5,  dunkel:17, gesamt:22 },
+        { akt:'Haus- und AC-Newsletter · Frühphase',            gemessen:5,  dunkel:7,  gesamt:12 },
+        { akt:'Inserat · Print',                                gemessen:0,  dunkel:1,  gesamt:1 },
+        { akt:'Empfehlung',                                     gemessen:1,  dunkel:0,  gesamt:1 }
+      ]
     }
   };
 
@@ -331,6 +352,136 @@
       row.querySelector('.mn').textContent = fmt(x.n);
       list.appendChild(row);
     });
+  }
+
+  // ── Aktivität → Abschlüsse (gemessen, live) ─────────────────────────────────
+  // Beantwortet «welche Aktivität hat zu welchen Abschlüssen geführt?» aus harten
+  // Daten: Abschlüsse je Motiv-Tupel aus der Attribution (echte Zählung), Klicks
+  // aus dem Link-Register (DE+EN sind eigene Kurzcodes → summiert). Zeigt neben
+  // den Abschlüssen die Klicks, damit ein Attributions-Leck sichtbar wird
+  // (viele Klicks, kaum gemessene Abschlüsse = die Spur ging unterwegs verloren).
+  // Die Anmeldungen OHNE Spur stehen als eigene Fusszeile und werden darunter
+  // (renderDunkelfeld) den Aktivitäten als Schätzung zugeordnet.
+  function renderAktivitaeten(attribution, links, kanaele){
+    if (!el('aktBody')) return;
+    var body = el('aktBody'); body.innerHTML = '';
+    var keyOf = function(s, m, c){ return (s || '') + '|' + (m || '') + '|' + (c || ''); };
+    var acts = {};
+    (attribution || []).forEach(function(r){
+      if (!r.utm_source && !r.utm_content) return;   // ohne Spur → Dunkelfeld
+      var k = keyOf(r.utm_source, r.utm_medium, r.utm_content);
+      var a = acts[k] || (acts[k] = { source:r.utm_source, medium:r.utm_medium, content:r.utm_content, kanal:r.kanal, ab:0, kl:0 });
+      a.ab += Number(r.n) || 0;
+      if (!a.kanal) a.kanal = r.kanal;
+    });
+    (links || []).forEach(function(l){
+      var k = keyOf(l.utm_source, l.utm_medium, l.utm_content);
+      var a = acts[k] || (acts[k] = { source:l.utm_source, medium:l.utm_medium, content:l.utm_content, kanal:null, ab:0, kl:0 });
+      a.kl += Number(l.klicks) || 0;
+    });
+    var items = Object.keys(acts).map(function(k){ return acts[k]; })
+      .filter(function(x){ return x.ab > 0 || x.kl > 0; })
+      .sort(function(a, b){ return b.ab - a.ab || b.kl - a.kl; });
+    if (!items.length){
+      body.innerHTML = '<tr><td class="empty" colspan="4">Noch keine Anmeldung mit UTM-Spur.</td></tr>';
+    } else items.forEach(function(x){
+      var tr = document.createElement('tr');
+      tr.innerHTML = '<td></td><td></td><td class="num"></td><td class="num"></td>';
+      tr.children[0].textContent = x.content || x.source || '—';
+      var quelle = [x.source, x.medium].filter(Boolean).join(' · ');
+      if (quelle){ var sp = document.createElement('span'); sp.className = 'akt-q'; sp.textContent = quelle; tr.children[0].appendChild(sp); }
+      tr.children[1].textContent = KANAL_LABEL[x.kanal] || x.kanal || '—';
+      tr.children[2].textContent = x.kl ? fmt(x.kl) : '–';
+      tr.children[3].textContent = fmt(x.ab);
+      // Leck-Markierung: viele Klicks, kaum gemessene Abschlüsse (Spur verloren).
+      if (x.kl >= 40 && x.ab <= 1) tr.classList.add('akt-leck');
+      body.appendChild(tr);
+    });
+    var foot = el('aktFoot');
+    if (foot){
+      var ohne = 0; (kanaele || []).forEach(function(r){ if (r.kanal === 'andere') ohne += Number(r.n) || 0; });
+      foot.innerHTML = '';
+      var tr = document.createElement('tr'); tr.className = 'akt-ohne';
+      tr.innerHTML = '<td></td><td></td><td class="num"></td><td class="num"></td>';
+      tr.children[0].textContent = 'ohne UTM-Spur';
+      var note = document.createElement('span'); note.className = 'akt-q'; note.textContent = 'unten eingeordnet (Schätzung)';
+      tr.children[0].appendChild(note);
+      tr.children[1].textContent = '—';
+      tr.children[2].textContent = '–';
+      tr.children[3].textContent = fmt(ohne);
+      foot.appendChild(tr);
+    }
+  }
+
+  // ── Dunkelfeld eingeordnet (Schätzung, datiert) ─────────────────────────────
+  // Die Anmeldungen ohne UTM den Aktivitäten zugeordnet: «gemessen» + «≈ dunkel»
+  // = «≈ gesamt». Die Zahlen stehen in CONFIG.dunkelLesart (datierte Lesart,
+  // ±30 %) – hier nur gerendert, damit die Einordnung an EINER Stelle gepflegt
+  // wird. Herleitung im Repo (CONFIG.dunkelLesart.doc).
+  function renderDunkelfeld(){
+    if (!el('dunkelBody')) return;
+    var L = CONFIG.dunkelLesart; if (!L) return;
+    var body = el('dunkelBody'); body.innerHTML = '';
+    var sg = 0, sd = 0, ss = 0;
+    L.zeilen.forEach(function(z){
+      sg += z.gemessen; sd += z.dunkel; ss += z.gesamt;
+      var tr = document.createElement('tr');
+      tr.innerHTML = '<td></td><td class="num"></td><td class="num"></td><td class="num"></td>';
+      tr.children[0].textContent = z.akt;
+      tr.children[1].textContent = fmt(z.gemessen);
+      tr.children[2].textContent = z.dunkel ? ('≈' + fmt(z.dunkel)) : '–';
+      tr.children[3].textContent = '≈' + fmt(z.gesamt);
+      body.appendChild(tr);
+    });
+    var foot = el('dunkelFoot');
+    if (foot){
+      foot.innerHTML = '<tr><td>Summe</td><td class="num"></td><td class="num"></td><td class="num"></td></tr>';
+      var tds = foot.querySelector('tr').children;
+      tds[1].textContent = fmt(sg); tds[2].textContent = fmt(sd); tds[3].textContent = fmt(ss);
+    }
+    if (el('dunkelStand')) el('dunkelStand').textContent = L.stand;
+  }
+
+  // ── Vermutete Herkunft der dunklen Anmeldungen (Live-Aggregat) ──────────────
+  // Das Live-Fundament unter der Schätzung: je dunkler Anmeldung der letzten 14
+  // Tage der zeitlich nächste Kurzlink-Klick (aus sommer2026_ereignisse) – ein
+  // Indiz, keine Messung. Atmet mit dem 60-Sekunden-Takt. Ordnet die Klicks nach
+  // vermuteter Aktivität, plus die Zahl der dunklen ohne zeitnahen Klick.
+  function renderVermutet(rows){
+    if (!el('vermutetList')) return;
+    var host = el('vermutetList'); host.innerHTML = '';
+    var dunkel = (rows || []).filter(function(r){ return !r.utm_source && !r.utm_content; });
+    var mitHinweis = dunkel.filter(function(r){ return r.vermutet_code; });
+    var agg = {};
+    mitHinweis.forEach(function(r){
+      var label = [r.vermutet_source, r.vermutet_content].filter(Boolean).join(' · ') || r.vermutet_code;
+      agg[label] = (agg[label] || 0) + 1;
+    });
+    var items = Object.keys(agg).map(function(k){ return { label:k, n:agg[k] }; })
+      .sort(function(a, b){ return b.n - a.n; });
+    if (el('vermutetKopf')){
+      el('vermutetKopf').textContent = 'Vermutete Herkunft der ' + fmt(dunkel.length) +
+        ' Anmeldungen ohne UTM der letzten 14 Tage – Indiz, keine Messung';
+    }
+    if (!dunkel.length){
+      host.innerHTML = '<div class="empty">In den letzten 14 Tagen kam keine Anmeldung ohne UTM.</div>';
+      return;
+    }
+    items.forEach(function(x){
+      var row = document.createElement('div'); row.className = 'motrow';
+      row.innerHTML = '<span class="mc"></span><span class="mn"></span>';
+      row.querySelector('.mc').textContent = x.label;
+      row.querySelector('.mn').textContent = fmt(x.n);
+      host.appendChild(row);
+    });
+    var ohneHinweis = dunkel.length - mitHinweis.length;
+    if (ohneHinweis > 0){
+      var row = document.createElement('div'); row.className = 'motrow qz-rest';
+      row.innerHTML = '<span class="mc"></span><span class="mn"></span>';
+      row.querySelector('.mc').textContent = 'ohne zeitnahen Klick · Direkt oder Organik';
+      row.querySelector('.mn').textContent = fmt(ohneHinweis);
+      host.appendChild(row);
+    }
   }
 
   // ── Aktivitäten-Protokoll ───────────────────────────────────────────────────
@@ -1039,19 +1190,25 @@
     renderDeadline();
     renderQuelleSocial();
     // Ereignis-Protokoll separat laden: fällt der RPC aus, bleibt der Rest des
-    // Cockpits vollständig – nur die Liste meldet sich als nicht ladbar.
-    if (el('evList')) rpc('sommer2026_ereignisse')
-      .then(renderEreignisse)
-      .catch(function(){ el('evList').innerHTML = '<div class="err">nicht ladbar</div>'; });
+    // Cockpits vollständig – nur die Liste meldet sich als nicht ladbar. Speist
+    // sowohl das Protokoll («Was ist passiert?») als auch das Live-Aggregat der
+    // vermuteten Herkunft unter der Dunkelfeld-Schätzung.
+    if (el('evList') || el('vermutetList')) rpc('sommer2026_ereignisse')
+      .then(function(rows){ renderEreignisse(rows); renderVermutet(rows); })
+      .catch(function(){
+        if (el('evList')) el('evList').innerHTML = '<div class="err">nicht ladbar</div>';
+        if (el('vermutetList')) el('vermutetList').innerHTML = '<div class="err">nicht ladbar</div>';
+      });
     if(CONFIG.zahlenProvisorisch && el('provisorisch')){
       el('provisorisch').textContent = 'Zielmarken, Preise und die Bleibe-Quote sind vorläufig hinterlegt – sobald die echten Werte gesetzt sind, rechnet das Cockpit unverändert weiter.';
     }
     Promise.all([ rpc('sommer2026_stats'), rpc('sommer2026_timeline'), rpc('sommer2026_kohorten'), rpc('sommer2026_kanaele'),
-                  rpc('sommer2026_trichter'), rpc('sommer2026_attribution'), rpc('sommer2026_massnahmen_public'), rpc('sommer2026_kosten_public'), rpc('sommer2026_multi_liste'), rpc('sommer2026_multi_protokoll') ])
+                  rpc('sommer2026_trichter'), rpc('sommer2026_attribution'), rpc('sommer2026_massnahmen_public'), rpc('sommer2026_kosten_public'), rpc('sommer2026_multi_liste'), rpc('sommer2026_multi_protokoll'), rpc('sommer2026_links_public') ])
       .then(function(res){
         var stats = res[0] || [], timeline = res[1] || [], kohorten = res[2] || [], kanaele = res[3] || [];
         var trichter = res[4] || [], attribution = res[5] || [], massnahmen = res[6] || [], kostenPosten = res[7] || [];
         muListe = res[8] || []; muProto = res[9] || [];
+        var links = res[10] || [];
         var total = stats.reduce(function(s, r){ return s + Number(r.n); }, 0);
         var revenue = projectRevenue(stats);
         var mo = renderSpark(timeline);
@@ -1061,6 +1218,8 @@
         renderKanaele(kanaele, total);
         renderSpurTile(kanaele, total);
         renderMotive(attribution);
+        renderAktivitaeten(attribution, links, kanaele);
+        renderDunkelfeld();
         renderTarif(stats);
         renderMilestones(total);
         renderCohort(kohorten, revenue);

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -102,23 +102,48 @@
     <div class="panel" style="margin-top:var(--s5)">
       <div class="funnel" id="funnel"><div class="empty">lädt …</div></div>
     </div>
-    <details class="zb-form">
-      <summary>Lesart: die Abos ohne UTM eingeordnet – Schätzung, Stand 18. Juli</summary>
+    <div id="quelleSocial" style="margin-top:var(--s5)"></div>
+  </section>
+
+
+  <section id="aktivitaeten-abschluesse">
+    <div class="shead"><h2>Aktivität → Abschlüsse</h2><p>Welche Aktivität zu welchen Abschlüssen geführt hat – erst die harte Messung (Abschlüsse je Aktivität, live aus den UTM-Spuren, mit den Klicks daneben), dann die Anmeldungen ohne UTM den Aktivitäten zugeordnet.</p></div>
+    <div class="panel">
+      <div class="mh">Gemessen · je Aktivität mit UTM-Spur</div>
       <div class="tablewrap" style="margin-top:var(--s4)">
-        <table class="tarif">
-          <thead><tr><th>Aktivität</th><th class="num">gemessen</th><th class="num">≈ geschätzt dazu</th><th class="num">≈ gesamt</th></tr></thead>
-          <tbody>
-            <tr><td>Mailing (Mail-Welle 1)</td><td class="num">34</td><td class="num">≈21</td><td class="num">≈55</td></tr>
-            <tr><td>Haus-Newsletter (Sommerfestivals, AWW, TV-Weekly)</td><td class="num">6</td><td class="num">≈20</td><td class="num">≈26</td></tr>
-            <tr><td>Organik und Bestand (Suche, Haus-Seiten, Storefront)</td><td class="num">7</td><td class="num">≈23</td><td class="num">≈30</td></tr>
-            <tr><td>Social Media</td><td class="num">8</td><td class="num">≈5</td><td class="num">≈13</td></tr>
-            <tr><td>Print und Festival</td><td class="num">0</td><td class="num">≈0–2</td><td class="num">≈0–2</td></tr>
-          </tbody>
+        <table class="tarif akt-tab">
+          <thead><tr><th>Aktivität</th><th>Kanal</th><th class="num">Klicks</th><th class="num">Abschlüsse</th></tr></thead>
+          <tbody id="aktBody"><tr><td class="empty" colspan="4">lädt …</td></tr></tbody>
+          <tfoot id="aktFoot"></tfoot>
         </table>
       </div>
-      <p class="provisorisch">Die Spalte «gemessen» sind harte UTM-Zuordnungen. «≈ geschätzt» ist eine <b>Lesart</b> der Abos ohne Spur (±30 %), gestützt auf vier belegte Anker: die Klick-Tageskurven des ActiveCampaign-Newsletters, die Kurzlink-Klicks, das Konto-Alter der goetheanum.tv-Abonnenten (31 der dunklen TV-Abos sind Bestandskonten von vor der Aktion) und die Referrer aus dem Uscreen-Export. Nichts davon steht in der Datenbank – die Messwerte bleiben unangetastet. Herleitung: <code>docs/wirkungs-lesart-18-07.md</code> im Werkzeug-Repo.</p>
+      <p class="provisorisch">Abschlüsse = echte Zählung je Motiv-Spur (Attribution); Klicks = Kurzlink-Klicks aus dem Link-Register (DE und EN zusammengezählt). Eine Zeile mit vielen Klicks, aber kaum Abschlüssen ist markiert: dort ging die Spur zwischen Klick und Anmeldung verloren – bei der bezahlten Meta-Anzeige führt der Weg auf den goetheanum.tv-Checkout (Uscreen), der die UTM nicht bis zur Anmeldung trägt. Deshalb landet ihre Wirkung unten im Dunkelfeld.</p>
+    </div>
+
+    <div class="panel" style="margin-top:var(--s5)">
+      <div class="mh">Dunkelfeld eingeordnet · Schätzung, Stand <span id="dunkelStand">–</span></div>
+      <div class="tablewrap" style="margin-top:var(--s4)">
+        <table class="tarif">
+          <thead><tr><th>Aktivität</th><th class="num">gemessen</th><th class="num">≈ dunkel</th><th class="num">≈ gesamt</th></tr></thead>
+          <tbody id="dunkelBody"><tr><td class="empty" colspan="4">lädt …</td></tr></tbody>
+          <tfoot id="dunkelFoot"></tfoot>
+        </table>
+      </div>
+      <p class="provisorisch">Die Spalte «gemessen» ist hart (UTM). «≈ dunkel» verteilt die Anmeldungen ohne Spur nach vier Ankern – am stärksten der <b>vermuteten Herkunft</b> je Anmeldung (zeitnächster Kurzlink-Klick), die inzwischen 72 der 84 dunklen der letzten 14 Tage abdeckt. Alles mit ≈ ist eine Lesart (±30 %), keine Messung; die Datenbank bleibt unberührt. Herleitung: <code>docs/wirkungs-lesart-22-07.md</code>.</p>
+      <details class="zb-form">
+        <summary id="vermutetKopf">Vermutete Herkunft der letzten 14 Tage – das Live-Fundament unter der Schätzung</summary>
+        <div id="vermutetList" style="margin-top:var(--s4)"><div class="empty">lädt …</div></div>
+        <p class="provisorisch">Live aus den Ereignissen: je Anmeldung ohne UTM der zeitlich nächste Kurzlink-Klick (bis 90 Min. davor) auf einen passenden Kampagnen-Link. Ein Indiz, keine Messung – gezählt wird es nirgends, es ordnet nur ein.</p>
+      </details>
+    </div>
+
+    <details class="zb-form">
+      <summary>Warum kommen so viele ohne UTM – und was hilft?</summary>
+      <div class="card soft" style="margin-top:var(--s4)">
+        <p class="modell">Von den dunklen Anmeldungen der letzten 14 Tage sind rund zwei Drittel <b>goetheanum.tv</b> (Uscreen). Deren Spur hängt an einem einzigen Faden: dem <code>user_created</code>-Event, das Uscreen mit den UTM-Parametern schickt. Kommt es ohne (In-App-Browser aus Social, verlorene Cookies), ist die Anmeldung dunkel – der Checkout selbst trägt keine Spur.</p>
+        <p class="provisorisch">Grösster Hebel: die UTM auf der TV-Landingpage an den goetheanum.tv-Checkout weiterreichen und bezahlte wie soziale TV-Wege über den Kurzlink (<code>/s/&lt;code&gt;</code>) führen – dann wandert allein die Meta-Anzeige (≈44 Anmeldungen) von dunkel nach gemessen. Zweiter Hebel: auf allen vier Wochenschrift-Formularen die versteckten UTM-Prefill-Felder gegenprüfen. Schritte im Repo unter <code>services/sommer-zaehler/utm-ablauf.md</code>.</p>
+      </div>
     </details>
-    <div id="quelleSocial" style="margin-top:var(--s5)"></div>
   </section>
 
 

--- a/docs/wirkungs-lesart-22-07.md
+++ b/docs/wirkungs-lesart-22-07.md
@@ -1,0 +1,132 @@
+# Wirkungs-Lesart der Sommer-Aktion — Stand 22. Juli 2026
+
+Dieses Dokument ordnet die Anmeldungen **ohne UTM-Spur** («ohne UTM» im
+Cockpit) den Aktivitäten der Kampagne zu. Es ist eine **Lesart, keine
+Messung**: Alle mit ≈ markierten Zahlen sind Schätzungen (±30 %). Die
+Datenbank bleibt unangetastet — dort stehen nur harte Zuordnungen. Die
+Kompaktfassung steht im Cockpit unter Wirkung → «Aktivität → Abschlüsse».
+
+Diese Fassung löst `wirkungs-lesart-18-07.md` ab (die bleibt als Historie
+liegen). Neu gegenüber dem 18. Juli: ein Live-Anker mehr — die **vermutete
+Herkunft** je dunkler Anmeldung (zeitnächster Kurzlink-Klick, RPC
+`sommer2026_ereignisse`) deckt inzwischen **72 der 84** dunklen Anmeldungen
+der letzten 14 Tage ab. Die Schätzung steht damit auf deutlich festerem
+Grund als am 18. Juli.
+
+Grundlage am Stichtag: **109 Anmeldungen ohne UTM** von insgesamt **216**
+(mit UTM: 107). Der Dunkel-Anteil ist von **60 %** (18. Juli: 84 von 139)
+auf **50 %** gefallen — die Attributions-Reparaturen vom 18. Juli greifen:
+von den 77 seither hinzugekommenen Anmeldungen tragen gut zwei Drittel eine
+Spur.
+
+## Warum kommen überhaupt so viele ohne UTM an?
+
+Die Frage aus dem Auftrag, mit den Zahlen dahinter. Von den 84 dunklen
+Anmeldungen der letzten 14 Tage sind **58 goetheanum.tv (Uscreen)** und
+**26 Wochenschrift (Paperform)**. Das ist der Kern:
+
+1. **goetheanum.tv / Uscreen ist das strukturelle Leck (58 von 84).** Die
+   Attribution von goetheanum.tv hängt an **einem** Faden: dem
+   `user_created`-Event, das Uscreen aus seiner eigenen Session-Erfassung
+   mit `utm_params` schickt. Kommt dieses Event ohne `utm_params` (In-App-
+   Browser aus Instagram/Facebook, verlorene Cookies, Weiterleitungsketten),
+   ist die Anmeldung dunkel — der Uscreen-Checkout selbst trägt keine
+   Landingpage und keine UTM in die Subscription. Darum steht bei allen 58
+   `landing_path = NULL`.
+2. **Die bezahlte Meta-Anzeige ist der grösste einzelne Dunkel-Treiber.**
+   Der Link `story_statisch` sammelt **rund 600 Kurzlink-Klicks** (377 EN +
+   220 DE), aber nur **eine** hart zugeordnete Anmeldung. Die restlichen
+   Abschlüsse dieser Anzeige landen im Dunkelfeld: **43 der 84** dunklen
+   Anmeldungen tragen einen zeitnahen Klick genau auf diese Anzeige. Grund
+   ist Punkt 1 — die Anzeige führt auf goetheanum.tv, und die Spur überlebt
+   den Uscreen-Checkout nicht. Klicks werden serverseitig gezählt (link_hits
+   je Kurzcode), der Abschluss danach nicht.
+3. **Paperform / Wochenschrift (26 von 84).** Hier soll die Spur über
+   versteckte Prefill-Felder **und** `device.utm` ankommen. 26 dunkle von
+   ~55 WoS zeigen: auf einzelnen Wegen reicht die Landingpage die `?utm_*`
+   noch nicht ans Formular weiter, oder es sind echte Direkt-/Organik-
+   Zugänge (getippte URL, Lesezeichen — die tragen nie Parameter).
+
+## Die vier belegten Anker (Stand 22. Juli)
+
+1. **Vermutete Herkunft (neu, halb-hart):** je dunkler Anmeldung der
+   zeitlich nächste Kurzlink-Klick (≤ 90 Min. davor) auf einen zum Produkt
+   passenden Kampagnen-Link. Deckt 72 der 84 dunklen der letzten 14 Tage.
+   Verteilung: `meta-anzeige/story_statisch` 43 · `tv-weekly*/nl-tv phase1`
+   15 · Instagram/Facebook (story, reel_wolfgang, karussell) 11 · LinkedIn 1
+   · `inserat_rsv` 1 · `mailing/newsletter_agid` 1.
+2. **Kurzlink-Klicks (link_hits):** je Link automatisch gezählt. Grosse
+   Treiber: Meta-Anzeige ~600, `otter-2` (tv-weekly Übersicht) 73, `spinne`
+   (Instagram-Story) 32, `biber-4` (nl-tv) 27, `rabbit` (tv-weekly-abo EN)
+   26. Die Inserat-Kurzlinks: einstellig (`dachs-2` 8, `zebra` 0).
+3. **Quelle/Produkt der dunklen Anmeldungen:** 58 Uscreen (goetheanum.tv),
+   26 Paperform (Wochenschrift) in den letzten 14 Tagen — der Rest ohne
+   zeitnahen Klick (12) ist echte Direkt-/Organik-Anmeldung.
+4. **Frühphase 3.–7. Juli (~25 Anmeldungen ausserhalb des 14-Tage-
+   Fensters):** die löchrige Startwoche — AC-Newsletter «Sommerfestivals»
+   (4.7.), Hinweis-Newsletter AWW (3.7.), Bestandskonten und Organik. Für
+   diese greift die Vermutungs-Logik nicht mehr (Klick-Log rollt); sie
+   bleiben die weichste Ecke der Schätzung (wie schon am 18. Juli).
+
+## Kampagnenweite Rangfolge (gemessen + geschätzt)
+
+| Rang | Aktivität | gemessen | ≈ dazu (dunkel) | ≈ gesamt |
+|---|---|---|---|---|
+| 1 | Mailing (Welle 1) | 79 | ≈1 | **≈80** |
+| 2 | Meta-Anzeige (bezahlt) | 0 | ≈44 | **≈44** |
+| 3 | Organik · Bestand · Direkt | 8 | ≈25 | **≈33** |
+| 4 | Social organisch (Reels · Stories · Karussell) | 9 | ≈14 | **≈23** |
+| 5 | goetheanum.tv-Newsletter (TV-Weekly) | 5 | ≈17 | **≈22** |
+| 6 | Haus-/AC-Newsletter (Frühphase) | 5 | ≈7 | **≈12** |
+| 7 | Inserat · Print | 0 | ≈1 | **≈1** |
+| 8 | Empfehlung | 1 | ≈0 | **≈1** |
+| | **Summe** | **107** | **109** | **216** |
+
+Die Spalte «gemessen» sind harte UTM-Zuordnungen (RPC
+`sommer2026_kanaele` / `sommer2026_attribution`). «≈ dazu» verteilt das
+Dunkelfeld (109) nach den vier Ankern oben; die Summen sind mit den
+Live-Zahlen abgeglichen (107 mit UTM, 109 ohne, 216 gesamt).
+
+Drei Sätze dazu: **Das Mailing trägt die Aktion weiter** — eine Welle, gut
+ein Drittel aller Abos, fast alles messbar. **Die bezahlte Meta-Anzeige ist
+der neue grosse Posten** und läuft fast vollständig dunkel — hier liegt der
+grösste Attributions-Gewinn, wenn das Uscreen-Leck geschlossen wird.
+**Print/Inserat trägt weiter kaum etwas** (Kurzlinks einstellig) — der
+ehrlichste Einzelbefund bleibt.
+
+## Was sich verbessern lässt (nach Hebel)
+
+1. **Grösster Hebel — die goetheanum.tv-Spur bis in den Uscreen-Checkout
+   tragen.** Heute reicht die Landingpage `tv-sommer2026…` die `?utm_*` nicht
+   sicher an den Uscreen-Checkout weiter; darum hängt alles am
+   `user_created`-Event. Zwei Wege, am besten beide:
+   - Auf der TV-Landingpage die eingehenden `?utm_*` an den «3 Monate
+     gratis»-Button hängen (an die Checkout-URL), damit Uscreen sie in der
+     Session sicher aufnimmt — analog zur Paperform-Weiterreichung.
+   - Bezahlte und soziale TV-Wege **über den Kurzlink** (`/s/<code>`, Function
+     `go`) führen: 302 mit voller UTM-URL, robuster gegen In-App-Browser als
+     ein direkt geteilter Roh-Link. Details in `services/sommer-zaehler/
+     utm-ablauf.md` → «Sonderfall goetheanum.tv / Uscreen».
+2. **Meta-Anzeige zuerst umstellen** (grösster Einzelposten). Sobald die
+   Anzeige über den Kurzlink läuft und die Landingpage die Spur weiterreicht,
+   wandern ~44 Anmeldungen von dunkel nach gemessen — der Dunkel-Anteil
+   fiele auf einen Schlag Richtung 30 %.
+3. **Paperform gegenprüfen (26 dunkel).** Auf allen vier Formularen die vier
+   versteckten Prefill-Felder (`utm_source/medium/campaign/content`) und die
+   Weiterreichung Landingpage → Formular verifizieren; ein Testlink je
+   Formular durchschicken (siehe utm-ablauf.md → «Test»).
+4. **Optionaler Backend-Ausbau (nicht deployt, zur Entscheidung):** das
+   Vermutungs-Fenster in `sommer2026_ereignisse` von 90 Minuten auf die
+   Sitzungsdauer erweitern und für Paperform zusätzlich über `landing_path`
+   ankern — dann bekämen auch die 12 hint-losen dunklen eine Lesart. Erst
+   nach Freigabe, weil es die Auslegung (nicht die Messung) verschiebt.
+
+## Pflege
+
+Die Lesart ist datiert und wird **nicht** automatisch nachgeführt. Bei einer
+neuen Auswertung: Kopie mit neuem Datum anlegen, `CONFIG.dunkelLesart` in
+`apps/sommer-zaehler/campaign.js` nachziehen (Stand-Datum + Zeilen), Cockpit
+zeigt sie dann automatisch. Das Live-Aggregat «vermutete Herkunft» im
+Cockpit atmet ohnehin mit — es zieht sich jede Minute frisch aus den
+Ereignissen. Seit dem 18. Juli entsteht immer weniger dunkler Bestand;
+künftige Auswertungen brauchen immer weniger Schätzung.

--- a/services/sommer-zaehler/utm-ablauf.md
+++ b/services/sommer-zaehler/utm-ablauf.md
@@ -124,6 +124,40 @@ Test: einen generierten Link mit `utm_*` öffnen, Formular abschicken → in
 `sommer2026_signups` steht die Zeile mit gefüllten `utm_*`, im Cockpit unter
 «Nach Motiv».
 
+## Sonderfall goetheanum.tv / Uscreen: damit die Spur den Checkout überlebt
+
+Der grösste blinde Fleck der Attribution (Befund 22. Juli: rund zwei Drittel
+aller dunklen Anmeldungen sind goetheanum.tv). Anders als bei Paperform gibt
+es **kein** verstecktes UTM-Feld, das man setzen kann — die Spur überlebt nur
+so weit, wie Uscreen sie in seiner eigenen Session mitführt und im
+`user_created`-Event als `utm_params` mitschickt. Bricht diese Kette (In-App-
+Browser aus Instagram/Facebook, Cookie-Verlust, Weiterleitungen), ist die
+Anmeldung dunkel. Sinnbild: die bezahlte Meta-Anzeige (`story_statisch`)
+sammelt ~600 Kurzlink-Klicks, aber nur eine hart zugeordnete Anmeldung.
+
+Zwei Stellen, am besten beide:
+
+**1. Landingpage → Uscreen-Checkout (Web-Seite):** Die TV-Landingpage
+(`tv-sommer2026…` / `tv-en-sommer2026…`) muss die eingehenden `?utm_*` an den
+«3 Monate gratis»-Button hängen — also an die Uscreen-Checkout-URL
+anhängen, genau wie die WoS-Landingpage sie ans Paperform-Formular reicht.
+Ohne das sieht Uscreen die UTM nur, wenn sein eigenes Session-Tracking sie
+zufällig aufgenommen hat.
+
+**2. Bezahlte und soziale TV-Wege über den Kurzlink führen.** Statt den
+Roh-Link zu teilen, den Kurzlink `/s/<code>` aus dem Generator einsetzen
+(Function `go`, 302 auf die volle UTM-URL). Der serverseitige Redirect ist
+robuster gegen In-App-Browser als ein direkt geteilter Roh-Link und zählt
+den Klick verlässlich in `link_hits` (Grundlage der vermuteten Herkunft im
+Cockpit). Die **Meta-Anzeige zuerst umstellen** — sie ist der grösste
+Einzelposten (≈44 Anmeldungen), der heute dunkel läuft.
+
+Test: einen TV-Kurzlink mit `utm_*` öffnen, Trial über den Uscreen-Checkout
+starten → in `sommer2026_signups` trägt die Zeile die `utm_*` (nicht nur der
+`user_created`-Fallback). Solange das nicht greift, bleibt die Wirkung dieser
+Wege in der Dunkelfeld-Lesart des Cockpits (Wirkung → «Aktivität →
+Abschlüsse»), nicht in der harten Messung.
+
 ## Pflege
 
 Neue Massnahme → Zeile im Massnahmen-Protokoll (`sommer2026_massnahmen`, Service-


### PR DESCRIPTION
## Worum es geht

Im Sommer-Cockpit fehlte die Übersicht, **welche Aktivität zu welchen Abschlüssen geführt hat**. Bei der Gelegenheit wurde erneut geprüft, warum so viele Abschlüsse ohne UTM ankommen, und die Einordnung der dunklen Anmeldungen auf den heutigen Stand (22. Juli) gebracht.

## Was neu ist (Cockpit → Wirkung → «Aktivität → Abschlüsse»)

1. **Gemessen · je Aktivität** — Live-Tabelle aus `sommer2026_attribution` (echte Abschluss-Zählung je Motiv-Spur) und `sommer2026_links_public` (Kurzlink-Klicks, DE+EN zusammengezählt). Klicks stehen neben den Abschlüssen; eine Zeile mit vielen Klicks und kaum Abschlüssen wird markiert – so wird das Attributions-Leck sichtbar (die bezahlte Meta-Anzeige: ~600 Klicks, 1 gemessene Anmeldung).
2. **Dunkelfeld eingeordnet · Schätzung Stand 22.7.** — die 109 Anmeldungen ohne UTM (von 216) den Aktivitäten zugeordnet: `gemessen + ≈ dunkel = ≈ gesamt`, Summen mit den Live-Zahlen abgeglichen (107 / 109 / 216). Gepflegt an einer Stelle in `CONFIG.dunkelLesart`.
3. **Vermutete Herkunft (Live-Aggregat)** — das Fundament unter der Schätzung: je dunkler Anmeldung der zeitnächste Kurzlink-Klick aus `sommer2026_ereignisse` (deckt 72 der 84 dunklen der letzten 14 Tage). Atmet mit dem 60-Sekunden-Takt.

## Befund «warum ohne UTM» (erneut geprüft, mit Live-Zahlen)

Der Dunkel-Anteil ist von **60 %** (18.7.: 84/139) auf **50 %** (22.7.: 109/216) gefallen – die Reparaturen vom 18.7. greifen. Kern des Rests: **goetheanum.tv/Uscreen ist das strukturelle Leck** (58 der 84 dunklen der letzten 14 Tage). Grösster einzelner Dunkel-Treiber ist die **bezahlte Meta-Anzeige** (≈44 Anmeldungen), deren Weg über den Uscreen-Checkout die Spur verliert.

**Abhilfe** (konkret dokumentiert in `services/sommer-zaehler/utm-ablauf.md` → «Sonderfall goetheanum.tv / Uscreen»): UTM auf der TV-Landingpage bis in den Checkout weiterreichen und bezahlte/soziale TV-Wege über den Kurzlink führen. Zweiter Hebel: Paperform-Prefill-Felder gegenprüfen.

## Aktuelle Schätzung, in die Übersicht eingearbeitet

| Aktivität | gemessen | ≈ dunkel | ≈ gesamt |
|---|--:|--:|--:|
| Mailing · Welle 1 | 79 | ≈1 | ≈80 |
| Meta-Anzeige · bezahlt | 0 | ≈44 | ≈44 |
| Organik · Bestand · Direkt | 8 | ≈25 | ≈33 |
| Social organisch | 9 | ≈14 | ≈23 |
| goetheanum.tv-Newsletter · TV-Weekly | 5 | ≈17 | ≈22 |
| Haus-/AC-Newsletter · Frühphase | 5 | ≈7 | ≈12 |
| Inserat · Print | 0 | ≈1 | ≈1 |
| Empfehlung | 1 | – | ≈1 |
| **Summe** | **107** | **109** | **216** |

Herleitung: `docs/wirkungs-lesart-22-07.md` (die 18-07-Fassung bleibt als Historie liegen).

## Datenlage

Nur bestehende, anon-offene Aggregat-RPCs; **keine** Backend-Migration, keine Personendaten. Frontend-only, gegen die Live-Daten gerendert und geprüft.

## Regeln / Prüfmaschinen

Gestalt nur über Tokens (DS02/DS07), Tabellen-Ziffern tabellarisch (G25), Grössen über die Skala-Tokens (B03). `ds-lint` 100 % (61/61 konform), `typo-check --all` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eee8tzL29NsZC4Tw3MP54

---
_Generated by [Claude Code](https://claude.ai/code/session_019eee8tzL29NsZC4Tw3MP54)_