### PR TITLE
Landweg: Herkunftsland aus der Zahlung – Sprache bei goetheanum.tv messbar machen

### DIFF
--- a/.github/workflows/deploy-ingest-uscreen.yml
+++ b/.github/workflows/deploy-ingest-uscreen.yml
@@ -1,0 +1,47 @@
+# Deploy der Edge Function «ingest-uscreen» — automatisch bei Änderung.
+# -----------------------------------------------------------------------------
+# Warum es diesen Workflow gibt: Die Funktion wurde bisher von Hand deployt, und
+# genau das ist einmal ausgeblieben — Verbesserung #482 («Sprache aus dem
+# Link-Register») lag ab dem 19. Juli im Repo, während in der Produktion noch der
+# Stand vom 18. Juli lief. Ein Repo, das nicht deployt, ist eine Behauptung.
+# Darum: was auf main liegt, ist auch, was läuft.
+#
+# Voraussetzung (bereits eingerichtet für «Deploy sortierer-commit»):
+#   Repo-Secret SUPABASE_ACCESS_TOKEN
+#   (https://supabase.com/dashboard/account/tokens → «Generate new token»).
+#
+# verify_jwt bleibt aus: die Funktion prüft selbst (?key=<webhook_secret>) und
+# wird von Uscreen ohne JWT aufgerufen.
+name: Deploy ingest-uscreen
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "services/sommer-zaehler/ingest-uscreen/index.ts"
+      - ".github/workflows/deploy-ingest-uscreen.yml"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      PROJECT_REF: dagcsnfrlbpxcmdimnrw
+    steps:
+      - uses: actions/checkout@v4
+      - name: Supabase-CLI bereitstellen
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - name: Token prüfen
+        run: |
+          if [ -z "$SUPABASE_ACCESS_TOKEN" ]; then
+            echo "::error::Secret SUPABASE_ACCESS_TOKEN fehlt. Anleitung im Workflow-Kopf." && exit 1
+          fi
+      - name: Funktion ins CLI-Layout kopieren
+        run: |
+          mkdir -p supabase/functions/ingest-uscreen
+          cp services/sommer-zaehler/ingest-uscreen/index.ts supabase/functions/ingest-uscreen/index.ts
+      - name: Deploy
+        run: supabase functions deploy ingest-uscreen --project-ref "$PROJECT_REF" --no-verify-jwt

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -279,6 +279,67 @@
       td[3].textContent = sz ? (Math.round(total / sz * 100) + ' %') : '–';
     }
     if (el('stroemeKopf')) el('stroemeKopf').textContent = 'Woraus sich die ' + fmt(total) + ' Abos zusammensetzen';
+    if (el('stroemeNote')){
+      el('stroemeNote').textContent = 'Bei der Wochenschrift ist die Sprache gemessen – jede Sprache hat ihr eigenes Formular. ' +
+        'Bei goetheanum.tv ist sie es nicht: die Uscreen-Plan-Titel sind durchweg deutsch, und DE- wie EN-Landingpage führen in dasselbe Angebot. ' +
+        'Die TV-Zeile «Englisch» zählt darum nur die Anmeldungen, deren Link-Spur die Sprache selbst trägt – sie ist eine Untergrenze, keine Aufteilung. ' +
+        'Was von ausserhalb des Sprachraums kommt, steht darunter unter «Woher die Abos kommen».';
+    }
+  }
+
+  // Herkunft: Land aus der Zahlung (Uscreen country_code, Migration «sommer2026_land»).
+  // Gemessen, nicht geraten – und bei goetheanum.tv das einzige belastbare Mass
+  // für die Nachfrage ausserhalb des deutschen Sprachraums, weil die Sprache dort
+  // nicht aus dem Abo hervorgeht. Land ist NICHT Sprache; die Notiz sagt es auch.
+  var DACH = ['DE', 'CH', 'AT', 'LI'];
+  var LAND_NAME = { DE:'Deutschland', CH:'Schweiz', AT:'Österreich', LI:'Liechtenstein',
+    US:'USA', GB:'Grossbritannien', NL:'Niederlande', AU:'Australien', NZ:'Neuseeland',
+    CA:'Kanada', BE:'Belgien', IT:'Italien', FR:'Frankreich', ES:'Spanien', DK:'Dänemark',
+    NO:'Norwegen', SE:'Schweden', FI:'Finnland', BR:'Brasilien', CL:'Chile', CO:'Kolumbien',
+    IE:'Irland', SI:'Slowenien', HR:'Kroatien', HU:'Ungarn', CZ:'Tschechien', EE:'Estland',
+    LU:'Luxemburg', TR:'Türkei', TW:'Taiwan', IN:'Indien' };
+  function renderHerkunft(rows){
+    if (!el('herkunftBody')) return;
+    var gtv = (rows || []).filter(function(r){ return r.produkt === 'gtv'; });
+    var summe = gtv.reduce(function(s, r){ return s + Number(r.n || 0); }, 0);
+    if (!summe){ el('herkunftBody').innerHTML = '<tr><td class="empty" colspan="3">noch keine Landangaben</td></tr>'; return; }
+    var dach = 0, uebrige = 0, offen = 0;
+    gtv.forEach(function(r){
+      var n = Number(r.n || 0);
+      if (!r.land) offen += n; else if (DACH.indexOf(r.land) >= 0) dach += n; else uebrige += n;
+    });
+    var zeilen = [
+      { t:'deutschsprachig · DE, CH, AT', n:dach },
+      { t:'übrige Länder', n:uebrige },
+      { t:'ohne Landangabe', n:offen }
+    ];
+    var body = el('herkunftBody'); body.innerHTML = '';
+    zeilen.forEach(function(z){
+      var tr = document.createElement('tr');
+      tr.innerHTML = '<td></td><td class="num"></td><td class="num"></td>';
+      tr.children[0].textContent = z.t;
+      tr.children[1].textContent = fmt(z.n);
+      tr.children[2].textContent = Math.round(z.n / summe * 100) + ' %';
+      body.appendChild(tr);
+    });
+    var liste = el('herkunftLaender');
+    if (liste){
+      liste.innerHTML = '';
+      gtv.filter(function(r){ return r.land && DACH.indexOf(r.land) < 0; })
+        .sort(function(a, b){ return Number(b.n) - Number(a.n); })
+        .slice(0, 10)
+        .forEach(function(r){
+          var row = document.createElement('div'); row.className = 'motrow';
+          row.innerHTML = '<span class="mc"></span><span class="mn"></span>';
+          row.querySelector('.mc').textContent = LAND_NAME[r.land] || r.land;
+          row.querySelector('.mn').textContent = fmt(r.n);
+          liste.appendChild(row);
+        });
+    }
+    if (el('herkunftKopf')){
+      el('herkunftKopf').textContent = 'Woher die goetheanum.tv-Abos kommen – ' + fmt(uebrige) +
+        ' von ' + fmt(summe) + ' aus dem übrigen Ausland';
+    }
   }
 
   // ── 2 · Gebiete: eine Liste, jede Zeile die ganze Kette ───────────────────
@@ -1356,6 +1417,10 @@
         if (el('evList')) el('evList').innerHTML = '<div class="err">nicht ladbar</div>';
         if (el('vermutetList')) el('vermutetList').innerHTML = '<div class="err">nicht ladbar</div>';
       });
+    // Herkunft separat laden – fällt sie aus, bleibt das übrige Cockpit ganz.
+    if (el('herkunftBody')) rpc('sommer2026_herkunft')
+      .then(renderHerkunft)
+      .catch(function(){ el('herkunftBody').innerHTML = '<tr><td class="err" colspan="3">nicht ladbar</td></tr>'; });
     if(CONFIG.zahlenProvisorisch && el('provisorisch')){
       el('provisorisch').textContent = 'Zielmarken, Preise und die Bleibe-Quote sind vorläufig hinterlegt – sobald die echten Werte gesetzt sind, rechnet das Cockpit unverändert weiter.';
     }

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -68,6 +68,19 @@
             <tfoot id="stroemeFoot"></tfoot>
           </table>
         </div>
+        <p class="provisorisch" id="stroemeNote"></p>
+      </details>
+
+      <details class="zb-form">
+        <summary id="herkunftKopf">Woher die Abos kommen – Land aus der Zahlung</summary>
+        <div class="tablewrap" style="margin-top:var(--s4)">
+          <table class="tarif">
+            <thead><tr><th>Herkunft</th><th class="num">goetheanum.tv</th><th class="num">Anteil</th></tr></thead>
+            <tbody id="herkunftBody"><tr><td class="empty" colspan="3">lädt …</td></tr></tbody>
+          </table>
+        </div>
+        <div id="herkunftLaender" class="motive" style="margin-top:var(--s4)"></div>
+        <p class="provisorisch">Das Land steht im Zahlungs-Ereignis (<code>country_code</code>) und ist damit gemessen. Es sagt nicht, welche Sprache jemand schaut – aber es ist bei goetheanum.tv das einzige belastbare Mass für die Frage, wie viel Nachfrage von ausserhalb des deutschen Sprachraums kommt. Für die Wochenschrift ist es nicht nötig: dort füllt jede Sprache ihr eigenes Formular, die Sprache ist dort gemessen.</p>
       </details>
     </div>
   </section>

--- a/services/sommer-zaehler/README.md
+++ b/services/sommer-zaehler/README.md
@@ -137,6 +137,22 @@ verfeinern.
   Registrierungen zählen nie als Abo. Rückwirkend lässt sich dasselbe über
   den People-CSV-Export ziehen (Filter «Created on date», enthält
   UTM-Spalten; so am 18.7. für den Altbestand geschehen).
+- **Herkunftsland (`land`, seit 24.7.):** Die Sprache lässt sich bei
+  goetheanum.tv nicht messen — die Uscreen-Plan-Titel sind durchweg deutsch, und
+  DE- wie EN-Landingpage führen in **dasselbe** Angebot (`?o=84317`). Auch das
+  Link-Register hilft kaum: 47 der 64 UTM-Tupel sind für beide Sprachen
+  registriert (dieselbe Spur, nur andere Landingpage), womit
+  `spracheAusRegister` leer zurückkommt und der deutsche Titel-Rat stehen
+  bleibt. Darum wird das **Land aus der Zahlung** (`order_paid.country_code`)
+  mitgeschrieben: gemessen statt geraten. Es kommt mit dem Zahlungs-Ereignis,
+  wird bei der Anlage aus dem Roh-Log nachgezogen und sonst vom `isPay`-Zweig
+  nachgetragen. Land ist **nicht** Sprache — es beantwortet nur die Frage, wie
+  viel Nachfrage von ausserhalb des deutschen Sprachraums kommt (RPC
+  `sommer2026_herkunft`, im Cockpit unter «Woher die Abos kommen»).
+  Paperform liefert kein Land; dort ist die Sprache am Formular gemessen.
+- **Deploy:** Workflow [`deploy-ingest-uscreen.yml`](../../.github/workflows/deploy-ingest-uscreen.yml)
+  deployt die Funktion, sobald sich ihre Quelle auf `main` ändert — von Hand
+  deployt fiel die Produktion schon einmal hinter das Repo zurück (#482).
 - **Aktions-Isolierung:** jede Neuanmeldung (`subscription_assigned` u. ä.) im
   Aktionszeitraum zählt als `neu`. Trials hinterlegen eine Kreditkarte, darum ist
   `transaction_id` **kein** Unterscheidungsmerkmal. Verlängerungen legen nichts an

--- a/services/sommer-zaehler/ingest-uscreen/index.ts
+++ b/services/sommer-zaehler/ingest-uscreen/index.ts
@@ -16,6 +16,12 @@
 // im Link-Register eindeutig ist, aus sommer2026_links.sprache (die Uscreen-Plan-
 // Titel sind durchweg deutsch, der Titel-Rat bliebe sonst immer 'de').
 //
+// Herkunftsland (`land`, Migration «sommer2026_land»): ISO-Code aus der Zahlung.
+// Der Sprach-Rat trägt bei goetheanum.tv kaum – das Link-Register führt fast
+// jedes UTM-Tupel in BEIDEN Sprachen (dieselbe Spur, nur andere Landingpage),
+// und DE- wie EN-Landing schicken in dasselbe Angebot. Das Land ist gemessen,
+// nicht geraten; es ersetzt die Sprache nicht, es ergänzt sie.
+//
 // Entdopplung: dedup_key = <produkt>:<gesalzener E-Mail-Hash> (Person je Produkt,
 // auch über Quellen hinweg), Fallback <source>:<ext_id>. Upsert/Update laufen
 // über dedup_key – dieselbe Person zählt nie doppelt, auch bei mehreren Events.
@@ -54,6 +60,18 @@ async function sha256Hex(s: string): Promise<string> {
 // E-Mail-artige Werte aus Freitext entfernen (Selbstauskunft ist qualitativ, nicht personenbezogen).
 function scrubEmail(s: string): string {
   return s.replace(/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi, "***");
+}
+
+// Herkunftsland aus der Zahlung (`order_paid.country_code`). Das ist das einzige
+// gemessene Herkunfts-Merkmal, das Uscreen liefert – und für goetheanum.tv das
+// Ersatzmass für die Sprache: die Plan-Titel sind durchweg deutsch, das Angebot
+// für DE und EN dasselbe (`?o=84317`), darum geht die Sprache aus dem Abo selbst
+// nicht hervor. Land ist NICHT Sprache, aber es ist gemessen statt geraten.
+function landAus(data: any): string | null {
+  const v = pick(data, ["country_code", "country", "billing_country", "user.country_code"]);
+  if (!v) return null;
+  const s = String(v).trim().toUpperCase();
+  return /^[A-Z]{2}$/.test(s) ? s : null;
 }
 
 // Platzhalter-Werte (Feld-Default «none», leer, «n/a» …) NICHT als UTM werten.
@@ -198,8 +216,18 @@ Deno.serve(async (req) => {
   if (isCancel) { await patchStatus(dedupKey, "gekuendigt"); return json({ ok: true, status: "gekuendigt" }); }
   // Jeder Trial hinterlegt eine Karte → Zahlung fällt sofort an. Darum setzt eine
   // Zahlung (noch) KEIN 'bleibt': die echte Umwandlung wird erst nach der
-  // 3-Monats-Frist bestimmt (separater Schritt im Oktober).
-  if (isPay && !isNew) return json({ ok: true, note: "Zahlung ignoriert (Umwandlung erst nach 3 Monaten)" });
+  // 3-Monats-Frist bestimmt (separater Schritt im Oktober). EIN Feld wird aber
+  // mitgenommen: das Herkunftsland – nur die Zahlung trägt es.
+  if (isPay && !isNew) {
+    const herkunft = landAus(data);
+    if (herkunft) {
+      await fetch(`${SB}/rest/v1/sommer2026_signups?dedup_key=eq.${encodeURIComponent(dedupKey)}&land=is.null`, {
+        method: "PATCH", headers: { ...H, Prefer: "return=minimal" },
+        body: JSON.stringify({ land: herkunft }),
+      }).catch(() => {});
+    }
+    return json({ ok: true, note: "Zahlung ignoriert (Umwandlung erst nach 3 Monaten)", land: !!herkunft });
+  }
 
   // «User Created» ist KEINE Aktions-Anmeldung (Registrierung ≠ Abo) – aber es
   // ist das einzige Event, das Attribution mitbringt: das VOLLE UTM-Tupel
@@ -258,7 +286,7 @@ Deno.serve(async (req) => {
   const { sprache: planSprache, intervall, tarif } = mapPlan(title);
   const utmRaw = utmFrom(data);
   let src = cleanUtm(utmRaw.src), med = cleanUtm(utmRaw.med), camp = cleanUtm(utmRaw.camp), cont = cleanUtm(utmRaw.cont);
-  const land = utmRaw.land;
+  const landingPfad = utmRaw.land;   // Landingpage-Pfad – NICHT das Herkunftsland (Spalte `land`)
   // Offene Selbstauskunft «Wie sind Sie aufmerksam geworden?» (Custom User Field,
   // Slot 1 = custom_field_1) – O-Ton, E-Mail-redigiert.
   const selbst0 = pick(data, ["referral_source", "how_heard", "how_did_you_hear", "custom_fields.how_did_you_hear",
@@ -283,6 +311,19 @@ Deno.serve(async (req) => {
       }
     } catch { /* kein Fallback */ }
   }
+  // Herkunftsland: trägt nur die Zahlung. Der Trial belastet die Karte sofort,
+  // darum liegt «order paid» oft schon VOR dieser Anmeldung im Roh-Log (die
+  // Redaktion lässt country_code stehen). Kommt die Zahlung später, holt der
+  // isPay-Zweig oben das Land nach.
+  let herkunft = landAus(data);
+  if (!herkunft && ext) {
+    try {
+      const bez = await fetch(`${SB}/rest/v1/sommer2026_ingest_raw?source=eq.uscreen&event=eq.order_paid&payload->>user_id=eq.${encodeURIComponent(ext)}&order=received_at.desc&limit=1&select=payload`, { headers: H })
+        .then((r) => r.json());
+      herkunft = landAus(bez?.[0]?.payload);
+    } catch { /* kein Land */ }
+  }
+
   const kanal = mapKanal(src || pick(data, ["source", "referral_source"]) || selbst);
   const sprache = (await spracheAusRegister(src, med, camp, cont)) ?? planSprache;
   const when = pick(data, ["created_at", "subscribed_at", "started_at", "date"]) || new Date().toISOString();
@@ -300,7 +341,10 @@ Deno.serve(async (req) => {
     kampagne: (camp ? String(camp) : "summer26_trial"),
     utm_source: src ? String(src) : null, utm_medium: med ? String(med) : null,
     utm_campaign: camp ? String(camp) : null, utm_content: cont ? String(cont) : null,
-    landing_path: land ? String(land).slice(0, 200) : null, selbstauskunft: selbst,
+    landing_path: landingPfad ? String(landingPfad).slice(0, 200) : null, selbstauskunft: selbst,
+    // Nur setzen, wenn bekannt: der Upsert läuft mit merge-duplicates, ein
+    // zweites Ereignis ohne Land würde ein bereits gefundenes sonst löschen.
+    ...(herkunft ? { land: herkunft } : {}),
   };
   const res = await fetch(`${SB}/rest/v1/sommer2026_signups?on_conflict=dedup_key`, {
     method: "POST",

--- a/services/sommer-zaehler/schema.sql
+++ b/services/sommer-zaehler/schema.sql
@@ -31,8 +31,16 @@ create table if not exists public.sommer2026_signups (
   utm_campaign  text,                                 -- i. d. R. = kampagne
   utm_content   text,                                 -- konkretes Motiv (z. B. reel_ernst_zuercher)
   landing_path  text,                                 -- Pfad der genutzten Landingpage
-  selbstauskunft text                                 -- «Wie aufmerksam geworden?», E-Mail-redigiert (O-Ton)
+  selbstauskunft text,                                -- «Wie aufmerksam geworden?», E-Mail-redigiert (O-Ton)
+  -- Herkunftsland (Migration «sommer2026_land»): ISO-3166-alpha-2 aus der Zahlung
+  -- (Uscreen order_paid.country_code). Gemessen statt geraten – und für
+  -- goetheanum.tv das einzige brauchbare Ersatzmass für die Sprache: die
+  -- Plan-Titel sind durchweg deutsch, DE- und EN-Landing führen in dasselbe
+  -- Angebot. Land ist NICHT Sprache; es ergänzt sie, es ersetzt sie nicht.
+  -- Paperform liefert kein Land (dort ist die Sprache am Formular gemessen).
+  land          text
 );
+-- Bestand: alter table public.sommer2026_signups add column if not exists land text;
 -- Entdopplung strikt über dedup_key (Person je Produkt, auch über Quellen hinweg)
 create unique index if not exists sommer2026_signups_dedup_uk on public.sommer2026_signups (dedup_key);
 
@@ -92,10 +100,23 @@ language sql security definer set search_path to 'public' as $$
    order by n desc;
 $$;
 
+-- 5) Herkunft: Anmeldungen je Produkt und Land (Migration «sommer2026_land»).
+-- Antwortet auf die Frage, die die Sprache bei goetheanum.tv nicht beantworten
+-- kann – wie viel der Nachfrage von ausserhalb des deutschen Sprachraums kommt.
+create or replace function public.sommer2026_herkunft()
+returns table(produkt text, land text, n bigint)
+language sql security definer set search_path to 'public' as $$
+  select produkt, land, count(*)::bigint as n
+    from public.sommer2026_signups
+   group by produkt, land
+   order by produkt, count(*) desc;
+$$;
+
 grant execute on function public.sommer2026_stats()    to anon, authenticated;
 grant execute on function public.sommer2026_timeline() to anon, authenticated;
 grant execute on function public.sommer2026_kohorten() to anon, authenticated;
 grant execute on function public.sommer2026_kanaele()  to anon, authenticated;
+grant execute on function public.sommer2026_herkunft() to anon, authenticated;
 
 -- =============================================================================
 -- Wirkungskette: Massnahmen-Protokoll + feinere Attribution + Trichter

--- a/services/sommer-zaehler/utm-ablauf.md
+++ b/services/sommer-zaehler/utm-ablauf.md
@@ -23,6 +23,14 @@ Link. Ohne sie entsteht ein Datenhaufen statt einer lesbaren Geschichte.
 | `utm_medium` | Welche Art Kontakt? | `social` · `email` · `print` · `cpc` · `popup` · `organic` · `referral` |
 | `utm_content` | Welches konkrete Motiv / welche Platzierung? | `reel_ernst_zuercher` · `story_probeabo` · `teaser_kopf` · `footer_link` · `qr_inserat` · `popup_exit` · `vorab_nl1` |
 
+**Englische Links bekommen ein eigenes `utm_content`** (Suffix `-en`, wie
+`karussell-en`). Grund: Sprache ist keine eigene UTM-Dimension. Trägt die
+englische Variante dasselbe Tupel wie die deutsche und unterscheidet sich nur
+in der Landingpage, ist die Sprache im Register mehrdeutig — und bei
+goetheanum.tv, wo sie sonst nirgends herkommt, dann gar nicht mehr feststellbar
+(Befund 24.7.: 47 der 64 Tupel mehrdeutig, darum nur 2 als englisch verbuchte
+TV-Abos bei 61 Anmeldungen aus dem übrigen Ausland).
+
 Regeln: nur Kleinbuchstaben, keine Umlaute (`ue/oe/ae`), keine Leerzeichen. Der
 `kanal`-Bucket im Cockpit wird aus `utm_source`/`utm_medium` abgeleitet – die
 Rohwerte bleiben erhalten, damit «Nach Motiv» das einzelne Reel vom Footer-Link


### PR DESCRIPTION
## Worum es geht

Im Cockpit standen **2 englische goetheanum.tv-Abos von 150**. Tatsächlich kommen **61 von 133** Anmeldungen mit Landangabe aus dem übrigen Ausland (US, GB, NL, AU, NZ, CA …), 72 aus DE/CH/AT. Bei der Wochenschrift — wo die Sprache gemessen wird, weil jede Sprache ihr eigenes Formular hat — sind es 37 von 94 englischen Abos. Dieselbe Grössenordnung. Die TV-Sprache war also nie eine Messung, sondern ein Rat.

## Warum sie nicht ankommt

Drei Stufen, alle enden bei «de»:

1. **Das Link-Register ist mehrdeutig** — 47 der 64 UTM-Tupel sind für beide Sprachen registriert (dieselbe Spur, nur andere Landingpage). `spracheAusRegister` kommt leer zurück.
2. **Der Titel-Rat kann nur Deutsch** — die Uscreen-Plan-Titel sind durchweg deutsch («Standard-Abo Monatlich»).
3. **Die dunklen Anmeldungen** (90 von 148) tragen ohnehin kein Tupel.

Dazu: die englische Landing (`tv-en-sommer2026`, sauber englisch) schickt in **dasselbe** Angebot wie die deutsche — `?o=84317`. Ab dem Knopf gibt es kein Merkmal mehr, das die Sprache trüge. Und die englische Seite wird nachgefragt: 451 der 714 Anzeigen-Klicks liefen auf den EN-Kurzlink, 606 von 1197 Kurzlink-Klicks der Aktion sind englisch.

## Der Landweg

Das Zahlungs-Ereignis trägt `country_code` — ein gemessenes Feld, das an Cookies und Browsern vorbeikommt.

- **Migration «sommer2026_land»** (angewandt): Spalte `land` (ISO-3166-alpha-2), RPC `sommer2026_herkunft()` (nur Summen, Grant wie die übrigen Aggregat-RPCs).
- **Bestand nachgetragen** aus dem Roh-Log: 133 der 150 TV-Anmeldungen haben jetzt ein Land. Die übrigen 17 haben (noch) kein Zahlungs-Ereignis mit Landangabe.
- **`ingest-uscreen`**: Land beim Anlegen aus dem Roh-Log gezogen (der Trial belastet die Karte sofort, `order_paid` liegt oft schon vor der Anmeldung), sonst vom `isPay`-Zweig nachgetragen. Nie überschrieben — der Upsert läuft mit `merge-duplicates`, darum wird `land` nur gesetzt, wenn bekannt.
- **Cockpit**: neuer Aufklapp «Woher die Abos kommen» mit Gruppen und den zehn grössten Ländern; bei den Strömen steht jetzt, dass die TV-Zeile «Englisch» eine **Untergrenze** ist, keine Aufteilung.
- **`utm-ablauf.md`**: englische Links bekommen ein eigenes `utm_content` (Suffix `-en`), damit das Register eindeutig bleibt.

Land ist nicht Sprache — das steht auch so im Cockpit. Es beantwortet die Frage, die die Sprache dort nicht beantworten kann.

## Nebenbefund, mitbehoben

Die Produktion lief noch auf dem Stand vom **18. Juli**: #482 («Sprache aus dem Link-Register») lag seit dem 19. im Repo, war aber nie deployt — die Funktion wurde bisher von Hand deployt. Neuer Workflow `deploy-ingest-uscreen.yml` (nach dem Muster von `deploy-sortierer.yml`) deployt sie künftig bei jeder Änderung auf `main`. Mit dem Merge dieses PR geht damit auch #482 live.

## Prüfung

`typo-check` und `ds-lint --staged` grün (Score 100 %), `node --check` auf `campaign.js` sauber, RPC gegen den Live-Bestand geprüft. Der Deploy-Workflow braucht das bereits vorhandene Secret `SUPABASE_ACCESS_TOKEN`; schlägt er fehl, ist das in Actions sichtbar und die Funktion bleibt auf dem alten Stand.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVJjdBudvviYw1h8LRJzB1)_