### PR TITLE
Backend-Logo: kleiner (100×17), mehr Abstand, img ohne Alt-Text

### DIFF
--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -585,12 +585,15 @@ function buildSignature() {
     //        blockierten Bildern (in Outlook nicht vermeidbar).
     let logo;
     if (logoTech() === "img") {
-      logo = "<a href=\"https://goetheanum.ch\" style=\"text-decoration:none;border:0;\">" +
-        "<img src=\"" + LOGO_URL + "\" width=\"120\" height=\"20\" alt=\"Goetheanum\" " +
-        "style=\"display:block;border:0;outline:none;text-decoration:none;margin:22px 0 0;-ms-interpolation-mode:bicubic;\" /></a>";
+      // alt="" → bei blockierten Bildern nur das Kästchen, KEIN Text daneben.
+      // Link-Name für Screenreader über aria-label am <a> (erscheint nicht im
+      // Kästchen).
+      logo = "<a href=\"https://goetheanum.ch\" aria-label=\"Goetheanum\" style=\"text-decoration:none;border:0;\">" +
+        "<img src=\"" + LOGO_URL + "\" width=\"100\" height=\"17\" alt=\"\" " +
+        "style=\"display:block;border:0;outline:none;text-decoration:none;margin:30px 0 0;-ms-interpolation-mode:bicubic;\" /></a>";
     } else {
-      logo = "<a href=\"https://goetheanum.ch\" style=\"display:inline-block;border:0;text-decoration:none;\">" +
-        "<div style=\"width:120px;height:20px;background:url('" + LOGO_URL + "') no-repeat left center/contain;margin:22px 0 0;\"></div></a>";
+      logo = "<a href=\"https://goetheanum.ch\" aria-label=\"Goetheanum\" style=\"display:inline-block;border:0;text-decoration:none;\">" +
+        "<div style=\"width:100px;height:17px;background:url('" + LOGO_URL + "') no-repeat left center/contain;margin:30px 0 0;\"></div></a>";
     }
     hl.push(logo);
   }


### PR DESCRIPTION
- **Kein Text neben dem kaputten Bild:** `alt=""` in der img-Variante — bei blockierten Bildern zeigt Outlook nur das kleine Kästchen, kein Wort daneben. Der Link-Name für Screenreader hängt als `aria-label` am `<a>` (erscheint nicht im Kästchen).
- **Logo noch kleiner** (120×20 → 100×17) und **mehr Abstand davor** (22 → 30 px), beide Varianten.

Headless geprüft: `alt=""` + `aria-label` gesetzt, neue Grösse aktiv; blockierter Zustand ohne Text. Prüfmaschinen grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bef4eJDccJnhmgnQuyvCMM)_