### PR TITLE
Drei Szenarien statt einer Quote – und die Klappe unter die Signaturzahl gehoben

### DIFF
--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -21,12 +21,33 @@
     // Zeitbands. Die Ingestion kennt kein Enddatum (nur aktion_start und
     // aktion_aktiv) – Anmeldungen der Zusatztage zählen von selbst mit.
     ende:  '2026-08-11',
-    // Annahme, bis Erfahrungswerte vorliegen. Bleibt eine Annahme bis in den
-    // Herbst: Die Aktion ist «3 Monate gratis», die erste Kohorte (Juli)
-    // entscheidet also frühestens ab dem 3. Oktober 2026. Bis dahin steht in
-    // der Datenbank bei keiner Anmeldung «bleibt» – die Projektion ist reine
-    // Rechnung, keine Beobachtung.
-    bleibeQuote: 0.62,
+    // Drei Szenarien statt einer Quote (Beschluss 7. August). Eine einzelne
+    // Projektion sieht nach Wissen aus, wo eine Spanne die Wahrheit ist: Es hat
+    // noch KEINE Kohorte entschieden – die erste (Juli) tut es frühestens ab
+    // dem 3. Oktober 2026, bis dahin trägt keine Anmeldung den Status «bleibt».
+    //
+    // Zwei Stellschrauben, nicht eine:
+    // 1) bleibt – wer nach der Gratis-Zeit zahlend bleibt, je Produkt. Die
+    //    Wochenschrift steht höher als goetheanum.tv: Beide Angebote sind
+    //    Opt-out, aber dort ist das Nein einen Klick weit weg, und die
+    //    monatliche Kartenbelastung erinnert jeden Monat an die Entscheidung.
+    //    Der Frühindikator zeigt dasselbe – im Gratis-Zeitraum kündigten 21 von
+    //    440 goetheanum.tv-Abos, bei der Wochenschrift 0 von 274.
+    // 2) monate – wie viele der zwölf Folgemonate ein MONATLICHES Abo im
+    //    Schnitt trägt. Über 85 Prozent der Abos zahlen monatlich; wer für sie
+    //    zwölf volle Monate ansetzt, rechnet mit einer Treue, die niemand
+    //    zugesagt hat. Jährliche Abos zählen voll – das Jahr ist bezahlt.
+    //    Ein Monat Verweildauer ist rund CHF 4200 wert, der grösste Hebel.
+    // Herleitung und Empfindlichkeit: docs/einnahmen-perspektive-07-08.md.
+    szenarien: {
+      doc:     'docs/einnahmen-perspektive-07-08.md',
+      referenz:'erwartet',                 // dieses trägt die grosse Zahl und den Rückfluss
+      liste: [
+        { key:'vorsichtig', name:'Vorsichtig', bleibt:{ gtv:0.35, wos:0.55 }, monate:7  },
+        { key:'erwartet',   name:'Erwartet',   bleibt:{ gtv:0.50, wos:0.70 }, monate:9  },
+        { key:'gut',        name:'Gut',        bleibt:{ gtv:0.65, wos:0.85 }, monate:11 }
+      ]
+    },
     zielGesamt: 500,                // Gesamtziel der Aktion (neue Abos) – GF-Vorgabe, zurückgestellt 30.7.
     // Zielmarke je Strom – Zwischenmarken, Summe = Gesamtziel. Historie: 24.7.
     // von 1000 auf 700 gesenkt (Faktor 0,7); 30.7. zurück auf die ursprüngliche
@@ -1383,56 +1404,137 @@
   // goetheanum.tv rechnet ausschliesslich in EUR – Zeilen ohne Währungsangabe
   // fallen darum auf EUR. Preis-Lookup: Währung → Produkt → Format → Tarif
   // (ermässigt hat im Shop keinen eigenen Preis → Fallback Standard).
-  function projectRevenue(rows){
-    var summe = { chf: 0, eur: 0 };
+  // Die Szenarien der Reihe nach; ohne Treffer das erste.
+  function szenarien(){ return (CONFIG.szenarien && CONFIG.szenarien.liste) || []; }
+  function referenzSzenario(){
+    var l = szenarien(), k = CONFIG.szenarien && CONFIG.szenarien.referenz;
+    for (var i = 0; i < l.length; i++) if (l[i].key === k) return l[i];
+    return l[0] || { name:'', bleibt:{}, monate:12 };
+  }
+  // Bleibe-Quote je Produkt. Ein unbekanntes Produkt erbt die vorsichtigste
+  // hinterlegte Quote – lieber zu wenig versprochen als zu viel.
+  function bleibeQuote(sz, produkt){
+    var b = (sz && sz.bleibt) || {};
+    if (b[produkt] != null) return b[produkt];
+    var werte = Object.keys(b).map(function(k){ return b[k]; });
+    return werte.length ? Math.min.apply(null, werte) : 0;
+  }
+  function projectRevenue(rows, sz){
+    sz = sz || referenzSzenario();
+    var summe = { chf: 0, eur: 0, bleibend: 0, szenario: sz };
     rows.forEach(function(r){
       var w = r.waehrung === 'chf' ? 'chf' : 'eur';
       var jeFormat = ((CONFIG.preise[w] || {})[r.produkt] || {})[r.format] || {};
       var jeTarif = jeFormat[r.tarif] || jeFormat.standard || {};
       var preis = jeTarif[r.intervall];
       if(!preis) return;
-      var jahr = r.intervall === 'monatlich' ? preis * 12 : preis;
+      // Monatliche Abos tragen nur so viele Monate, wie das Szenario ansetzt;
+      // jährliche zählen voll, das Jahr ist im Voraus bezahlt.
+      var jahr = r.intervall === 'monatlich' ? preis * (sz.monate || 12) : preis;
       var bleibend;
       if(r.status === 'bleibt') bleibend = Number(r.n);
-      else if(r.status === 'neu' || r.status === 'laeuft-aus') bleibend = Number(r.n) * CONFIG.bleibeQuote;
+      else if(r.status === 'neu' || r.status === 'laeuft-aus') bleibend = Number(r.n) * bleibeQuote(sz, r.produkt);
       else bleibend = 0;                     // gekuendigt zählt nicht
       summe[w] += bleibend * jahr;
+      summe.bleibend += bleibend;
     });
     summe.chfGesamt = summe.chf + summe.eur * CONFIG.eurChf;
     return summe;
   }
+  // Die Decke: alle bleiben, monatliche zahlen zwölf volle Monate. Keine
+  // Erwartung – sie sagt nur, worüber wir reden.
+  function deckeRevenue(rows){
+    return projectRevenue(rows, { name:'Decke', bleibt:{ gtv:1, wos:1 }, monate:12 });
+  }
+  // Gemischte Quote über den tatsächlichen Produkt-Mix – für die Kohorte, die
+  // nur eine Gesamtzahl kennt.
+  function mischQuote(rows, sz){
+    var oben = 0, unten = 0;
+    (rows || []).forEach(function(r){
+      if (r.status === 'gekuendigt') return;
+      var n = Number(r.n) || 0;
+      oben += n * bleibeQuote(sz, r.produkt); unten += n;
+    });
+    return unten > 0 ? oben / unten : 0;
+  }
 
-  // ── Wer bleibt? (jüngste Kohorte) ──────────────────────────────────────────
-  function renderCohort(kohorten, revenue){
-    if (!el('cohortCard')) return;
+  // ── Wer bleibt, und was bringt das? (Kohorte + drei Szenarien) ─────────────
+  // Steht direkt unter der Signaturzahl: Die zweite Frage nach «wie viele» ist
+  // «was bringt das» – sie gehört nicht unter die Belege. Gezeigt wird die
+  // SPANNE, nicht eine Zahl, denn es hat noch keine Kohorte entschieden.
+  function renderCohort(kohorten, revenue, stats){
+    var ref = (revenue && revenue.szenario) || referenzSzenario();
+
     var card = el('cohortCard');
-    if(!kohorten || !kohorten.length){ card.innerHTML = '<div class="empty">Noch keine Kohorte.</div>'; return; }
-    var k = kohorten[kohorten.length - 1];
-    var neu = Number(k.neu), bleibt = Number(k.bleibt), offen = Number(k.offen);
-    var projektiert = bleibt + Math.round(offen * CONFIG.bleibeQuote);
-    var quote = neu > 0 ? Math.round(projektiert / neu * 100) : 0;
-    var kMonat = new Date(k.kohorte + 'T00:00:00');
-    var kEntsch = new Date(k.entscheidung_ab + 'T00:00:00');
-    var monat = kMonat.toLocaleDateString('de-CH', { month:'long', year:'numeric' });
-    card.innerHTML =
-      '<div class="when"></div><h4></h4>' +
-      '<div class="conv"><div class="ring"><div class="inner"></div></div>' +
-      '<div class="txt"><b></b><br><span class="m"></span><div class="pill"></div></div></div>';
-    card.querySelector('.when').textContent = 'Kohorte ' + monat + ' · Entscheidung ab ' + dmy(kEntsch);
-    card.querySelector('h4').textContent = fmt(neu) + ' Anmeldungen im Gratis-Zeitraum';
-    card.querySelector('.ring').style.setProperty('--p', quote);
-    card.querySelector('.ring .inner').textContent = quote + '%';
-    card.querySelector('.txt b').textContent = '~' + fmt(projektiert) + ' bleiben voraussichtlich zahlend';
-    card.querySelector('.txt .m').textContent = fmt(offen) + ' Entscheidungen noch offen · ' + fmt(bleibt) + ' bereits umgewandelt';
-    card.querySelector('.pill').textContent = 'Projektion · Annahme ' + Math.round(CONFIG.bleibeQuote * 100) + ' % Bleibe-Quote';
+    if (card){
+      if(!kohorten || !kohorten.length){ card.innerHTML = '<div class="empty">Noch keine Kohorte.</div>'; }
+      else {
+        var k = kohorten[kohorten.length - 1];
+        var neu = Number(k.neu), bleibt = Number(k.bleibt), offen = Number(k.offen);
+        var projektiert = bleibt + Math.round(offen * mischQuote(stats, ref));
+        var quote = neu > 0 ? Math.round(projektiert / neu * 100) : 0;
+        var kMonat = new Date(k.kohorte + 'T00:00:00');
+        var kEntsch = new Date(k.entscheidung_ab + 'T00:00:00');
+        var monat = kMonat.toLocaleDateString('de-CH', { month:'long', year:'numeric' });
+        card.innerHTML =
+          '<div class="when"></div><h4></h4>' +
+          '<div class="conv"><div class="ring"><div class="inner"></div></div>' +
+          '<div class="txt"><b></b><br><span class="m"></span><div class="pill"></div></div></div>';
+        card.querySelector('.when').textContent = 'Kohorte ' + monat + ' · Entscheidung ab ' + dmy(kEntsch);
+        card.querySelector('h4').textContent = fmt(neu) + ' Anmeldungen im Gratis-Zeitraum';
+        card.querySelector('.ring').style.setProperty('--p', quote);
+        card.querySelector('.ring .inner').textContent = quote + '%';
+        card.querySelector('.txt b').textContent = '~' + fmt(projektiert) + ' bleiben voraussichtlich zahlend';
+        card.querySelector('.txt .m').textContent = fmt(offen) + ' Entscheidungen noch offen · ' + fmt(bleibt) + ' bereits umgewandelt';
+        card.querySelector('.pill').textContent = 'Szenario ' + ref.name + ' · noch hat keine Kohorte entschieden';
+      }
+    }
 
-    el('projValue').textContent = geld(revenue.chfGesamt);
+    if (el('projValue')) el('projValue').textContent = geld(revenue.chfGesamt);
+    if (el('projLabel')) el('projLabel').textContent = 'Folgejahr-Umsatz · Szenario ' + ref.name;
+
+    // Die Spanne: ein Szenario je Zeile, das Referenz-Szenario im Gewicht
+    // hervorgehoben – ein Merkmal, nicht zwei (G01).
+    var body = el('szenarienBody');
+    if (body && stats){
+      body.innerHTML = '';
+      szenarien().forEach(function(sz){
+        var r = projectRevenue(stats, sz);
+        var tr = document.createElement('tr');
+        tr.innerHTML = '<td></td><td class="num"></td><td class="num"></td><td class="num"></td>';
+        if (sz.key === ref.key){
+          var b = document.createElement('b'); b.textContent = sz.name + ' · Referenz';
+          tr.children[0].appendChild(b);
+        } else {
+          tr.children[0].textContent = sz.name;
+        }
+        tr.children[1].textContent = Math.round(bleibeQuote(sz, 'gtv') * 100) + ' / ' +
+                                     Math.round(bleibeQuote(sz, 'wos') * 100) + ' %';
+        tr.children[2].textContent = fmt(Math.round(r.bleibend));
+        tr.children[3].textContent = geld(r.chfGesamt);
+        body.appendChild(tr);
+      });
+      var foot = el('szenarienFoot');
+      if (foot){
+        foot.innerHTML = '<tr><td>Decke · alle bleiben, volle zwölf Monate</td>' +
+                         '<td class="num">100 / 100 %</td><td class="num"></td><td class="num"></td></tr>';
+        var d = deckeRevenue(stats), td = foot.querySelector('tr').children;
+        td[2].textContent = fmt(Math.round(d.bleibend));
+        td[3].textContent = geld(d.chfGesamt);
+      }
+    }
+
     var teile = [];
     if (revenue.chf > 0) teile.push('CHF ' + Math.round(revenue.chf).toLocaleString('de-CH') + ' von CHF-Zahlern');
-    if (revenue.eur > 0) teile.push('€ ' + Math.round(revenue.eur).toLocaleString('de-CH') + ' von EUR-Zahlern, umgerechnet zum Kurs ' + CONFIG.eurChf);
-    el('projNote').textContent = 'Hochgerechnet: bleibende Abos zum echten Vollpreis je Zahlungswährung' +
-      (teile.length ? ' (' + teile.join(' + ') + ')' : '') + ', bei ' +
-      Math.round(CONFIG.bleibeQuote * 100) + ' % Bleibe-Quote.';
+    if (revenue.eur > 0) teile.push('EUR ' + Math.round(revenue.eur).toLocaleString('de-CH') + ' von EUR-Zahlern, umgerechnet zum Kurs ' + CONFIG.eurChf);
+    if (el('projNote')) el('projNote').textContent = 'Bleibende Abos zum echten Vollpreis je Zahlungswährung' +
+      (teile.length ? ' (' + teile.join(' + ') + ')' : '') + '. Monatliche Abos mit ' + ref.monate +
+      ' von zwölf Monaten gerechnet, jährliche voll.';
+    if (el('szenarienNote')) el('szenarienNote').textContent =
+      'Zwei Stellschrauben je Szenario: die Bleibe-Quote (goetheanum.tv / Wochenschrift) und die Zahl der Monate, die ein monatliches Abo im Schnitt trägt (' +
+      szenarien().map(function(s){ return s.monate; }).join(' · ') + ' von zwölf). ' +
+      'Keine Prognose – es hat noch keine Kohorte entschieden, die erste tut es Anfang Oktober. ' +
+      'Herleitung, Begründung der Quoten und Empfindlichkeit: ' + ((CONFIG.szenarien && CONFIG.szenarien.doc) || '') + '.';
   }
 
   // ── Ereignis-Protokoll: die einzelnen Abos («Was ist passiert?») ────────────
@@ -1542,8 +1644,9 @@
       .catch(function(){ el('herkunftBody').innerHTML = '<tr><td class="err" colspan="3">nicht ladbar</td></tr>'; });
     if(CONFIG.zahlenProvisorisch && el('provisorisch')){
       el('provisorisch').textContent = 'Preise und Zielmarken sind echt hinterlegt (Formular- und Uscreen-Preise, Stand 17. Juli). ' +
-        'Annahme bleibt allein die Bleibe-Quote von ' + Math.round(CONFIG.bleibeQuote * 100) + ' %: Die Aktion läuft drei Monate gratis, ' +
-        'die erste Kohorte entscheidet frühestens Anfang Oktober. Bis dahin ist jede Zahl zum Folgejahr eine Rechnung, keine Beobachtung.';
+        'Annahme bleiben allein die Bleibe-Quoten und die Verweildauer der monatlichen Abos – darum drei Szenarien statt einer Zahl, ' +
+        'oben unter der Signaturzahl. Die Aktion läuft drei Monate gratis, die erste Kohorte entscheidet frühestens Anfang Oktober; ' +
+        'bis dahin ist jede Zahl zum Folgejahr eine Rechnung, keine Beobachtung.';
     }
     Promise.all([ rpc('sommer2026_stats'), rpc('sommer2026_timeline'), rpc('sommer2026_kohorten'), rpc('sommer2026_kanaele'),
                   rpc('sommer2026_attribution'), rpc('sommer2026_massnahmen_public'), rpc('sommer2026_kosten_public'),
@@ -1563,7 +1666,7 @@
         renderDunkelfeld(kanaele, attribution);
         renderMotive(attribution);
         renderTarif(stats);
-        renderCohort(kohorten, revenue);
+        renderCohort(kohorten, revenue, stats);
         // Schwesterseiten (element-gewächtert, hier ohne Wirkung).
         renderKosten(total, revenue, kostenPosten);
         renderMassnahmen(massnahmen);

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -65,6 +65,28 @@
         <div class="b-meta" id="befundMeta"></div>
       </div>
 
+      <!-- Direkt unter der Signaturzahl: Die zweite Frage nach «wie viele» ist
+           «was bringt das». Gezeigt wird die Spanne, nicht eine Zahl. -->
+      <details class="zb-form">
+        <summary>Wer bleibt, und was bringt das? – drei Szenarien</summary>
+        <div class="stay" style="margin-top:var(--s4)">
+          <div class="cohort" id="cohortCard"><div class="empty">lädt …</div></div>
+          <div class="proj">
+            <div class="pl" id="projLabel">Folgejahr-Umsatz</div>
+            <div class="pv" id="projValue">–</div>
+            <div class="pn" id="projNote">Bleibende Abos zum echten Vollpreis je Zahlungswährung.</div>
+          </div>
+        </div>
+        <div class="tablewrap" style="margin-top:var(--s6)">
+          <table class="tarif">
+            <thead><tr><th>Szenario</th><th class="num">bleiben tv/WoS</th><th class="num">Abos</th><th class="num">Folgejahr</th></tr></thead>
+            <tbody id="szenarienBody"><tr><td class="empty" colspan="4">lädt …</td></tr></tbody>
+            <tfoot id="szenarienFoot"></tfoot>
+          </table>
+        </div>
+        <p class="provisorisch" id="szenarienNote"></p>
+      </details>
+
       <details class="zb-form">
         <summary id="stroemeKopf">Woraus sich die Abos zusammensetzen</summary>
         <div class="tablewrap" style="margin-top:var(--s4)">
@@ -141,18 +163,6 @@
         <summary>Alle Motive einzeln</summary>
         <div class="motive" id="motive" hidden>
           <div id="motiveList"></div>
-        </div>
-      </details>
-
-      <details class="zb-form">
-        <summary>Wer bleibt? – der Drei-Monats-Moment</summary>
-        <div class="stay" style="margin-top:var(--s4)">
-          <div class="cohort" id="cohortCard"><div class="empty">lädt …</div></div>
-          <div class="proj">
-            <div class="pl">Hochgerechneter Folgejahr-Umsatz</div>
-            <div class="pv" id="projValue">–</div>
-            <div class="pn" id="projNote">Projektion auf Basis der angenommenen Bleibe-Quote und der hinterlegten Preise.</div>
-          </div>
         </div>
       </details>
 


### PR DESCRIPTION
Zwei Änderungen, die zusammengehören.

**Ort:** «Wer bleibt?» lag unter den *Belegen*, zwischen Dunkelfeld und Tarif-Tabelle — also dort, wo steht, was man selten braucht. Die zweite Frage nach «wie viele» ist aber «was bringt das». Die Klappe steht jetzt als **erste Klappe direkt unter der Signaturzahl**.

**Inhalt:** Dort stand eine einzelne Zahl mit 62 % Bleibe-Quote. Eine einzelne Projektion sieht nach Wissen aus, wo eine Spanne die Wahrheit ist — es hat noch keine Kohorte entschieden. Jetzt stehen drei Szenarien nebeneinander, dazu die Decke als Obergrenze.

| Szenario | bleiben tv/WoS | Abos | Folgejahr |
|---|---:|---:|---:|
| Vorsichtig | 35 / 55 % | 297 | CHF 26 995 |
| **Erwartet · Referenz** | 50 / 70 % | 401 | **CHF 45 115** |
| Gut | 65 / 85 % | 505 | CHF 67 693 |
| Decke · alle bleiben, volle zwölf Monate | 100 / 100 % | 693 | CHF 101 904 |

## Zwei Stellschrauben statt einer

- **Bleibe-Quote je Produkt.** Dass die Wochenschrift höher steht als goetheanum.tv, ist begründet: Beide Angebote sind Opt-out, aber dort ist das Nein einen Klick weit weg, und die monatliche Kartenbelastung erinnert jeden Monat an die Entscheidung. Der Frühindikator zeigt dasselbe — im Gratis-Zeitraum kündigten **21 von 440** goetheanum.tv-Abos, bei der Wochenschrift **0 von 274**.
- **Monats-Faktor** (7 · 9 · 11 von zwölf). Über 85 % der Abos zahlen monatlich; wer für sie zwölf volle Monate ansetzt, rechnet mit einer Treue, die niemand zugesagt hat. Jährliche zählen voll — das Jahr ist bezahlt.

## Technisch

`CONFIG.bleibeQuote` ist abgelöst durch `CONFIG.szenarien`. Alle Verbraucher — Umsatz-Projektion, Kohorten-Ring, Rückfluss auf der Kosten-Seite — hängen am Referenz-Szenario. Die Kohorte kennt nur eine Gesamtzahl, darum mischt `mischQuote()` die Quoten über den tatsächlichen Produkt-Mix (aktuell 57,9 %).

**Gegengeprüft:** der Seiten-Code in einer DOM-Attrappe gegen die echten Daten gerechnet — Ergebnis deckungsgleich mit `docs/einnahmen-perspektive-07-08.md`. Die Tabelle im Cockpit und das Dokument können also nicht auseinanderlaufen.

## Regeln

G01 (Referenz-Zeile nur im Gewicht hervorgehoben — ein Merkmal, nicht zwei) · G25 (Beträge tabellarisch, rechtsbündig) · `typo-check` konform · `ds-lint` 0 Fehler, Score 100 %.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUqZZzUQntMLiZPecAsBBc)_