### PR TITLE
Statusbalken zeigt Übererfüllung in Grün

### DIFF
--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -24,8 +24,9 @@
   .deadline .drow{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:8px;gap:12px}
   .deadline .dlab{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)}
   .deadline .dd{font-family:var(--font-text);font-variant-numeric:tabular-nums;font-size:var(--t-small);color:var(--ink);font-weight:600}
-  .meter{height:12px;border-radius:var(--r-pill);background:var(--line-soft);overflow:hidden}
-  .meter>span{display:block;height:100%;border-radius:var(--r-pill);background:linear-gradient(90deg,var(--gold),var(--gold-ink));transition:width .6s ease}
+  .meter{display:flex;height:12px;border-radius:var(--r-pill);background:var(--line-soft);overflow:hidden}
+  .meter>span{display:block;height:100%;background:linear-gradient(90deg,var(--gold),var(--gold-ink));transition:width .6s ease}
+  .meter>.ueber{background:var(--ok)} /* Übererfüllung über der Zielmarke */
 
   .board{display:grid;grid-template-columns:1fr 1fr;gap:var(--s6)}
   .panel{background:var(--card,var(--paper));border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);box-shadow:var(--shadow-card)}

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -216,7 +216,16 @@
     el('kTempo').textContent = t.tempo.toFixed(1).replace('.', ',');
     var noetig = t.rest > 0 ? Math.max(0, (ziel - total) / t.rest) : 0;
     el('kNoetig').textContent = t.rest > 0 ? noetig.toFixed(1).replace('.', ',') : '–';
-    el('ddBar').style.width = Math.min(100, pct) + '%';
+    // Über 100 % wird die Spur zum Ist-Stand: Gold bis zur Zielmarke,
+    // die Übererfüllung dahinter in Grün (--ok).
+    var ueber = el('ddBarUeber');
+    if (pct > 100){
+      el('ddBar').style.width = (100 / pct * 100).toFixed(2) + '%';
+      if (ueber) ueber.style.width = ((pct - 100) / pct * 100).toFixed(2) + '%';
+    } else {
+      el('ddBar').style.width = pct + '%';
+      if (ueber) ueber.style.width = '0';
+    }
 
     // Puls: der ganze Zeitraum seit Aktionsstart, ein Balken je Kalendertag
     // (Lücken = 0). Die Spalte ist das Zeigeziel; die Tageszahl erscheint als

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -54,7 +54,7 @@
             <div class="k"><b id="kTempo">–</b><span>Abos/Tag aktuell</span></div>
             <div class="k warn"><b id="kNoetig">–</b><span>Abos/Tag nötig</span></div>
           </div>
-          <div class="meter"><span id="ddBar" style="width:0"></span></div>
+          <div class="meter"><span id="ddBar" style="width:0"></span><span id="ddBarUeber" class="ueber" style="width:0"></span></div>
           <div class="puls" id="puls"></div>
           <div class="puls-l" id="pulsL"></div>
         </div>


### PR DESCRIPTION
Der Statusbalken im Aktions-Cockpit der Sommer-Aktion (`apps/sommer-zaehler/`) kappte die Füllung bisher bei 100 % — eine Übererfüllung des Ziels war unsichtbar.

Neu: Liegt der Stand über 100 %, wird die Spur zum Ist-Stand skaliert. Gold reicht bis zur Zielmarke, der Teil darüber hinaus erscheint in Grün.

- Farbe aus den Tokens: `--ok` (Erfolgsgrün, hell wie dunkel definiert) — kein Hartwert (B05/DS02).
- Kontrast der Grafikflächen: dunkles Grün `#3f7d46` auf der hellen Spur `--line-soft` hält ≥3:1 (B02); im Dunkelmodus greift die Token-Variante `#5aa367`.
- Unter 100 % verhält sich der Balken unverändert (Gold-Verlauf, Breite = Prozent).

`typo-check` und `ds-lint` sind grün (Score 100 %).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QwK6YkM4rR2dMzmtB3CB8L)_