### PR TITLE
Cockpit: Kanäle-Übersicht – Reichweite und Klicks je Kanal, aufklappbar

### DIFF
--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -117,20 +117,19 @@
   .funnel .s3>span{background:linear-gradient(90deg,var(--gold),var(--gold-ink))}
   .funnel .s4>span{background:var(--ok)}
   .funnel .fnote{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);margin-top:var(--s5);line-height:1.5}
-  /* Reichweite je Kanal – Aufschlüsselung unter der Kette (nutzt die .stream-Balken). */
-  .funnel .reach-kanal{margin-top:var(--s6);padding-top:var(--s5);border-top:1px solid var(--line-soft)}
-  .funnel .reach-kanal .rk-h{font-family:var(--font-text);font-size:var(--t-small);color:var(--ink);font-weight:600;margin-bottom:var(--s4)}
-  /* Aufklappbarer Kanal-Balken: Summary trägt den Balken, darunter die Quellen-Liste. */
-  .funnel .reach-detail{margin-bottom:var(--s5)}
-  .funnel .reach-detail:last-of-type{margin-bottom:0}
-  .funnel .reach-detail>summary{list-style:none;cursor:pointer;display:block;border-radius:var(--r-pill)}
-  .funnel .reach-detail>summary::-webkit-details-marker{display:none}
-  .funnel .reach-detail>summary:focus-visible{outline:2px solid var(--gold-ink);outline-offset:3px}
-  .funnel .reach-detail>summary .stream{margin-bottom:0}
-  .funnel .reach-detail .rk-caret{display:inline-block;width:0;height:0;margin-left:8px;vertical-align:middle;border-left:5px solid var(--muted);border-top:4px solid transparent;border-bottom:4px solid transparent;transition:transform .2s ease}
-  .funnel .reach-detail[open] .rk-caret{transform:rotate(90deg)}
-  .funnel .reach-detail .quellen{margin:var(--s3) 0 var(--s4);padding-left:var(--s4);border-left:2px solid var(--line-soft)}
-  .funnel .reach-detail .quellen .qz-hint{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);padding:8px 0;line-height:1.5}
+  /* Kanäle: Reichweite/Klicks je Kanal, aufklappbar zu den Aktivitäten (eigene
+     Sektion; nutzt die .stream-Balken). Zuvor unter der Wirkungskette, darum
+     Selektoren un-gescoped. Nur Tokens (DS02), Ziffern tnum über .stream (G25). */
+  .reach-detail{margin-bottom:var(--s5)}
+  .reach-detail:last-of-type{margin-bottom:0}
+  .reach-detail>summary{list-style:none;cursor:pointer;display:block;border-radius:var(--r-pill);min-height:var(--tap)}
+  .reach-detail>summary::-webkit-details-marker{display:none}
+  .reach-detail>summary:focus-visible{outline:2px solid var(--gold-ink);outline-offset:3px}
+  .reach-detail>summary .stream{margin-bottom:0}
+  .reach-detail .rk-caret{display:inline-block;width:0;height:0;margin-left:8px;vertical-align:middle;border-left:5px solid var(--muted);border-top:4px solid transparent;border-bottom:4px solid transparent;transition:transform .2s ease}
+  .reach-detail[open] .rk-caret{transform:rotate(90deg)}
+  .reach-detail .quellen{margin:var(--s3) 0 var(--s4);padding-left:var(--s4);border-left:2px solid var(--line-soft)}
+  .reach-detail .quellen .qz-hint{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);padding:8px 0;line-height:1.5}
 
   /* Attribution nach Motiv (utm_content) – feiner als der kanal-Bucket. */
   .motive{margin-top:var(--s6)}

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -239,73 +239,110 @@
       lvl.querySelector('.ftrack > span').style.width = Math.max(3, Math.round(v / max * 100)) + '%';
       host.appendChild(lvl);
     });
-    // Reichweite je Kanal – aus den Aktivitäten summiert (Social, Newsletter, …).
-    // Neben der Summe je Kanal auch die einzelnen Aktivitäten sammeln, damit der
-    // Balken zu einer Liste der Quellen aufklappt (Herkunft der Reichweite prüfbar).
-    var reach = {}, klick = {}, quellen = {};
+    // Die Aufschlüsselung «Reichweite und Klicks je Kanal» (mit Aufklapp auf die
+    // einzelnen Aktivitäten) steht jetzt in der eigenen Sektion «Kanäle»
+    // (renderKanalUebersicht) – hier bleibt die Kette als Summe.
+    var note = document.createElement('div'); note.className = 'fnote';
+    note.textContent = 'Reichweite und Klicks kommen aus den Aktivitäten (je Kanal aufgeschlüsselt unter «Kanäle»). Klicks = erfasste Aktivitäts-Klicks plus die automatisch gezählten Kurzlink-Klicks aller Kampagnen-Links; dieselben Klicks nicht zusätzlich von Hand eintragen, sonst zählen sie doppelt. Abschlüsse und Geblieben zählt das Cockpit live aus den Anmeldungen.';
+    host.appendChild(note);
+  }
+
+  // ── Kanäle: Reichweite und Klicks je Kanal (aufklappbar zu Aktivitäten) ─────
+  // Eigene Übersicht über den Kopf der Wirkungskette: je Kanal (Mailing,
+  // Newsletter, Social Media …) die summierte Reichweite und die Klicks; ein
+  // Klick auf den Kanal klappt die einzelnen Aktivitäten dahinter auf. Reichweite
+  // und die von Hand erfassten Klicks kommen aus dem Aktivitäten-Protokoll
+  // (massnahmen), die Kurzlink-Klicks aus dem Link-Register (links) – über die
+  // UTM-Spur dem Kanal zugeordnet (kanalVonLink). Summenlogik wie die Kette.
+  function kanalVonLink(l){
+    var s = ((l.utm_source || '') + ' ' + (l.utm_medium || '')).toLowerCase();
+    if (!s.trim()) return 'andere';
+    if (/(news|\bnl\b|weekly)/.test(s)) return 'newsletter';     // vor mailer: «email» enthält «mail»
+    if (/(mailing|\bmail\b|post|brief)/.test(s)) return 'mailer';
+    if (/(insta|face|\bfb\b|social|linkedin|youtube|twitter|tiktok|meta)/.test(s)) return 'social';
+    if (/(popup|overlay)/.test(s)) return 'popup';
+    if (/(inserat|flyer|stand|plakat|print)/.test(s)) return 'flyer';
+    if (/(web|site|direct|organic)/.test(s)) return 'website';
+    if (/(refer|empfehl|friend|partner)/.test(s)) return 'empfehlung';
+    return 'andere';
+  }
+  function renderKanalUebersicht(massnahmen, links){
+    if (!el('kanalReichweite')) return;
+    var host = el('kanalReichweite'); host.innerHTML = '';
+    // Reichweite + Hand-Klicks + Aktivitäten je Kanal aus dem Protokoll.
+    var reach = {}, klickHand = {}, quellen = {};
     (massnahmen || []).forEach(function(m){
       var r = Number(m.reichweite) || 0, k = Number(m.klicks) || 0, kn = m.kanal || 'andere';
       if (r) reach[kn] = (reach[kn] || 0) + r;
-      if (k) klick[kn] = (klick[kn] || 0) + k;
+      if (k) klickHand[kn] = (klickHand[kn] || 0) + k;
       if (r || k) (quellen[kn] = quellen[kn] || []).push({ name:m.massnahme || '—', tag:m.tag, reichweite:r, klicks:k });
     });
-    var kanalItems = Object.keys(reach).map(function(kn){ return { kanal:kn, reach:reach[kn], klick:klick[kn] || 0 }; })
-                                       .sort(function(a, b){ return b.reach - a.reach; });
-    if (kanalItems.length){
-      var kmax = kanalItems.reduce(function(m, x){ return Math.max(m, x.reach); }, 0) || 1;
-      var box = document.createElement('div'); box.className = 'reach-kanal';
-      var head = document.createElement('div'); head.className = 'rk-h'; head.textContent = 'Reichweite je Kanal';
-      box.appendChild(head);
-      kanalItems.forEach(function(x){
-        // Jeder Kanal-Balken ist aufklappbar (details/summary) und listet darunter
-        // die einzelnen Quellen (Aktivitäten), die die Reichweite ausmachen.
-        var det = document.createElement('details'); det.className = 'reach-detail';
-        var sum = document.createElement('summary');
-        var row = document.createElement('div'); row.className = 'stream';
-        row.innerHTML = '<div class="top2"><span class="name"></span>' +
-          '<span class="val"><b></b> <span class="g"></span></span></div>' +
-          '<div class="track"><span></span></div>';
-        var qs = (quellen[x.kanal] || []).slice().sort(function(a, b){ return b.reichweite - a.reichweite; });
-        row.querySelector('.name').textContent = KANAL_LABEL[x.kanal] || x.kanal;
-        var caret = document.createElement('span'); caret.className = 'rk-caret'; caret.setAttribute('aria-hidden', 'true');
-        row.querySelector('.name').appendChild(caret);
-        row.querySelector('.val b').textContent = fmt(x.reach);
-        var g = x.klick ? (fmt(x.klick) + ' Klicks') : '';
-        if (qs.length) g += (g ? ' · ' : '') + qs.length + (qs.length === 1 ? ' Quelle' : ' Quellen');
-        row.querySelector('.val .g').textContent = g;
-        row.querySelector('.track > span').style.width = Math.max(3, Math.round(x.reach / kmax * 100)) + '%';
-        sum.appendChild(row); det.appendChild(sum);
+    // Kurzlink-Klicks je Kanal aus dem Register (über die UTM-Spur zugeordnet).
+    var klickKurz = {};
+    (links || []).forEach(function(l){
+      var k = Number(l.klicks) || 0; if (!k) return;
+      var kn = kanalVonLink(l); klickKurz[kn] = (klickKurz[kn] || 0) + k;
+    });
+    var alle = {}; [reach, klickHand, klickKurz].forEach(function(o){ Object.keys(o).forEach(function(kn){ alle[kn] = true; }); });
+    var items = Object.keys(alle).map(function(kn){
+      var kh = klickHand[kn] || 0, kk = klickKurz[kn] || 0;
+      return { kanal:kn, reach:reach[kn] || 0, klickHand:kh, klickKurz:kk, klick:kh + kk };
+    }).sort(function(a, b){ return b.reach - a.reach || b.klick - a.klick; });
+    if (!items.length){ host.innerHTML = '<div class="empty">Noch keine Aktivitäten erfasst.</div>'; return; }
+    var rmax = items.reduce(function(m, x){ return Math.max(m, x.reach); }, 0) || 1;
+    items.forEach(function(x){
+      var det = document.createElement('details'); det.className = 'reach-detail';
+      var summary = document.createElement('summary');
+      var row = document.createElement('div'); row.className = 'stream';
+      row.innerHTML = '<div class="top2"><span class="name"></span>' +
+        '<span class="val"><b></b> <span class="g"></span></span></div>' +
+        '<div class="track"><span></span></div>';
+      var qs = (quellen[x.kanal] || []).slice().sort(function(a, b){ return b.reichweite - a.reichweite; });
+      row.querySelector('.name').textContent = KANAL_LABEL[x.kanal] || x.kanal;
+      var caret = document.createElement('span'); caret.className = 'rk-caret'; caret.setAttribute('aria-hidden', 'true');
+      row.querySelector('.name').appendChild(caret);
+      row.querySelector('.val b').textContent = fmt(x.reach);
+      var g = (x.klick ? (fmt(x.klick) + ' Klicks') : 'keine Klicks');
+      g += ' · ' + qs.length + (qs.length === 1 ? ' Aktivität' : ' Aktivitäten');
+      row.querySelector('.val .g').textContent = g;
+      row.querySelector('.track > span').style.width = Math.max(3, Math.round(x.reach / rmax * 100)) + '%';
+      summary.appendChild(row); det.appendChild(summary);
 
-        var list = document.createElement('div'); list.className = 'quellen';
-        qs.forEach(function(q){
-          var qr = document.createElement('div'); qr.className = 'motrow';
-          var mc = document.createElement('span'); mc.className = 'mc'; mc.textContent = q.name;
-          if (q.tag){ var ms = document.createElement('span'); ms.className = 'ms';
-            ms.textContent = new Date(q.tag + 'T00:00:00').toLocaleDateString('de-CH', { day:'numeric', month:'numeric' });
-            mc.appendChild(ms); }
-          var mn = document.createElement('span'); mn.className = 'mn';
-          mn.textContent = fmt(q.reichweite) + (q.klicks ? (' · ' + fmt(q.klicks) + ' Klicks') : '');
-          qr.appendChild(mc); qr.appendChild(mn); list.appendChild(qr);
-        });
-        if (!qs.length){
-          var leer = document.createElement('div'); leer.className = 'qz-hint';
-          leer.textContent = 'Keine Einzel-Quellen erfasst.'; list.appendChild(leer);
-        }
-        // Social: die externe Quelle (Metricool) direkt aus der Liste verlinken.
-        if (x.kanal === 'social' && CONFIG.quelleSocial){
-          var qlink = document.createElement('div'); qlink.className = 'qz-hint';
-          qlink.appendChild(document.createTextNode('Quelle der Zahlen: '));
-          var qa = document.createElement('a'); qa.href = CONFIG.quelleSocial.url;
-          qa.target = '_blank'; qa.rel = 'noopener'; qa.textContent = CONFIG.quelleSocial.label;
-          qlink.appendChild(qa); list.appendChild(qlink);
-        }
-        det.appendChild(list);
-        box.appendChild(det);
+      var list = document.createElement('div'); list.className = 'quellen';
+      qs.forEach(function(q){
+        var qr = document.createElement('div'); qr.className = 'motrow';
+        var mc = document.createElement('span'); mc.className = 'mc'; mc.textContent = q.name;
+        if (q.tag){ var ms = document.createElement('span'); ms.className = 'ms';
+          ms.textContent = new Date(q.tag + 'T00:00:00').toLocaleDateString('de-CH', { day:'numeric', month:'numeric' });
+          mc.appendChild(ms); }
+        var mn = document.createElement('span'); mn.className = 'mn';
+        mn.textContent = fmt(q.reichweite) + (q.klicks ? (' · ' + fmt(q.klicks) + ' Klicks') : '');
+        qr.appendChild(mc); qr.appendChild(mn); list.appendChild(qr);
       });
-      host.appendChild(box);
-    }
+      if (!qs.length){
+        var leer = document.createElement('div'); leer.className = 'qz-hint';
+        leer.textContent = 'Keine Aktivität mit Reichweite oder Klicks erfasst.'; list.appendChild(leer);
+      }
+      // Kurzlink-Klicks je Kanal lassen sich nicht einer einzelnen Aktivität
+      // zuordnen – darum als eigene, klar beschriftete Zeile ausweisen.
+      if (x.klickKurz){
+        var kz = document.createElement('div'); kz.className = 'qz-hint';
+        kz.textContent = '+ ' + fmt(x.klickKurz) + ' Kurzlink-Klicks der Kampagnen-Links (nicht je Aktivität aufgeschlüsselt).';
+        list.appendChild(kz);
+      }
+      // Social: die externe Quelle (Metricool) direkt aus der Liste verlinken.
+      if (x.kanal === 'social' && CONFIG.quelleSocial){
+        var qlink = document.createElement('div'); qlink.className = 'qz-hint';
+        qlink.appendChild(document.createTextNode('Quelle der Zahlen: '));
+        var qa = document.createElement('a'); qa.href = CONFIG.quelleSocial.url;
+        qa.target = '_blank'; qa.rel = 'noopener'; qa.textContent = CONFIG.quelleSocial.label;
+        qlink.appendChild(qa); list.appendChild(qlink);
+      }
+      det.appendChild(list);
+      host.appendChild(det);
+    });
     var note = document.createElement('div'); note.className = 'fnote';
-    note.textContent = 'Reichweite kommt aus den Aktivitäten (je Eintrag erfassen). Klicks = erfasste Aktivitäts-Klicks plus die automatisch gezählten Kurzlink-Klicks aller Kampagnen-Links; dieselben Klicks nicht zusätzlich von Hand eintragen, sonst zählen sie doppelt. Abschlüsse und Geblieben zählt das Cockpit live aus den Anmeldungen.';
+    note.textContent = 'Reichweite und die je Aktivität erfassten Klicks kommen aus dem Aktivitäten-Protokoll, die Kurzlink-Klicks aus dem Link-Register (über die UTM-Spur dem Kanal zugeordnet). Dieselben Klicks nicht zusätzlich von Hand eintragen, sonst zählen sie doppelt.';
     host.appendChild(note);
   }
 
@@ -657,9 +694,10 @@
         if (ergebnis === 'ok'){
           sagen(istEdit ? 'Geändert.' : 'Eingetragen – erscheint im Zeitband, im Protokoll und in der Reichweite.');
           mfZuruecksetzen();
-          // Reichweite/Klicks fliessen in die Wirkungskette – darum Zeitband, Protokoll UND Trichter neu laden.
-          Promise.all([rpc('sommer2026_massnahmen_public'), rpc('sommer2026_trichter')])
-            .then(function(res){ var rows = res[0] || []; renderZeitband(rows); renderMassnahmen(rows); renderFunnel(res[1] || [], rows); })
+          // Reichweite/Klicks fliessen in die Wirkungskette – darum Zeitband, Protokoll,
+          // Trichter UND die Kanal-Übersicht neu laden.
+          Promise.all([rpc('sommer2026_massnahmen_public'), rpc('sommer2026_trichter'), rpc('sommer2026_links_public')])
+            .then(function(res){ var rows = res[0] || []; renderZeitband(rows); renderMassnahmen(rows); renderFunnel(res[1] || [], rows); renderKanalUebersicht(rows, res[2] || []); })
             .catch(function(){});
         } else { sagen('Datum und Aktivität prüfen.', true); }
       })
@@ -1219,6 +1257,7 @@
         renderSpurTile(kanaele, total);
         renderMotive(attribution);
         renderAktivitaeten(attribution, links, kanaele);
+        renderKanalUebersicht(massnahmen, links);
         renderDunkelfeld();
         renderTarif(stats);
         renderMilestones(total);

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -106,6 +106,14 @@
   </section>
 
 
+  <section id="kanaele">
+    <div class="shead"><h2>Kanäle</h2><p>Reichweite und Klicks je Kanal – Mailing, Newsletter, Social Media und die übrigen. Ein Kanal aufklappen zeigt die einzelnen Aktivitäten dahinter.</p></div>
+    <div class="panel">
+      <div id="kanalReichweite"><div class="empty">lädt …</div></div>
+    </div>
+  </section>
+
+
   <section id="aktivitaeten-abschluesse">
     <div class="shead"><h2>Aktivität → Abschlüsse</h2><p>Welche Aktivität zu welchen Abschlüssen geführt hat – erst die harte Messung (Abschlüsse je Aktivität, live aus den UTM-Spuren, mit den Klicks daneben), dann die Anmeldungen ohne UTM den Aktivitäten zugeordnet.</p></div>
     <div class="panel">


### PR DESCRIPTION
## Worum es geht

Auf Wunsch: eine eigene **Kanäle**-Übersicht im Sommer-Cockpit — Reichweite und Klicks je Kanal (Mailing, Newsletter, Social Media, Flyer/Stand …). Erst beim **Aufklappen** eines Kanals erscheinen die einzelnen Aktivitäten dahinter.

## Was neu ist (Cockpit → Sektion «Kanäle»)

- Je Kanal ein aufklappbarer Balken: **Reichweite** (Summe) und **Klicks**, daneben die Zahl der Aktivitäten. Aufklappen zeigt die einzelnen Aktivitäten mit Datum und Reichweite.
- **Reichweite** und die je Aktivität erfassten **Klicks** kommen aus dem Aktivitäten-Protokoll (`sommer2026_massnahmen_public`).
- Die automatisch gezählten **Kurzlink-Klicks** (`sommer2026_links_public`) werden über die UTM-Spur dem Kanal zugeordnet (`kanalVonLink`) und im Aufklapp als eigene Zeile ausgewiesen. Summenlogik wie die Wirkungskette, mitsamt Doppelzählungs-Hinweis.

## Aufgeräumt

Die bisher in die Wirkungskette eingebettete «Reichweite je Kanal» wird durch diese eigenständige, umfassendere Übersicht abgelöst (G03: keine doppelte Darstellung); die CSS-Selektoren wurden entsprechend un-gescoped.

## Datenlage & Regeln

Nur bestehende, anon-offene Aggregat-RPCs; keine Backend-Migration, keine Personendaten. Gestalt nur über Tokens (DS02/DS07), Ziffern tabellarisch (G25), Fingerziele ≥44px (B04). `ds-lint` 100 %, `typo-check` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eee8tzL29NsZC4Tw3MP54

---
_Generated by [Claude Code](https://claude.ai/code/session_019eee8tzL29NsZC4Tw3MP54)_