### PR TITLE
Abschalt-Probe der Anzeige ausgewertet; Zug erkennt gestoppte Wege

### DIFF
--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -94,21 +94,26 @@
   /* ── Stand: eine Zahl, ein Tempo, eine Prognose (ersetzt Kacheln + Momentum) ── */
   .stand{display:grid;grid-template-columns:auto 1fr;gap:var(--s8);align-items:end}
   .stand .zahl{font-family:var(--font-display);font-weight:var(--w-strong);
-    font-size:clamp(64px,14vw,112px);line-height:.9;letter-spacing:-.02em;
+    font-size:clamp(52px,11vw,88px);line-height:.9;letter-spacing:-.02em;
     color:var(--ink);font-variant-numeric:tabular-nums lining-nums}
   .stand .zahl-u{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);margin-top:var(--s2)}
   .stand .rechts{min-width:min(100%,260px)}
   .kpi{display:flex;flex-wrap:wrap;gap:var(--s2) var(--s6);margin-bottom:var(--s3)}
   .kpi .k{font-family:var(--font-text);font-size:var(--t-small)}
-  .kpi .k b{display:block;font-size:var(--t-lede);color:var(--ink);font-variant-numeric:tabular-nums}
+  .kpi .k b{display:block;font-size:var(--t-body);color:var(--ink);font-variant-numeric:tabular-nums;font-weight:600}
   .kpi .k span{color:var(--muted);font-size:var(--t-micro)}
   .kpi .k.warn b{color:var(--bad)}
-  /* Befund: die Fortschreibung im Klartext – der Satz, den eine Prozentzahl verschweigt. */
-  .befund{margin-top:var(--s6);padding:var(--s4) var(--s6);border-radius:var(--r-card);
-    background:color-mix(in srgb,var(--bad) 10%,transparent);border-left:3px solid var(--bad)}
-  .befund p{font-family:var(--font-display);font-weight:var(--w-text);font-size:var(--t-lede);
-    line-height:1.4;color:var(--ink);margin:0;max-width:var(--measure)}
-  .befund .b-meta{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);margin-top:var(--s2)}
+  /* Befund: die Fortschreibung im Klartext – der Satz, den eine Prozentzahl
+     verschweigt. Zurückhaltend gesetzt: er soll auffallen, weil er dasteht,
+     nicht weil er laut ist (G03). Lesegrösse statt Lede, getönte Kante statt
+     Signalbalken, Fläche nur angedeutet. */
+  .befund{margin-top:var(--s4);padding:var(--s3) var(--s4);border-radius:var(--r-control);
+    background:color-mix(in srgb,var(--bad) 5%,transparent);
+    border-left:2px solid color-mix(in srgb,var(--bad) 55%,transparent)}
+  .befund p{font-family:var(--font-text);font-size:var(--t-small);
+    line-height:1.55;color:var(--ink);margin:0;max-width:var(--measure)}
+  .befund p b{font-weight:600}
+  .befund .b-meta{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);margin-top:var(--s1)}
   /* Puls: der Takt neben der Zahl, nicht als eigene Sektion. */
   .puls{display:flex;align-items:flex-end;gap:var(--s1);height:56px;margin-top:var(--s6)}
   .puls .p{flex:1;background:color-mix(in srgb,var(--blue) 55%,transparent);border-radius:3px 3px 0 0;min-height:2px}

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -469,9 +469,10 @@
     (links || []).forEach(function(l){
       var k = (l.utm_content || '') + '|' + (l.utm_source || '');
       grp[k] = grp[k] || { content:l.utm_content || '', source:l.utm_source || '', med:l.utm_medium || '',
-                           landing:l.landing || '', kl:0, n:0 };
+                           landing:l.landing || '', kl:0, n:0, letzter:null };
       grp[k].kl += Number(l.klicks) || 0; grp[k].n++;
       if (l.landing) grp[k].landing = l.landing;
+      if (l.letzter_klick && (!grp[k].letzter || l.letzter_klick > grp[k].letzter)) grp[k].letzter = l.letzter_klick;
     });
     var stumm = {};
     Object.keys(grp).forEach(function(k){
@@ -518,7 +519,7 @@
     // und trägt die UTM. Bleibt der Befund selbst: diese Wege werden geklickt und
     // münden kaum in Abos. Darum ein Zug, der misst statt umbaut.
     // Herleitung: docs/wirkungs-lesart-24-07.md.
-    var leck = { kl:0, motive:[] };
+    var leck = { kl:0, motive:[], letzter:null, bezahltKl:0, bezahltLetzter:null };
     Object.keys(grp).forEach(function(k){
       var g = grp[k], a2 = ab[k] || 0;
       if (g.kl < 20 || a2 > 1) return;
@@ -526,6 +527,14 @@
       var geb = gebietVonSpur(g.source, g.med);
       if (tv || geb === 'bezahlt'){
         leck.kl += g.kl; leck.motive.push((g.content || g.source) + ' (' + fmt(g.kl) + ')');
+        if (g.letzter && (!leck.letzter || g.letzter > leck.letzter)) leck.letzter = g.letzter;
+        // Der bezahlte Weg getrennt: nur er ist es, dessen Aussetzen empfohlen
+        // wird – die organischen TV-Wege laufen weiter und dürfen die Erkennung
+        // nicht überdecken.
+        if (geb === 'bezahlt'){
+          leck.bezahltKl += g.kl;
+          if (g.letzter && (!leck.bezahltLetzter || g.letzter > leck.bezahltLetzter)) leck.bezahltLetzter = g.letzter;
+        }
       } else if (a2 === 0) {
         // Nur echte Nullen melden: ein Motiv mit einer brauchbaren Quote ist
         // keine Schwäche, auch wenn die absolute Zahl klein ist.
@@ -536,14 +545,30 @@
       }
     });
     if (leck.kl > 0){
-      zuege.push({ titel:'Bezahlte Anzeige 3–4 Tage aussetzen und vergleichen', art:2, mass:leck.kl,
-        warum:fmt(leck.kl) + ' Klicks auf TV-Wege führen zu fast keinem Abschluss',
-        hebel:'Klarheit',
-        text:'Betroffen: ' + leck.motive.slice(0, 5).join(', ') + (leck.motive.length > 5 ? ' und weitere' : '') +
-             '. Die Spur ist geprüft und intakt: die Landingpages hängen die UTM an die Checkout-URL, Uscreen liefert sie im user_created-Event, die Ingestion verheftet sie. ' +
-             'Die organischen Wege über dieselbe Seite und dieselben In-App-Browser werden mit 3 bis 5 Prozent ihrer Klicks messbar, die bezahlte Anzeige mit 0,4 Prozent – die Klicks werden also nicht verloren, sie werden kaum zu Abos. ' +
-             'Darum zuerst messen statt umbauen: die Anzeige aussetzen, solange die Grundlinie sauber ist (Mailing abgeklungen, nächste Welle später), und die Anmeldungen je Tag vergleichen. ' +
-             'Soll sie danach weiterlaufen, macht ein eigenes Uscreen-Angebot je bezahltem Weg sie hart messbar (offer_id kommt serverseitig im Webhook an): services/sommer-zaehler/uscreen-angebot-attribution-auftrag.md.' });
+      // Läuft der Weg noch, oder ist er schon abgestellt? Der jüngste Kurzlink-
+      // Klick sagt es. Ohne diese Unterscheidung empfiehlt das Cockpit weiter
+      // eine Abschalt-Probe, die längst läuft – der häufigste Weg, wie ein
+      // Cockpit unglaubwürdig wird.
+      var bezug = leck.bezahltLetzter || leck.letzter;
+      var stillTage = bezug ? Math.floor((Date.now() - new Date(bezug).getTime()) / 86400000) : 99;
+      if (stillTage <= 1){
+        zuege.push({ titel:'Bezahlte Anzeige 3–4 Tage aussetzen und vergleichen', art:2, mass:leck.kl,
+          warum:fmt(leck.kl) + ' Klicks auf TV-Wege führen zu fast keinem Abschluss',
+          hebel:'Klarheit',
+          text:'Betroffen: ' + leck.motive.slice(0, 5).join(', ') + (leck.motive.length > 5 ? ' und weitere' : '') +
+               '. Die Spur ist geprüft und intakt: die Landingpages hängen die UTM an die Checkout-URL, Uscreen liefert sie im user_created-Event, die Ingestion verheftet sie. ' +
+               'Die organischen Wege über dieselbe Seite und dieselben In-App-Browser werden mit 3 bis 5 Prozent ihrer Klicks messbar, die bezahlte Anzeige mit 0,4 Prozent – die Klicks werden also nicht verloren, sie werden kaum zu Abos. ' +
+               'Darum zuerst messen statt umbauen: die Anzeige aussetzen, solange die Grundlinie sauber ist, und die Anmeldungen je Tag vergleichen. ' +
+               'Soll sie danach weiterlaufen, macht ein eigenes Uscreen-Angebot je bezahltem Weg sie hart messbar: services/sommer-zaehler/uscreen-angebot-attribution-auftrag.md.' });
+      } else {
+        zuege.push({ titel:'Abschalt-Probe auswerten – die Anzeige liefert seit ' + stillTage + ' Tagen keine Klicks', art:2, mass:leck.kl,
+          warum:'letzter Klick der Anzeige vor ' + stillTage + ' Tagen · ' + fmt(leck.bezahltKl) + ' Klicks insgesamt · die Probe läuft bereits',
+          hebel:'jetzt ablesen',
+          text:'Der teuerste Weg der Aktion ist aus – damit lässt sich endlich in Abos statt in Zuordnungswahrscheinlichkeiten rechnen. ' +
+               'Verglichen wird nicht die Gesamtzahl, sondern die goetheanum.tv-Anmeldungen je Tag vor und nach dem Stopp, bei möglichst gleicher übriger Aktivität. ' +
+               'Vorsicht bei der Lesart: laufen im selben Fenster neue Newsletter, stützen sie die Zahlen und lassen die Anzeige besser aussehen, als sie war. ' +
+               'Fällt der Unterschied klein aus, ist der Befund der alten Lesart widerlegt und die Anzeige trug einstellig. Ergebnis in einer datierten Lesart festhalten (docs/wirkungs-lesart-<datum>.md) und CONFIG.dunkel nachziehen.' });
+      }
     }
 
     // (c) Datengrundlage: Aktivitäten ohne Reichweite und ohne Klicks.

--- a/docs/abschaltprobe-anzeige-27-07.md
+++ b/docs/abschaltprobe-anzeige-27-07.md
@@ -1,0 +1,100 @@
+# Abschalt-Probe der bezahlten Anzeige — Ergebnis, 27. Juli 2026
+
+Die Lesart vom 24. Juli (`wirkungs-lesart-24-07.md`) empfahl als ersten Zug,
+die bezahlte Meta-Anzeige auszusetzen und die Anmeldungen zu vergleichen —
+«das beantwortet ‹5 oder 60› endgültig, und zwar in Abos, nicht in
+Zuordnungswahrscheinlichkeiten». Die Anzeige ist inzwischen gestoppt. Hier
+das Ergebnis.
+
+**Kurz: Die Anzeige hat nicht nichts gebracht, aber sehr wenig — rund ein
+Abo pro Tag, im Zweifel weniger. Die ≈44 der Lesart vom 22. Juli sind
+endgültig widerlegt; die ≈9 der Lesart vom 24. Juli halten stand.**
+
+## Wann die Anzeige aufhörte
+
+Aus den Kurzlink-Zählern (`sommer2026_links_public`, Codes `dachs-4` DE und
+`elster-2` EN), gemessen an drei Zeitpunkten:
+
+| Stichtag | Klicks der Anzeige | Zuwachs |
+|---|---:|---|
+| 22. Juli | 597 | — |
+| 24. Juli | 713 | +116 in 2 Tagen (~58/Tag) |
+| 27. Juli | 716 | **+3 in 3 Tagen (~1/Tag)** |
+
+Die Anzeige lief also bis zum 24. Juli und ist seither aus; der letzte
+Einzelklick fiel am 26. Juli.
+
+## Der Vergleich
+
+Verglichen werden die goetheanum.tv-Anmeldungen je Tag — das Ziel der
+Anzeige — in zwei Fenstern, beide nach dem Abklingen der Mailing-Welle.
+Die Klick-Mengen je Weg stammen aus der Differenz derselben Zähler.
+
+| | Anzeige AN (22.–24.) | Anzeige AUS (24.–27.) |
+|---|---:|---:|
+| Klicks der Anzeige | **58/Tag** | **1/Tag** |
+| Klicks Newsletter | 40/Tag | 40/Tag |
+| Klicks Social | 8/Tag | 16/Tag |
+| Klicks Mailing | 0/Tag | 9/Tag |
+| **goetheanum.tv-Anmeldungen** | **8,5/Tag** | **7,7/Tag** |
+
+Der bezahlte Weg verliert **57 Klicks am Tag** — über die Hälfte des
+gesamten Klick-Aufkommens. Die Anmeldungen fallen um **0,8 am Tag**.
+
+Zwei Einschränkungen, beide gegen die Anzeige:
+
+- Im Abschalt-Fenster laufen Social und Mailing **stärker** als vorher
+  (+8 bzw. +9 Klicks/Tag). Sie fangen einen Teil des Rückgangs auf; der
+  Anteil der Anzeige an den 0,8 ist damit eher kleiner als grösser.
+- Das Fenster ist mit drei Tagen kurz. Eine einzelne gute Tageskurve
+  (25. Juli mit 12 Anmeldungen) hebt den Schnitt spürbar.
+
+Hochgerechnet auf die ganze Laufzeit der Anzeige (~10 Tage, 716 Klicks)
+ergibt das eine Grössenordnung von **rund 8–12 Abos** — genau das Band, das
+die Lesart vom 24. Juli aus Placebo-Probe, Tageskurve und Selbstauskunft
+angesetzt hatte (≈9, Band 4–18). Die Anteile in `CONFIG.dunkel` bleiben
+darum unverändert; sie sind jetzt zusätzlich empirisch gestützt.
+
+## Der zweite, unabhängige Beleg
+
+Die «vermutete Herkunft» im Ereignis-Protokoll zeigt das Artefakt der alten
+Lesart in Reinform. Zahl der dunklen Anmeldungen, denen der zeitlich
+nächste Klick auf die Anzeige zugeordnet wurde:
+
+| Tag | 17. | 18. | 19. | 20. | 21. | 22. | 23. | **24.** | **25.** | **26.** | **27.** |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| «vermutet: meta-anzeige» | 8 | 16 | 9 | 5 | 4 | 3 | 3 | **0** | **0** | **0** | **0** |
+
+Der Anker verschwindet mit dem letzten Klick vollständig — **die dunklen
+Anmeldungen aber bleiben** (dunkle goetheanum.tv-Abschlüsse: 5,7/Tag mit
+Anzeige, 4,7/Tag ohne). Sie werden jetzt einfach dem zugeordnet, was
+stattdessen klickt: Newsletter, Facebook, Mailing. Genau so verhält sich
+ein Zufallstreffer, nicht eine Ursache.
+
+## Hart gemessen bleibt es bei eins
+
+Über die ganze Laufzeit trägt genau **eine** Anmeldung die UTM-Spur der
+Anzeige (`meta-anzeige / story_statisch`), bei 716 Klicks. Die Kette ist
+geprüft und intakt (siehe `utm-ablauf.md`) — die Klicks gehen also nicht
+verloren, sie werden kaum zu Abos.
+
+## Was daraus folgt
+
+1. **Nicht wieder einschalten**, solange kein eigenes Uscreen-Angebot je
+   bezahltem Weg eingerichtet ist (`uscreen-angebot-attribution-auftrag.md`).
+   Erst dann ist der Ertrag serverseitig zählbar statt schätzbar.
+2. **Die Kosten der Anzeige fehlen im Cockpit.** Erfasst sind nur Flyer und
+   Roll-Ups (CHF 310). Ohne den Anzeigen-Betrag lässt sich der teuerste
+   Posten der Aktion nicht gegen ~10 Abos rechnen — eine Zeile unter Kosten
+   schliesst die letzte offene Frage.
+3. **Der frei gewordene Aufwand gehört in die Mail-Wellen.** Welle 1 trug
+   87 gemessene Abschlüsse; Welle 2 (30. Juli) und 3 sind vorbereitet und
+   tragen seit kurzem Kurzcodes — ihre Klicks werden damit erstmals sichtbar.
+
+## Prüfweg (wiederholbar)
+
+Klick-Differenzen je Weg aus zwei Abrufen von `sommer2026_links_public` zu
+verschiedenen Zeitpunkten; Anmeldungen je Tag aus `sommer2026_timeline`;
+die Verteilung der vermuteten Herkunft aus `sommer2026_ereignisse`. Alle
+drei sind offene Aggregat-RPCs — die Probe braucht keinen Datenbankzugriff
+und lässt sich jederzeit wiederholen.

--- a/docs/wirkungs-lesart-24-07.md
+++ b/docs/wirkungs-lesart-24-07.md
@@ -120,6 +120,11 @@ alte Lesart hinter einem Attributions-Problem verborgen hat.
 
 ## Was daraus folgt
 
+> **Nachtrag 27. Juli: Die Abschalt-Probe ist gelaufen — Ergebnis in
+> `abschaltprobe-anzeige-27-07.md`.** Die Anzeige verlor 57 Klicks am Tag,
+> die goetheanum.tv-Anmeldungen fielen um 0,8 am Tag. Die hier angesetzten
+> ≈9 halten stand; die Anteile in `CONFIG.dunkel` bleiben unverändert.
+
 1. **Abschalt-Probe statt Attributions-Umbau (sofort, kostenlos).** Die
    Anzeige 3–4 Tage aussetzen und die goetheanum.tv-Anmeldungen vergleichen.
    Die Grundlinie ist gerade sauber wie nie: das Mailing ist abgeklungen,


### PR DESCRIPTION
## Worum es geht

Die Lesart vom 24. Juli empfahl als **ersten Zug**, die bezahlte Anzeige auszusetzen und zu vergleichen — «das beantwortet ‹5 oder 60› endgültig, und zwar in Abos». Die Anzeige ist seit dem 24. Juli aus. Hier das Ergebnis und die Konsequenz fürs Cockpit.

## Ergebnis: die Anzeige trug rund ein Abo pro Tag

| | Anzeige AN (22.–24.) | Anzeige AUS (24.–27.) |
|---|---:|---:|
| Klicks der Anzeige | **58/Tag** | **1/Tag** |
| Klicks Newsletter | 40/Tag | 40/Tag |
| Klicks Social | 8/Tag | 16/Tag |
| Klicks Mailing | 0/Tag | 9/Tag |
| **goetheanum.tv-Anmeldungen** | **8,5/Tag** | **7,7/Tag** |

Der bezahlte Weg verliert **57 Klicks am Tag** — über die Hälfte des gesamten Klick-Aufkommens. Die Anmeldungen fallen um **0,8 am Tag**. Und das, obwohl Social und Mailing im selben Fenster *stärker* laufen und den Rückgang teilweise auffangen.

Hochgerechnet auf die ganze Laufzeit: **rund 8–12 Abos**. Das Band der 24-07-Lesart (≈9, Band 4–18) hält; die ≈44 der 22-07-Lesart sind endgültig widerlegt. **`CONFIG.dunkel` bleibt darum unverändert** — die Anteile sind jetzt zusätzlich empirisch gestützt statt nur inferiert.

### Zweiter, unabhängiger Beleg

«vermutet: meta-anzeige» je Tag: 8 · 16 · 9 · 5 · 4 · 3 · 3 → **0 · 0 · 0 · 0** ab dem 24. Juli. Der Anker verschwindet mit dem letzten Klick vollständig — **die dunklen Anmeldungen aber bleiben** (5,7/Tag → 4,7/Tag) und werden nun dem zugeordnet, was stattdessen klickt. Genau so verhält sich ein Zufallstreffer, keine Ursache.

Hart gemessen bleibt es über die ganze Laufzeit bei **einer** Anmeldung mit der UTM-Spur der Anzeige, bei 716 Klicks.

## Cockpit-Fix: der Zug empfahl, was längst geschehen war

Der Zug riet weiterhin, die Anzeige auszusetzen — der häufigste Weg, wie ein Cockpit unglaubwürdig wird. Er liest jetzt den jüngsten Kurzlink-Klick des **bezahlten** Weges (getrennt von den organischen TV-Wegen, die weiterlaufen und die Erkennung sonst überdecken) und schlägt bei stillem Weg stattdessen vor, die laufende Probe **auszuwerten** — mit dem ausdrücklichen Hinweis, dass gleichzeitige Newsletter die Zahlen stützen und die Anzeige besser aussehen lassen.

Beide Zweige gegen die Live-Daten geprüft (der Auswert-Zweig mit vorgestellter Uhr).

## Offen geblieben

Die **Kosten der Anzeige sind nicht erfasst** — im Kosten-Modul stehen nur Flyer und Roll-Ups (CHF 310). Ohne den Betrag lässt sich der teuerste Posten der Aktion nicht gegen ~10 Abos rechnen. Das ist eine Zeile unter Kosten, kein Code.

`ds-lint` 100 %, `typo-check` grün. Nur bestehende Aggregat-RPCs, keine Backend-Änderung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eee8tzL29NsZC4Tw3MP54

---
_Generated by [Claude Code](https://claude.ai/code/session_019eee8tzL29NsZC4Tw3MP54)_