### PR TITLE
Cockpit auf den Stand 7. August gebracht: neue Dunkelfeld-Lesart, erledigte Züge

### DIFF
--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -11,8 +11,12 @@
   var CONFIG = {
     start: '2026-07-03',            // Aktionsstart (Nachmittag 3. Juli 2026)
     ende:  '2026-08-08',            // Aktionsende
-    bleibeQuote: 0.62,             // Annahme, bis Erfahrungswerte vorliegen
-    meilensteine: [100, 250, 500, 1000],
+    // Annahme, bis Erfahrungswerte vorliegen. Bleibt eine Annahme bis in den
+    // Herbst: Die Aktion ist «3 Monate gratis», die erste Kohorte (Juli)
+    // entscheidet also frühestens ab dem 3. Oktober 2026. Bis dahin steht in
+    // der Datenbank bei keiner Anmeldung «bleibt» – die Projektion ist reine
+    // Rechnung, keine Beobachtung.
+    bleibeQuote: 0.62,
     zielGesamt: 500,                // Gesamtziel der Aktion (neue Abos) – GF-Vorgabe, zurückgestellt 30.7.
     // Zielmarke je Strom – Zwischenmarken, Summe = Gesamtziel. Historie: 24.7.
     // von 1000 auf 700 gesenkt (Faktor 0,7); 30.7. zurück auf die ursprüngliche
@@ -20,6 +24,10 @@
     // Ströme-Tabelle nicht gegen den Stand-Block rechnet. goetheanum.tv zählt
     // seither als EIN Strom ohne Sprachtrennung (Beschluss 30.7.): die Sprache
     // ist dort nicht gemessen, die alte EN-Zeile war nur eine Untergrenze.
+    // Das Gesamtziel ist am 5. August überschritten worden. Die Marken bleiben
+    // stehen, wie sie vereinbart waren – eine nachträglich angehobene Zielmarke
+    // wäre keine Messung mehr, sondern eine Erzählung. Der Stand-Block zeigt die
+    // Übererfüllung in Grün, die Ströme-Tabelle zeigt sie je Strom in Prozent.
     ziele: {
       'wos.de.papier': 100, 'wos.de.digital': 125,
       'wos.en.digital': 60,
@@ -54,32 +62,55 @@
     // während die Zahlen weiterlaufen. Schätzung (±30 %), keine Messung; die
     // Messwerte in der Datenbank bleiben unangetastet. Bei neuer Auswertung:
     // stand/doc/anteile hier nachziehen, sonst nichts.
-    // Korrektur 24. Juli: der Anteil der bezahlten Anzeige fiel von 40 % auf 7 %.
-    // Die alte Zahl kam aus der vermuteten Herkunft (zeitnächster Klick) – ein
-    // Anker, der nur bei spärlichen Klicks trägt. Die Anzeige stellt fast das
-    // ganze Klick-Log und gewann darum fast jede Nähe-Lotterie; eine Placebo-Probe
-    // (Anmeldezeiten um ±24/48 h verschoben) trifft sie fast gleich oft.
+    // Fortschreibung 7. August (löst die Lesart vom 24. Juli ab). Gerechnet aus
+    // drei Ankern: (1) der Grundlinie der 14 Tage vor der ersten Mail-Welle –
+    // 3,7 Anmeldungen ohne Spur je Tag, auf jedes spätere Fenster
+    // fortgeschrieben; (2) den GEMESSENEN Anteilen desselben Fensters, nach
+    // denen der Überschuss verteilt wird; (3) den 42 Selbstauskünften, die
+    // allein die Grundlinie und das Gebiet «Empfehlung» tragen können.
+    // Zwei Änderungen im Zuschnitt: «Popup» kam am 25. Juli dazu, «Empfehlung»
+    // ist im gemessenen Feld strukturell unsichtbar (dieser Weg trägt nie einen
+    // Link) und stand darum bisher nirgends.
+    // Die bezahlte Anzeige bleibt bei ≈9 Abos insgesamt: sie ist seit dem
+    // 24. Juli aus (letzter Klick 26. Juli), ihr Anteil wächst nicht mehr und
+    // ist durch die Abschalt-Probe gedeckelt, nicht durch die Fensterrechnung.
     dunkel: {
-      stand: '24. Juli',
-      doc:   'docs/wirkungs-lesart-24-07.md',
+      stand: '7. August',
+      doc:   'docs/wirkungs-lesart-07-08.md',
       anteile: {
-        newsletter: 0.346,   // TV-Weekly und Haus-Newsletter (Placebo-Überschuss belegt)
-        organik:    0.300,   // Direkt, Suche, Storefront, Bestandskonten
-        mailing:    0.208,   // Nachlauf der Welle 1 ohne Spur
-        bezahlt:    0.069,   // Meta-Anzeige – Obergrenze aus dem sauberen Fenster
-        social:     0.069,   // Reels, Stories, Karussell
-        print:      0.008
+        mailing:    0.399,   // die drei Mail-Wellen – jede als Sprung in der Tageskurve belegt
+        newsletter: 0.230,   // Haus-Newsletter und TV-Weekly, inkl. der beiden Eröffnungs-Mails
+        organik:    0.140,   // Direkt, Suche, Storefront, Bestandskonten
+        empfehlung: 0.112,   // persönliches Umfeld, Praxen, Schulen, Tagungen – nur aus Selbstauskunft
+        social:     0.043,   // Reels, Stories, Karussell
+        popup:      0.029,   // Webseiten-Popup seit 25. Juli
+        print:      0.025,   // Stand, Flyer, Inserate
+        bezahlt:    0.022    // Meta-Anzeige – Deckel aus der Abschalt-Probe (docs/abschaltprobe-anzeige-27-07.md)
       }
     },
-    // Kosten der Aktion (in CONFIG.waehrung) – stehen auf 0, echte Zahlen werden erfragt.
-    zahlenProvisorisch: true,      // blendet den Hinweis auf Beispielwerte ein
+    // Die Abschalt-Probe der bezahlten Anzeige ist gelaufen UND ausgewertet.
+    // Ohne diesen Eintrag empfiehlt das Cockpit unter «Nächste Züge» weiterhin,
+    // sie auszuwerten – ein Zug, der längst erledigt ist. Steht hier ein
+    // Ergebnis, wird daraus ein Befund statt einer Aufforderung.
+    abschaltprobe: {
+      stand:    '27. Juli',
+      doc:      'docs/abschaltprobe-anzeige-27-07.md',
+      ergebnis: 'Die Anzeige verlor beim Stopp 57 Klicks am Tag – über die Hälfte des gesamten Klick-Aufkommens –, ' +
+                'die goetheanum.tv-Anmeldungen fielen um 0,8 am Tag. Über die ganze Laufzeit rund 8 bis 12 Abos ' +
+                'aus 965 Klicks und 131 000 erreichten Personen. Damit ist sie der teuerste und der schwächste Weg der Aktion.'
+    },
+    // Zeigt an, was im Cockpit noch Annahme ist und nicht gemessen. Preise und
+    // Zielmarken sind es seit dem 17. Juli nicht mehr (echte Formular- und
+    // Uscreen-Preise, ratifizierte GF-Vorgabe) – allein die Bleibe-Quote bleibt
+    // eine Annahme, bis die erste Kohorte im Oktober entscheidet.
+    zahlenProvisorisch: true,
     // Externe Quelle der Social-Media-Zahlen (Reichweite/Klicks je Kanal).
     // Metricool gibt die Zahlen nur im geschützten Dashboard aus – ein Live-Abgriff
     // aus dem Browser ist nicht möglich. Darum ablesen und je Aktivität eintragen.
     quelleSocial: {
       label: 'Metricool · Kampagnen-Auswertung',
       url:   'https://app.metricool.com/reporting/campaigns-dashboard/public?token=eyJ6aXAiOiJERUYiLCJhbGciOiJIUzUxMiJ9.eJxVztFSgkAUgOF3ObcywhrCxh3VTLLWZmZmNU2Dy5Lgrhzg5AhN7x7jXZf_d_X_QPqdQfQOOyJsI9dNEcdWU1OoqjJjVVn4cKBICSIW8ouQ-YwFDhy2-X_QJxyAs-lk6p3B0icaiEBjU6_atpJHafY66b6sElsSM755NJORZFjGwdO8v85ewxN7vkoal4tDvWyThUrucS1fVOnFYo_Ey5u7oq770L_t5w9Wr5ualqsyrUaoWrmIdZG7lF_yYOfHb8UmnOVCd4EHDlCHejjBLDUE5zM6Ds3g9w85oFAH.cL8xJiluV4VRcqD2tsOIXKgpvI7UfN_fbvREgPpiP_r0T0JTBfS_vH2cnrq50d-kogWBjyZLE_OMINhFqo8dIw',
-      takt:  'Empfehlung: wöchentlich (montags) übernehmen; in der Schlussspurt-Woche ab 3. August täglich.'
+      takt:  'Die Aktion endet am 8. August: die Schlusszahlen einmal vollständig übernehmen, sobald Metricool die letzte Woche abgerechnet hat – danach ist die Auswertung fest und der Takt endet.'
     }
   };
 
@@ -616,7 +647,9 @@
     // das ist widerlegt: die Kette Landing → Checkout → user_created ist geprüft
     // und trägt die UTM. Bleibt der Befund selbst: diese Wege werden geklickt und
     // münden kaum in Abos. Darum ein Zug, der misst statt umbaut.
-    // Herleitung: docs/wirkungs-lesart-24-07.md.
+    // Herleitung: docs/wirkungs-lesart-24-07.md, Ergebnis der Probe in
+    // docs/abschaltprobe-anzeige-27-07.md, fortgeschrieben in
+    // docs/wirkungs-lesart-07-08.md.
     var leck = { kl:0, motive:[], letzter:null, bezahltKl:0, bezahltLetzter:null };
     Object.keys(grp).forEach(function(k){
       var g = grp[k], a2 = ab[k] || 0;
@@ -658,6 +691,17 @@
                'Die organischen Wege über dieselbe Seite und dieselben In-App-Browser werden mit 3 bis 5 Prozent ihrer Klicks messbar, die bezahlte Anzeige mit 0,4 Prozent – die Klicks werden also nicht verloren, sie werden kaum zu Abos. ' +
                'Darum zuerst messen statt umbauen: die Anzeige aussetzen, solange die Grundlinie sauber ist, und die Anmeldungen je Tag vergleichen. ' +
                'Soll sie danach weiterlaufen, macht ein eigenes Uscreen-Angebot je bezahltem Weg sie hart messbar: services/sommer-zaehler/uscreen-angebot-attribution-auftrag.md.' });
+      } else if (CONFIG.abschaltprobe && CONFIG.abschaltprobe.ergebnis){
+        // Die Probe ist gelaufen UND ausgewertet: kein Zug mehr, sondern ein
+        // Befund. Er steht zuunterst (art 0) und trägt kein «jetzt» – nichts
+        // ist mehr zu tun, es ist etwas zu wissen.
+        zuege.push({ titel:'Bezahlte Anzeige – Abschalt-Probe ausgewertet', art:0, mass:0,
+          warum:'aus seit dem 24. Juli · letzter Klick vor ' + stillTage + ' Tagen · ' + fmt(leck.bezahltKl) + ' Klicks insgesamt',
+          hebel:'ausgewertet',
+          text:CONFIG.abschaltprobe.ergebnis + ' Festgehalten am ' + CONFIG.abschaltprobe.stand + ' in ' + CONFIG.abschaltprobe.doc +
+               '; die Anteile im Dunkelfeld sind entsprechend gedeckelt. ' +
+               'Für eine nächste bezahlte Runde gilt der Schluss daraus: erst hart messbar machen, dann buchen – ein eigenes Uscreen-Angebot je bezahltem Weg, ' +
+               'siehe services/sommer-zaehler/uscreen-angebot-attribution-auftrag.md.' });
       } else {
         zuege.push({ titel:'Abschalt-Probe auswerten – die Anzeige liefert seit ' + stillTage + ' Tagen keine Klicks', art:2, mass:leck.kl,
           warum:'letzter Klick der Anzeige vor ' + stillTage + ' Tagen · ' + fmt(leck.bezahltKl) + ' Klicks insgesamt · die Probe läuft bereits',
@@ -1487,7 +1531,9 @@
       .then(renderHerkunft)
       .catch(function(){ el('herkunftBody').innerHTML = '<tr><td class="err" colspan="3">nicht ladbar</td></tr>'; });
     if(CONFIG.zahlenProvisorisch && el('provisorisch')){
-      el('provisorisch').textContent = 'Zielmarken, Preise und die Bleibe-Quote sind vorläufig hinterlegt – sobald die echten Werte gesetzt sind, rechnet das Cockpit unverändert weiter.';
+      el('provisorisch').textContent = 'Preise und Zielmarken sind echt hinterlegt (Formular- und Uscreen-Preise, Stand 17. Juli). ' +
+        'Annahme bleibt allein die Bleibe-Quote von ' + Math.round(CONFIG.bleibeQuote * 100) + ' %: Die Aktion läuft drei Monate gratis, ' +
+        'die erste Kohorte entscheidet frühestens Anfang Oktober. Bis dahin ist jede Zahl zum Folgejahr eine Rechnung, keine Beobachtung.';
     }
     Promise.all([ rpc('sommer2026_stats'), rpc('sommer2026_timeline'), rpc('sommer2026_kohorten'), rpc('sommer2026_kanaele'),
                   rpc('sommer2026_attribution'), rpc('sommer2026_massnahmen_public'), rpc('sommer2026_kosten_public'),

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -134,7 +134,7 @@
         <p class="provisorisch" id="dunkelNote"></p>
         <div id="vermutetKopf" class="mh" style="margin-top:var(--s6)"></div>
         <div id="vermutetList"><div class="empty">lädt …</div></div>
-        <p class="provisorisch">Live aus den Ereignissen: je Anmeldung ohne UTM der zeitlich nächste Kurzlink-Klick (bis 90 Min. davor) auf einen passenden Kampagnen-Link. Ein Indiz, keine Messung – gezählt wird es nirgends, es ordnet nur ein. Das Indiz trägt nur bei spärlichen Klicks: wo ein Weg mehr als die Hälfte aller Klicks stellt – heute die bezahlte Anzeige –, steht er zufällig bei fast jeder Anmeldung daneben und sagt nichts. Nachgerechnet in <code>docs/wirkungs-lesart-24-07.md</code>.</p>
+        <p class="provisorisch">Live aus den Ereignissen: je Anmeldung ohne UTM der zeitlich nächste Kurzlink-Klick (bis 90 Min. davor) auf einen passenden Kampagnen-Link. Ein Indiz, keine Messung – gezählt wird es nirgends, es ordnet nur ein. Das Indiz trägt nur bei spärlichen Klicks: Solange die bezahlte Anzeige lief, stellte sie über die Hälfte aller Klicks und stand darum zufällig bei fast jeder Anmeldung daneben – nachgerechnet in <code>docs/wirkungs-lesart-24-07.md</code>. Seit ihrem Stopp am 24. Juli beherrscht kein Weg mehr das Klick-Log; das Indiz ist damit brauchbarer geworden, bleibt aber ein Indiz. Die geltende Zuordnung des Dunkelfeldes rechnet nicht damit, sondern aus Tageskurve, gemessenen Fenster-Anteilen und Selbstauskunft: <code>docs/wirkungs-lesart-07-08.md</code>.</p>
       </details>
 
       <details class="zb-form">

--- a/docs/wirkungs-lesart-07-08.md
+++ b/docs/wirkungs-lesart-07-08.md
@@ -1,0 +1,139 @@
+# Wirkungs-Lesart der Sommer-Aktion — Stand 7. August 2026
+
+Dieses Dokument ordnet die Anmeldungen **ohne UTM-Spur** («ohne UTM» im
+Cockpit) den Aktivitäten der Kampagne zu. Es ist eine **Lesart, keine
+Messung**: Alle mit ≈ markierten Zahlen sind Schätzungen (±30 %). Die
+Datenbank bleibt unangetastet — dort stehen nur harte Zuordnungen. Die
+Anteile daraus stehen im Cockpit (`CONFIG.dunkel.anteile`) und werden dort
+auf den jeweils aktuellen Stand angewandt.
+
+Diese Fassung löst `wirkungs-lesart-24-07.md` ab (die bleibt als Historie
+liegen). Sie widerspricht ihr nicht — sie schreibt sie auf die letzten zwei
+Wochen fort, in denen zwei Mail-Wellen, das Popup und der Schlussspurt
+dazugekommen sind.
+
+Grundlage am Stichtag (7. August, ein Tag vor Aktionsende): **636
+Anmeldungen**, davon **358 mit UTM** und **278 ohne**. Das Dunkelfeld ist
+damit von 54 % (24. Juli) auf **44 %** gesunken — nicht, weil weniger dunkel
+hereinkommt, sondern weil das Mailing mit sauberer Spur so viel dazugelegt
+hat.
+
+## Was sich gegenüber dem 24. Juli ändert
+
+1. **Das Mailing trägt die Aktion.** Am 24. Juli war es eine von mehreren
+   Kräften; heute stellt es mit 282 gemessenen Abschlüssen **79 % des
+   gemessenen Feldes**. Beide Wellen sind als Sprung in der Tageskurve
+   sichtbar (18. Juli: 56 Abos, 30. Juli: 60).
+2. **Die bezahlte Anzeige ist aus** — seit dem 24. Juli, letzter Einzelklick
+   am 26. Juli (`abschaltprobe-anzeige-27-07.md`). Ihr Anteil bleibt bei den
+   dort belegten ≈9 Abos und wächst nicht mehr. Damit fällt auch die
+   Vorsichtsklausel der alten Lesart weg: das Klick-Log wird **nicht mehr**
+   von einem einzelnen Weg beherrscht.
+3. **Zwei neue Gebiete im Dunkelfeld:** **Popup** (seit 25. Juli auf den
+   Webseiten, 21 gemessene Abschlüsse) und **Empfehlung** (persönliches
+   Umfeld, Praxen, Schulen, Tagungen — in den Selbstauskünften der
+   zweitgrösste Block, im gemessenen Feld strukturell unsichtbar, weil er nie
+   einen Link trägt).
+
+## Wie gerechnet wurde
+
+Drei Anker, wie am 24. Juli — der schwächste (vermutete Herkunft aus dem
+zeitnächsten Klick) bleibt aussen vor.
+
+### Anker 1 · Die Tageskurve (Grundlinie und Überschuss)
+
+Vor der ersten Mail-Welle lief die Aktion 14 Tage ohne Mailer und ohne
+Anzeige. Das Dunkelfeld dieser Tage ist die **Grundlinie**: 52 Anmeldungen
+ohne Spur, **3,7 pro Tag**. Diese Rate wird auf jedes spätere Fenster
+fortgeschrieben; was darüber liegt, ist der **Überschuss** des Fensters.
+
+| Fenster | Tage | dunkel | Grundlinie | Überschuss |
+|---|---:|---:|---:|---:|
+| 3.–16. Juli (vor dem Mailing) | 14 | 52 | 52 | — |
+| 17.–23. Juli (Welle 1) | 7 | 69 | 26 | **+43** |
+| 24.–29. Juli (Zwischenfeld) | 6 | 42 | 22 | +20 |
+| 30. Juli–6. Aug. (Welle 2) | 8 | 89 | 30 | **+59** |
+| 7. August (Welle 3, Frist) | 1 | 26 | 4 | **+22** |
+| **Summe** | 36 | **278** | | |
+
+### Anker 2 · Die gemessenen Anteile desselben Fensters
+
+Der Überschuss eines Fensters wird nach den **gemessenen** Anteilen
+**dieses Fensters** verteilt — was im Hellen dominiert, dominiert auch im
+Dunkeln, denn es sind dieselben Wege mit derselben Landingpage.
+
+| Fenster | gemessen (ohne dunkel) |
+|---|---|
+| Welle 1 | Mailing 81 · Newsletter 4 · Social 2 · Organik 2 · Bezahlt 1 |
+| Zwischenfeld | Mailing 13 · Newsletter 6 · Organik 1 · Social 1 |
+| Welle 2 | Mailing 139 · Popup 18 · Newsletter 8 · Social 4 · Bezahlt 2 |
+| Welle 3 | Mailing 49 · Newsletter 6 · Popup 4 · Social 3 · Organik 1 |
+
+Die **Grundlinie** trägt diesen Schlüssel nicht: In ihr wurde fast nichts
+gemessen (7 Social, 4 Mailing, 2 Organik). Sie wird darum nach Anker 3
+verteilt.
+
+### Anker 3 · Die Selbstauskunft
+
+42 der 278 dunklen Anmeldungen beantworten «Wie sind Sie auf uns aufmerksam
+geworden?». Von 40 einordenbaren Antworten:
+
+| Antwort-Gruppe | Anzahl | Anteil |
+|---|---:|---:|
+| E-Mail, Newsletter, Verteiler | 15 | 37,5 % |
+| Direkt, Suche, Bestand («kenne es schon lange») | 10 | 25,0 % |
+| Empfehlung, Praxis, Schule, Tagung | 9 | 22,5 % |
+| Print, Stand, Flyer | 2 | 5,0 % |
+| Social | 2 | 5,0 % |
+| Anzeige, Werbung | 2 | 5,0 % |
+
+Die Selbstauskunft kann **Mailing und Newsletter nicht trennen** — für den
+Empfänger ist beides «eine Mail». Diese Trennung leistet Anker 2. Umgekehrt
+ist die Selbstauskunft der **einzige** Beleg für Empfehlung: Dieser Weg
+trägt nie einen Link und ist im gemessenen Feld notwendig eine Null.
+
+## Das Ergebnis
+
+Die 278 Anmeldungen ohne Spur, verteilt (Grundlinie nach Anker 3, jeder
+Überschuss nach Anker 2, die Anzeige gedeckelt durch die Abschalt-Probe):
+
+| Gebiet | ≈ dunkel | Anteil | dazu gemessen | ≈ gesamt |
+|---|---:|---:|---:|---:|
+| Mailing | 111 | 39,9 % | 282 | **393** |
+| Newsletter | 64 | 23,0 % | 28 | 92 |
+| Organik · Direkt · Bestand | 39 | 14,0 % | 7 | 46 |
+| Empfehlung | 31 | 11,2 % | 0 | 31 |
+| Social organisch | 12 | 4,3 % | 17 | 29 |
+| Popup | 8 | 2,9 % | 21 | 29 |
+| Print · Stand · Inserat | 7 | 2,5 % | 0 | 7 |
+| Bezahlt · Anzeige | 6 | 2,2 % | 3 | **9** |
+| **Summe** | **278** | **100 %** | **358** | **636** |
+
+**Die eine Aussage:** Rund **62 % der ganzen Aktion** gehen auf die drei
+Mail-Wellen an den eigenen Verteiler zurück, weitere 14 % auf die
+Newsletter. Die Aktion ist damit im Kern **keine Gewinnung neuer
+Öffentlichkeit, sondern eine Aktivierung des eigenen Umfelds** — was die
+Zielmarke erreicht hat (636 von 500, übertroffen am 5. August), aber für die
+nächste Aktion die entscheidende Frage stellt.
+
+**Die Anzeige** bleibt bei ≈9 Abos aus rund 965 gemessenen Klicks und
+131 000 erreichten Personen. Diese Zahl ist seit dem 24. Juli dreifach
+gestützt: Placebo-Probe, Abschalt-Probe und jetzt die Fensterrechnung, in
+der die Anzeige-Fenster keinen eigenen Überschuss zeigen.
+
+## Wo diese Lesart schwach ist
+
+- **Grundlinie als Konstante.** Sie unterstellt, dass die organische
+  Nachfrage über 36 Tage gleich bleibt. In der Schlusswoche stimmt das
+  vermutlich nicht: Die Frist selbst erzeugt Direktverkehr, der hier dem
+  Mailing zugeschlagen wird. Der Mailing-Anteil ist darum eher eine
+  Obergrenze.
+- **Newsletter gegen Mailing.** Beide fallen auf dieselben Tage (17. Juli,
+  31. Juli). Anker 2 trennt sie nach dem gemessenen Verhältnis; sind die
+  Newsletter schlechter ausgezeichnet als der Mailer, ist ihr Anteil zu
+  klein geraten.
+- **Empfehlung** steht allein auf 9 Selbstauskünften. Die Grössenordnung ist
+  belegt, die Zahl nicht.
+
+Bei neuer Auswertung: `CONFIG.dunkel` (stand / doc / anteile) im Cockpit
+nachziehen, sonst nichts.

--- a/services/sommer-zaehler/README.md
+++ b/services/sommer-zaehler/README.md
@@ -183,9 +183,21 @@ Strikt über `dedup_key`:
   `dedup_key = <produkt>:<gesalzener E-Mail-Hash>` – E-Mail wird **nur gehasht**
   gespeichert (Salt in `sommer2026_config.hash_salt`), nie im Klartext.
 
-## Fest im Cockpit hinterlegt (bis echte Werte vorliegen)
+## Fest im Cockpit hinterlegt
 
-In `apps/sommer-zaehler/index.html` im `CONFIG`-Block: Zielmarken je Strom,
-Preise je Tarif/Intervall, angenommene Bleibe-Quote, Aktionsstart/-ende,
-Meilensteine. Diese Werte sind vorläufig markiert — nur diese ersetzen, sobald
-die echten Zahlen da sind; die Aggregation rechnet unverändert weiter.
+Im `CONFIG`-Block von `apps/sommer-zaehler/campaign.js`: Aktionsstart/-ende,
+Zielmarken je Strom, Preise je Tarif/Intervall, angenommene Bleibe-Quote,
+Dunkelfeld-Anteile, Ergebnis der Abschalt-Probe. Nur diese Werte ersetzen —
+die Aggregation rechnet unverändert weiter.
+
+Echt sind Preise und Zielmarken (Formular- und Uscreen-Preise Stand 17. Juli,
+GF-Vorgabe 500). Annahme bleibt allein die **Bleibe-Quote**: Die Aktion läuft
+drei Monate gratis, die erste Kohorte entscheidet frühestens Anfang Oktober
+2026 — bis dahin trägt keine Anmeldung den Status `bleibt`.
+
+Die **Dunkelfeld-Anteile** (`CONFIG.dunkel`) sind eine datierte Lesart und
+gehören bei jeder neuen Auswertung nachgezogen (stand / doc / anteile), zuletzt
+`docs/wirkungs-lesart-07-08.md` vom 7. August. Sie verteilt die Anmeldungen ohne Spur aus drei Ankern: Grundlinie
+der Tageskurve vor der ersten Mail-Welle, gemessene Anteile desselben Fensters,
+Selbstauskunft. Historie: `wirkungs-lesart-18-07.md`, `-22-07`, `-24-07` und
+die Abschalt-Probe der bezahlten Anzeige (`abschaltprobe-anzeige-27-07.md`).


### PR DESCRIPTION
Die Zahlen des Cockpits laufen live aus dem Backend — die **Lesart daneben nicht**. Sie stand auf dem 24. Juli (242 Anmeldungen, Anzeige noch an) und trug Aussagen, die heute falsch sind. Nachgezogen auf den Stand **636 Anmeldungen**, einen Tag vor Aktionsende.

## Die neue Lesart · `docs/wirkungs-lesart-07-08.md`

Gerechnet aus drei Ankern:

1. **Grundlinie der Tageskurve** — die 14 Tage vor der ersten Mail-Welle liefen ohne Mailer und ohne Anzeige: 3,7 Anmeldungen ohne Spur je Tag. Diese Rate wird auf jedes spätere Fenster fortgeschrieben.
2. **Gemessene Anteile desselben Fensters** — der Überschuss über die Grundlinie wird nach dem verteilt, was im selben Fenster im Hellen gemessen wurde.
3. **Selbstauskunft** (42 Antworten) — trägt allein die Grundlinie und das Gebiet Empfehlung, das im gemessenen Feld notwendig eine Null ist.

Ergebnis der Verteilung der 278 Anmeldungen ohne Spur:

| Gebiet | ≈ dunkel | dazu gemessen | ≈ gesamt |
|---|---:|---:|---:|
| Mailing | 111 | 282 | **393** |
| Newsletter | 64 | 28 | 92 |
| Organik · Direkt · Bestand | 39 | 7 | 46 |
| Empfehlung | 31 | 0 | 31 |
| Social organisch | 12 | 17 | 29 |
| Popup | 8 | 21 | 29 |
| Print · Stand · Inserat | 7 | 0 | 7 |
| Bezahlt · Anzeige | 6 | 3 | **9** |
| **Summe** | **278** | **358** | **636** |

**Die eine Aussage:** Rund 62 Prozent der ganzen Aktion gehen auf die drei Mail-Wellen an den eigenen Verteiler zurück, weitere 14 Prozent auf die Newsletter. Die bezahlte Anzeige bleibt bei neun Abos — jetzt dreifach gestützt (Placebo-Probe, Abschalt-Probe, Fensterrechnung).

## Was sich im Cockpit ändert

- **`CONFIG.dunkel`** — Anteile neu, Stand und Herleitungs-Dokument nachgezogen. Zwei Gebiete kommen dazu: **Popup** (seit 25. Juli auf den Webseiten) und **Empfehlung** (persönliches Umfeld, Praxen, Schulen — dieser Weg trägt nie einen Link und stand darum bisher nirgends).
- **`CONFIG.abschaltprobe`** — Ergebnis der Probe hinterlegt. Ohne diesen Eintrag empfahl «Nächste Züge» weiterhin, eine Probe auszuwerten, die am 27. Juli ausgewertet wurde. Aus der Aufforderung wird ein Befund.
- **Vorläufigkeits-Hinweis** — Preise und Zielmarken sind seit dem 17. Juli echt; vorläufig ist allein die Bleibe-Quote. Der Hinweis sagt das jetzt und nennt den Grund: die erste Kohorte entscheidet frühestens Anfang Oktober.
- **`quelleSocial.takt`** — der Schlussspurt-Takt vom 3. August ist abgelaufen, ersetzt durch die Schlussabrechnung.
- **`meilensteine`** entfernt — seit der neuen Ordnung nirgends mehr gelesen.
- **Kommentar zur Zielmarke** — am 5. August überschritten (636 von 500). Die Marken bleiben stehen, wie sie vereinbart waren; eine nachträglich angehobene Zielmarke wäre keine Messung mehr.
- **Seitentext** — der Satz zur vermuteten Herkunft nannte die bezahlte Anzeige als «heute» beherrschenden Weg im Klick-Log. Sie ist seit dem 24. Juli aus.

## Offener Punkt (nicht in diesem PR)

In `sommer2026_kosten` stehen nur 309.70 CHF Druck. Die **Kosten der Meta-Anzeige fehlen** — damit sind Kosten je Abo und Rückfluss auf der Kosten-Seite zu günstig. Die Zahl liegt nicht im Repo; sie muss abgelesen und eingetragen werden.

## Prüfmaschinen

`typo-check` konform · `ds-lint --staged` 0 Fehler, Score 100 %.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUqZZzUQntMLiZPecAsBBc)_