### PR TITLE
Dunkelfeld-Lesart 24.7.: Meta-Anzeige von ≈44 auf ≈9 korrigiert

### DIFF
--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -48,16 +48,21 @@
     // während die Zahlen weiterlaufen. Schätzung (±30 %), keine Messung; die
     // Messwerte in der Datenbank bleiben unangetastet. Bei neuer Auswertung:
     // stand/doc/anteile hier nachziehen, sonst nichts.
+    // Korrektur 24. Juli: der Anteil der bezahlten Anzeige fiel von 40 % auf 7 %.
+    // Die alte Zahl kam aus der vermuteten Herkunft (zeitnächster Klick) – ein
+    // Anker, der nur bei spärlichen Klicks trägt. Die Anzeige stellt fast das
+    // ganze Klick-Log und gewann darum fast jede Nähe-Lotterie; eine Placebo-Probe
+    // (Anmeldezeiten um ±24/48 h verschoben) trifft sie fast gleich oft.
     dunkel: {
-      stand: '22. Juli',
-      doc:   'docs/wirkungs-lesart-22-07.md',
+      stand: '24. Juli',
+      doc:   'docs/wirkungs-lesart-24-07.md',
       anteile: {
-        bezahlt:    0.404,   // Meta-Anzeige über den Uscreen-Checkout
-        organik:    0.229,   // Direkt, Suche, Storefront, Bestandskonten
-        newsletter: 0.220,   // TV-Weekly und Haus-Newsletter
-        social:     0.128,   // Reels, Stories, Karussell
-        mailing:    0.009,
-        print:      0.009
+        newsletter: 0.346,   // TV-Weekly und Haus-Newsletter (Placebo-Überschuss belegt)
+        organik:    0.300,   // Direkt, Suche, Storefront, Bestandskonten
+        mailing:    0.208,   // Nachlauf der Welle 1 ohne Spur
+        bezahlt:    0.069,   // Meta-Anzeige – Obergrenze aus dem sauberen Fenster
+        social:     0.069,   // Reels, Stories, Karussell
+        print:      0.008
       }
     },
     // Kosten der Aktion (in CONFIG.waehrung) – stehen auf 0, echte Zahlen werden erfragt.
@@ -335,7 +340,7 @@
       nm.appendChild(car); nm.appendChild(document.createTextNode(gebietLabel(x.g)));
       // Merkzeichen: ein Wort, das sagt, was diese Zeile bedeutet.
       var z = null;
-      if (x.kl >= 40 && x.ab <= 1) z = ['leck', 'Spur bricht ab'];
+      if (x.kl >= 40 && x.ab <= 1) z = ['leck', 'viel Klick, kaum Abschluss'];
       else if (total > 0 && x.gesamt >= total * 0.3) z = ['traegt', 'trägt die Aktion'];
       else if (x.kl === 0 && x.gesamt === 0 && x.links > 0) z = ['still', 'nie ausgespielt'];
       else if (x.kl >= 20 && x.ab === 0) z = ['still', 'ohne messbaren Ertrag'];
@@ -504,10 +509,12 @@
       });
     });
 
-    // (b) Viel Klick, (fast) kein gemessener Abschluss. Alle Wege, die auf
-    // goetheanum.tv führen, teilen EINE Ursache (der Uscreen-Checkout trägt die
-    // Spur nicht bis zur Anmeldung) – darum ein einziger Zug statt vieler
-    // Einzelmeldungen. Was nicht auf TV führt, ist ein Landungs-Problem.
+    // (b) Viel Klick, (fast) kein gemessener Abschluss. Bis zum 24. Juli stand
+    // hier EINE gemeinsame Ursache (der Uscreen-Checkout trage die Spur nicht) –
+    // das ist widerlegt: die Kette Landing → Checkout → user_created ist geprüft
+    // und trägt die UTM. Bleibt der Befund selbst: diese Wege werden geklickt und
+    // münden kaum in Abos. Darum ein Zug, der misst statt umbaut.
+    // Herleitung: docs/wirkungs-lesart-24-07.md.
     var leck = { kl:0, motive:[] };
     Object.keys(grp).forEach(function(k){
       var g = grp[k], a2 = ab[k] || 0;
@@ -526,15 +533,14 @@
       }
     });
     if (leck.kl > 0){
-      var dunkelTv = dunkelVerteilen(ohneSpur);
-      var sichtbar = (dunkelTv.bezahlt || 0);
-      zuege.push({ titel:'UTM-Spur bis in den goetheanum.tv-Checkout tragen', art:2, mass:leck.kl,
-        warum:fmt(leck.kl) + ' Klicks auf TV-Wege führen zu fast keinem messbaren Abschluss',
-        hebel:sichtbar ? ('≈ ' + fmt(sichtbar) + ' sichtbar') : 'sichtbar machen',
+      zuege.push({ titel:'Bezahlte Anzeige 3–4 Tage aussetzen und vergleichen', art:2, mass:leck.kl,
+        warum:fmt(leck.kl) + ' Klicks auf TV-Wege führen zu fast keinem Abschluss',
+        hebel:'Klarheit',
         text:'Betroffen: ' + leck.motive.slice(0, 5).join(', ') + (leck.motive.length > 5 ? ' und weitere' : '') +
-             '. Alle führen auf goetheanum.tv, und der Uscreen-Checkout trägt die UTM nicht bis zur Anmeldung. ' +
-             'Das schafft keine neuen Abos – es macht vorhandene erst zählbar und die bezahlte Anzeige überhaupt steuerbar. ' +
-             'Zwei Schritte: die eingehenden ?utm_* auf der TV-Landingpage an den Checkout-Knopf hängen und die bezahlten Wege über den Kurzlink /s/<code> führen. Schritte in services/sommer-zaehler/utm-ablauf.md.' });
+             '. Die Spur ist geprüft und intakt: die Landingpages hängen die UTM an die Checkout-URL, Uscreen liefert sie im user_created-Event, die Ingestion verheftet sie. ' +
+             'Die organischen Wege über dieselbe Seite und dieselben In-App-Browser werden mit 3 bis 5 Prozent ihrer Klicks messbar, die bezahlte Anzeige mit 0,4 Prozent – die Klicks werden also nicht verloren, sie werden kaum zu Abos. ' +
+             'Darum zuerst messen statt umbauen: die Anzeige aussetzen, solange die Grundlinie sauber ist (Mailing abgeklungen, nächste Welle später), und die Anmeldungen je Tag vergleichen. ' +
+             'Soll sie danach weiterlaufen, macht ein eigenes Uscreen-Angebot je bezahltem Weg sie hart messbar (offer_id kommt serverseitig im Webhook an): services/sommer-zaehler/uscreen-angebot-attribution-auftrag.md.' });
     }
 
     // (c) Datengrundlage: Aktivitäten ohne Reichweite und ohne Klicks.
@@ -1331,7 +1337,8 @@
     });
     var note = document.createElement('div'); note.className = 'fnote';
     note.textContent = 'Zeiten auf die Stunde gerundet, keine Personendaten. «ohne UTM» = Anmeldung kam ohne UTM-Parameter an – so heisst sie auch in der Wirkung. ' +
-      '«vermutet» = der zeitlich nächste Kurzlink-Klick (bis 90 Minuten davor) auf einen passenden Kampagnen-Link – ein Indiz, keine Messung; gezählt wird es nirgends.';
+      '«vermutet» = der zeitlich nächste Kurzlink-Klick (bis 90 Minuten davor) auf einen passenden Kampagnen-Link – ein Indiz, keine Messung; gezählt wird es nirgends. ' +
+      'Bei einem Weg, der fast alle Klicks stellt, steht dieses Indiz zufällig daneben und trägt nichts.';
     host.appendChild(note);
   }
 

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -115,7 +115,7 @@
         <p class="provisorisch" id="dunkelNote"></p>
         <div id="vermutetKopf" class="mh" style="margin-top:var(--s6)"></div>
         <div id="vermutetList"><div class="empty">lädt …</div></div>
-        <p class="provisorisch">Live aus den Ereignissen: je Anmeldung ohne UTM der zeitlich nächste Kurzlink-Klick (bis 90 Min. davor) auf einen passenden Kampagnen-Link. Ein Indiz, keine Messung – gezählt wird es nirgends, es ordnet nur ein.</p>
+        <p class="provisorisch">Live aus den Ereignissen: je Anmeldung ohne UTM der zeitlich nächste Kurzlink-Klick (bis 90 Min. davor) auf einen passenden Kampagnen-Link. Ein Indiz, keine Messung – gezählt wird es nirgends, es ordnet nur ein. Das Indiz trägt nur bei spärlichen Klicks: wo ein Weg mehr als die Hälfte aller Klicks stellt – heute die bezahlte Anzeige –, steht er zufällig bei fast jeder Anmeldung daneben und sagt nichts. Nachgerechnet in <code>docs/wirkungs-lesart-24-07.md</code>.</p>
       </details>
 
       <details class="zb-form">

--- a/docs/wirkungs-lesart-22-07.md
+++ b/docs/wirkungs-lesart-22-07.md
@@ -1,5 +1,11 @@
 # Wirkungs-Lesart der Sommer-Aktion — Stand 22. Juli 2026
 
+> **Abgelöst am 24. Juli 2026 — in einem Kernpunkt falsch.** Die hier der
+> bezahlten Meta-Anzeige zugeschriebenen ≈44 Anmeldungen sind ein Artefakt der
+> Nächster-Klick-Zuordnung, und die Ursache («der Uscreen-Checkout trägt die
+> Spur nicht») ist widerlegt. Gültig ist `wirkungs-lesart-24-07.md`. Dieses
+> Dokument bleibt als Historie stehen.
+
 Dieses Dokument ordnet die Anmeldungen **ohne UTM-Spur** («ohne UTM» im
 Cockpit) den Aktivitäten der Kampagne zu. Es ist eine **Lesart, keine
 Messung**: Alle mit ≈ markierten Zahlen sind Schätzungen (±30 %). Die

--- a/docs/wirkungs-lesart-24-07.md
+++ b/docs/wirkungs-lesart-24-07.md
@@ -1,0 +1,152 @@
+# Wirkungs-Lesart der Sommer-Aktion — Stand 24. Juli 2026
+
+Dieses Dokument ordnet die Anmeldungen **ohne UTM-Spur** («ohne UTM» im
+Cockpit) den Aktivitäten der Kampagne zu. Es ist eine **Lesart, keine
+Messung**: Alle mit ≈ markierten Zahlen sind Schätzungen. Die Datenbank
+bleibt unangetastet — dort stehen nur harte Zuordnungen. Die Anteile daraus
+stehen im Cockpit (`CONFIG.dunkel.anteile`) und werden dort auf den jeweils
+aktuellen Stand angewandt.
+
+Diese Fassung löst `wirkungs-lesart-22-07.md` ab (die bleibt als Historie
+liegen). Sie korrigiert deren Hauptaussage.
+
+Grundlage am Stichtag: **242 Anmeldungen**, davon **112 mit UTM** und
+**130 ohne**.
+
+## Was sich gegenüber dem 22. Juli ändert
+
+Die Lesart vom 22. Juli schrieb der bezahlten Meta-Anzeige **≈44
+Anmeldungen** zu und nannte als Ursache, der Uscreen-Checkout trage die
+UTM-Spur nicht bis zur Anmeldung. Beides hält der Prüfung nicht stand.
+
+**Die Kette ist intakt.** Nachgemessen am 24. Juli, an den ausgelieferten
+Landing-Bundles und am Roh-Log:
+
+- Die Übersichts-Landing hängt die eingehenden `utm_*` beim Klick an die
+  Ziel-URL (delegierter Handler auf `pointerdown`/`click`/`keydown`).
+- Die TV-Landing sichert sie in `sessionStorage` (`lovable_utm:`) und hängt
+  sie an die Checkout-URL `goetheanum.tv/checkout/new?o=84317`.
+- Uscreen liefert sie im `user_created`-Event: **144 von 144** dieser Events
+  tragen den `utm_params`-Block, 117 davon mit gefülltem `utm_source`.
+- Auf unserer Seite ist nichts liegengeblieben: **kein einziger** dunkler
+  goetheanum.tv-Abschluss hat ein `user_created` mit Spur, das die Ingestion
+  nicht verheftet hätte.
+
+**Die Anzeige konvertiert kaum.** Gegenprobe an den organischen Wegen, die
+denselben Weg nehmen — Kurzlink → Übersichts-Landing → TV-Landing → Uscreen,
+dieselben In-App-Browser aus Instagram und Facebook:
+
+| Quelle | Kurzlink-Klicks | goetheanum.tv-Konten mit Spur | Quote |
+|---|---:|---:|---:|
+| meta-anzeige (bezahlt) | 714 | 3 | 0,4 % |
+| instagram organisch | 131 | 7 | 5,3 % |
+| facebook organisch | 64 | 2 | 3,1 % |
+| nl-tv | 52 | 4 | 7,7 % |
+
+Wäre die Spur technisch gebrochen, müsste sie bei den organischen Stories
+genauso brechen: dieselbe Landing (`spinne`, `kroete` führen auf dieselbe
+Übersichts-Seite wie `dachs-4`/`elster-2`), dieselben In-App-Browser. Sie
+bricht dort nicht.
+
+## Die Placebo-Probe — warum ≈44 ein Artefakt war
+
+Der stärkste Anker der alten Lesart war die **vermutete Herkunft**: je
+dunkler Anmeldung der zeitlich nächste Kurzlink-Klick (bis 90 Min. davor).
+Dieser Anker taugt nur, solange die Klicks **spärlich** sind. Die Anzeige
+stellt mit 714 Klicks fast das gesamte Klick-Log — sie gewinnt damit fast
+jede Nähe-Lotterie.
+
+Prüfbar gemacht: dieselbe Zuordnung, aber die Anmeldezeiten künstlich um
+±24/48 Stunden verschoben. Eine Anmeldung, die zu diesem Zeitpunkt gar nicht
+stattfand, dürfte keinen Treffer bekommen.
+
+| Quelle (9-Tage-Fenster, 81 dunkle) | echt | Placebo (Mittel) | Überschuss |
+|---|---:|---:|---:|
+| goetheanum.tv-Newsletter (nl-tv, tv-weekly*) | 47 | 22 | **≈25** |
+| Meta-Anzeige | 72 | 57 | ≈15 |
+| Social organisch | 26 | 31 | keiner |
+
+Im sauberen Fenster 19.–23. Juli, in dem die Anzeige durchgehend lief und
+die Mailing-Welle abgeklungen war, bleibt vom Anzeigen-Überschuss fast
+nichts: 32 dunkle Anmeldungen, **32** mit Anzeigen-Klick in den 90 Minuten
+davor — und **28** auch dann, wenn man die Anmeldung um einen Tag
+verschiebt. Überschuss ≈4 auf 325 Klicks.
+
+Bei den Newslettern trägt derselbe Anker echte Information (Überschuss das
+Zwei- bis Dreifache des Placebos). Er bleibt dort gültig — nur für die
+Anzeige nicht.
+
+## Zwei weitere Anker, unabhängig davon
+
+**Tageskurve.** Seit die Mailing-Welle abgeklungen ist (20.–23. Juli):
+269 Anzeigen-Klicks, und **insgesamt** 26 goetheanum.tv-Anmeldungen, davon
+14 dunkel — die sich alle Kanäle teilen. Die Grundlinie ohne Anzeige und
+ohne Mailing (10.–14. Juli) lag bei rund zwei goetheanum.tv-Anmeldungen pro
+Tag.
+
+**Selbstauskunft.** «Wie sind Sie auf uns aufmerksam geworden?» ist bei
+goetheanum.tv 37-mal beantwortet. Darin einmal «Instagram», einmal
+«Werbung», einmal «jetzt durch Ihre Anzeige» — der Rest Mail, Newsletter,
+Bestand, Empfehlung.
+
+Alle drei Anker zeigen in dieselbe Richtung: die Anzeige trägt **einstellig
+bis niedrig zweistellig**, nicht ≈44. Angesetzt wird **≈9** für die ganze
+Laufzeit (Band ≈4–18).
+
+## Kampagnenweite Rangfolge (gemessen + geschätzt)
+
+| Rang | Aktivität | gemessen | ≈ dazu (dunkel) | ≈ gesamt |
+|---|---|---:|---:|---:|
+| 1 | Mailing (Welle 1) | 87 | ≈27 | **≈114** |
+| 2 | Direkt · Organik · Bestand | 5 | ≈39 | **≈44** |
+| 3 | goetheanum.tv-Newsletter (TV-Weekly) | 6 | ≈33 | **≈39** |
+| 4 | Social organisch (Reels · Stories · Karussell) | 9 | ≈9 | **≈18** |
+| 5 | Haus- und AC-Newsletter (Frühphase) | 4 | ≈12 | **≈16** |
+| 6 | Meta-Anzeige (bezahlt) | 1 | ≈9 | **≈10** |
+| 7 | Inserat · Print | 0 | ≈1 | **≈1** |
+| | **Summe** | **112** | **130** | **242** |
+
+Die Spalte «gemessen» sind harte UTM-Zuordnungen. «≈ dazu» verteilt das
+Dunkelfeld nach den Ankern oben: Newsletter und Mailing nach dem
+Placebo-Überschuss, die Anzeige nach der Obergrenze aus dem sauberen
+Fenster, der Rest — die Frühphase 3.–16. Juli mit 52 dunklen ohne Anzeige
+und ohne Mailing — nach Direkt, Bestand und Organik.
+
+Drei Sätze dazu: **Das Mailing trägt die Aktion** — eine Welle, knapp die
+Hälfte aller Abos. **Der grösste stille Posten ist Direkt/Bestand**, nicht
+die Anzeige: Menschen, die ohnehin kommen. **Die bezahlte Anzeige ist der
+teuerste Posten mit dem kleinsten Ertrag** — das ist der Befund, den die
+alte Lesart hinter einem Attributions-Problem verborgen hat.
+
+## Was daraus folgt
+
+1. **Abschalt-Probe statt Attributions-Umbau (sofort, kostenlos).** Die
+   Anzeige 3–4 Tage aussetzen und die goetheanum.tv-Anmeldungen vergleichen.
+   Die Grundlinie ist gerade sauber wie nie: das Mailing ist abgeklungen,
+   die nächste Welle steht erst am 30. Juli. Das beantwortet «5 oder 60»
+   endgültig — und zwar in Abos, nicht in Zuordnungswahrscheinlichkeiten.
+2. **Hart messbar machen, falls die Anzeige weiterläuft:** ein **eigenes
+   Uscreen-Angebot** je bezahltem Weg. Der Checkout läuft über
+   `?o=<offer_id>`, und `offer_id` wie `coupon` kommen im `order_paid`-Webhook
+   **serverseitig** an — an Cookies, In-App-Browsern und Weiterleitungen
+   vorbei. Auftrag: `services/sommer-zaehler/uscreen-angebot-attribution-auftrag.md`.
+3. **Die vermutete Herkunft im Cockpit bleibt** — sie ist für die spärlichen
+   Kanäle belegt. Sie darf nur nicht mehr als Hauptanker für einen Kanal
+   gelesen werden, der das Klick-Log dominiert. Faustregel: wo ein Kanal mehr
+   als die Hälfte aller Klicks stellt, ist seine Nähe-Zuordnung wertlos.
+
+## Prüfwege (wiederholbar)
+
+Alle Zahlen dieser Fassung stammen aus dem Live-Bestand. Die Placebo-Probe
+ist eine Abfrage: dunkle Anmeldungen des Fensters, je Quelle die Zahl mit
+Klick in den 90 Minuten davor — einmal echt, einmal mit um ±24/48 Stunden
+verschobenen Anmeldezeiten. Übersteigt «echt» das Placebo nicht deutlich,
+trägt der Anker für diese Quelle keine Information.
+
+## Pflege
+
+Die Lesart ist datiert und wird **nicht** automatisch nachgeführt. Bei einer
+neuen Auswertung: Kopie mit neuem Datum anlegen, `CONFIG.dunkel` in
+`apps/sommer-zaehler/campaign.js` nachziehen (Stand-Datum, Doc-Pfad,
+Anteile), Cockpit zeigt sie dann automatisch auf dem jeweils aktuellen
+Stand.

--- a/services/sommer-zaehler/uscreen-angebot-attribution-auftrag.md
+++ b/services/sommer-zaehler/uscreen-angebot-attribution-auftrag.md
@@ -1,0 +1,96 @@
+# Auftrag für Claude im Chrome: eigenes Uscreen-Angebot je bezahltem Weg
+
+*Stand 24. Juli 2026. Vorgeschichte und Zahlen: `docs/wirkungs-lesart-24-07.md`.
+Vorläufer-Auftrag (Custom-Feld, Webhooks, API, Snippets):
+`uscreen-attribution-auftrag.md` — dort steht, was im Konto bereits eingerichtet
+ist.*
+
+## Warum dieser Auftrag
+
+Die Browser-Kette (Landingpage → Checkout → `user_created` mit `utm_params`)
+ist geprüft und trägt. Sie hat aber eine Grenze: sie überlebt nur, solange
+Uscreen die Spur in seiner eigenen Session mitführt. Für Wege, deren Wirkung
+wir **hart** kennen müssen — bezahlte Anzeigen, Partner, Inserate —, brauchen
+wir einen Träger, der nicht am Browser hängt.
+
+Den gibt es: der Checkout läuft über `goetheanum.tv/checkout/new?o=<offer_id>`,
+und das Webhook-Ereignis `order_paid` liefert **`offer_id`** und **`coupon`**
+serverseitig mit. Beides ist im Roh-Log belegt (u. a. `84317` Standard-Abo
+Monatlich, `84322` Standard-Abo Jährlich; Coupon-Werte wie `LEGEN12` kommen
+an). Ein eigenes Angebot je bezahltem Weg macht dessen Abschlüsse damit
+zählbar — an Cookies, In-App-Browsern und Weiterleitungen vorbei.
+
+**Vorher entscheiden:** Dieser Auftrag ändert Produkt-Einstellungen im
+laufenden Verkauf. Er wird erst ausgeführt, wenn feststeht, dass die bezahlte
+Anzeige weiterläuft. Die günstigere Reihenfolge ist: zuerst die Abschalt-Probe
+(3–4 Tage aussetzen, Anmeldungen vergleichen), dann erst instrumentieren.
+
+## Regeln für diesen Auftrag
+
+- Nichts löschen, nichts abschalten, keine Preise ändern. Nur **duplizieren**,
+  prüfen und dokumentieren.
+- Keine Aktion, die Mails an Kundinnen oder Kunden auslöst.
+- Geheimnisse (Webhook-URLs mit `?key=…`, Tokens) nie in den Chat schreiben
+  und nicht in Screenshots zeigen — nur bestätigen, DASS sie existieren.
+- Das neue Angebot muss für die Kundin **gleich** aussehen: gleicher Name,
+  gleicher Preis, gleiche Gratis-Frist wie `84317`. Es ist ein Mess-Duplikat,
+  kein neues Produkt.
+- Wenn eine Einstellung anders heisst oder fehlt: nicht improvisieren,
+  sondern notieren, wie der Bereich wirklich heisst, und im Bericht melden.
+
+## Die Schritte
+
+**Schritt 1 — Bestandsaufnahme.** Öffne die Angebots-/Plan-Verwaltung
+(Offers bzw. Plans). Notiere für `84317` (Standard-Abo Monatlich): Preis,
+Währung, Abrechnungsintervall, Gratis-Frist (Trial), Zugriffsrechte und ob
+das Angebot öffentlich gelistet oder nur per Link erreichbar ist.
+
+**Schritt 2 — Duplikat anlegen.** Lege ein Duplikat von `84317` an, intern
+benannt `Standard-Abo Monatlich · Kampagne bezahlt` (der intern sichtbare
+Name darf sich unterscheiden, der für Kundinnen sichtbare nicht). Alle Werte
+aus Schritt 1 übernehmen. Falls wählbar: **nicht** öffentlich listen, nur
+per Link erreichbar. Notiere die neue `offer_id` und die vollständige
+Checkout-URL (`…/checkout/new?o=<neue_id>`).
+
+**Schritt 3 — Gegenprobe Coupon.** Prüfe, ob die Checkout-URL einen Coupon
+vorbelegen kann (Parameter am Link oder Einstellung am Angebot) und ob sich
+ein Coupon anlegen lässt, der **keinen** zusätzlichen Rabatt gibt, sondern
+nur als Kennung mitläuft. Das wäre der Ersatzweg, falls das Duplikat
+Nebenwirkungen hat. Nur prüfen und berichten, noch nichts anlegen.
+
+**Schritt 4 — Sichtprüfung.** Öffne die neue Checkout-URL in einem privaten
+Fenster (nicht abschliessen) und prüfe: gleicher Name, gleicher Preis,
+gleiche Gratis-Frist wie beim bestehenden Weg. Screenshot ohne Personendaten.
+
+**Schritt 5 — Bericht.** Kompakt in dieser Gliederung:
+1. `84317` — Preis, Intervall, Gratis-Frist, Sichtbarkeit
+2. neue `offer_id` + vollständige Checkout-URL
+3. Coupon-Weg: möglich ja/nein, wie genau
+4. Sichtprüfung: stimmt die Kundenansicht überein?
+5. Auffälligkeiten, besonders alles, was Bestandskunden berühren könnte
+
+## Was danach bei uns passiert (Backend-Seite)
+
+1. **Mapping eintragen.** In `sommer2026_config` eine Zeile
+   `angebot_<offer_id>` mit dem UTM-Tupel des Weges, z. B.
+   `meta-anzeige|social|summer26_trial|story_statisch`.
+2. **Ingestion erweitern** (`ingest-uscreen/index.ts`): trägt eine Anmeldung
+   keine Spur, aber eine bekannte `offer_id`, wird das hinterlegte Tupel
+   gesetzt. Reihenfolge: echte UTM schlägt Angebots-Mapping, Angebots-Mapping
+   schlägt `user_created`-Fallback. Der Coupon-Wert wird analog gelesen
+   (`coupon` steht bereits im Payload).
+3. **Link umstellen:** die Ziel-URL des Kurzlinks der Anzeige zeigt auf die
+   TV-Landing, deren Knopf auf die neue Checkout-URL führen muss — das ist
+   eine Lovable-Änderung an der TV-Landing (Knopf-Ziel je nach `utm_source`).
+   Ohne diesen Schritt greift das Mapping nicht.
+4. **Prüfen:** eine Test-Anmeldung mit einer `hao.bu`-Adresse läuft ins
+   Roh-Protokoll, ohne als Abo zu zählen — damit lässt sich die Kette
+   gefahrlos verifizieren.
+
+## Was dieser Weg nicht leistet
+
+Er misst den **Abschluss**, nicht die Wirkung auf Meta-Seite. Wer die Anzeige
+im Werbekonto optimieren will (Gebote, Zielgruppen), braucht zusätzlich ein
+Konversions-Ereignis im Post-purchase-Snippet — also Meta-Pixel und damit
+eine Datenschutz-Entscheidung. Die ist ausdrücklich **nicht** Teil dieses
+Auftrags und wird vom Auftraggeber getroffen.

--- a/services/sommer-zaehler/utm-ablauf.md
+++ b/services/sommer-zaehler/utm-ablauf.md
@@ -136,39 +136,44 @@ Test: einen generierten Link mit `utm_*` öffnen, Formular abschicken → in
 `sommer2026_signups` steht die Zeile mit gefüllten `utm_*`, im Cockpit unter
 «Nach Motiv».
 
-## Sonderfall goetheanum.tv / Uscreen: damit die Spur den Checkout überlebt
+## Sonderfall goetheanum.tv / Uscreen: wie weit die Spur trägt
 
-Der grösste blinde Fleck der Attribution (Befund 22. Juli: rund zwei Drittel
-aller dunklen Anmeldungen sind goetheanum.tv). Anders als bei Paperform gibt
-es **kein** verstecktes UTM-Feld, das man setzen kann — die Spur überlebt nur
-so weit, wie Uscreen sie in seiner eigenen Session mitführt und im
-`user_created`-Event als `utm_params` mitschickt. Bricht diese Kette (In-App-
-Browser aus Instagram/Facebook, Cookie-Verlust, Weiterleitungen), ist die
-Anmeldung dunkel. Sinnbild: die bezahlte Meta-Anzeige (`story_statisch`)
-sammelt ~600 Kurzlink-Klicks, aber nur eine hart zugeordnete Anmeldung.
+> **Stand 24. Juli 2026 — die Kette ist geprüft und intakt.** Der frühere
+> Befund («der Uscreen-Checkout trägt die UTM nicht bis zur Anmeldung») ist
+> widerlegt. Herleitung: `docs/wirkungs-lesart-24-07.md`.
 
-Zwei Stellen, am besten beide:
+Nachgemessen an den ausgelieferten Landing-Bundles und am Roh-Log:
 
-**1. Landingpage → Uscreen-Checkout (Web-Seite):** Die TV-Landingpage
-(`tv-sommer2026…` / `tv-en-sommer2026…`) muss die eingehenden `?utm_*` an den
-«3 Monate gratis»-Button hängen — also an die Uscreen-Checkout-URL
-anhängen, genau wie die WoS-Landingpage sie ans Paperform-Formular reicht.
-Ohne das sieht Uscreen die UTM nur, wenn sein eigenes Session-Tracking sie
-zufällig aufgenommen hat.
+- Die Übersichts-Landing hängt die eingehenden `utm_*` beim Klick an die
+  Ziel-URL (delegierter Handler auf `pointerdown`/`click`/`keydown`).
+- Die TV-Landing sichert sie in `sessionStorage` (`lovable_utm:`) und hängt
+  sie an die Checkout-URL `goetheanum.tv/checkout/new?o=<offer_id>`.
+- Uscreen liefert sie im `user_created`-Event (`utm_params`), die Ingestion
+  heftet sie an die Anmeldung derselben Person.
 
-**2. Bezahlte und soziale TV-Wege über den Kurzlink führen.** Statt den
-Roh-Link zu teilen, den Kurzlink `/s/<code>` aus dem Generator einsetzen
-(Function `go`, 302 auf die volle UTM-URL). Der serverseitige Redirect ist
-robuster gegen In-App-Browser als ein direkt geteilter Roh-Link und zählt
-den Klick verlässlich in `link_hits` (Grundlage der vermuteten Herkunft im
-Cockpit). Die **Meta-Anzeige zuerst umstellen** — sie ist der grösste
-Einzelposten (≈44 Anmeldungen), der heute dunkel läuft.
+Anders als bei Paperform gibt es weiterhin **kein** verstecktes UTM-Feld: die
+Spur überlebt so weit, wie Uscreen sie in seiner eigenen Session mitführt.
+Das bleibt eine echte Grenze — sie fällt nur weniger ins Gewicht als gedacht.
+Belegt an den Klick-Quoten: organische Social-Wege über **dieselbe** Landing
+und in denselben In-App-Browsern werden mit 3–5 % ihrer Klicks als Konto mit
+Spur sichtbar, die bezahlte Meta-Anzeige mit 0,4 % (714 Klicks, 3 Konten).
+Die Spur bricht dort also nicht — die Klicks werden kaum zu Anmeldungen.
+
+**Wenn ein Weg trotzdem hart messbar sein muss** (bezahlte Anzeige, Partner,
+Inserat), führt er nicht über den Browser, sondern über das Produkt: ein
+**eigenes Uscreen-Angebot** je Weg. `offer_id` und `coupon` stehen im
+`order_paid`-Webhook und kommen serverseitig an — an Cookies, In-App-Browsern
+und Weiterleitungen vorbei. Auftrag und Mapping:
+`services/sommer-zaehler/uscreen-angebot-attribution-auftrag.md`.
+
+**Kurzlinks bleiben Pflicht** für alle geteilten Wege (`/s/<code>`, Function
+`go`, 302 auf die volle UTM-URL): sie zählen den Klick in `link_hits` — die
+einzige Reichweiten-Grundlage, die wir selbst besitzen. Ihre Grenze steht
+ebenfalls im Lesart-Dokument: als Herkunfts-Indiz taugen sie nur, solange ein
+Weg nicht fast alle Klicks stellt.
 
 Test: einen TV-Kurzlink mit `utm_*` öffnen, Trial über den Uscreen-Checkout
-starten → in `sommer2026_signups` trägt die Zeile die `utm_*` (nicht nur der
-`user_created`-Fallback). Solange das nicht greift, bleibt die Wirkung dieser
-Wege in der Dunkelfeld-Lesart des Cockpits (Spalte «≈ mit Dunkelfeld» der
-Gebiete-Liste), nicht in der harten Messung.
+starten → in `sommer2026_signups` trägt die Zeile die `utm_*`.
 
 ## Pflege
 


### PR DESCRIPTION
## Worum es geht

Im Cockpit stand: 713 Klicks der bezahlten Meta-Anzeige, ein einziger messbarer Abschluss — Ursache sei, dass der Uscreen-Checkout die UTM-Spur nicht bis zur Anmeldung trage, die Abschlüsse lägen im Dunkelfeld (≈44). Nachgemessen an den ausgelieferten Landing-Bundles, am Roh-Log und am Klick-Log hält beides nicht stand.

## Befund

**Die Kette ist intakt.** Die Übersichts-Landing hängt die eingehenden `utm_*` beim Klick an die Ziel-URL (delegierter Handler), die TV-Landing sichert sie in `sessionStorage` und hängt sie an `goetheanum.tv/checkout/new?o=84317`, Uscreen liefert sie in **144 von 144** `user_created`-Events im `utm_params`-Block. Auf unserer Seite ist nichts liegengeblieben: kein dunkler goetheanum.tv-Abschluss hat ein `user_created` mit Spur, das die Ingestion nicht verheftet hätte.

**Die ≈44 waren ein Artefakt der Nächster-Klick-Zuordnung.** Mit 714 von rund 1200 Kurzlink-Klicks stellt die Anzeige fast das ganze Klick-Log und gewinnt damit fast jede Nähe-Lotterie. Placebo-Probe (Anmeldezeiten künstlich um ±24/48 h verschoben, 9-Tage-Fenster, 81 dunkle Anmeldungen):

| Quelle | echt | Placebo (Mittel) | Überschuss |
|---|---:|---:|---:|
| goetheanum.tv-Newsletter | 47 | 22 | ≈25 |
| Meta-Anzeige | 72 | 57 | ≈15 |
| Social organisch | 26 | 31 | keiner |

Im sauberen Fenster 19.–23. Juli (Mailing abgeklungen, Anzeige durchgehend) bleibt ein Überschuss von ≈4 auf 325 Klicks. Zwei unabhängige Anker zeigen dasselbe: organische Social-Wege über **dieselbe** Landing und dieselben In-App-Browser werden mit 3–5 % ihrer Klicks als Konto mit Spur sichtbar, die bezahlte Anzeige mit 0,4 %; in der Selbstauskunft nennen 3 von 37 Antworten Werbung oder Instagram.

Der Anker bleibt für die spärlichen Kanäle gültig — nur nicht für einen, der das Klick-Log dominiert.

## Änderungen

- **`docs/wirkungs-lesart-24-07.md`** (neu) — datierte Lesart mit Herleitung, Placebo-Probe und wiederholbarem Prüfweg; neue Rangfolge (Mailing ≈114, Direkt/Bestand ≈44, TV-Newsletter ≈39, Social ≈18, Haus-/AC-Newsletter ≈16, Meta-Anzeige ≈10, Print ≈1). `wirkungs-lesart-22-07.md` bleibt als Historie mit Ablösungs-Hinweis stehen.
- **`apps/sommer-zaehler/campaign.js`** — `CONFIG.dunkel` nachgezogen (bezahlt 40 % → 7 %, Newsletter und Organik hoch); Merkzeichen «Spur bricht ab» → «viel Klick, kaum Abschluss»; der Zug «UTM-Spur in den Checkout tragen» ersetzt durch «Bezahlte Anzeige 3–4 Tage aussetzen und vergleichen» mit der geprüften Begründung.
- **`apps/sommer-zaehler/index.html`** — die Grenze des Herkunfts-Indizes benannt.
- **`services/sommer-zaehler/utm-ablauf.md`** — Sonderfall Uscreen auf den geprüften Stand gebracht.
- **`services/sommer-zaehler/uscreen-angebot-attribution-auftrag.md`** (neu) — Auftrag für Claude im Chrome: eigenes Uscreen-Angebot je bezahltem Weg. `offer_id` und `coupon` kommen im `order_paid`-Webhook serverseitig an, also an Cookies und In-App-Browsern vorbei. Ausdrücklich erst auszuführen, wenn feststeht, dass die Anzeige weiterläuft.

## Empfehlung, die im Cockpit jetzt oben steht

Zuerst die Abschalt-Probe: die Anzeige 3–4 Tage aussetzen und die Anmeldungen vergleichen. Die Grundlinie ist sauber (Mailing abgeklungen, nächste Welle am 30. Juli). Das beantwortet «5 oder 60» in Abos statt in Zuordnungswahrscheinlichkeiten — und kostet nichts.

## Prüfung

`typo-check` und `ds-lint --staged` grün (Score 100 %), `node --check` auf `campaign.js` sauber. Keine neuen Auszeichnungen eingeführt (G03), keine Farb- oder Grössenwerte ausserhalb der Tokens.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVJjdBudvviYw1h8LRJzB1)_