### PR TITLE
Aktion um drei Tage verlängert: Ende 11. statt 8. August

### DIFF
--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -10,7 +10,12 @@
      diese Werte anpassen. */
   var CONFIG = {
     start: '2026-07-03',            // Aktionsstart (Nachmittag 3. Juli 2026)
-    ende:  '2026-08-08',            // Aktionsende
+    // Aktionsende. Am 7. August um drei Tage verlängert (zuvor 8. August).
+    // Dieses Datum steuert alles Zeitliche: Resttage, «Abos/Tag nötig», die
+    // Breite des Pulses, die Fortschreibung im Befund und das Wochenraster des
+    // Zeitbands. Die Ingestion kennt kein Enddatum (nur aktion_start und
+    // aktion_aktiv) – Anmeldungen der Zusatztage zählen von selbst mit.
+    ende:  '2026-08-11',
     // Annahme, bis Erfahrungswerte vorliegen. Bleibt eine Annahme bis in den
     // Herbst: Die Aktion ist «3 Monate gratis», die erste Kohorte (Juli)
     // entscheidet also frühestens ab dem 3. Oktober 2026. Bis dahin steht in
@@ -110,7 +115,7 @@
     quelleSocial: {
       label: 'Metricool · Kampagnen-Auswertung',
       url:   'https://app.metricool.com/reporting/campaigns-dashboard/public?token=eyJ6aXAiOiJERUYiLCJhbGciOiJIUzUxMiJ9.eJxVztFSgkAUgOF3ObcywhrCxh3VTLLWZmZmNU2Dy5Lgrhzg5AhN7x7jXZf_d_X_QPqdQfQOOyJsI9dNEcdWU1OoqjJjVVn4cKBICSIW8ouQ-YwFDhy2-X_QJxyAs-lk6p3B0icaiEBjU6_atpJHafY66b6sElsSM755NJORZFjGwdO8v85ewxN7vkoal4tDvWyThUrucS1fVOnFYo_Ey5u7oq770L_t5w9Wr5ualqsyrUaoWrmIdZG7lF_yYOfHb8UmnOVCd4EHDlCHejjBLDUE5zM6Ds3g9w85oFAH.cL8xJiluV4VRcqD2tsOIXKgpvI7UfN_fbvREgPpiP_r0T0JTBfS_vH2cnrq50d-kogWBjyZLE_OMINhFqo8dIw',
-      takt:  'Die Aktion endet am 8. August: die Schlusszahlen einmal vollständig übernehmen, sobald Metricool die letzte Woche abgerechnet hat – danach ist die Auswertung fest und der Takt endet.'
+      takt:  'Die Aktion endet am 11. August: bis dahin täglich übernehmen, danach die Schlusszahlen einmal vollständig, sobald Metricool die letzte Woche abgerechnet hat – dann ist die Auswertung fest und der Takt endet.'
     }
   };
 
@@ -870,7 +875,7 @@
   var PHASEN = [
     { name: 'Auftakt',       von: '2026-06-29', bis: '2026-07-19' },
     { name: 'Verdichtung',   von: '2026-07-20', bis: '2026-08-02' },
-    { name: 'Schlussspurt',  von: '2026-08-03', bis: '2026-08-08' }
+    { name: 'Schlussspurt',  von: '2026-08-03', bis: '2026-08-11' }
   ];
   var ZB_KANAELE = [
     ['social', 'Social'], ['newsletter', 'Newsletter'], ['mailer', 'Mailing/Post'], ['flyer', 'Flyer/Stand'],

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -27,7 +27,7 @@
     <h1 class="lead-title">Sommer-Aktion 2026</h1>
     <details class="modell-box">
       <summary>Wozu diese Aktion? · Aktionsseiten</summary>
-      <p class="modell">Wir wollen, dass kulturinteressierte Menschen bis zum <span class="k">8. August</span> ein Gratis-Abo starten – und danach als zahlende Leser und Zuschauer bleiben. Jede Aktivität hat darin ihre Aufgabe.</p>
+      <p class="modell">Wir wollen, dass kulturinteressierte Menschen bis zum <span class="k">11. August</span> ein Gratis-Abo starten – und danach als zahlende Leser und Zuschauer bleiben. Jede Aktivität hat darin ihre Aufgabe.</p>
       <div class="landing" style="margin-top:var(--s4)">
         <span class="meta">Aktionsseiten</span>
         <a class="btn" href="https://global-sommer2026.goetheanum.online" target="_blank" rel="noopener">Übersicht · 3 Monate gratis</a>
@@ -35,7 +35,7 @@
         <a class="btn" href="https://tv-sommer2026.goetheanum.tv" target="_blank" rel="noopener">goetheanum.tv</a>
       </div>
     </details>
-    <p class="kampagne">Kampagne <code>summer26_trial</code> · 3. Juli bis 8. August 2026 · <a href="../utm-generator/">UTM-Links für die Aktion bauen →</a></p>
+    <p class="kampagne">Kampagne <code>summer26_trial</code> · 3. Juli bis 11. August 2026 · <a href="../utm-generator/">UTM-Links für die Aktion bauen →</a></p>
   </section>
 
 

--- a/docs/wirkungs-lesart-07-08.md
+++ b/docs/wirkungs-lesart-07-08.md
@@ -12,8 +12,8 @@ liegen). Sie widerspricht ihr nicht — sie schreibt sie auf die letzten zwei
 Wochen fort, in denen zwei Mail-Wellen, das Popup und der Schlussspurt
 dazugekommen sind.
 
-Grundlage am Stichtag (7. August, ein Tag vor Aktionsende): **636
-Anmeldungen**, davon **358 mit UTM** und **278 ohne**. Das Dunkelfeld ist
+Grundlage am Stichtag (7. August, vier Tage vor dem verlängerten Aktionsende
+am 11. August): **636 Anmeldungen**, davon **358 mit UTM** und **278 ohne**. Das Dunkelfeld ist
 damit von 54 % (24. Juli) auf **44 %** gesunken — nicht, weil weniger dunkel
 hereinkommt, sondern weil das Mailing mit sauberer Spur so viel dazugelegt
 hat.
@@ -128,6 +128,13 @@ der die Anzeige-Fenster keinen eigenen Überschuss zeigen.
   vermutlich nicht: Die Frist selbst erzeugt Direktverkehr, der hier dem
   Mailing zugeschlagen wird. Der Mailing-Anteil ist darum eher eine
   Obergrenze.
+- **Die Aktion ist nach diesem Stichtag um drei Tage verlängert worden**
+  (neues Ende: 11. August). Der 7. August ist damit nicht mehr der Schlusstag,
+  sondern ein Zwischenstand. Die kommunizierte Frist bleibt der 8. August —
+  die Mail-Wellen 3 und 3b nennen ihn —, der gemessene Zeitraum endet drei
+  Tage später. Wer diese Lesart nach dem 11. August fortschreibt, rechnet die
+  Tage 8. bis 11. August als eigenes Fenster: Sie stehen unter einer Frist,
+  die für die Empfänger bereits abgelaufen war.
 - **Newsletter gegen Mailing.** Beide fallen auf dieselben Tage (17. Juli,
   31. Juli). Anker 2 trennt sie nach dem gemessenen Verhältnis; sind die
   Newsletter schlechter ausgezeichnet als der Mailer, ist ihr Anteil zu

--- a/services/sommer-zaehler/kurzlink-site/README.md
+++ b/services/sommer-zaehler/kurzlink-site/README.md
@@ -44,7 +44,8 @@ oder Papier.
 - `index.html` — die Wurzel leitet auf die Aktions-Landingpage weiter.
   **Kein Schaufenster:** die internen Werkzeuge (Generator, Cockpit) werden
   hier bewusst nicht verlinkt — die Wurzel eines Kürzers zeigt nie das
-  Werkzeug. Nach dem 8. August 2026 das Ziel auf `goetheanum.ch` umstellen.
+  Werkzeug. Nach dem 11. August 2026 das Ziel auf `goetheanum.ch` umstellen
+  (die Aktion ist am 7. August um drei Tage verlängert worden).
 - `404.html` — die Weiterleitungs-Brücke; leere und unbekannte Pfade landen
   ebenfalls auf der Aktions-Landingpage.
 - `CNAME` — `tools.goetheanum.ch` (von GitHub Pages gesetzt).

--- a/services/sommer-zaehler/kurzlink-site/index.html
+++ b/services/sommer-zaehler/kurzlink-site/index.html
@@ -6,7 +6,8 @@
      der Hand – er landet auf der Aktions-Landingpage (ohne UTM, zaehlt als
      direkt). Die internen Werkzeuge (Generator, Cockpit) werden hier bewusst
      NICHT verlinkt: Die Wurzel eines Kuerzers zeigt nie das Werkzeug.
-     Nach dem 8. August 2026 das Ziel auf https://goetheanum.ch umstellen.
+     Nach dem 11. August 2026 das Ziel auf https://goetheanum.ch umstellen
+     (Aktion am 7. August um drei Tage verlaengert, zuvor 8. August).
      ============================================================================= -->
 <html lang="de-CH">
 <head>


### PR DESCRIPTION
Das Enddatum steuert im Cockpit **alles Zeitliche**: Resttage, «Abos/Tag nötig», die Breite des Pulses, die Fortschreibung im Befund und das Wochenraster des Zeitbands. Stand es falsch, rechnete das Cockpit die Aktion drei Tage zu kurz — und hätte ab morgen «Aktion beendet» gemeldet, während sie noch lief.

## Geändert

- **`CONFIG.ende`** auf `2026-08-11`, Phase «Schlussspurt» bis dahin verlängert.
- **Zwei Datumsangaben im Seitenkopf** — die Modell-Erklärung («bis zum …  ein Gratis-Abo starten») und die Kampagnen-Zeile.
- **Metricool-Takt** — bis zum 11. täglich übernehmen, danach die Schlussabrechnung.
- **Kurzlink-Site** — dort stand das Schaltdatum, an dem die Wurzel wieder auf `goetheanum.ch` zeigen soll, auf dem 8. August. Drei Tage zu früh umgelegt hätte es die letzten Aktionstage ins Leere geführt.
- **Lesart vom 7. August** — als Zwischenstand statt als Schlussstand ausgewiesen, mit dem Hinweis, dass kommunizierte Frist und gemessener Zeitraum jetzt auseinanderliegen.

## Am Backend nichts zu ändern

Die Ingestion kennt nur `aktion_start` und `aktion_aktiv`, **kein Enddatum** — die Anmeldungen der drei Zusatztage zählen von selbst mit. Geprüft in `sommer2026_config`.

## Nicht angefasst: die versandte Kommunikation

Die Mail-Wellen 3 und 3b nennen den 8. August als Frist («morgen läuft es aus», «heute läuft es aus»), ebenso die Mail-Vorlagen im Editor und die Landingpages. Diese Texte sind bereits draussen — ob und wie die Verlängerung kommuniziert wird, ist eine Entscheidung der Redaktion, keine Datenpflege. Betroffene Stellen im Repo: `apps/mail-editor/mails/*_w3*_de.html`, `services/mailing-sommer2026/{heroes,config}.json`, `docs/kampagnen-drehbuch.md`.

## Prüfmaschinen

`typo-check` konform · `ds-lint --staged` 0 Fehler, Score 100 %.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUqZZzUQntMLiZPecAsBBc)_