### PR TITLE
Wort «Hausgrafik» aus dem ganzen Repo entfernt

### DIFF
--- a/abo.html
+++ b/abo.html
@@ -97,7 +97,7 @@
 
 <footer class="ds-footer">
   <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Hausgrafik</span>
+    <span><strong>Goetheanum</strong></span>
     <span><a href="design-system/">Design-System</a></span>
   </div>
 </footer>

--- a/apps/bewegte-schrift/index.html
+++ b/apps/bewegte-schrift/index.html
@@ -170,7 +170,7 @@
 
 <footer class="ds-footer">
   <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Hausgrafik</span>
+    <span><strong>Goetheanum</strong></span>
     <span><a href="../../design-system/">Design-System</a></span>
   </div>
 </footer>

--- a/apps/editor/index.html
+++ b/apps/editor/index.html
@@ -118,7 +118,7 @@
 
 <footer class="ds-footer">
   <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Werkzeuge für die Hausgrafik</span>
+    <span><strong>Goetheanum</strong> · Werkzeuge</span>
     <span>Allgemeine Anthroposophische Gesellschaft · <a href="https://www.goetheanum.ch">goetheanum.ch</a></span>
   </div>
 </footer>

--- a/apps/schilder/index.html
+++ b/apps/schilder/index.html
@@ -556,7 +556,7 @@
 
 <footer class="ds-footer">
   <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Hausgrafik</span>
+    <span><strong>Goetheanum</strong></span>
     <span><a href="../../design-system/">Design-System</a></span>
   </div>
 </footer>

--- a/apps/seelenkalender/index.html
+++ b/apps/seelenkalender/index.html
@@ -112,7 +112,7 @@
 
 <footer class="ds-footer">
   <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Hausgrafik</span>
+    <span><strong>Goetheanum</strong></span>
     <span><a href="../../design-system/">Design-System</a></span>
   </div>
 </footer>

--- a/apps/signatur-generator/index.html
+++ b/apps/signatur-generator/index.html
@@ -456,7 +456,7 @@
 </main>
 
 <footer class="ds-footer"><div class="wrap frow">
-  <span><strong>Goetheanum</strong> · Hausgrafik · E-Mail-Signatur</span>
+  <span><strong>Goetheanum</strong> · E-Mail-Signatur</span>
 </div></footer>
 
 <script>

--- a/apps/wallpaper-generator/index.html
+++ b/apps/wallpaper-generator/index.html
@@ -71,7 +71,7 @@
 <main class="wrap">
 
   <section class="hero">
-    <span class="kicker">Hausgrafik · Anwendungen</span>
+    <span class="kicker">Anwendungen</span>
     <h1>Wallpaper-Generator</h1>
     <p class="lede">Ein eigener Hintergrund fürs Videogespräch oder den Desktop – das
       Grundmotiv in deiner Sektionsfarbe, die Marke an definierter Stelle. Wählen,
@@ -160,7 +160,7 @@
 
 <footer class="ds-footer">
   <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Hausgrafik</span>
+    <span><strong>Goetheanum</strong></span>
     <span><a href="../../design-system/">Design-System</a></span>
   </div>
 </footer>
@@ -241,7 +241,7 @@
     img.src="data:image/svg+xml;base64,"+btoa(unescape(encodeURIComponent(markSVG(glyphHex))));
   }); }
 
-  // --- Grundmotiv: drei Archetypen aus der Hausgrafik ------------------------
+  // --- Grundmotiv: drei Archetypen ------------------------
   //   flaechen = gefaltete, eckige Ebenen (Bau-Silhouette, monochrom)
   //   bogen    = grosser weicher Bogen oben links + Facette oben rechts
   //   verlauf  = ruhiger Verlauf, marken-vorwärts

--- a/apps/werkzeugpost/index.html
+++ b/apps/werkzeugpost/index.html
@@ -162,7 +162,7 @@
 
 <footer class="ds-footer">
   <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Hausgrafik</span>
+    <span><strong>Goetheanum</strong></span>
     <span><a href="../../design-system/">Design-System</a></span>
   </div>
 </footer>

--- a/assets/merkblaetter/src/warum-ohne-bilder.html
+++ b/assets/merkblaetter/src/warum-ohne-bilder.html
@@ -99,7 +99,7 @@
         weg.</p></div>
   </div>
 
-  <div class="foot"><span>Goetheanum · Hausgrafik</span><span>Seite 1 von 2</span></div>
+  <div class="foot"><span>Goetheanum</span><span>Seite 1 von 2</span></div>
 </div>
 
 <div class="page">
@@ -149,7 +149,7 @@
     Begründung: werkzeuge.goetheanum.ch/signatur – elf Empfehlungen samt
     Fussnote ‹Was in der Schweiz gilt›, als Seite und A4-PDF.</p>
 
-  <div class="foot"><span>Goetheanum · Hausgrafik · Stand 10. Juli 2026</span><span>Seite 2 von 2</span></div>
+  <div class="foot"><span>Goetheanum · Stand 10. Juli 2026</span><span>Seite 2 von 2</span></div>
 </div>
 
 </body>

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -440,7 +440,7 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 - **PowerPoint** (`powerpoint.html`) – Platzhalterseite (Vorlage wird überarbeitet, Datei folgt).
 - **Neue Welt ‹Anwendungen›** (cat `anwendung`) in `nav.js`/`tools.json`/Startseite – für fertige
   Vorlagen (Wallpaper, PowerPoint); **Pantone aus der Farbseite entfernt** (wird nicht mehr verwendet).
-- **Globaler Feedback-Link** im Menü (Schubladen-Fuss, `nav.js`) – mailto an die Hausgrafik, auf jeder
+- **Globaler Feedback-Link** im Menü (Schubladen-Fuss, `nav.js`) – mailto, auf jeder
   Seite erreichbar. Bewusst NICHT in der Kopfzeile: dort frass ein Icon die leere Fläche an, über die
   der (geheime) Dreifach-Klick die Intern-Ansicht schaltet. Anfrage-/Druckformular bleibt getrennt (Todo).
 

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -1,6 +1,6 @@
 # Goetheanum Design-System
 
-Das gemeinsame Fundament der Hausgrafik – Farben, Schrift, Typografie-Regeln und
+Das gemeinsame Fundament – Farben, Schrift, Typografie-Regeln und
 Komponenten an einem Ort, aus **einer Quelle** gerendert. Gebaut, damit beim
 Erstellen neuer Werkzeuge und Seiten **alles parat steht** und **nichts hinterher
 geprüft** werden muss.

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Design-System · Goetheanum Grafik</title>
-<meta name="description" content="Das lebende Design-System der Goetheanum-Hausgrafik: Farben, Schnitte, Typografie-Regeln und Komponenten – aus einer Quelle gerendert." />
+<meta name="description" content="Das lebende Design-System des Goetheanum: Farben, Schnitte, Typografie-Regeln und Komponenten – aus einer Quelle gerendert." />
 <meta name="robots" content="noindex" />
 <link rel="icon" type="image/svg+xml" href="../assets/logos/goetheanum-mark-blue.svg" />
 
@@ -108,7 +108,7 @@
   <section class="hero">
     <span class="kicker">Design-System</span>
     <h1>Ein Fundament, viele Werkzeuge.</h1>
-    <p class="lede">Farben, Schnitte, Typografie-Regeln und Komponenten der Goetheanum-Hausgrafik – an einem Ort, aus einer Quelle gerendert. Was hier steht, steht beim Bauen bereits parat und muss nicht hinterher geprüft werden.</p>
+    <p class="lede">Farben, Schnitte, Typografie-Regeln und Komponenten des Goetheanum – an einem Ort, aus einer Quelle gerendert. Was hier steht, steht beim Bauen bereits parat und muss nicht hinterher geprüft werden.</p>
     <div class="meta" id="heroMeta"></div>
   </section>
 
@@ -430,7 +430,7 @@
 
 <footer class="ds-footer">
   <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Design-System der Hausgrafik</span>
+    <span><strong>Goetheanum</strong> · Design-System</span>
     <span><a href="../start/">Interner Hub</a> · <a href="https://github.com/phtok/goeloggen/blob/main/docs/strategie.md">Strategieblatt</a></span>
   </div>
 </footer>

--- a/design-system/starter-artikel.html
+++ b/design-system/starter-artikel.html
@@ -99,7 +99,7 @@
 
 <footer class="ds-footer">
   <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Hausgrafik</span>
+    <span><strong>Goetheanum</strong></span>
     <span><a href="design-system/">Design-System</a></span>
   </div>
 </footer>

--- a/design-system/starter.html
+++ b/design-system/starter.html
@@ -100,7 +100,7 @@
 <!-- Fusszeile – aus base.css (.ds-footer). -->
 <footer class="ds-footer">
   <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Hausgrafik</span>
+    <span><strong>Goetheanum</strong></span>
     <span><a href="design-system/">Design-System</a></span>
   </div>
 </footer>

--- a/docs/strategie.md
+++ b/docs/strategie.md
@@ -19,13 +19,13 @@ mit dem **Onliness-Statement** als Herzstück.
 > und sprechen.
 
 ### Onliness-Statement — das ZAG (Herzstück)
-> Die **Goetheanum-Werkzeugkiste** ist die **EINZIGE** Hausgrafik-Umgebung, die die
+> Die **Goetheanum-Werkzeugkiste** ist die **EINZIGE** Umgebung, die die
 > Corporate Identity des Goetheanum nicht als Regelwerk *beschreibt*, sondern sie in
 > **einfachen Alltagswerkzeugen verkörpert** – sodass **jede mitarbeitende Person ohne
 > Designkenntnis** in **Minuten** markenkonformes Material erzeugt, in einer Zeit, in
 > der Identität sonst in Wildwuchs und Beliebigkeit zerfällt.
 
-*(Raster: WAS = Hausgrafik-Umgebung · WIE = CI verkörpert statt beschrieben · WER =
+*(Raster: WAS = Umgebung · WIE = CI verkörpert statt beschrieben · WER =
 Mitarbeitende ohne Designkenntnis · WO = Goetheanum/AAG · WARUM = korrektes Material
 in Minuten · WANN = Zeit der gestalterischen Beliebigkeit.)*
 

--- a/icons.html
+++ b/icons.html
@@ -129,7 +129,7 @@
 
 <main>
   <div class="wrap hero">
-    <div class="kick">Hausgrafik · Icons</div>
+    <div class="kick">Icons</div>
     <h1>Goetheanum Icons</h1>
     <p class="lede">Ein Satz Piktogramme in der Sprache der Hausschrift – Wegweisung, Hinweise, Pfeile und Kompass. Als Webfont per Tastatur gesetzt oder einzeln als SVG, PNG und PDF.</p>
     <div class="meta">

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="robots" content="noindex" />
-<title>Goetheanum Werkzeuge – Hausgrafik</title>
-<meta name="description" content="Werkzeuge für die Hausgrafik des Goetheanum: Logos, Schriften, E-Mail-Signatur, Visitenkarten und das Design-System." />
+<title>Goetheanum Werkzeuge</title>
+<meta name="description" content="Werkzeuge für das Goetheanum: Logos, Schriften, E-Mail-Signatur, Visitenkarten und das Design-System." />
 <link rel="icon" type="image/svg+xml" href="assets/logos/goetheanum-mark-blue.svg" />
 <link rel="stylesheet" href="design-system/tokens.css" />
 <link rel="stylesheet" href="design-system/base.css" />
@@ -151,14 +151,14 @@
 <script src="design-system/nav.js" data-root="./" data-active="start"></script>
 
 <main class="wrap" id="inhalt">
-  <h1 class="sr-only">Goetheanum Werkzeuge – Hausgrafik</h1>
+  <h1 class="sr-only">Goetheanum Werkzeuge</h1>
   <section class="carousel" id="carousel" aria-roledescription="Karussell" aria-label="Entdecken" hidden></section>
   <div class="grid" id="cards"></div>
 </main>
 
 <footer class="ds-footer">
   <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Werkzeuge für die Hausgrafik</span>
+    <span><strong>Goetheanum</strong> · Werkzeuge</span>
     <span>Allgemeine Anthroposophische Gesellschaft · <a href="https://www.goetheanum.ch">goetheanum.ch</a></span>
   </div>
 </footer>

--- a/marketing-maschine.html
+++ b/marketing-maschine.html
@@ -218,7 +218,7 @@
 
 <footer class="ds-footer">
   <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Hausgrafik</span>
+    <span><strong>Goetheanum</strong></span>
     <span><a href="https://github.com/phtok/goeloggen/blob/main/docs/marketing-maschine.md">Konzept im Volltext</a></span>
   </div>
 </footer>

--- a/powerpoint.html
+++ b/powerpoint.html
@@ -32,7 +32,7 @@
 
 <main class="wrap">
   <div class="hero">
-    <div class="kicker">Hausgrafik · Anwendungen</div>
+    <div class="kicker">Anwendungen</div>
     <h1>PowerPoint-Vorlagen</h1>
     <p class="lede">Präsentationsvorlagen im Hausbild – Titel, Inhalts- und Bildfolien, abgestimmt auf
       Schrift und Farben des Goetheanum.</p>

--- a/prinzipien.html
+++ b/prinzipien.html
@@ -316,7 +316,7 @@
 
 <footer class="ds-footer">
   <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Hausgrafik</span>
+    <span><strong>Goetheanum</strong></span>
     <span><a href="design-system/">Design-System</a></span>
   </div>
 </footer>

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
-# werkzeuge.goetheanum.ch — interne Werkzeuge der Goetheanum-Hausgrafik.
+# werkzeuge.goetheanum.ch — interne Werkzeuge des Goetheanum.
 # Nicht für Suchtreffer und nicht als Material für KI-Crawler gedacht.
 #
 # Arbeitsteilung (bewusst so, nicht anders):

--- a/sektionsfarben.html
+++ b/sektionsfarben.html
@@ -43,7 +43,7 @@
 
 <main class="wrap">
   <div class="hero">
-    <div class="kicker">Hausgrafik · Elemente</div>
+    <div class="kicker">Elemente</div>
     <h1>Sektionsfarben</h1>
     <p class="lede">Die Identitätsfarben der Schul-Sektionen und der Bereiche – Hex, RGB und HSB exakt
       aus der Quelle (<code>assets/goe-orgs.js</code>, speist die Logo-Engine). Jede Zelle ist

--- a/start/index.html
+++ b/start/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Goetheanum Grafik – Werkzeuge</title>
-<meta name="description" content="Werkzeuge für die Hausgrafik des Goetheanum: Generatoren, Schriften, Typografie und Werkstatt – an einem Ort." />
+<meta name="description" content="Werkzeuge für das Goetheanum: Generatoren, Schriften, Typografie und Werkstatt – an einem Ort." />
 <meta name="robots" content="noindex" />
 <link rel="icon" type="image/svg+xml" href="../assets/logos/goetheanum-mark-blue.svg" />
 <link rel="stylesheet" href="../design-system/tokens.css" />
@@ -62,7 +62,7 @@
 
 <main>
   <div class="wrap hero">
-    <div class="kick">Goetheanum · Hausgrafik</div>
+    <div class="kick">Goetheanum</div>
     <h1>Werkzeuge für ein einheitliches Bild.</h1>
     <p class="lede">Alles an einem Ort: Generatoren für Logo, Visitenkarten und E-Mail-Signatur,
       die Hausschrift mit ihren Regeln und die Werkstatt dahinter. Schlank, im Browser, ohne Login –
@@ -95,7 +95,7 @@
 </main>
 
 <footer class="ds-footer"><div class="wrap frow">
-  <span><strong>Goetheanum Grafik</strong> · Werkzeuge für die Hausgrafik</span>
+  <span><strong>Goetheanum Grafik</strong> · Werkzeuge</span>
   <span>Allgemeine Anthroposophische Gesellschaft · <a href="https://www.goetheanum.ch">goetheanum.ch</a></span>
 </div></footer>
 

--- a/uebersetzungen.html
+++ b/uebersetzungen.html
@@ -38,7 +38,7 @@
 
 <main class="wrap">
   <div class="hero">
-    <div class="kicker">Hausgrafik · Sprache</div>
+    <div class="kicker">Sprache</div>
     <h1>Übersetzungen</h1>
     <p class="lede">Gängige Schreibweisen und Übersetzungen der Sektionen, Bereiche und der institutionellen Begriffe – Deutsch, English, Français, Español. Für Karten, Signaturen, Briefe und die Sekretariate. Klick auf eine Zelle kopiert sie.</p>
     <div class="find">
@@ -73,7 +73,7 @@
 
 <footer class="ds-footer">
   <div class="wrap frow">
-    <span><strong>Goetheanum</strong> · Übersetzungen für die Hausgrafik</span>
+    <span><strong>Goetheanum</strong> · Übersetzungen</span>
     <span>Quelle <a href="https://goetheanum.ch">goetheanum.ch</a> · <a href="./">alle Werkzeuge</a></span>
   </div>
 </footer>

--- a/wallpaper.html
+++ b/wallpaper.html
@@ -34,7 +34,7 @@
 
 <main class="wrap">
   <div class="hero">
-    <div class="kicker">Hausgrafik · Anwendungen</div>
+    <div class="kicker">Anwendungen</div>
     <h1>Wallpaper</h1>
     <p class="lede">Desktop-Hintergründe in 2500 × 1406. Auf ein Motiv tippen lädt die Datei herunter.</p>
   </div>

--- a/zeichen.html
+++ b/zeichen.html
@@ -35,7 +35,7 @@
 
 <main class="wrap">
   <div class="hero">
-    <div class="kicker">Hausgrafik · Elemente</div>
+    <div class="kicker">Elemente</div>
     <h1>Zeichen</h1>
     <p class="lede">Die Zeichen von Rudolf Steiner werden für Briefpapiere, Mitgliederkarten und die
       Generalversammlung der Gesellschaft eingesetzt. Hier die Vorschau; das vollständige Paket


### PR DESCRIPTION
Alle **38 Vorkommen** des Wortes «Hausgrafik» in **26 Dateien** entfernt. Formulierungen wurden nur so weit angepasst, dass die Sätze grammatikalisch stehen bleiben — ohne neue Begriffe zu erfinden.

## Was geändert wurde

| Muster | vorher → nachher | Stellen |
|---|---|---|
| Fusszeile | `Goetheanum · Hausgrafik` → `Goetheanum` | 12 |
| Fusszeile | `Werkzeuge für die Hausgrafik` → `Werkzeuge` | 4 |
| Kicker | `Hausgrafik · Anwendungen/Elemente/Icons/Sprache` → nur die zweite Hälfte | 7 |
| Titel/Meta | `Goetheanum Werkzeuge – Hausgrafik` → `Goetheanum Werkzeuge` | 3 |
| Meta | `Werkzeuge für die Hausgrafik des Goetheanum:` → `Werkzeuge für das Goetheanum:` | 2 |
| Doku/Fliesstext | siehe unten | 10 |

## Stellen mit Bedeutungsverlust (Rückfrage an den Auftraggeber)

1. **`docs/strategie.md:22,28`** — im Onliness-Statement stand «die **EINZIGE** Hausgrafik-Umgebung»; jetzt «die **EINZIGE** Umgebung». Die Kategorie, in der die Werkzeugkiste einzig ist, fehlt damit — das Statement verliert seinen Kern. Gleiches im Raster («WAS = Umgebung»).
2. **`design-system/README.md:3`** — «Das gemeinsame Fundament der Hausgrafik –» → «Das gemeinsame Fundament –». Fundament wovon, steht nicht mehr da.
3. **`design-system/CHANGELOG.md:443`** — «mailto an die Hausgrafik» → «mailto». Der Empfänger des Feedback-Links ist nicht mehr benannt. (Ausserdem: der Ledger ist Gedächtnis — ein rückwirkend geänderter Eintrag beschreibt den damaligen Stand nicht mehr genau.)
4. **`apps/wallpaper-generator/index.html:244`** — Code-Kommentar «drei Archetypen aus der Hausgrafik» → «drei Archetypen». Die Herkunft der Motive ist nicht mehr dokumentiert.
5. **`apps/editor/index.html:121`, `index.html:161`, `start/index.html:98`** — Fusszeile endet auf blosses «Werkzeuge»; wofür, sagt sie nicht mehr.
6. **`robots.txt:1`** — «interne Werkzeuge der Goetheanum-Hausgrafik.» → «… des Goetheanum.» Die Zuständigkeit ist weiter gefasst als vorher.

## Offener Punkt: PDF

`assets/merkblaetter/warum-ohne-bilder.pdf` zeigt in der Fusszeile weiterhin «Goetheanum · Hausgrafik» — die Druckquelle `src/warum-ohne-bilder.html` ist bereinigt, das PDF müsste nach der dokumentierten Strecke (Chromium, A4, `printBackground`) neu erzeugt und mit dem Auge geprüft werden. Ein blindes Neu-Rendern in dieser Umgebung wäre nicht verifizierbar gewesen, darum bewusst nicht gemacht.

## Prüfmaschinen

- `tools/typo-check.py --staged`: 0 Fehler (1 Hinweis, G20, vorbestehend)
- `tools/ds-lint.py --staged`: 0 Fehler, Score 100 % (1 Hinweis DS05, vorbestehend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FqWotEw8QGZiSjWB2SMhy

---
_Generated by [Claude Code](https://claude.ai/code/session_013FqWotEw8QGZiSjWB2SMhy)_