### PR TITLE
Drei Szenarien als drei gleich grosse Zahlen, nicht eine grosse und eine Tabelle

### DIFF
--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -59,6 +59,15 @@
   .conv .txt b{font-weight:600}
   .conv .txt .m{color:var(--muted);font-size:var(--t-micro)}
   .pill{display:inline-block;font-family:var(--font-text);font-size:var(--t-micro);line-height:1.45;padding:6px 13px;border-radius:var(--r-control);background:color-mix(in srgb,var(--gold) 15%,transparent);color:var(--gold-ink);margin-top:var(--s4);max-width:100%}
+  /* Drei Szenarien nebeneinander, gleiches Gewicht: die Spanne ist die Aussage.
+     Die Zahl steht in --ink, nicht in --ok – Grün auf «Vorsichtig» würde
+     schmeicheln. Die Referenz nennt sich per Wort (Pille), nicht per Farbe. */
+  .szen{display:grid;grid-template-columns:repeat(3,1fr);gap:var(--s4);margin-top:var(--s4)}
+  .szen .s{background:var(--soft);border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s5);display:flex;flex-direction:column;gap:6px}
+  .szen .s-n{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)}
+  .szen .s-w{font-family:var(--font-display);font-weight:var(--w-strong);font-size:clamp(26px,3.4vw,36px);color:var(--ink);font-variant-numeric:tabular-nums;line-height:1.05}
+  .szen .s-m{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);line-height:1.55}
+  .szen .pill{margin-top:0}
   .proj{background:var(--soft);border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6)}
   .proj .pl{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)}
   .proj .pv{font-family:var(--font-display);font-weight:var(--w-strong);font-size:clamp(30px,5vw,42px);color:var(--ok);font-variant-numeric:tabular-nums;line-height:1;margin-top:6px}
@@ -300,6 +309,7 @@
 
   @media (max-width:720px){
     .board{grid-template-columns:1fr} .stay{grid-template-columns:1fr}
+    .szen{grid-template-columns:1fr}
   }
   @media (max-width:640px){
     .stand{grid-template-columns:1fr;gap:var(--s6)}

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -1446,6 +1446,12 @@
   function deckeRevenue(rows){
     return projectRevenue(rows, { name:'Decke', bleibt:{ gtv:1, wos:1 }, monate:12 });
   }
+  // Aktive Abos – gekündigte zählen nicht mit; Bezugsgrösse der Karten.
+  function aktiveAbos(rows){
+    return (rows || []).reduce(function(s, r){
+      return r.status === 'gekuendigt' ? s : s + (Number(r.n) || 0);
+    }, 0);
+  }
   // Gemischte Quote über den tatsächlichen Produkt-Mix – für die Kohorte, die
   // nur eine Gesamtzahl kennt.
   function mischQuote(rows, sz){
@@ -1490,49 +1496,40 @@
       }
     }
 
-    if (el('projValue')) el('projValue').textContent = geld(revenue.chfGesamt);
-    if (el('projLabel')) el('projLabel').textContent = 'Folgejahr-Umsatz · Szenario ' + ref.name;
-
-    // Die Spanne: ein Szenario je Zeile, das Referenz-Szenario im Gewicht
-    // hervorgehoben – ein Merkmal, nicht zwei (G01).
-    var body = el('szenarienBody');
-    if (body && stats){
-      body.innerHTML = '';
+    // Drei Karten, gleiches Gewicht – die Spanne IST die Aussage. Eine
+    // hervorgehobene Zahl neben zwei kleinen liest sich als Prognose mit
+    // Fehlerbalken; das wäre gelogen, solange keine Kohorte entschieden hat.
+    var host = el('szenKarten');
+    if (host && stats){
+      host.innerHTML = '';
       szenarien().forEach(function(sz){
         var r = projectRevenue(stats, sz);
-        var tr = document.createElement('tr');
-        tr.innerHTML = '<td></td><td class="num"></td><td class="num"></td><td class="num"></td>';
+        var karte = document.createElement('div'); karte.className = 's';
+        var n = document.createElement('div'); n.className = 's-n'; n.textContent = sz.name;
+        var w = document.createElement('div'); w.className = 's-w'; w.textContent = geld(r.chfGesamt);
+        var m = document.createElement('div'); m.className = 's-m';
+        m.textContent = fmt(Math.round(r.bleibend)) + ' von ' + fmt(Math.round(aktiveAbos(stats))) + ' Abos bleiben · ' +
+                        Math.round(bleibeQuote(sz, 'gtv') * 100) + ' % goetheanum.tv, ' +
+                        Math.round(bleibeQuote(sz, 'wos') * 100) + ' % Wochenschrift · monatliche Abos ' +
+                        sz.monate + ' von zwölf Monaten';
+        karte.appendChild(n); karte.appendChild(w); karte.appendChild(m);
         if (sz.key === ref.key){
-          var b = document.createElement('b'); b.textContent = sz.name + ' · Referenz';
-          tr.children[0].appendChild(b);
-        } else {
-          tr.children[0].textContent = sz.name;
+          var pill = document.createElement('div'); pill.className = 'pill';
+          pill.textContent = 'Referenz – diese Zahl trägt den Rückfluss';
+          karte.appendChild(pill);
         }
-        tr.children[1].textContent = Math.round(bleibeQuote(sz, 'gtv') * 100) + ' / ' +
-                                     Math.round(bleibeQuote(sz, 'wos') * 100) + ' %';
-        tr.children[2].textContent = fmt(Math.round(r.bleibend));
-        tr.children[3].textContent = geld(r.chfGesamt);
-        body.appendChild(tr);
+        host.appendChild(karte);
       });
-      var foot = el('szenarienFoot');
-      if (foot){
-        foot.innerHTML = '<tr><td>Decke · alle bleiben, volle zwölf Monate</td>' +
-                         '<td class="num">100 / 100 %</td><td class="num"></td><td class="num"></td></tr>';
-        var d = deckeRevenue(stats), td = foot.querySelector('tr').children;
-        td[2].textContent = fmt(Math.round(d.bleibend));
-        td[3].textContent = geld(d.chfGesamt);
-      }
     }
 
     var teile = [];
     if (revenue.chf > 0) teile.push('CHF ' + Math.round(revenue.chf).toLocaleString('de-CH') + ' von CHF-Zahlern');
     if (revenue.eur > 0) teile.push('EUR ' + Math.round(revenue.eur).toLocaleString('de-CH') + ' von EUR-Zahlern, umgerechnet zum Kurs ' + CONFIG.eurChf);
-    if (el('projNote')) el('projNote').textContent = 'Bleibende Abos zum echten Vollpreis je Zahlungswährung' +
-      (teile.length ? ' (' + teile.join(' + ') + ')' : '') + '. Monatliche Abos mit ' + ref.monate +
-      ' von zwölf Monaten gerechnet, jährliche voll.';
     if (el('szenarienNote')) el('szenarienNote').textContent =
-      'Zwei Stellschrauben je Szenario: die Bleibe-Quote (goetheanum.tv / Wochenschrift) und die Zahl der Monate, die ein monatliches Abo im Schnitt trägt (' +
-      szenarien().map(function(s){ return s.monate; }).join(' · ') + ' von zwölf). ' +
+      'Blieben alle und zahlten die monatlichen zwölf volle Monate, wären es ' + geld(deckeRevenue(stats).chfGesamt) +
+      ' – die Decke, keine Erwartung. Gerechnet wird zum echten Vollpreis je Zahlungswährung' +
+      (teile.length ? ' (Referenz: ' + teile.join(' + ') + ')' : '') + '. ' +
+      'Zwei Stellschrauben je Szenario: die Bleibe-Quote je Produkt und die Zahl der Monate, die ein monatliches Abo im Schnitt trägt. ' +
       'Keine Prognose – es hat noch keine Kohorte entschieden, die erste tut es Anfang Oktober. ' +
       'Herleitung, Begründung der Quoten und Empfindlichkeit: ' + ((CONFIG.szenarien && CONFIG.szenarien.doc) || '') + '.';
   }

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -69,21 +69,11 @@
            «was bringt das». Gezeigt wird die Spanne, nicht eine Zahl. -->
       <details class="zb-form">
         <summary>Wer bleibt, und was bringt das? – drei Szenarien</summary>
-        <div class="stay" style="margin-top:var(--s4)">
-          <div class="cohort" id="cohortCard"><div class="empty">lädt …</div></div>
-          <div class="proj">
-            <div class="pl" id="projLabel">Folgejahr-Umsatz</div>
-            <div class="pv" id="projValue">–</div>
-            <div class="pn" id="projNote">Bleibende Abos zum echten Vollpreis je Zahlungswährung.</div>
-          </div>
-        </div>
-        <div class="tablewrap" style="margin-top:var(--s6)">
-          <table class="tarif">
-            <thead><tr><th>Szenario</th><th class="num">bleiben tv/WoS</th><th class="num">Abos</th><th class="num">Folgejahr</th></tr></thead>
-            <tbody id="szenarienBody"><tr><td class="empty" colspan="4">lädt …</td></tr></tbody>
-            <tfoot id="szenarienFoot"></tfoot>
-          </table>
-        </div>
+        <!-- Drei gleichwertige Karten: Die Spanne IST die Aussage, darum trägt
+             keine der drei mehr Gewicht als die andere. Die Referenz nennt sich
+             mit einem Wort, nicht mit Farbe oder Grösse (G01, G03). -->
+        <div class="szen" id="szenKarten"><div class="empty">lädt …</div></div>
+        <div class="cohort" id="cohortCard" style="margin-top:var(--s6)"><div class="empty">lädt …</div></div>
         <p class="provisorisch" id="szenarienNote"></p>
       </details>
 


### PR DESCRIPTION
Die Klappe zeigte die Spanne zwar vollständig, aber im **falschen Gewicht**: eine grosse Zahl (das Referenz-Szenario) und darunter die drei klein in einer Tabelle. Gelesen wird so trotzdem die eine Zahl — die Spanne war da, aber nicht zu sehen.

Jetzt **drei gleich grosse Karten** nebeneinander, am Handy gestapelt. Alle drei Zahlen im selben Grad (36px, im Browser nachgemessen).

## Warum gleich gross

Die Spanne *ist* die Aussage. Eine hervorgehobene Zahl neben zwei kleinen liest sich als Prognose mit Fehlerbalken — und das wäre gelogen, solange keine Kohorte entschieden hat.

- Die Zahlen stehen in `--ink`, nicht in `--ok`. **Grün auf «Vorsichtig» würde schmeicheln**, wo nichts zu feiern ist.
- Die Referenz nennt sich mit einem Wort («Referenz – diese Zahl trägt den Rückfluss»), nicht mit Farbe oder Grösse (G01, G03).
- Jede Karte trägt ihre Annahmen selbst: bleibende Abos, beide Quoten, Monatszahl. Die Tabelle mit denselben Werten entfällt ersatzlos.
- Die **Decke** wandert in die Fussnote — sie ist eine Obergrenze, kein Szenario, und stand als vierte Tabellenzeile zu gleichrangig da.

## Gegengeprüft im Browser

Chromium mit untergelegten echten Daten, zwei Breiten: drei Karten, alle Zahlen 36px, Werte deckungsgleich mit `docs/einnahmen-perspektive-07-08.md` (CHF 26 995 · 45 115 · 67 693, Decke 101 904). Bei 420px sauber gestapelt.

## Regeln

G01 / G03 (ein Merkmal, Entbehrliches weg) · G25 (Ziffern tabellarisch) · B03 (Kartentext ≥ `--t-micro`) · `typo-check` konform · `ds-lint` 0 Fehler, Score 100 %.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUqZZzUQntMLiZPecAsBBc)_