### PR TITLE
Kartentool: Nordatelier liegt in der 5. Etage, nicht der 6.

### DIFF
--- a/apps/karten-generator/orte.js
+++ b/apps/karten-generator/orte.js
@@ -331,8 +331,8 @@ const ORTE = [
         "en": "Nordsaal · 5th Floor"
       },
       {
-        "de": "Nordatelier · 6. Etage",
-        "en": "Nordatelier · 6th Floor"
+        "de": "Nordatelier · 5. Etage",
+        "en": "Nordatelier · 5th Floor"
       }
     ],
     "badges": [

--- a/tools/karten/extract-marker-positionen.py
+++ b/tools/karten/extract-marker-positionen.py
@@ -88,7 +88,7 @@ LEGENDE = [
             {"de": "Galerie · 1. Etage", "en": "Gallery · 1st Floor"},
             {"de": "Grosser Saal · 2. Etage", "en": "Grosser Saal · 2nd Floor"},
             {"de": "Nordsaal · 5. Etage", "en": "Nordsaal · 5th Floor"},
-            {"de": "Nordatelier · 6. Etage", "en": "Nordatelier · 6th Floor"},
+            {"de": "Nordatelier · 5. Etage", "en": "Nordatelier · 5th Floor"},
         ],
     }),
     ("t-sued", "S", "treppe", {"de": "Südtreppe", "en": "South Stairs"}, {


### PR DESCRIPTION
Auftraggeber-Korrektur am Foto der Legende: Nordatelier (Nordtreppe/Nord-Lift) liegt auf derselben Etage wie der Nordsaal, nicht eine Etage höher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgMfxisgg9yjRqFZhd6wuC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgMfxisgg9yjRqFZhd6wuC)_