### PR TITLE
Seitentitel wird eine Rolle des Fundaments (Durchschuss 1.15, Laufweite 0)

### DIFF
--- a/abo.html
+++ b/abo.html
@@ -15,7 +15,7 @@
 
 <style>
   .hero{padding-block:clamp(40px,7vw,72px) var(--s8)}
-  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);line-height:1.05;letter-spacing:-.01em;max-width:18ch}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);max-width:18ch}
   .hero .lede{margin-top:var(--s6);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:58ch}
 
   /* Auswahl-Liste: Fingerziele ≥44px (B04), Lese-Grotesk für Label (Schrift-Grenze) */

--- a/apps/editor/index.html
+++ b/apps/editor/index.html
@@ -13,7 +13,7 @@
 <style>
   /* Nur seiten-eigenes Layout – Farben/Schrift/Abstände kommen aus tokens.css/base.css. */
   .hero{padding-block:clamp(36px,6vw,60px) var(--s6)}
-  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(28px,4.6vw,44px);line-height:1.08;letter-spacing:-.01em;max-width:20ch}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(28px,4.6vw,44px);max-width:20ch}
   .hero .lede{margin-top:var(--s4);color:var(--muted);font-size:var(--t-body);line-height:1.55;max-width:60ch}
 
   .work{display:grid;grid-template-columns:1fr;gap:var(--s6);align-items:start;padding-bottom:var(--s8)}

--- a/apps/grenzgaenger/index.html
+++ b/apps/grenzgaenger/index.html
@@ -22,7 +22,7 @@
 
 <style>
   .hero{padding-block:clamp(40px,7vw,72px) var(--s6)}
-  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);line-height:1.05;letter-spacing:-.01em;max-width:18ch}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);max-width:18ch}
   .hero .lede{margin-top:var(--s6);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:58ch}
   .griffe{display:grid;gap:var(--s3);margin-top:var(--s5)}
   .griff{display:grid;gap:var(--s2)}

--- a/apps/kampagnen-drehbuch/index.html
+++ b/apps/kampagnen-drehbuch/index.html
@@ -22,7 +22,7 @@
 <style>
   /* Nur seiteneigene Gestalt; alles Gemeinsame aus base.css, nur Tokens (DS02). */
   .hero{padding-block:clamp(40px,7vw,72px) var(--s6)}
-  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);line-height:1.05;letter-spacing:-.01em;max-width:18ch}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);max-width:18ch}
   .hero .lede{margin-top:var(--s6);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:58ch}
   .leitsaetze{display:grid;gap:var(--s2);max-width:760px;margin-bottom:var(--s8)}
   .leitsaetze p{margin:0;padding:var(--s3) var(--s4);background:var(--field-bg);border-left:3px solid var(--gold-deep);border-radius:0 8px 8px 0;line-height:1.5}

--- a/apps/seelenkalender/index.html
+++ b/apps/seelenkalender/index.html
@@ -24,7 +24,7 @@
 <style>
   /* Nur seiteneigene Gestaltung – alles Gemeinsame kommt aus base.css. */
   .hero{padding-block:clamp(36px,6vw,60px) var(--s6)}
-  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(28px,4.6vw,44px);line-height:1.06;letter-spacing:-.01em;max-width:20ch}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(28px,4.6vw,44px);max-width:20ch}
   .hero .lede{margin-top:var(--s4);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:58ch}
 
   /* Der Spruch – die Stimme des Hauses, gross und ruhig */

--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -9,7 +9,7 @@
 
   .lead{padding:clamp(28px,6vw,52px) 0 var(--s6)}
   .lead .status{margin-left:8px}
-  .lead-title{font-family:var(--font-display);font-weight:var(--w-deutlich);color:var(--gold-ink);font-size:clamp(32px,7vw,58px);line-height:1.02;letter-spacing:-.01em;margin:8px 0 0;max-width:18ch}
+  .lead-title{font-family:var(--font-display);font-weight:var(--w-deutlich);color:var(--gold-ink);font-size:clamp(32px,7vw,58px);margin:8px 0 0;max-width:18ch}
   /* Titel-Atem (Aktivitäten): Zeichen einzeln ansprechbar, nur das Gewicht bewegt sich. */
   .lead-title .ltr{display:inline-block;will-change:font-weight}
   .heroline{display:flex;flex-wrap:wrap;align-items:flex-end;gap:clamp(16px,5vw,48px);margin-top:var(--s8)}

--- a/apps/visitenkarten-generator/index.html
+++ b/apps/visitenkarten-generator/index.html
@@ -114,7 +114,7 @@
     }
     .hero h1 {
       font-family: var(--font-display); font-weight: var(--w-deutlich);
-      font-size: var(--t-h1); line-height: 1.08; letter-spacing: -.005em;
+      font-size: var(--t-h1);  
     }
     .hero .lede { margin-top: var(--s3); color: var(--muted); max-width: 60ch; }
 

--- a/apps/werkzeugpost/index.html
+++ b/apps/werkzeugpost/index.html
@@ -14,7 +14,7 @@
 
 <style>
   .hero{padding-block:clamp(28px,5vw,52px) var(--s5)}
-  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(26px,4.4vw,44px);line-height:1.06;letter-spacing:-.01em;max-width:20ch}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(26px,4.4vw,44px);max-width:20ch}
   .hero .lede{margin-top:var(--s4);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:60ch}
 
   .toolbar{display:flex;gap:var(--s2);flex-wrap:wrap;align-items:center;margin-block:var(--s5)}

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -16,6 +16,25 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ---
 
+## [1.10.0] – 2026-08-04
+
+### Der Seitentitel wird eine Rolle des Fundaments
+- **Was:** Neue kanonische Rolle `.hero h1, .lead-title` in `base.css` — sie
+  setzt Schrift, Schnitt, **Durchschuss (`--lh-tight` 1.15)** und **Laufweite
+  (0)**. Aus 16 Seiten wurden die lokalen `line-height`- und
+  `letter-spacing`-Angaben am Titel entfernt; `font-size` und `max-width`
+  bleiben bei der Seite. `lead-title` steht jetzt im Vertrag unter
+  `rollen.kanonische_klassen`, damit DS04 künftige Alleingänge meldet.
+- **Warum:** Jede Seite hatte ihren Titel selbst gesetzt — Durchschuss zwischen
+  **1.02 und 1.08**, durchweg mit negativer Laufweite (`-.01em`). Zweizeilige
+  Titel stiessen dadurch zusammen, Umlaute berührten die Zeile darüber. Auch
+  `design-system/starter.html` trug die enge Fassung, hat sie also an jede neue
+  Seite weitergegeben — die Abweichung pflanzte sich fort, statt aufzufallen.
+  Aufgefallen am Sommer-Cockpit auf dem Handy (Rückmeldung 4.8.2026).
+- **Wirkung:** Titel atmen überall gleich; der Grad bleibt eine Satzentscheidung
+  der Seite, der Durchschuss ist Hausregel. Wer künftig `.lead-title` lokal
+  redefiniert, wird von `ds-lint` (DS04) darauf hingewiesen.
+
 ## [1.9.5] – 2026-07-17
 
 ### Gedämpfter Text auf Blau bekommt ein Token: `--on-accent-muted`

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -42,6 +42,15 @@ p a:hover,li a:hover,.note a:hover,.hint a:hover,.help a:hover,.desc a:hover{tex
    keine Seite ausscheren (Konformität durch Konstruktion). Titel = Deutlich, nie Laut. */
 h1,h2,h3,h4,.h-display{font-family:var(--font-display);font-weight:var(--w-deutlich);line-height:var(--lh-tight)}
 h1,h2{letter-spacing:0}   /* B3: grosse Display-Grade bleiben eng (Tracking nur an Lesegraden) */
+/* Seitentitel — EINE Rolle fuer alle Werkzeuge (Beschluss 4.8.2026). Vorher hat
+   jede Seite ihren Titel selbst gesetzt, mit Durchschuss 1.02 bis 1.08 und
+   negativer Laufweite; zweizeilige Titel stiessen dadurch zusammen. Durchschuss
+   und Laufweite kommen ab jetzt von hier (--lh-tight 1.15, Laufweite 0). Die
+   GROESSE darf eine Seite weiterhin selbst waehlen (font-size/max-width) — der
+   Grad ist eine Satzentscheidung, der Durchschuss eine Hausregel. */
+.hero h1,.lead-title{font-family:var(--font-display);font-weight:var(--w-deutlich);
+  line-height:var(--lh-tight);letter-spacing:0}
+.lead-title{color:var(--gold-ink);margin:8px 0 0}
 /* B7: Halations-Absenkung im Dunkeln NUR an grossen Display-Rollen – gegen das
    Bleeding heller, fetter Grossbuchstaben. Fliess-/Kleintext behält sein Gewicht. */
 :root[data-theme="dark"] h1,:root[data-theme="dark"] h2,:root[data-theme="dark"] .h-display{font-weight:540}
@@ -54,7 +63,7 @@ h4{font-size:var(--t-h3)}
    NUR vertikales Padding (padding-block): der seitliche Rand kommt aus .wrap. Sonst
    würde `.wrap.hero` den seitlichen .wrap-Rand auf 0 setzen (Text klebt am Rand). */
 .hero{padding-block:clamp(40px,7vw,72px) var(--s6)}
-.hero h1{max-width:20ch;letter-spacing:-.005em}
+.hero h1{max-width:20ch}
 .hero .lede{margin-top:var(--s4)}
 
 /* Zugänglichkeit: Zustand = Blau */

--- a/design-system/contract.json
+++ b/design-system/contract.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://goetheanum/design-system/contract.schema.json",
-  "version": "1.9.5",
+  "version": "1.10.0",
   "titel": "Goetheanum Design-System – Struktur-Vertrag",
   "zweck": "Maschinenlesbare Grundlage der GESTALT-Konformität (symmetrisch zum sprachlichen Kanon in assets/typografie/). ds-lint.py prüft jede Seite hiergegen, ds-fix.py korrigiert deterministisch, das Schaufenster bildet es ab. Eine Quelle der Wahrheit für Struktur; Werte/Farben/Schnitte bleiben in tokens.css/tokens.json.",
   "geltungsbereich": {
@@ -86,6 +86,7 @@
       "field",
       "shead",
       "hero",
+      "lead-title",
       "card",
       "step-num",
       "crumbs",

--- a/design-system/navigation.html
+++ b/design-system/navigation.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="nav.css" />
 <style>
   .hero{padding-block:clamp(40px,7vw,80px) var(--s8)}
-  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.4vw,52px);line-height:1.04;letter-spacing:-.01em;max-width:17ch}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.4vw,52px);max-width:17ch}
   .hero .lede{margin-top:var(--s6);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:60ch}
   .two{display:grid;gap:var(--s4);grid-template-columns:1fr}
   @media(min-width:760px){.two{grid-template-columns:1fr 1fr}}

--- a/design-system/starter.html
+++ b/design-system/starter.html
@@ -44,7 +44,7 @@
   /* NUR werkzeug-eigene Gestaltung hierher. Alles Gemeinsame steht schon in base.css.
      Greife auf die Tokens zu (var(--gold), var(--s6) …), erfinde keine neuen Werte. */
   .hero{padding-block:clamp(40px,7vw,72px) var(--s8)}
-  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);line-height:1.05;letter-spacing:-.01em;max-width:18ch}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);max-width:18ch}
   .hero .lede{margin-top:var(--s6);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:58ch}
 </style>
 </head>

--- a/kampagne/g/g001-en.html
+++ b/kampagne/g/g001-en.html
@@ -18,7 +18,7 @@
 
 <style>
   .hero{padding-block:clamp(40px,7vw,72px) var(--s6)}
-  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);line-height:1.05;letter-spacing:-.01em;max-width:18ch}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);max-width:18ch}
   .hero .lede{margin-top:var(--s6);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:58ch}
   .sprachen{margin-top:var(--s4);font-size:var(--t-small)}
 </style>

--- a/kampagne/g/g001.html
+++ b/kampagne/g/g001.html
@@ -22,7 +22,7 @@
 
 <style>
   .hero{padding-block:clamp(40px,7vw,72px) var(--s6)}
-  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);line-height:1.05;letter-spacing:-.01em;max-width:18ch}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);max-width:18ch}
   .hero .lede{margin-top:var(--s6);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:58ch}
   .sprachen{margin-top:var(--s4);font-size:var(--t-small)}
 </style>

--- a/marketing-maschine.html
+++ b/marketing-maschine.html
@@ -22,7 +22,7 @@
 <style>
   /* Nur seiteneigene Feinheiten – alles Gemeinsame steht in base.css. Tokens statt Werte. */
   .hero{padding-block:clamp(40px,7vw,72px) var(--s8)}
-  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);line-height:1.05;letter-spacing:-.01em;max-width:20ch}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(30px,5.2vw,52px);max-width:20ch}
   .hero .lede{margin-top:var(--s6);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:60ch}
 
   /* Zwei-Stimmen-Karten */

--- a/ordner.html
+++ b/ordner.html
@@ -14,7 +14,7 @@
 
 <style>
   .hero{padding-block:clamp(28px,5vw,52px) var(--s5)}
-  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(26px,4.4vw,44px);line-height:1.06;letter-spacing:-.01em;max-width:22ch}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(26px,4.4vw,44px);max-width:22ch}
   .hero .lede{margin-top:var(--s4);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:66ch}
   .hero .lede code{font-family:var(--font-text);background:var(--field-bg);padding:.05em .35em;border-radius:6px}
 

--- a/sortierer.html
+++ b/sortierer.html
@@ -14,7 +14,7 @@
 
 <style>
   .hero{padding-block:clamp(28px,5vw,52px) var(--s5)}
-  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(26px,4.4vw,44px);line-height:1.06;letter-spacing:-.01em;max-width:20ch}
+  .hero h1{font-family:var(--font);font-weight:var(--w-deutlich);font-size:clamp(26px,4.4vw,44px);max-width:20ch}
   .hero .lede{margin-top:var(--s4);color:var(--muted);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:64ch}
   .hero .lede code{font-family:var(--font-text);background:var(--field-bg);padding:.05em .35em;border-radius:6px}
 

--- a/start/index.html
+++ b/start/index.html
@@ -13,7 +13,7 @@
   /* Übersicht-spezifisch (Hero, Karten-Raster, Werkstatt-Liste) */
   .hero{padding:clamp(48px,9vw,96px) 0 var(--s8)}
   .hero .kick{color:var(--gold-ink);font-size:var(--t-small);letter-spacing:.08em;margin-bottom:var(--s4)}
-  .hero h1{font-family:var(--font);font-weight:700;font-size:clamp(34px,6.4vw,64px);line-height:1.02;letter-spacing:-.01em;max-width:16ch}
+  .hero h1{font-family:var(--font);font-weight:700;font-size:clamp(34px,6.4vw,64px);max-width:16ch}
   .hero .lede{margin-top:var(--s6);color:var(--ink);font-size:clamp(16px,2vw,19px);line-height:1.55;max-width:58ch}
   .hero .meta{margin-top:var(--s8);display:flex;gap:var(--s2);flex-wrap:wrap}
 


### PR DESCRIPTION
## Worum es geht

Aufgefallen am Sommer-Cockpit auf dem Handy: die Seitentitel sind zu eng gesetzt. Die Ursache lag nicht beim Cockpit, sondern an einem fehlenden Stück Fundament.

## Der Befund

**Jede Seite hatte ihren Titel selbst gesetzt** — Durchschuss zwischen **1.02 und 1.08**, durchweg mit negativer Laufweite (`-.01em`). Zweizeilige Titel stiessen dadurch zusammen, Umlaute berührten die Zeile darüber.

Entscheidend: auch `design-system/starter.html` — die Vorlage, aus der jede neue Seite entsteht — trug die enge Fassung. Die Abweichung pflanzte sich also fort, statt aufzufallen.

## Die Aufnahme ins Fundament

- **`base.css`** bekommt die kanonische Rolle `.hero h1, .lead-title`: Schrift, Schnitt, **Durchschuss (`--lh-tight` 1.15)** und **Laufweite (0)** kommen ab jetzt von dort.
- Aus **16 Seiten** sind die lokalen `line-height`- und `letter-spacing`-Angaben am Titel entfernt. **`font-size` und `max-width` bleiben bei der Seite** — der Grad ist eine Satzentscheidung, der Durchschuss eine Hausregel.
- **`contract.json`**: `lead-title` als kanonische Rolle eingetragen, damit DS04 künftige Alleingänge meldet. Version **1.9.5 → 1.10.0**.
- **Beschluss-Ledger** (`design-system/CHANGELOG.md`) mit Was/Warum/Wirkung.

## Wirkung

`ds-lint`: **0 Fehler bei 61 Seiten**, und die **DS04-Hinweise fallen von 39 auf 0** — die lokalen Rollen-Neudefinitionen sind weg. `typo-check --all` grün, Driftwächter und Typo-Leiter ebenfalls.

Gegenprobe im Browser (Handy-Breite): Cockpit, Startseite und Sortierer rechnen jetzt alle mit Durchschuss 1.15 und Laufweite normal, in der Hausschrift.

Die Alternativen (1.02 heute · 1.15 Fundament · 1.22 offener) wurden als Specimen mit der echten Schrift verglichen; die Wahl fiel auf die Fundament-Regel — sie bedeutet nicht «neu erfinden», sondern «die eigene Regel wieder einhalten».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eee8tzL29NsZC4Tw3MP54

---
_Generated by [Claude Code](https://claude.ai/code/session_019eee8tzL29NsZC4Tw3MP54)_