### PR TITLE
Sommer-Cockpit: Entwurf «Neue Ordnung» als Mockup zur Beurteilung

### DIFF
--- a/apps/sommer-zaehler/neue-ordnung.html
+++ b/apps/sommer-zaehler/neue-ordnung.html
@@ -1,0 +1,473 @@
+<!doctype html>
+<!-- =============================================================================
+     Sommer-Zähler · MOCKUP «Neue Ordnung»
+     -----------------------------------------------------------------------------
+     Entwurf für den radikalen Umbau des Cockpits – vier Fragen statt acht
+     Sektionen. STATISCH: alle Zahlen sind der echte Stand vom 24. Juli 2026,
+     von Hand eingesetzt, damit die Ordnung an echten Werten beurteilt werden
+     kann. Nichts hier ruft das Backend. Das laufende Cockpit (./) bleibt
+     unberührt, bis diese Ordnung beschlossen ist.
+
+     Fundament eingebunden (nicht kopiert): tokens.css + base.css + nav.css und
+     campaign.css (für .panel/.stream/.track/.tarif/.motrow – dieselbe Gestalt
+     wie das Cockpit).
+     ============================================================================= -->
+<html lang="de-CH">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sommer-Aktion · Neue Ordnung (Mockup) · Goetheanum</title>
+<meta name="description" content="Entwurf der neuen Cockpit-Ordnung: Stand, Gebiete, Nächste Züge – alles auf einen Blick, Details klappen auf." />
+<meta name="robots" content="noindex" />
+<link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
+<link rel="stylesheet" href="../../design-system/tokens.css" />
+<link rel="stylesheet" href="../../design-system/base.css" />
+<link rel="stylesheet" href="../../design-system/nav.css" />
+<link rel="stylesheet" href="campaign.css" />
+<style>
+  /* Nur mockup-eigene Gestalt – ausschliesslich Tokens (DS02/DS07).
+     Achtung: --s5 und --s7 existieren NICHT in tokens.css (nur s1–s4, s6, s8). */
+
+  /* Hinweisband: dies ist ein Entwurf, keine Live-Ansicht. */
+  .entwurf{border:1px dashed var(--gold);border-radius:var(--r-card);
+    padding:var(--s4) var(--s6);margin-top:var(--s6);background:var(--soft)}
+  .entwurf p{font-family:var(--font-text);font-size:var(--t-small);color:var(--ink);margin:0;line-height:1.55}
+  .entwurf p + p{margin-top:var(--s2);color:var(--muted);font-size:var(--t-micro)}
+
+  /* ── 1 Stand ─────────────────────────────────────────────────────────── */
+  .stand{display:grid;grid-template-columns:auto 1fr;gap:var(--s8);align-items:end}
+  .stand .zahl{font-family:var(--font-display);font-weight:var(--w-strong);
+    font-size:clamp(64px,14vw,112px);line-height:.9;letter-spacing:-.02em;
+    color:var(--ink);font-variant-numeric:tabular-nums lining-nums}
+  .stand .zahl-u{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);margin-top:var(--s2)}
+  .stand .rechts{min-width:min(100%,260px)}
+  .kpi{display:flex;flex-wrap:wrap;gap:var(--s2) var(--s6);margin-bottom:var(--s3)}
+  .kpi .k{font-family:var(--font-text);font-size:var(--t-small)}
+  .kpi .k b{display:block;font-size:var(--t-lede);color:var(--ink);font-variant-numeric:tabular-nums}
+  .kpi .k span{color:var(--muted);font-size:var(--t-micro)}
+  .kpi .k.warn b{color:var(--bad)}
+  .kpi .k.gut b{color:var(--ok)}
+
+  /* Prognose-Satz: der ehrliche Kernbefund, nicht hinter einer Prozentzahl versteckt. */
+  .befund{margin-top:var(--s6);padding:var(--s4) var(--s6);border-radius:var(--r-card);
+    background:color-mix(in srgb,var(--bad) 10%,transparent);border-left:3px solid var(--bad)}
+  .befund p{font-family:var(--font-display);font-weight:var(--w-text);font-size:var(--t-lede);
+    line-height:1.4;color:var(--ink);margin:0;max-width:var(--measure)}
+  .befund .b-meta{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);margin-top:var(--s2)}
+
+  /* Puls – kleiner Takt statt eigener Sektion. */
+  .puls{display:flex;align-items:flex-end;gap:var(--s1);height:56px;margin-top:var(--s6)}
+  .puls .p{flex:1;background:color-mix(in srgb,var(--blue) 55%,transparent);border-radius:3px 3px 0 0;min-height:2px}
+  .puls .p.hoch{background:var(--blue-solid)}
+  .puls-l{display:flex;justify-content:space-between;font-family:var(--font-text);
+    font-size:var(--t-micro);color:var(--muted);margin-top:var(--s1)}
+
+  /* ── 2 Gebiete: EINE Liste, jede Zeile die ganze Kette ───────────────── */
+  .geb{border-bottom:1px solid var(--line-soft)}
+  .geb>summary{list-style:none;cursor:pointer;padding:var(--s3) 0;min-height:var(--tap)}
+  .geb>summary::-webkit-details-marker{display:none}
+  .geb>summary:focus-visible{outline:2px solid var(--blue);outline-offset:2px}
+  .geb-kopf{display:flex;justify-content:space-between;align-items:baseline;gap:var(--s4)}
+  .geb-name{font-family:var(--font-text);font-size:var(--t-body);color:var(--ink);font-weight:600}
+  .geb-name .car{display:inline-block;width:0;height:0;margin-right:var(--s2);vertical-align:middle;
+    border-left:5px solid var(--muted);border-top:4px solid transparent;border-bottom:4px solid transparent;transition:transform .2s}
+  .geb[open] .geb-name .car{transform:rotate(90deg)}
+  .geb-wert{font-family:var(--font-text);font-variant-numeric:tabular-nums lining-nums;
+    font-size:var(--t-lede);color:var(--ink);font-weight:600;white-space:nowrap}
+  .geb-wert .du{color:var(--muted);font-size:var(--t-micro);font-weight:400}
+  .geb-kette{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);
+    margin-top:var(--s1);display:flex;flex-wrap:wrap;gap:var(--s1) var(--s3)}
+  .geb-kette b{color:var(--ink);font-weight:600;font-variant-numeric:tabular-nums}
+  .geb .track{margin-top:var(--s2)}
+  .geb-tief{padding:0 0 var(--s4) var(--s4);border-left:2px solid var(--line-soft);margin-bottom:var(--s3)}
+
+  /* Merkzeichen: was diese Zeile bedeutet – ein Wort, keine Ampel-Spielerei. */
+  .zeichen{display:inline-block;font-family:var(--font-text);font-size:var(--t-micro);font-weight:600;
+    border-radius:var(--r-pill);padding:2px 10px;margin-left:var(--s2);white-space:nowrap}
+  .zeichen.traegt{color:var(--ok);background:color-mix(in srgb,var(--ok) 14%,transparent)}
+  .zeichen.leck{color:var(--bad);background:color-mix(in srgb,var(--bad) 12%,transparent)}
+  .zeichen.still{color:var(--muted);background:var(--soft)}
+  .zeichen.dunkel{color:var(--gold-ink);background:color-mix(in srgb,var(--gold) 15%,transparent)}
+
+  /* ── 3 Nächste Züge ──────────────────────────────────────────────────── */
+  .zug{border-bottom:1px solid var(--line-soft)}
+  .zug>summary{list-style:none;cursor:pointer;padding:var(--s3) 0;min-height:var(--tap);
+    display:flex;justify-content:space-between;align-items:baseline;gap:var(--s4)}
+  .zug>summary::-webkit-details-marker{display:none}
+  .zug>summary:focus-visible{outline:2px solid var(--blue);outline-offset:2px}
+  .zug-t{font-family:var(--font-text);font-size:var(--t-body);color:var(--ink)}
+  .zug-t .car{display:inline-block;width:0;height:0;margin-right:var(--s2);vertical-align:middle;
+    border-left:5px solid var(--muted);border-top:4px solid transparent;border-bottom:4px solid transparent;transition:transform .2s}
+  .zug[open] .zug-t .car{transform:rotate(90deg)}
+  .zug-t .warum{display:block;color:var(--muted);font-size:var(--t-micro);margin-top:2px;margin-left:var(--s4)}
+  .zug-h{font-family:var(--font-text);font-size:var(--t-small);font-weight:600;white-space:nowrap;
+    font-variant-numeric:tabular-nums;color:var(--gold-ink)}
+  .zug-tief{padding:0 0 var(--s4) var(--s4);border-left:2px solid var(--line-soft);margin-bottom:var(--s3);
+    font-family:var(--font-text);font-size:var(--t-small);color:var(--ink);line-height:1.55;max-width:var(--measure)}
+  .zug-tief p{margin:0 0 var(--s2)}
+
+  /* Umzugs-Tabelle: was wohin wandert (Kontrolle, dass nichts verloren geht). */
+  .umzug td:first-child{color:var(--muted)}
+
+  @media (max-width:640px){
+    .stand{grid-template-columns:1fr;gap:var(--s6)}
+    .geb-kopf{flex-wrap:wrap}
+  }
+</style>
+</head>
+<body>
+
+<script src="../../design-system/nav.js"
+        data-root="../../"
+        data-variant="werkzeug"
+        data-onpage="Cockpit:./|Neue Ordnung:neue-ordnung.html|Aktivitäten:aktivitaeten.html|Kosten:kosten.html|Multiplikatoren:multiplikatoren.html|Links:../utm-generator/|Mail:../mail-editor/"></script>
+
+<main class="wrap">
+
+  <section class="lead">
+    <span class="kick">Entwurf · neue Ordnung des Cockpits</span>
+    <h1 class="lead-title">Sommer-Aktion 2026</h1>
+    <div class="entwurf">
+      <p>Vorschlag: <b>vier Fragen statt acht Sektionen</b> – wo stehen wir, was wirkt, was ist als Nächstes möglich, und wo liegen die Belege. Jede Zeile klappt auf.</p>
+      <p>Mockup mit den echten Zahlen vom 24. Juli, von Hand eingesetzt. Das laufende Cockpit bleibt unberührt, bis diese Ordnung beschlossen ist.</p>
+    </div>
+  </section>
+
+
+  <!-- ══ 1 · STAND ═══════════════════════════════════════════════════════ -->
+  <section id="stand">
+    <div class="shead"><h2>Stand</h2><p>Eine Zahl, ein Tempo, eine Prognose – ohne Beschönigung.</p></div>
+    <div class="panel">
+      <div class="stand">
+        <div>
+          <div class="zahl">239</div>
+          <div class="zahl-u">neue Abos · Ziel 1000 · noch 15 Tage bis 8. August</div>
+        </div>
+        <div class="rechts">
+          <div class="kpi">
+            <div class="k"><b>24 %</b><span>vom Ziel erreicht</span></div>
+            <div class="k"><b>9,7</b><span>Abos/Tag aktuell</span></div>
+            <div class="k warn"><b>50,7</b><span>Abos/Tag nötig</span></div>
+          </div>
+          <div class="meter"><span style="width:23.9%"></span></div>
+          <div class="puls">
+            <span class="p" style="height:9%"></span>
+            <span class="p" style="height:7%"></span>
+            <span class="p" style="height:55%"></span>
+            <span class="p hoch" style="height:100%"></span>
+            <span class="p" style="height:50%"></span>
+            <span class="p" style="height:26%"></span>
+            <span class="p" style="height:19%"></span>
+            <span class="p" style="height:17%"></span>
+            <span class="p" style="height:16%"></span>
+            <span class="p" style="height:17%"></span>
+          </div>
+          <div class="puls-l"><span>14. Juli</span><span>Mail-Welle 1 → 58</span><span>heute 10</span></div>
+        </div>
+      </div>
+
+      <div class="befund">
+        <p>Bei diesem Tempo endet die Aktion bei rund <b>384 Abos</b>. Das Ziel 1000 ist nur erreichbar, wenn ein Impuls von der Grösse der Mail-Welle kommt – <b>mehrfach</b>.</p>
+        <div class="b-meta">Fortschreibung des Schnitts der letzten drei Tage (9,7/Tag) auf die restlichen 15 Tage. Die Mail-Welle 1 am 17./18. Juli brachte an zwei Tagen 90 Abos – so viel wie die drei Wochen davor zusammen.</div>
+      </div>
+
+      <details class="zb-form">
+        <summary>Woraus sich die 239 zusammensetzen</summary>
+        <div class="tablewrap" style="margin-top:var(--s4)">
+          <table class="tarif">
+            <thead><tr><th>Strom</th><th class="num">Abos</th><th class="num">Zielmarke</th></tr></thead>
+            <tbody>
+              <tr><td>goetheanum.tv · Deutsch</td><td class="num">143</td><td class="num">250</td></tr>
+              <tr><td>Wochenschrift · Englisch Digital</td><td class="num">37</td><td class="num">120</td></tr>
+              <tr><td>Wochenschrift · Deutsch Digital</td><td class="num">29</td><td class="num">250</td></tr>
+              <tr><td>Wochenschrift · Deutsch Papier</td><td class="num">28</td><td class="num">200</td></tr>
+              <tr><td>goetheanum.tv · Englisch</td><td class="num">2</td><td class="num">180</td></tr>
+            </tbody>
+            <tfoot><tr><td>Summe</td><td class="num">239</td><td class="num">1000</td></tr></tfoot>
+          </table>
+        </div>
+        <p class="provisorisch">Auffällig: goetheanum.tv Deutsch trägt allein 60 % – die englischen Ströme und das Papier-Abo bleiben weit zurück. Tarife, Zahlungsweise und die Umsatz-Projektion klappen hier ebenfalls auf (im Mockup weggelassen).</p>
+      </details>
+    </div>
+  </section>
+
+
+  <!-- ══ 2 · GEBIETE ═════════════════════════════════════════════════════ -->
+  <section id="gebiete">
+    <div class="shead"><h2>Gebiete</h2><p>Jede Zeile ein Gebiet, jede Zeile die ganze Kette: Reichweite → Klicks → Abschlüsse. Sortiert nach Wirkung. Aufklappen zeigt die einzelnen Aktivitäten und den Befund.</p></div>
+    <div class="panel">
+
+      <details class="geb" open>
+        <summary>
+          <div class="geb-kopf">
+            <span class="geb-name"><span class="car" aria-hidden="true"></span>Mailing · Welle 1<span class="zeichen traegt">trägt die Aktion</span></span>
+            <span class="geb-wert">87 <span class="du">· ≈88 mit Dunkelfeld</span></span>
+          </div>
+          <div class="geb-kette"><span>Reichweite <b>–</b></span><span>Klicks <b>9</b></span><span>Abschlüsse <b>87</b></span></div>
+          <div class="track"><span style="width:100%"></span></div>
+        </summary>
+        <div class="geb-tief">
+          <div class="motrow"><span class="mc">w1_noabo <span class="ms">an alle ohne Abo</span></span><span class="mn">60</span></div>
+          <div class="motrow"><span class="mc">w1_nurws <span class="ms">an Wochenschrift-Leser</span></span><span class="mn">22</span></div>
+          <div class="motrow"><span class="mc">w1_nurtv <span class="ms">an goetheanum.tv-Zuschauer</span></span><span class="mn">4</span></div>
+          <div class="motrow"><span class="mc">w1_*_share <span class="ms">Weiterleitungen</span></span><span class="mn">1</span></div>
+          <p class="provisorisch">Ein einziger Versand am 17. Juli – mehr als ein Drittel aller Abos der ganzen Aktion. Die Mail-Links tragen keinen Kurzcode, darum steht bei Klicks fast nichts: die Wirkung ist gemessen, der Weg dahin nicht.</p>
+        </div>
+      </details>
+
+      <details class="geb">
+        <summary>
+          <div class="geb-kopf">
+            <span class="geb-name"><span class="car" aria-hidden="true"></span>Bezahlt · Meta-Anzeige<span class="zeichen leck">Spur bricht ab</span></span>
+            <span class="geb-wert">1 <span class="du">· ≈53 mit Dunkelfeld</span></span>
+          </div>
+          <div class="geb-kette"><span>Reichweite <b>35 000</b></span><span>Klicks <b>713</b></span><span>Abschlüsse gemessen <b>1</b></span><span>Klickquote <b>2,0 %</b></span></div>
+          <div class="track"><span style="width:60%"></span></div>
+        </summary>
+        <div class="geb-tief">
+          <div class="motrow"><span class="mc">story_statisch · DE <span class="ms">Kurzlink dachs-4</span></span><span class="mn">336 Klicks</span></div>
+          <div class="motrow"><span class="mc">story_statisch · EN <span class="ms">Kurzlink elster-2</span></span><span class="mn">377 Klicks</span></div>
+          <p class="provisorisch">Der grösste Klick-Bringer der Aktion und zugleich das grösste Loch: 713 Klicks, aber nur <b>ein</b> messbar zugeordneter Abschluss. Die Anzeige führt auf goetheanum.tv, und der Uscreen-Checkout trägt die UTM-Spur nicht bis zur Anmeldung – die Abschlüsse landen im Dunkelfeld. Solange das so ist, lässt sich die bezahlte Anzeige nicht steuern: niemand weiss, ob sie 5 oder 60 Abos bringt.</p>
+        </div>
+      </details>
+
+      <details class="geb">
+        <summary>
+          <div class="geb-kopf">
+            <span class="geb-name"><span class="car" aria-hidden="true"></span>Newsletter · Haus und TV-Weekly<span class="zeichen still">unter Wert</span></span>
+            <span class="geb-wert">9 <span class="du">· ≈37 mit Dunkelfeld</span></span>
+          </div>
+          <div class="geb-kette"><span>Reichweite <b>16 286</b></span><span>Klicks <b>217</b></span><span>Abschlüsse gemessen <b>9</b></span><span>Klickquote <b>1,3 %</b></span></div>
+          <div class="track"><span style="width:42%"></span></div>
+        </summary>
+        <div class="geb-tief">
+          <div class="motrow"><span class="mc">tv-weekly-abo · phase1 <span class="ms">Übersicht</span></span><span class="mn">101 Klicks · 2</span></div>
+          <div class="motrow"><span class="mc">nl-tv · phase1 <span class="ms">goetheanum.tv</span></span><span class="mn">34 Klicks · 2</span></div>
+          <div class="motrow"><span class="mc">tv-weekly · phase1 <span class="ms">Wochenschrift</span></span><span class="mn">22 Klicks · 1</span></div>
+          <div class="motrow"><span class="mc">Sommerfestivals · AC-Newsletter <span class="ms">4. Juli, 6 999 Empfänger</span></span><span class="mn">4</span></div>
+          <p class="provisorisch">Läuft, aber nur die <b>erste</b> von vier vorbereiteten Phasen ist ausgespielt. Phase 3 und 4 liegen als fertige Links im Register und haben bis heute keinen einzigen Klick – siehe «Nächste Züge».</p>
+        </div>
+      </details>
+
+      <details class="geb">
+        <summary>
+          <div class="geb-kopf">
+            <span class="geb-name"><span class="car" aria-hidden="true"></span>Organik · Direkt · Bestand<span class="zeichen dunkel">grösstenteils dunkel</span></span>
+            <span class="geb-wert">5 <span class="du">· ≈35 mit Dunkelfeld</span></span>
+          </div>
+          <div class="geb-kette"><span>Reichweite <b>–</b></span><span>Klicks <b>–</b></span><span>Abschlüsse gemessen <b>5</b></span></div>
+          <div class="track"><span style="width:40%"></span></div>
+        </summary>
+        <div class="geb-tief">
+          <p class="provisorisch">Getippte Adressen, Lesezeichen, Suche, Storefront-Banner und Bestandskonten auf goetheanum.tv. Trägt nie Parameter – hier bleibt eine Lesart immer nötig. Kein Handlungsbedarf, aber gut zu wissen, dass rund ein Siebtel der Aktion von selbst kommt.</p>
+        </div>
+      </details>
+
+      <details class="geb">
+        <summary>
+          <div class="geb-kopf">
+            <span class="geb-name"><span class="car" aria-hidden="true"></span>Social organisch<span class="zeichen still">viel Aufwand, wenig Ertrag</span></span>
+            <span class="geb-wert">9 <span class="du">· ≈25 mit Dunkelfeld</span></span>
+          </div>
+          <div class="geb-kette"><span>Reichweite <b>4 426</b></span><span>Klicks <b>227</b></span><span>Abschlüsse gemessen <b>9</b></span><span>Klickquote <b>5,1 %</b></span></div>
+          <div class="track"><span style="width:28%"></span></div>
+        </summary>
+        <div class="geb-tief">
+          <div class="motrow"><span class="mc">instagram · story</span><span class="mn">72 Klicks · 4</span></div>
+          <div class="motrow"><span class="mc">instagram · reel_wolfgang</span><span class="mn">15 Klicks · 2</span></div>
+          <div class="motrow"><span class="mc">karussell <span class="ms">Facebook + Instagram + LinkedIn</span></span><span class="mn">46 Klicks · 0</span></div>
+          <div class="motrow"><span class="mc">facebook · reel_thijs</span><span class="mn">22 Klicks · 0</span></div>
+          <p class="provisorisch">Die <b>Story</b> ist das stärkste organische Format (72 Klicks, 4 Abschlüsse). Das <b>Karussell</b> dagegen sammelt 46 Klicks ohne einen einzigen Abschluss – entweder führt es auf die falsche Seite oder das Versprechen trägt nicht bis zum Formular.</p>
+        </div>
+      </details>
+
+      <details class="geb">
+        <summary>
+          <div class="geb-kopf">
+            <span class="geb-name"><span class="car" aria-hidden="true"></span>Print · Stand · Inserat<span class="zeichen still">ohne messbaren Ertrag</span></span>
+            <span class="geb-wert">0 <span class="du">· ≈1 mit Dunkelfeld</span></span>
+          </div>
+          <div class="geb-kette"><span>Reichweite <b>1 900</b></span><span>Klicks <b>10</b></span><span>Abschlüsse gemessen <b>0</b></span></div>
+          <div class="track"><span style="width:3%"></span></div>
+        </summary>
+        <div class="geb-tief">
+          <div class="motrow"><span class="mc">Faust-Festival · Stand mit Heften <span class="ms">3 Wochenenden</span></span><span class="mn">1 900 erreicht</span></div>
+          <div class="motrow"><span class="mc">inserat_rsv · Web-Inserat</span><span class="mn">10 Klicks · 0</span></div>
+          <div class="motrow"><span class="mc">qr_inserat <span class="ms">QR im gedruckten Inserat</span></span><span class="mn">0 Scans</span></div>
+          <p class="provisorisch">Der ehrlichste Einzelbefund der Aktion: die QR-Codes im Print sind seit dem Start <b>kein einziges Mal</b> gescannt worden. Drei Festival-Wochenenden mit 1 900 Kontakten haben keine messbare Anmeldung erzeugt.</p>
+        </div>
+      </details>
+
+      <details class="geb">
+        <summary>
+          <div class="geb-kopf">
+            <span class="geb-name"><span class="car" aria-hidden="true"></span>Popup auf der Website<span class="zeichen still">nie ausgespielt</span></span>
+            <span class="geb-wert">0</span>
+          </div>
+          <div class="geb-kette"><span>Reichweite <b>–</b></span><span>Klicks <b>0</b></span><span>Abschlüsse <b>0</b></span><span>4 Links seit 18. Juli bereit</span></div>
+          <div class="track"><span style="width:3%"></span></div>
+        </summary>
+        <div class="geb-tief">
+          <p class="provisorisch">Am 18. Juli wurden vier Popup-Links angelegt (Wochenschrift und goetheanum.tv, je DE und EN). Seither <b>kein einziger Klick</b> – das Popup ist offenbar nie scharf geschaltet worden. Ein vorbereiteter, aber ungenutzter Kanal.</p>
+        </div>
+      </details>
+
+      <details class="geb">
+        <summary>
+          <div class="geb-kopf">
+            <span class="geb-name"><span class="car" aria-hidden="true"></span>Ohne UTM-Spur<span class="zeichen dunkel">Lesart, keine Messung</span></span>
+            <span class="geb-wert">128 <span class="du">· 54 % aller Abos</span></span>
+          </div>
+          <div class="geb-kette"><span>oben bereits auf die Gebiete verteilt</span><span>Deckung durch Kurzlink-Indiz <b>86 %</b></span></div>
+        </summary>
+        <div class="geb-tief">
+          <p class="provisorisch">Diese 128 Anmeldungen sind in den Zeilen oben als «≈ mit Dunkelfeld» bereits eingerechnet – hier stehen sie noch einmal als Ganzes, damit sichtbar bleibt, wie viel Lesart in der Rangfolge steckt. Zwei Drittel davon sind goetheanum.tv über den Uscreen-Checkout. Herleitung unter «Belege».</p>
+        </div>
+      </details>
+
+    </div>
+    <p class="provisorisch">«Gemessen» ist die harte UTM-Zählung. «≈ mit Dunkelfeld» verteilt die 128 Anmeldungen ohne Spur nach der datierten Lesart (±30 %). Die Summe der Zeilen ergibt wieder 239.</p>
+  </section>
+
+
+  <!-- ══ 3 · NÄCHSTE ZÜGE ════════════════════════════════════════════════ -->
+  <section id="zuege">
+    <div class="shead"><h2>Nächste Züge</h2><p>Was jetzt noch möglich ist – aus den Daten gelesen, nach Hebel sortiert. Der Plan steht schon im Link-Register und im Aktivitäten-Protokoll; hier steht, was davon noch nicht gezündet hat.</p></div>
+    <div class="panel">
+
+      <details class="zug" open>
+        <summary>
+          <span class="zug-t"><span class="car" aria-hidden="true"></span>Mail-Welle 2 senden – und Welle 3 vorbereiten
+            <span class="warum">24 Link-Gruppen registriert, null Klicks · Aktivität steht auf dem 30. Juli</span></span>
+          <span class="zug-h">≈ 60–90 Abos</span>
+        </summary>
+        <div class="zug-tief">
+          <p>Der mit Abstand grösste verfügbare Hebel. Welle 1 hat an zwei Tagen <b>90 Abos</b> gebracht – mehr als die drei Wochen davor zusammen. Die Links für Welle 2 (<code>w2_noabo</code>, <code>w2_nurws</code>, <code>w2_nurtv</code> …) und Welle 3 (<code>w3_*</code>, <code>w3b_*</code>) sind seit dem 10. Juli fertig im Register und haben bis heute keinen einzigen Klick.</p>
+          <p>Ohne diesen Zug bleibt die Aktion bei rund 384. Mit zwei weiteren Wellen in der Grössenordnung von Welle 1 kommt sie in die Nähe von 550–600. Das Ziel 1000 bleibt auch dann ambitioniert – dafür bräuchte es zusätzlich einen Kanal, den es heute nicht gibt.</p>
+        </div>
+      </details>
+
+      <details class="zug">
+        <summary>
+          <span class="zug-t"><span class="car" aria-hidden="true"></span>UTM-Spur bis in den goetheanum.tv-Checkout tragen
+            <span class="warum">713 Klicks der Meta-Anzeige führen zu 1 messbaren Abschluss</span></span>
+          <span class="zug-h">≈ 52 sichtbar</span>
+        </summary>
+        <div class="zug-tief">
+          <p>Bringt keine neuen Abos, aber es macht die grösste Ausgabe der Aktion erst steuerbar. Zwei Schritte: die eingehenden <code>?utm_*</code> auf der TV-Landingpage an den Checkout-Knopf hängen, und die bezahlten Wege über den Kurzlink <code>/s/&lt;code&gt;</code> führen (robuster gegen die In-App-Browser von Instagram und Facebook).</p>
+          <p>Solange das offen ist, sind rund 52 Abos nur geschätzt statt gezählt – und niemand kann sagen, ob sich die Anzeige lohnt.</p>
+        </div>
+      </details>
+
+      <details class="zug">
+        <summary>
+          <span class="zug-t"><span class="car" aria-hidden="true"></span>Newsletter-Phasen 3 und 4 ausspielen
+            <span class="warum">12 Links bereit seit dem 14. Juli, null Klicks</span></span>
+          <span class="zug-h">≈ 10–20 Abos</span>
+        </summary>
+        <div class="zug-tief">
+          <p>Von vier geplanten Newsletter-Phasen ist nur Phase 1 gelaufen (157 Klicks, 5 Abschlüsse). Phase 2 ist angelaufen (56 Klicks, 0 Abschlüsse – prüfen, wohin sie führt), Phase 3 und 4 sind unberührt. Die Empfängerlisten stehen, die Links auch.</p>
+        </div>
+      </details>
+
+      <details class="zug">
+        <summary>
+          <span class="zug-t"><span class="car" aria-hidden="true"></span>Popup scharf schalten
+            <span class="warum">4 Links seit 18. Juli bereit, nie ein Klick</span></span>
+          <span class="zug-h">≈ 5–15 Abos</span>
+        </summary>
+        <div class="zug-tief">
+          <p>Das Popup erreicht Menschen, die ohnehin schon auf den Haus-Seiten sind – die wärmste verfügbare Zielgruppe, und der einzige Kanal, der ohne neue Reichweite auskommt. Aufwand gering, die Links liegen fertig da.</p>
+        </div>
+      </details>
+
+      <details class="zug">
+        <summary>
+          <span class="zug-t"><span class="car" aria-hidden="true"></span>Karussell prüfen oder einstellen
+            <span class="warum">46 Klicks aus drei Netzwerken, 0 Abschlüsse</span></span>
+          <span class="zug-h">Verlust stoppen</span>
+        </summary>
+        <div class="zug-tief">
+          <p>Das Karussell wird geklickt, aber niemand meldet sich an. Entweder führt der Link auf die falsche Seite, oder das Versprechen im Bild deckt sich nicht mit der Landingpage. Ein Blick auf den Ziel-Link genügt; bis dahin lohnt die Produktion weiterer Karussells nicht.</p>
+        </div>
+      </details>
+
+      <details class="zug">
+        <summary>
+          <span class="zug-t"><span class="car" aria-hidden="true"></span>17 Aktivitäten ohne Zahlen nachtragen
+            <span class="warum">von 27 Einträgen haben 17 weder Reichweite noch Klicks</span></span>
+          <span class="zug-h">Grundlage</span>
+        </summary>
+        <div class="zug-tief">
+          <p>Darunter beide Newsletter vom 17. Juli, die Flyer-Auslagen und die Web-Inserate. Ohne diese Zahlen bleibt die Kette oben an mehreren Stellen leer – und die Kosten je Abo lassen sich nicht ehrlich rechnen. Nachtragen geht im <a href="aktivitaeten.html">Protokoll</a> über «Bearbeiten».</p>
+        </div>
+      </details>
+
+    </div>
+    <p class="provisorisch">Die Schätzungen sind grob und aus der bisherigen Wirkung derselben Kanäle abgeleitet – sie sortieren die Reihenfolge, sie versprechen nichts.</p>
+  </section>
+
+
+  <!-- ══ 4 · BELEGE ══════════════════════════════════════════════════════ -->
+  <section id="belege">
+    <div class="shead"><h2>Belege</h2><p>Alles, was man selten braucht, aber jederzeit nachschlagen können muss.</p></div>
+    <div class="panel">
+      <details class="zb-form"><summary>Was ist passiert? – die einzelnen Abos mit Herkunft</summary>
+        <p class="provisorisch" style="margin-top:var(--s4)">Das heutige Ereignis-Protokoll, unverändert: je Tag aufklappbar, mit vermuteter Herkunft für die Abos ohne Spur.</p></details>
+      <details class="zb-form"><summary>Dunkelfeld – wie die 128 verteilt wurden</summary>
+        <p class="provisorisch" style="margin-top:var(--s4)">Die datierte Lesart mit ihren vier Ankern, plus das Live-Aggregat der vermuteten Herkunft (86 % Deckung).</p></details>
+      <details class="zb-form"><summary>Alle Motive einzeln</summary>
+        <p class="provisorisch" style="margin-top:var(--s4)">Die vollständige Liste je <code>utm_content</code> – heute «Nach Motiv», künftig nur noch hier, weil die Gebiete-Zeilen sie bereits aufklappen.</p></details>
+      <details class="zb-form"><summary>Tarife, Zahlungsweise, Bleibe-Projektion</summary>
+        <p class="provisorisch" style="margin-top:var(--s4)">Die heutige Sektion «Details», unverändert übernommen.</p></details>
+      <details class="zb-form"><summary>Methode und Quellen</summary>
+        <p class="provisorisch" style="margin-top:var(--s4)">Woher jede Zahl kommt, was gemessen und was geschätzt ist, Metricool-Link, Stand der Lesart.</p></details>
+    </div>
+  </section>
+
+
+  <!-- ══ Umzug ═══════════════════════════════════════════════════════════ -->
+  <section id="umzug">
+    <div class="shead"><h2>Was wohin wandert</h2><p>Kontrolle, dass beim Aufräumen nichts verloren geht – und was ersatzlos entfällt, weil es dieselbe Zahl ein zweites Mal zeigte.</p></div>
+    <div class="tablewrap">
+      <table class="tarif umzug">
+        <thead><tr><th>heute</th><th>neu</th></tr></thead>
+        <tbody>
+          <tr><td>Held-Zahl · Deadline-Meter · Meilenstein</td><td>Stand – zusammengezogen, ergänzt um Tempo und Prognose</td></tr>
+          <tr><td>Vier Kacheln (Gesamt, Ø/Tag, Zielerreichung, Mit UTM)</td><td>Stand – als drei Kennzahlen; «Gesamt» stand dreimal auf der Seite</td></tr>
+          <tr><td>Fünf Ströme (zwei Tafeln)</td><td>Stand → Aufklapp «Woraus sich die 239 zusammensetzen»</td></tr>
+          <tr><td>Momentum – Balken je Tag</td><td>Stand – als Puls neben der Zahl, wo er die Aussage stützt</td></tr>
+          <tr><td>Wirkung – «Woher» je Kanal</td><td>Gebiete – dieselbe Zahl, jetzt in der Zeile mit ihrer Kette</td></tr>
+          <tr><td>Wirkung – Wirkungskette (Trichter)</td><td>Gebiete – je Gebiet statt einmal für alles; die Gesamtsumme trug wenig</td></tr>
+          <tr><td>Wirkung – «Nach Motiv»</td><td>Gebiete → Aufklapp, vollständig unter Belege</td></tr>
+          <tr><td>Kanäle – Reichweite und Klicks</td><td>Gebiete – geht in der Zeile auf</td></tr>
+          <tr><td>Aktivität → Abschlüsse</td><td>Gebiete – geht in der Zeile auf</td></tr>
+          <tr><td>Dunkelfeld-Tabelle · vermutete Herkunft</td><td>Gebiete (als Spalte «≈») + Belege (Herleitung)</td></tr>
+          <tr><td>Details – Bleiben, Umsatz, Tarife</td><td>Belege</td></tr>
+          <tr><td>Aktionsseiten-Knöpfe zweimal (Kopf und Fuss)</td><td>einmal, im Fuss</td></tr>
+          <tr><td>—</td><td><b>Nächste Züge</b> – neu, aus den Daten gelesen</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="provisorisch">Aus acht Sektionen werden vier. Kein Messwert geht verloren; was verschwindet, sind Doppelungen – dieselbe Zahl in anderem Gewand.</p>
+  </section>
+
+</main>
+
+<footer class="ds-footer">
+  <div class="wrap" style="display:flex;flex-direction:column;gap:var(--s2)">
+    <div class="landing">
+      <span class="meta">Aktionsseiten</span>
+      <a class="btn" href="https://global-sommer2026.goetheanum.online" target="_blank" rel="noopener">Übersicht · 3 Monate gratis</a>
+      <a class="btn" href="https://ws-sommer2026.dasgoetheanum.com" target="_blank" rel="noopener">Wochenschrift</a>
+      <a class="btn" href="https://tv-sommer2026.goetheanum.tv" target="_blank" rel="noopener">goetheanum.tv</a>
+    </div>
+    <div class="frow">
+      <span><strong>Mockup «Neue Ordnung»</strong> · statische Zahlen vom 24. Juli · <a href="./">zum laufenden Cockpit</a></span>
+      <span><a href="../../design-system/">Design-System</a></span>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/tools.json
+++ b/tools.json
@@ -260,6 +260,16 @@
       "such": "Perspektiven Webfamilie Testseiten goetheanum.ch dasgoetheanum goetheanum.tv anthroposophie Befund"
     },
     {
+      "slug": "sommer-neue-ordnung",
+      "cat": "schau",
+      "status": "intern",
+      "tag": "Entwurf",
+      "title": "Sommer-Cockpit · Neue Ordnung",
+      "href": "apps/sommer-zaehler/neue-ordnung.html",
+      "desc": "Entwurf für den Umbau des Aktions-Cockpits: vier Fragen statt acht Sektionen – Stand, Gebiete, Nächste Züge, Belege. Statische Zahlen vom 24. Juli, zur Beurteilung der Ordnung. Nichts davon ist beschlossen.",
+      "such": "Cockpit Umbau Ordnung Entwurf Mockup Sommer Aktion Gebiete Züge Stand Aufräumen Vorschlag"
+    },
+    {
       "slug": "my-goetheanum",
       "cat": "schau",
       "status": "entwurf",


### PR DESCRIPTION
## Worum es geht

Vorschlag für den **radikalen Umbau** des Aktions-Cockpits, als begutachtbares Mockup: statt acht Sektionen **vier Fragen** — Stand, Gebiete, Nächste Züge, Belege. Alles auf einer Achse, Details klappen auf.

Die Seite ist **statisch** (echte Zahlen vom 24. Juli, von Hand eingesetzt) und liegt neben dem Cockpit unter `apps/sommer-zaehler/neue-ordnung.html`. **Das laufende Cockpit bleibt unberührt**, bis die Ordnung beschlossen ist.

## Die vier Fragen

1. **Stand** — eine Zahl, ein Tempo, eine Prognose. Neu ist die Fortschreibung: 9,7 Abos/Tag → **≈384 am 8. August gegen das Ziel 1000**. Die heutige Kachel «24 % Zielerreichung» verschweigt diese Lücke.
2. **Gebiete** — *eine* Liste, jede Zeile trägt die ganze Kette (Reichweite → Klicks → Abschlüsse, gemessen und mit Dunkelfeld), sortiert nach Wirkung, aufklappbar auf die einzelnen Aktivitäten. Löst «Woher», Trichter, «Nach Motiv», «Kanäle» und «Aktivität → Abschlüsse» in *einer* Ansicht auf.
3. **Nächste Züge** — neu: was noch möglich ist, aus den Daten gelesen. Grösster Hebel: **Mail-Welle 2 und 3 sind seit dem 10. Juli fertig registriert und haben null Klicks**; ebenso Newsletter-Phase 3/4 und das nie ausgespielte Popup.
4. **Belege** — alles Selten-Gebrauchte eingeklappt.

## Was die Analyse zutage gefördert hat

| Befund | Zahl |
|---|---|
| Mailing trägt die Aktion | 87 von 111 gemessenen Abschlüssen aus *einem* Versand |
| Meta-Anzeige: Spur bricht ab | 713 Klicks → **1** messbarer Abschluss |
| Karussell ohne Ertrag | 46 Klicks → 0 Abschlüsse |
| QR im Print | **0** Scans seit Aktionsstart |
| Popup | 4 Links seit 18.7. bereit, nie ein Klick |
| Aktivitäten ohne Zahlen | 17 von 27 |

## Kontrolle: was wohin wandert

Enthält eine Umzugstabelle, die jede heutige Anzeige ihrem neuen Ort zuordnet — nachprüfbar, dass **kein Messwert verlorengeht**. Entfernt werden nur Doppelungen (z. B. stand «Gesamt» dreimal auf der Seite, die Attribution dreimal in verschiedenem Gewand).

## Zwei Nebenbefunde am Fundament

- `--s5` und `--s7` sind in `tokens.css` **nicht definiert**, werden im Cockpit aber 11× benutzt — dort fallen Abstände still auf 0. (Nicht in diesem PR angefasst.)
- Die Kachel «Mit UTM-Spur» rechnet mit dem Kanal-Eimer `andere` (121) statt der echten Spur-Zahl (128).

## Regeln

Vom Starter gebaut, Fundament eingebunden, nur Tokens (DS02/DS07), Ziffern tabellarisch (G25), Fingerziele ≥44px (B04), Betonung mit Laut (G05). `ds-lint` 100 %, `typo-check` grün. Eintrag in `tools.json` unter «Schau & Mockups», Status `intern` (nur Direktlink, nicht im öffentlichen Hub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eee8tzL29NsZC4Tw3MP54

---
_Generated by [Claude Code](https://claude.ai/code/session_019eee8tzL29NsZC4Tw3MP54)_