### PR TITLE
Cockpit: Ziel auf 700, Aktionsseiten in die Klappe, zwei Untertitel weg

### DIFF
--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -13,11 +13,14 @@
     ende:  '2026-08-08',            // Aktionsende
     bleibeQuote: 0.62,             // Annahme, bis Erfahrungswerte vorliegen
     meilensteine: [100, 250, 500, 1000],
-    zielGesamt: 1000,               // Gesamtziel der Aktion (neue Abos)
-    ziele: {                        // Zielmarke je Strom (Zwischenmarken, Summe = Gesamtziel)
-      'wos.de.papier': 200, 'wos.de.digital': 250,
-      'wos.en.digital': 120,
-      'gtv.de': 250, 'gtv.en': 180
+    zielGesamt: 700,                // Gesamtziel der Aktion (neue Abos)
+    // Zielmarke je Strom – Zwischenmarken, Summe = Gesamtziel. Beim Absenken des
+    // Gesamtziels auf 700 (24.7.) proportional mitgezogen (Faktor 0,7), damit die
+    // Ströme-Tabelle nicht gegen den Stand-Block rechnet.
+    ziele: {
+      'wos.de.papier': 140, 'wos.de.digital': 175,
+      'wos.en.digital': 84,
+      'gtv.de': 175, 'gtv.en': 126
     },
     // Anzeige-Währung aller Geldbeträge (Kosten, CPA, Summenzeile Folgejahr-Umsatz).
     waehrung: 'CHF',

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -26,8 +26,14 @@
     <span class="kick">Team-Cockpit · 3 Monate gratis <span class="status readout" id="status">lädt …</span></span>
     <h1 class="lead-title">Sommer-Aktion 2026</h1>
     <details class="modell-box">
-      <summary>Wozu diese Aktion?</summary>
+      <summary>Wozu diese Aktion? · Aktionsseiten</summary>
       <p class="modell">Wir wollen, dass kulturinteressierte Menschen bis zum <span class="k">8. August</span> ein Gratis-Abo starten – und danach als zahlende Leser und Zuschauer bleiben. Jede Aktivität hat darin ihre Aufgabe.</p>
+      <div class="landing" style="margin-top:var(--s4)">
+        <span class="meta">Aktionsseiten</span>
+        <a class="btn" href="https://global-sommer2026.goetheanum.online" target="_blank" rel="noopener">Übersicht · 3 Monate gratis</a>
+        <a class="btn" href="https://ws-sommer2026.dasgoetheanum.com" target="_blank" rel="noopener">Wochenschrift</a>
+        <a class="btn" href="https://tv-sommer2026.goetheanum.tv" target="_blank" rel="noopener">goetheanum.tv</a>
+      </div>
     </details>
     <p class="kampagne">Kampagne <code>summer26_trial</code> · 3. Juli bis 8. August 2026 · <a href="../utm-generator/">UTM-Links für die Aktion bauen →</a></p>
   </section>
@@ -35,7 +41,7 @@
 
   <!-- ══ 1 · STAND ═══════════════════════════════════════════════════════ -->
   <section id="stand">
-    <div class="shead"><h2>Stand</h2><p>Eine Zahl, ein Tempo, eine Prognose – ohne Beschönigung.</p></div>
+    <div class="shead"><h2>Stand</h2></div>
     <div class="panel">
       <div class="stand">
         <div>
@@ -75,7 +81,7 @@
 
   <!-- ══ 2 · GEBIETE ═════════════════════════════════════════════════════ -->
   <section id="gebiete">
-    <div class="shead"><h2>Gebiete</h2><p>Jede Zeile ein Gebiet, jede Zeile die ganze Kette: Reichweite → Klicks → Abschlüsse. Sortiert nach Wirkung. Aufklappen zeigt die einzelnen Aktivitäten und den Befund.</p></div>
+    <div class="shead"><h2>Gebiete</h2></div>
     <div class="panel">
       <div id="gebieteListe"><div class="empty">lädt …</div></div>
     </div>


### PR DESCRIPTION
## Worum es geht

Vier gewünschte Anpassungen am neuen Cockpit.

## 1 · Gesamtziel 1000 → 700

Mitgezogen habe ich die **Zielmarken je Strom** (proportional, Faktor 0,7: 140 / 175 / 84 / 175 / 126 = **700**). Ohne das hätte die Ströme-Tabelle im Stand-Aufklapp weiter gegen 1000 gerechnet und dem Stand-Block widersprochen.

Wirkung auf die Anzeige: **34 %** statt 24 % erreicht, nötiges Tempo **30,7** statt 50,7 Abos/Tag. Die Prognose bleibt bei ≈384 — der Abstand zum Ziel ist damit deutlich kleiner, aber nicht geschlossen.

## 2 · Aktionsseiten-Links zurück

Beim Umbau waren sie nur im Fuss geblieben. Sie stehen jetzt zusätzlich in der Klappe **«Wozu diese Aktion? · Aktionsseiten»** — dort, wo der Kontext ohnehin steht, ohne den Kopf wieder zu belasten.

## 3 · Zwei Untertitel entfernt

Unter «Stand» und «Gebiete» — die Ansichten sprechen für sich (G03: wer eine Auszeichnung weglassen kann, lässt sie weg).

## Geprüft

Gegen die Live-Daten im Browser gerendert, keine JS-Fehler. `ds-lint` 100 %, `typo-check` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eee8tzL29NsZC4Tw3MP54

---
_Generated by [Claude Code](https://claude.ai/code/session_019eee8tzL29NsZC4Tw3MP54)_