### PR TITLE
Cockpit-Puls: ganzer Aktionszeitraum, Tageszahl bei Hover und Fokus

### DIFF
--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -114,10 +114,25 @@
     line-height:1.55;color:var(--ink);margin:0;max-width:var(--measure)}
   .befund p b{font-weight:600}
   .befund .b-meta{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);margin-top:var(--s1)}
-  /* Puls: der Takt neben der Zahl, nicht als eigene Sektion. */
-  .puls{display:flex;align-items:flex-end;gap:var(--s1);height:56px;margin-top:var(--s6)}
+  /* Puls: der Takt neben der Zahl, nicht als eigene Sektion. Ein Balken je
+     Kalendertag seit Aktionsstart; die ganze Spalte (volle 56px) ist das
+     Zeigeziel, nicht nur der gemalte Balken. Die Tageszahl erscheint als Fahne
+     beim Zeigen UND beim Tastatur-Fokus – nie nur per Hover erreichbar. */
+  .puls{display:flex;align-items:flex-end;gap:2px;height:56px;margin-top:var(--s6)}
+  .puls .tag{position:relative;flex:1;height:100%;display:flex;align-items:flex-end}
+  .puls .tag:focus-visible{outline:2px solid var(--blue);outline-offset:1px}
   .puls .p{flex:1;background:color-mix(in srgb,var(--blue) 55%,transparent);border-radius:3px 3px 0 0;min-height:2px}
   .puls .p.hoch{background:var(--blue-solid)}
+  .puls .tag:hover .p,.puls .tag:focus-visible .p{background:var(--blue-solid)}
+  .puls .tag::after{content:attr(data-tip);position:absolute;bottom:calc(100% + var(--s1));left:50%;
+    transform:translateX(-50%);background:var(--ink);color:var(--paper);
+    font-family:var(--font-text);font-size:var(--t-micro);line-height:1.35;
+    padding:var(--s1) var(--s2);border-radius:6px;white-space:nowrap;
+    opacity:0;visibility:hidden;transition:opacity .12s;pointer-events:none;z-index:3}
+  .puls .tag:hover::after,.puls .tag:focus-visible::after{opacity:1;visibility:visible}
+  /* Randspalten: Fahne buendig statt zentriert, damit sie nicht aus dem Panel ragt. */
+  .puls .tag:nth-child(-n+6)::after{left:0;transform:none}
+  .puls .tag:nth-last-child(-n+6)::after{left:auto;right:0;transform:none}
   .puls-l{display:flex;justify-content:space-between;gap:var(--s2);font-family:var(--font-text);
     font-size:var(--t-micro);color:var(--muted);margin-top:var(--s1);flex-wrap:wrap}
 

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -176,6 +176,9 @@
   // Der Kern der Aufräumung: statt vier Kacheln, Deadline-Meter, Meilenstein und
   // eigener Momentum-Sektion EIN Block, der die Frage «wo stehen wir» beantwortet
   // – samt der Fortschreibung, die eine Prozentzahl allein verschweigt.
+  function isoTag(d){
+    return d.getFullYear() + '-' + ('0' + (d.getMonth() + 1)).slice(-2) + '-' + ('0' + d.getDate()).slice(-2);
+  }
   function tempoUndPrognose(timeline){
     var byDay = {};
     (timeline || []).forEach(function(r){ byDay[r.day] = (byDay[r.day] || 0) + Number(r.n); });
@@ -185,7 +188,16 @@
     var ende = new Date(CONFIG.ende + 'T00:00:00'), jetzt = new Date();
     var heute = new Date(jetzt.getFullYear(), jetzt.getMonth(), jetzt.getDate());
     var rest = Math.max(0, Math.round((ende - heute) / 86400000));
-    return { byDay:byDay, tage:tage, tempo:tempo, rest:rest };
+    // Alle Kalendertage der Aktion bis heute (bzw. bis zum Ende), Lücken = 0 –
+    // damit der Puls den ganzen Zeitraum zeigt, nicht nur Tage mit Anmeldungen.
+    var alle = [];
+    var erster = (CONFIG.start && (!tage.length || CONFIG.start < tage[0])) ? CONFIG.start : tage[0];
+    if (erster){
+      var stop = heute < ende ? heute : ende;
+      if (tage.length && tage[tage.length - 1] > isoTag(stop)) stop = new Date(tage[tage.length - 1] + 'T00:00:00');
+      for (var d = new Date(erster + 'T00:00:00'); d <= stop; d.setDate(d.getDate() + 1)) alle.push(isoTag(d));
+    }
+    return { byDay:byDay, tage:tage, alle:alle, tempo:tempo, rest:rest };
   }
   function renderStand(total, timeline){
     if (!el('standZahl')) return;
@@ -201,29 +213,39 @@
     el('kNoetig').textContent = t.rest > 0 ? noetig.toFixed(1).replace('.', ',') : '–';
     el('ddBar').style.width = Math.min(100, pct) + '%';
 
-    // Puls: die letzten zehn Tage – der Takt neben der Zahl, nicht als eigene Sektion.
+    // Puls: der ganze Zeitraum seit Aktionsstart, ein Balken je Kalendertag
+    // (Lücken = 0). Die Spalte ist das Zeigeziel; die Tageszahl erscheint als
+    // Fahne beim Zeigen und beim Tastatur-Fokus.
     var host = el('puls'); if (host){
       host.innerHTML = '';
-      var recent = t.tage.slice(-10);
-      var max = recent.reduce(function(m, d){ return Math.max(m, t.byDay[d]); }, 0) || 1;
-      var spitze = recent.reduce(function(b, d){ return t.byDay[d] > t.byDay[b] ? d : b; }, recent[0]);
-      recent.forEach(function(d){
+      var alle = t.alle.length ? t.alle : t.tage;
+      var max = alle.reduce(function(m, d){ return Math.max(m, t.byDay[d] || 0); }, 0) || 1;
+      var spitze = alle.reduce(function(b, d){ return (t.byDay[d] || 0) > (t.byDay[b] || 0) ? d : b; }, alle[0]);
+      alle.forEach(function(d){
+        var n = t.byDay[d] || 0;
+        var tag = document.createElement('span');
+        tag.className = 'tag';
+        tag.tabIndex = 0;
+        var tip = new Date(d + 'T00:00:00').toLocaleDateString('de-CH', { day:'numeric', month:'long' }) +
+                  ' · ' + fmt(n) + (n === 1 ? ' Abo' : ' Abos');
+        tag.setAttribute('data-tip', tip);
+        tag.setAttribute('role', 'img');
+        tag.setAttribute('aria-label', tip);
         var b = document.createElement('span');
         b.className = 'p' + (d === spitze ? ' hoch' : '');
-        b.style.height = Math.max(3, Math.round(t.byDay[d] / max * 100)) + '%';
-        b.title = new Date(d + 'T00:00:00').toLocaleDateString('de-CH', { day:'numeric', month:'long' }) +
-                  ' · ' + fmt(t.byDay[d]) + (t.byDay[d] === 1 ? ' Abo' : ' Abos');
-        host.appendChild(b);
+        b.style.height = Math.max(3, Math.round(n / max * 100)) + '%';
+        tag.appendChild(b);
+        host.appendChild(tag);
       });
       var lab = el('pulsL');
-      if (lab && recent.length){
+      if (lab && alle.length){
         lab.innerHTML = '';
         var von = document.createElement('span');
-        von.textContent = new Date(recent[0] + 'T00:00:00').toLocaleDateString('de-CH', { day:'numeric', month:'long' });
+        von.textContent = new Date(alle[0] + 'T00:00:00').toLocaleDateString('de-CH', { day:'numeric', month:'long' });
         var top = document.createElement('span');
-        top.textContent = 'Spitze ' + fmt(t.byDay[spitze]) + ' am ' + new Date(spitze + 'T00:00:00').toLocaleDateString('de-CH', { day:'numeric', month:'numeric' });
+        top.textContent = 'Spitze ' + fmt(t.byDay[spitze] || 0) + ' am ' + new Date(spitze + 'T00:00:00').toLocaleDateString('de-CH', { day:'numeric', month:'numeric' });
         var bis = document.createElement('span');
-        bis.textContent = 'heute ' + fmt(t.byDay[recent[recent.length - 1]] || 0);
+        bis.textContent = 'heute ' + fmt(t.byDay[alle[alle.length - 1]] || 0);
         lab.appendChild(von); lab.appendChild(top); lab.appendChild(bis);
       }
     }


### PR DESCRIPTION
## Was

Die Puls-Grafik im Stand-Block des Cockpits zeigte fest nur die **letzten zehn Tage mit Anmeldungen** – Tage ohne Abo fehlten zudem ganz. Jetzt:

- **Ganzer Zeitraum:** ein Balken je Kalendertag ab Aktionsstart (3. Juli) bis heute bzw. Aktionsende; Tage ohne Anmeldung erscheinen als Null-Linie statt zu fehlen.
- **Tageszahl bei Hover:** die Fahne «7. Juli · 22 Abos» erscheint beim Zeigen **und** beim Tastatur-Fokus (vorher nur natives `title`-Attribut). Jede Tagesspalte trägt zusätzlich ein `aria-label`.
- Die ganze 56px-Spalte ist das Zeigeziel (nicht nur der gemalte Balken); Randfahnen laufen bündig statt zentriert, damit sie nicht aus dem Panel ragen.

## Regeln

Farben und Grössen ausschliesslich aus den Tokens (B02/B03: `--t-micro` als Floor, Fahne Ink-auf-Papier ≥ 4.5:1, invertiert im Dunkelmodus automatisch – B05). Beschriftung wie gehabt über `textContent`/Attribute, kein `innerHTML` mit Daten.

## Geprüft

- Fülllogik mit Randfällen getestet (Lücken, Aktionsende klemmt, Datenpunkt vor Aktionsstart).
- Sichttest mit Playwright: 28 Spalten (3.–30. Juli), Fahne bei Hover, Fokus-Ring und Randfahne im Panel.
- `node --check`, ds-lint und die Commit-Hooks sind grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pjurZ6vWsFq7z4UnyJRq1

---
_Generated by [Claude Code](https://claude.ai/code/session_018pjurZ6vWsFq7z4UnyJRq1)_