### PR TITLE
Verlängerung läuft still – Beschluss festgehalten, Folge für die Auswertung benannt

### DIFF
--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -10,7 +10,12 @@
      diese Werte anpassen. */
   var CONFIG = {
     start: '2026-07-03',            // Aktionsstart (Nachmittag 3. Juli 2026)
-    // Aktionsende. Am 7. August um drei Tage verlängert (zuvor 8. August).
+    // Aktionsende. Am 7. August um drei Tage verlängert (zuvor 8. August) –
+    // und zwar STILL: keine Ankündigung, keine Mail, kein neues Datum auf den
+    // Aktionsseiten (Beschluss 7. August). Für die Zahlen heisst das: Die Tage
+    // vom 9. bis 11. August sind ein Nachzügler-Fenster ohne eigenen Impuls;
+    // wer die Aktion auswertet, darf sie nicht mit den Aktionstagen vergleichen
+    // – dort stand ein Versand dahinter, hier nur die offene Tür.
     // Dieses Datum steuert alles Zeitliche: Resttage, «Abos/Tag nötig», die
     // Breite des Pulses, die Fortschreibung im Befund und das Wochenraster des
     // Zeitbands. Die Ingestion kennt kein Enddatum (nur aktion_start und

--- a/docs/wirkungs-lesart-07-08.md
+++ b/docs/wirkungs-lesart-07-08.md
@@ -129,12 +129,19 @@ der die Anzeige-Fenster keinen eigenen Überschuss zeigen.
   Mailing zugeschlagen wird. Der Mailing-Anteil ist darum eher eine
   Obergrenze.
 - **Die Aktion ist nach diesem Stichtag um drei Tage verlängert worden**
-  (neues Ende: 11. August). Der 7. August ist damit nicht mehr der Schlusstag,
-  sondern ein Zwischenstand. Die kommunizierte Frist bleibt der 8. August —
-  die Mail-Wellen 3 und 3b nennen ihn —, der gemessene Zeitraum endet drei
-  Tage später. Wer diese Lesart nach dem 11. August fortschreibt, rechnet die
-  Tage 8. bis 11. August als eigenes Fenster: Sie stehen unter einer Frist,
-  die für die Empfänger bereits abgelaufen war.
+  (neues Ende: 11. August), und zwar **still**: keine Ankündigung, keine Mail,
+  kein neues Datum auf den Aktionsseiten (Beschluss 7. August). Der 7. August
+  ist damit nicht mehr der Schlusstag, sondern ein Zwischenstand. Die
+  kommunizierte Frist bleibt der 8. August — die Mail-Wellen 3 und 3b nennen
+  ihn —, der gemessene Zeitraum endet drei Tage später.
+
+  Wer diese Lesart nach dem 11. August fortschreibt, rechnet die Tage **9. bis
+  11. August als eigenes Fenster**: Hinter ihnen steht kein Versand, sondern
+  nur die offene Tür, und für die Empfänger war die Frist bereits abgelaufen.
+  Beides zieht die Zahlen nach unten. Die Methode oben trägt hier nicht — der
+  Schlüssel «Überschuss nach gemessenen Anteilen» setzt einen Impuls voraus,
+  den es in diesem Fenster nicht gibt. Diese Tage gehören darum in der
+  Grundlinie gerechnet, nicht im Schlussspurt.
 - **Newsletter gegen Mailing.** Beide fallen auf dieselben Tage (17. Juli,
   31. Juli). Anker 2 trennt sie nach dem gemessenen Verhältnis; sind die
   Newsletter schlechter ausgezeichnet als der Mailer, ist ihr Anteil zu


### PR DESCRIPTION
Die drei Zusatztage werden **nicht angekündigt**: keine Mail, kein neues Datum auf den Aktionsseiten (Beschluss 7. August). Das ist keine Kleinigkeit für die Zahlen, sondern ändert, wie die letzten Tage zu lesen sind.

Hinter dem 9. bis 11. August steht **kein Versand, sondern nur die offene Tür** — und für die Empfänger war die Frist am 8. August bereits abgelaufen. Beides zieht die Zahlen nach unten. Der Schlüssel der Lesart («Überschuss nach den gemessenen Anteilen desselben Fensters») setzt einen Impuls voraus, den es in diesem Fenster nicht gibt: Diese Tage gehören in der **Grundlinie** gerechnet, nicht im Schlussspurt.

Festgehalten an den zwei Stellen, an denen jemand danach sucht:

- Kommentar zu `CONFIG.ende` in `apps/sommer-zaehler/campaign.js` — dort steht das Datum, dort steht jetzt auch, wie es zustande kam.
- Schwächen-Liste in `docs/wirkungs-lesart-07-08.md` — wer die Lesart nach dem 11. August fortschreibt, liest die Einschränkung, bevor er rechnet.

Keine Änderung an Zahlen, Logik oder Oberfläche.

## Prüfmaschinen

`typo-check` konform · `ds-lint --staged` 0 Fehler, Score 100 % (keine HTML-Datei betroffen).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUqZZzUQntMLiZPecAsBBc)_