### PR TITLE
Einnahmen-Perspektive der Aktion in drei Szenarien gerechnet

### DIFF
--- a/docs/einnahmen-perspektive-07-08.js
+++ b/docs/einnahmen-perspektive-07-08.js
@@ -1,0 +1,63 @@
+// Einnahmen-Perspektive Sommer-Aktion 2026 – Stand 7. August
+// Preise aus CONFIG.preise (echt, Stand 17.7.), Kurs eurChf 0.93.
+var EURCHF = 0.93;
+
+// [produkt, format, waehrung, intervall, aktive Abos, Preis je Periode]
+var SEG = [
+  ['gtv', 'stream',  'eur', 'jaehrlich',  59, 149.0],   // 58 standard + 1 ermaessigt (Fallback Standardpreis)
+  ['gtv', 'stream',  'eur', 'monatlich', 360,  14.9],
+  ['wos', 'digital', 'chf', 'jaehrlich',   1, 109.0],
+  ['wos', 'digital', 'chf', 'monatlich',  11,  10.9],
+  ['wos', 'digital', 'eur', 'jaehrlich',  16,  99.0],
+  ['wos', 'digital', 'eur', 'monatlich', 159,   9.9],
+  ['wos', 'papier',  'chf', 'jaehrlich',   7, 149.0],
+  ['wos', 'papier',  'chf', 'monatlich',   9,  14.9],
+  ['wos', 'papier',  'eur', 'jaehrlich',  15, 139.0],
+  ['wos', 'papier',  'eur', 'monatlich',  56,  13.9]
+];
+
+var SZENARIEN = [
+  { name: 'Vorsichtig', gtv: 0.35, wos: 0.55, monate: 7  },
+  { name: 'Erwartet',   gtv: 0.50, wos: 0.70, monate: 9  },
+  { name: 'Gut',        gtv: 0.65, wos: 0.85, monate: 11 }
+];
+
+function chf(eur, waehrung){ return waehrung === 'eur' ? eur * EURCHF : eur; }
+function f(n){ return Math.round(n).toLocaleString('de-CH'); }
+
+// Decke: alle bleiben, monatliche zahlen volle 12 Monate.
+var decke = 0, decken = 0;
+SEG.forEach(function(s){
+  var jahr = s[3] === 'jaehrlich' ? s[5] : s[5] * 12;
+  decke += chf(jahr * s[4], s[2]); decken += s[4];
+});
+console.log('Decke (100 %, volle 12 Monate): CHF ' + f(decke) + ' aus ' + decken + ' Abos\n');
+
+SZENARIEN.forEach(function(sz){
+  var sum = 0, bleiben = 0, jeProdukt = { gtv: 0, wos: 0 };
+  SEG.forEach(function(s){
+    var quote = s[0] === 'gtv' ? sz.gtv : sz.wos;
+    var n = s[4] * quote;
+    var jahr = s[3] === 'jaehrlich' ? s[5] : s[5] * sz.monate;
+    var betrag = chf(jahr * n, s[2]);
+    sum += betrag; bleiben += n; jeProdukt[s[0]] += betrag;
+  });
+  console.log(sz.name.padEnd(11) +
+    ' | bleiben ' + String(Math.round(bleiben)).padStart(3) +
+    ' | CHF ' + f(sum).padStart(7) +
+    ' | gtv ' + f(jeProdukt.gtv).padStart(6) +
+    ' | wos ' + f(jeProdukt.wos).padStart(6) +
+    ' | je Abo ' + f(sum / bleiben));
+});
+
+// Empfindlichkeit: nur der Monats-Faktor, Quoten des Erwartet-Falls.
+console.log('\nEmpfindlichkeit (Quoten wie «Erwartet», nur Monate variiert):');
+[6, 8, 9, 10, 12].forEach(function(m){
+  var sum = 0;
+  SEG.forEach(function(s){
+    var quote = s[0] === 'gtv' ? 0.50 : 0.70;
+    var jahr = s[3] === 'jaehrlich' ? s[5] : s[5] * m;
+    sum += chf(jahr * s[4] * quote, s[2]);
+  });
+  console.log('  ' + m + ' Monate: CHF ' + f(sum));
+});

--- a/docs/einnahmen-perspektive-07-08.md
+++ b/docs/einnahmen-perspektive-07-08.md
@@ -1,0 +1,114 @@
+# Einnahmen-Perspektive der Sommer-Aktion — drei Szenarien, Stand 7. August 2026
+
+Was die Aktion im **Folgejahr** einbringt, wenn die Gratis-Zeit vorbei ist.
+Gerechnet auf dem Stand vom 7. August: **714 Anmeldungen, davon 693 aktiv**
+(21 bereits gekündigt). Die Aktion läuft noch bis zum 11. August — die Zahlen
+wachsen also weiter, die Verhältnisse voraussichtlich nicht.
+
+Nachrechenbar: `node docs/einnahmen-perspektive-07-08.js` — dort stehen die
+Segmente, die Preise und die Szenario-Annahmen als Code, damit die Tabellen
+unten nicht von Hand gepflegt werden müssen.
+
+Alle Beträge in CHF, EUR-Umsatz zum hinterlegten Kurs 0,93 umgerechnet.
+Preise sind echt (Kampagnen-Formulare und Uscreen-Store, Stand 17. Juli),
+nicht geschätzt. Die Szenarien selbst sind Annahmen — begründet, aber
+Annahmen.
+
+## Die Decke
+
+Blieben **alle** 693 und zahlten die monatlichen zwölf volle Monate:
+
+**CHF 101 904 im Folgejahr.**
+
+Diese Zahl ist keine Erwartung, sondern die Obergrenze. Sie zu nennen lohnt
+trotzdem: Sie sagt, worüber wir reden — die Aktion hat einen Gegenwert im
+sechsstelligen Bereich aufgebaut, nicht im fünfstelligen Zehner.
+
+## Die drei Szenarien
+
+| | bleiben | **Folgejahr CHF** | davon goetheanum.tv | davon Wochenschrift | je bleibendem Abo |
+|---|---:|---:|---:|---:|---:|
+| **Vorsichtig** | 297 | **26 995** | 15 083 | 11 911 | 91 |
+| **Erwartet** | 401 | **45 115** | 26 536 | 18 578 | 112 |
+| **Gut** | 505 | **67 693** | 40 982 | 26 711 | 134 |
+
+Die Spanne ist gross — Faktor 2,5 zwischen vorsichtig und gut. Das ist keine
+Rechenschwäche, sondern der ehrliche Zustand: **Noch keine einzige Kohorte
+hat entschieden.** Die erste (Juli-Anmeldungen) entscheidet ab Anfang Oktober.
+
+## Woraus die Szenarien gebaut sind
+
+Zwei Stellschrauben, nicht eine. Die zweite fehlt im Cockpit bisher und ist
+die wirksamere.
+
+### 1 · Wer bleibt (Bleibe-Quote)
+
+| | goetheanum.tv | Wochenschrift |
+|---|---:|---:|
+| Vorsichtig | 35 % | 55 % |
+| Erwartet | 50 % | 70 % |
+| Gut | 65 % | 85 % |
+
+Warum die Wochenschrift höher steht als goetheanum.tv — drei Gründe, alle
+aus den eigenen Daten und Texten:
+
+- **Beide Angebote sind Opt-out.** «Danach läuft das Abo regulär weiter,
+  jederzeit kündbar» steht so in den Kampagnentexten. Es braucht kein Ja, nur
+  ein ausbleibendes Nein.
+- **Das Nein ist bei goetheanum.tv einen Klick weit weg** («ein Klick im
+  Konto», eigene Formulierung), bei der Wochenschrift nicht. Und die
+  monatliche Kartenbelastung erinnert dort jeden Monat an die Entscheidung.
+- **Der Frühindikator zeigt genau das:** Schon im Gratis-Zeitraum haben
+  **21 von 440** goetheanum.tv-Abos gekündigt (4,8 %) — bei der Wochenschrift
+  **0 von 274**.
+
+### 2 · Wie lange die monatlichen zahlen
+
+**595 der 693 Abos zahlen monatlich, nur 98 jährlich.** Ein Folgejahr-Umsatz,
+der bei jedem monatlichen Abo zwölf volle Monate ansetzt, rechnet mit einer
+Treue, die niemand zugesagt hat. Darum trägt jedes Szenario einen
+Monats-Faktor: **7 · 9 · 11** von zwölf Monaten. Jährliche Abos zählen voll —
+sie haben das Jahr im Voraus bezahlt.
+
+### Empfindlichkeit
+
+Nur der Monats-Faktor bewegt, die Quoten bleiben auf «Erwartet»:
+
+| Monate | Folgejahr CHF |
+|---:|---:|
+| 6 | 32 504 |
+| 8 | 40 911 |
+| 9 | **45 115** |
+| 10 | 49 318 |
+| 12 | 57 725 |
+
+**Ein Monat durchschnittlicher Verweildauer ist rund CHF 4 200 wert.** Das
+ist der grösste einzelne Hebel in dieser Rechnung — grösser als jede
+plausible Verschiebung der Bleibe-Quote allein.
+
+## Was diese Rechnung nicht ist
+
+- **Keine Prognose.** Kein Wert stützt sich auf eine beobachtete
+  Bleibe-Entscheidung, weil es noch keine gibt. Wer die Zahlen weitergibt,
+  gibt Annahmen weiter.
+- **Kein Deckungsbeitrag.** Gegengerechnet sind nur die Einnahmen. Die Kosten
+  der Aktion stehen mit CHF 309.70 (Druck) in der Datenbank; **der Betrag der
+  Meta-Anzeige fehlt dort**. Solange er fehlt, ist jede Aussage über den
+  Rückfluss zu günstig.
+- **Keine Aussage über Papier.** Die Wochenschrift auf Papier trägt
+  Herstellungs- und Versandkosten je Exemplar, die hier nicht abgezogen sind.
+  Von den 274 WoS-Abos sind 87 Papier-Abos.
+
+## Was den Rat durch Messung ersetzt
+
+Zwei Termine, in dieser Reihenfolge:
+
+1. **Anfang Oktober** entscheidet die erste Kohorte (Juli-Anmeldungen). Dann
+   steht die Bleibe-Quote je Produkt zum ersten Mal als Zahl da und ersetzt
+   die Annahme in `CONFIG.bleibeQuote`.
+2. **Ab November** wird der Monats-Faktor sichtbar: Die Uscreen-Zahlungen
+   (`order_paid`, `success_recurring`) laufen ohnehin ins Roh-Log; wie viele
+   Monate ein Abo im Schnitt trägt, lässt sich daraus ablesen, sobald zwei
+   Zyklen durch sind.
+
+Bis dahin gilt: **«Erwartet» nennen, «Vorsichtig» einplanen.**


### PR DESCRIPTION
Was die Aktion im **Folgejahr** einbringt, wenn die Gratis-Zeit vorbei ist. Stand 7. August: 714 Anmeldungen, davon 693 aktiv. Echte Preise (Kampagnen-Formulare, Uscreen-Store), EUR zum hinterlegten Kurs 0,93.

## Das Ergebnis

**Decke** — alle bleiben, monatliche zahlen zwölf volle Monate: **CHF 101 904**. Keine Erwartung, sondern die Obergrenze.

| | bleiben | **Folgejahr CHF** | goetheanum.tv | Wochenschrift | je Abo |
|---|---:|---:|---:|---:|---:|
| **Vorsichtig** | 297 | **26 995** | 15 083 | 11 911 | 91 |
| **Erwartet** | 401 | **45 115** | 26 536 | 18 578 | 112 |
| **Gut** | 505 | **67 693** | 40 982 | 26 711 | 134 |

## Zwei Stellschrauben statt einer

**1 · Bleibe-Quote** (35/50/65 % für goetheanum.tv, 55/70/85 % für die Wochenschrift). Dass die Wochenschrift höher steht, ist begründet, nicht geraten: Beide Angebote sind Opt-out — aber das Nein ist bei goetheanum.tv einen Klick weit weg, und die monatliche Kartenbelastung erinnert jeden Monat an die Entscheidung. Der Frühindikator zeigt dasselbe: im Gratis-Zeitraum haben **21 von 440** goetheanum.tv-Abos gekündigt, bei der Wochenschrift **0 von 274**.

**2 · Monats-Faktor** (7/9/11 von zwölf) — diese Schraube fehlte bisher ganz. **595 der 693 Abos zahlen monatlich**, nur 98 jährlich. Ein Folgejahr-Umsatz, der bei jedem monatlichen Abo zwölf volle Monate ansetzt, rechnet mit einer Treue, die niemand zugesagt hat.

**Ein Monat durchschnittlicher Verweildauer ist rund CHF 4 200 wert** — der grösste einzelne Hebel der Rechnung, grösser als jede plausible Verschiebung der Bleibe-Quote allein.

## Nachrechenbar statt handgepflegt

`node docs/einnahmen-perspektive-07-08.js` — Segmente, Preise und Szenario-Annahmen stehen als Code, damit die Tabellen im Dokument nicht von Hand nachgezogen werden müssen.

## Was es nicht ist

Keine Prognose — es hat **noch keine Kohorte entschieden**, die erste tut es ab Anfang Oktober. Und kein Deckungsbeitrag: In den Kosten fehlt weiterhin der Betrag der Meta-Anzeige, damit ist jede Aussage über den Rückfluss zu günstig.

Reine Ergänzung, keine Änderung an Cockpit, Zahlen oder Logik.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUqZZzUQntMLiZPecAsBBc)_