### PR TITLE
DS08 · Barrierefreiheit messen statt behaupten (axe-core im Browser)

### DIFF
--- a/.github/workflows/pruefmaschinen.yml
+++ b/.github/workflows/pruefmaschinen.yml
@@ -22,3 +22,40 @@ jobs:
         run: python3 tools/typo-check.py --all
       - name: ds-lint (Gestalt, alle Seiten + Score)
         run: python3 tools/ds-lint.py
+
+  # DS08 · Barrierefreiheit lässt sich nicht lesen, nur messen: ob ein Kontrast
+  # trägt und ein Fingerziel gross genug ist, entscheidet sich erst am
+  # gerenderten Blatt. axe-core prüft die normativen Kriterien der WCAG 2.2
+  # (A und AA) in Chromium. Eigener Job, weil er einen Browser braucht.
+  #
+  # NOCH KEIN TOR: der Schritt läuft mit --check, darf aber scheitern
+  # (continue-on-error), solange der Rückstand aus der Erstmessung offen ist —
+  # er steht in CHANGELOG-a11y.md. Ist der abgetragen, wird aus dem Bericht
+  # ein Tor, indem die eine Zeile «continue-on-error» hier verschwindet. Sonst
+  # wäre jeder Push von Anfang an rot, und ein Tor, das immer rot steht, hütet
+  # nichts.
+  barrierefreiheit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Chromium holen
+        working-directory: tools
+        run: |
+          npm install --no-audit --no-fund
+          npx playwright install --with-deps chromium
+      - name: barrierefreiheit (WCAG 2.2 AA, alle Seiten)
+        continue-on-error: true
+        run: |
+          set +e
+          node tools/barrierefreiheit.mjs --check | tee wcag.txt
+          stand=$?
+          {
+            echo '## Barrierefreiheit · WCAG 2.2 AA (DS08)'
+            echo '```'
+            cat wcag.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $stand

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ services/brand-portrait/portrait_brand_generator.egg-info/
 services/brand-portrait/*.jpg
 services/brand-portrait/*.png
 __pycache__/
+
+# Browser-Werkzeuge (tools/barrierefreiheit.mjs) — Abhängigkeiten nicht versionieren
+tools/node_modules/

--- a/CHANGELOG-a11y.md
+++ b/CHANGELOG-a11y.md
@@ -45,3 +45,94 @@ Empfohlen: eine Runde reine Tastaturbedienung durch Karussell (Halt/Weiter, Punk
 und Schublade (Öffnen→Fokus, Tab-Falle, Escape→Burger), plus ein Screenreader-Durchgang
 (VoiceOver/NVDA). Keine visuelle Regression Hell **und** Dunkel (Startseite + Schriften geprüft).
 Design-System-Score bleibt 100 % (29/29).
+
+
+---
+
+# Block D — die Maschine misst (8. August 2026)
+
+Bis hierher war die Sanierung Handarbeit mit Nachweis. Seit dem 8. August
+misst sie eine Maschine: **`tools/barrierefreiheit.mjs`** (Regel **DS08** im
+Kontrakt) lädt jede Seite des Geltungsbereichs in Chromium auf zwei Achsen —
+390 px (Telefon) und 1440 px (Schreibtisch) — und lässt `axe-core` die
+**normativen** Erfolgskriterien der WCAG 2.2 auf Stufe A und AA prüfen. Damit
+gelten B01–B05 gemessen statt behauptet.
+
+    node tools/barrierefreiheit.mjs                          # Bericht
+    node tools/barrierefreiheit.mjs --check                  # als Tor
+    node tools/barrierefreiheit.mjs --seite ordner.html      # nur eine Seite
+    node tools/barrierefreiheit.mjs --regel select-name      # nur eine Regelsorte
+    node tools/barrierefreiheit.mjs --alles                  # samt Empfehlungen
+    node tools/barrierefreiheit.mjs --spur                   # Fortschritt je Seite
+
+Einmalig `cd tools && npm install`. Der ganze Lauf dauert rund sechs Minuten —
+darum läuft er **nicht** im Commit-Hook, sondern als eigener Job in
+`pruefmaschinen.yml`. Mit `--seite` sind es Sekunden.
+
+## Zwei Griffe, ohne die der Lauf lügt
+
+**Durchblättern vor dem Messen.** Wer eine Seite misst, ohne sie einmal
+durchzuscrollen, misst bei allen Blättern mit Einblende-Effekt Schrift in
+Grundfarbe auf Grund. Der Prüfer blättert darum jede Seite einmal durch.
+
+**Wer weiterleitet, wird übersprungen.** `services/sommer-zaehler/kurzlink-site/404.html`
+ist eine Brücke: sie liest den Pfad und schickt weiter. Ihr Ziel liegt
+ausserhalb, wird abgewiesen, und Chromium malt an ihrer Stelle seine eigene
+Fehlerseite — die dann gemessen würde. Genau das war der einzige
+`meta-viewport`-Fund der Erstmessung: nicht unsere Seite, sondern die des
+Browsers. Solche Blätter werden gezählt und übersprungen.
+
+## Sofort behoben
+
+| ID | Was | Datei | Begründung |
+|----|-----|-------|------------|
+| D1 | `role="tablist"` → `role="group"` auf beiden Tastatur-Umschaltern | `icons.html` | WCAG 1.3.1 – die Knöpfe sind Umschalter mit `aria-pressed`, keine Reiter; `tablist` verlangt Kinder mit `role="tab"` |
+| D2 | `role="group"` auf dem Ausgabe-Block ergänzt | `apps/bewegte-schrift/index.html` | WCAG 4.1.2 – `aria-label` auf einem `<pre>` ohne Rolle ist unzulässig; erst die Rolle macht die Beschriftung gültig |
+
+## Rückstand aus der Erstmessung
+
+**69 Verstösse, 399 betroffene Stellen, 120 Messungen.** Sechs Regelsorten —
+und der Rückstand ist stark konzentriert: **zwei Seiten tragen ein Viertel
+davon.**
+
+| Regel | Stellen | Seiten | Was zu tun ist |
+|---|---:|---:|---|
+| `color-contrast` | 145 | 14 | Kontrast unter 4.5:1 (B02). Rechnen, nicht schätzen; der Fund nennt Ist-Wert und Sollwert |
+| `select-name` | 106 | 2 | Auswahlfelder ohne zugänglichen Namen — ein Platzhalter genügt dort nicht |
+| `label` | 82 | 8 | Eingabefelder ohne Beschriftung (WCAG 4.1.2) |
+| `target-size` | 28 | 2 | Fingerziele unter dem Mass (B04) |
+| `link-in-text-block` | 22 | 4 | Links im Fliesstext, die sich allein durch Farbe unterscheiden (WCAG 1.4.1) |
+| `scrollable-region-focusable` | 16 | 10 | Behälter mit `overflow: auto` ohne `tabindex="0"` — die Tastatur kommt nicht an den verborgenen Teil |
+
+Die dicksten Brocken zuerst:
+
+| Stellen | Seite | Was |
+|---:|---|---|
+| 52 | `ordner.html` | ausschliesslich `select-name` — eine Seite, ein Muster, ein Durchgang |
+| 38 | `werkzeug.html` | 23× Kontrast, 15× fehlende Beschriftung |
+| 12 | `index.html` | `target-size` |
+| 12 | `ineinander.html` | `label` |
+| 12 | `schrift-webfont.html` | 11× Kontrast, 1× `label` |
+| 10 | `apps/gtv-naming/index.html` | Kontrast |
+
+**Merke für neue Seiten**
+
+- Jeder Behälter mit `overflow: auto` braucht `tabindex="0"`.
+- Jedes Auswahl- und Eingabefeld braucht einen Namen — `<label for>` oder
+  `aria-label`; ein Platzhalter ist keiner.
+- Links im Fliesstext brauchen mehr als Farbe (Unterstreichung).
+- Kontrast wird gerechnet: 4.5:1 für Lesetext, 3:1 für grosse oder fette
+  Schrift und für Ränder von Bedienelementen.
+
+## Aus dem Bericht wird ein Tor
+
+Der Job `barrierefreiheit` in `pruefmaschinen.yml` läuft bereits mit
+`--check`, darf aber scheitern (`continue-on-error`), solange der Rückstand
+oben offen ist. Ist er abgetragen, verschwindet diese eine Zeile — dann
+blockiert ein Verstoss den Merge wie `typo-check` und `ds-lint`. Ein Tor, das
+von Anfang an rot steht, hütet nichts.
+
+**Grenze:** rund ein Drittel der WCAG-Kriterien ist überhaupt maschinell
+prüfbar. Ein grüner Lauf heisst «keine der prüfbaren Regeln verletzt» — nicht
+«zugänglich». Der Prüfhinweis oben (Tastaturrunde, Screenreader-Durchgang)
+bleibt gültig; die Maschine ersetzt ihn nicht, sie hält ihm den Rücken frei.

--- a/CHANGELOG-a11y.md
+++ b/CHANGELOG-a11y.md
@@ -91,16 +91,22 @@ Browsers. Solche Blätter werden gezählt und übersprungen.
 
 ## Rückstand aus der Erstmessung
 
-**69 Verstösse, 399 betroffene Stellen, 120 Messungen.** Sechs Regelsorten —
-und der Rückstand ist stark konzentriert: **zwei Seiten tragen ein Viertel
-davon.**
+**70 Verstösse, 419 betroffene Stellen, 120 Messungen** (Lauf der CI). Sechs
+Regelsorten — und der Rückstand ist stark konzentriert: **zwei Seiten tragen
+ein Viertel davon.**
+
+**Der Lauf ist nicht auf jedem Rechner deckungsgleich.** Ob ein Fingerziel
+unter das Mass fällt oder ein Behälter überläuft, hängt an Schriftmetrik und
+Chromium-Bauart: derselbe Stand ergab lokal 28, in der CI 48
+`target-size`-Funde. **Im Zweifel gilt der CI-Lauf** — er misst auf der
+Maschine, die auch das Tor bedient. Die Zahlen unten sind seine.
 
 | Regel | Stellen | Seiten | Was zu tun ist |
 |---|---:|---:|---|
 | `color-contrast` | 145 | 14 | Kontrast unter 4.5:1 (B02). Rechnen, nicht schätzen; der Fund nennt Ist-Wert und Sollwert |
 | `select-name` | 106 | 2 | Auswahlfelder ohne zugänglichen Namen — ein Platzhalter genügt dort nicht |
 | `label` | 82 | 8 | Eingabefelder ohne Beschriftung (WCAG 4.1.2) |
-| `target-size` | 28 | 2 | Fingerziele unter dem Mass (B04) |
+| `target-size` | 48 | 2 | Fingerziele unter dem Mass (B04) |
 | `link-in-text-block` | 22 | 4 | Links im Fliesstext, die sich allein durch Farbe unterscheiden (WCAG 1.4.1) |
 | `scrollable-region-focusable` | 16 | 10 | Behälter mit `overflow: auto` ohne `tabindex="0"` — die Tastatur kommt nicht an den verborgenen Teil |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,15 @@ beschreiben. Solche Widersprüche **melden und vom Auftraggeber entscheiden
 lassen** — das Regelwerk **nicht** eigenmächtig umschreiben.
 
 ### Barrierefreiheit ist verbindlich (WCAG 2.2 AA)
+**Seit dem 8. August 2026 gemessen, nicht behauptet:** `node
+tools/barrierefreiheit.mjs` (Regel **DS08**) lädt jede Seite des
+Geltungsbereichs in Chromium auf 390 px und 1440 px und lässt `axe-core` die
+normativen Kriterien prüfen. Der Lauf dauert rund sechs Minuten und läuft
+darum **nicht** im Commit-Hook, sondern als eigener Job in
+`pruefmaschinen.yml` — vorerst **berichtend**, bis der Rückstand der
+Erstmessung abgetragen ist (`CHANGELOG-a11y.md`, Block D). `--seite <pfad>`
+prüft eine einzelne Seite in Sekunden, `--regel <id>` nur eine Regelsorte.
+
 Für jede Web-Oberfläche gilt, geprüft (Kontraste rechnen, nicht schätzen):
 - **B01 Kein dunkler Text auf farbigem Grund.** Auf Blau/Gold/Grün steht
   **Weiss** (`--on-accent`). Auswahl-Pille = dunkles Gold + Weiss (≥4.5:1),
@@ -103,9 +112,13 @@ nachkontrolliert. Symmetrisch zur sprachlichen Schleife (`typo-check`/`typo-sync
 gibt es die **Gestalt-Schleife**:
 
 - **Vertrag:** `design-system/contract.json` (Regeln DS01–DS07: Pflicht-Includes,
-  nur Token-Farben, Grössen-Untergrenze B03, kanonische Rollen, verbotene Muster).
+  nur Token-Farben, Grössen-Untergrenze B03, kanonische Rollen, verbotene Muster;
+  dazu **DS08** Barrierefreiheit).
 - **Prüfen:** `tools/ds-lint.py` — `ds-lint.py` (Audit + **Score**),
   `--staged` (Hook), `--score`. Meldet Verstösse nach Regel-ID + `Datei:Zeile`.
+  Was ds-lint nicht lesen kann, misst `tools/barrierefreiheit.mjs` im Browser
+  (**DS08**, siehe oben) — ob ein Kontrast trägt, entscheidet sich erst am
+  gerenderten Blatt.
 - **Korrigieren:** `tools/ds-fix.py` — hebt die Hauspalette **property-bewusst**
   auf Tokens (weisse Schrift → `--on-accent`, weisse Fläche → `--paper`).
   Vorschau ohne, schreiben mit `--apply`. Idempotent.

--- a/apps/bewegte-schrift/index.html
+++ b/apps/bewegte-schrift/index.html
@@ -160,7 +160,7 @@
 
         <div>
           <span class="lab">Code zum Übernehmen</span>
-          <pre class="code block" id="code" aria-label="Generierter Code"></pre>
+          <pre class="code block" id="code" role="group" aria-label="Generierter Code"></pre>
         </div>
       </div>
     </div>

--- a/design-system/contract.json
+++ b/design-system/contract.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://goetheanum/design-system/contract.schema.json",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "titel": "Goetheanum Design-System – Struktur-Vertrag",
   "zweck": "Maschinenlesbare Grundlage der GESTALT-Konformität (symmetrisch zum sprachlichen Kanon in assets/typografie/). ds-lint.py prüft jede Seite hiergegen, ds-fix.py korrigiert deterministisch, das Schaufenster bildet es ab. Eine Quelle der Wahrheit für Struktur; Werte/Farben/Schnitte bleiben in tokens.css/tokens.json.",
   "geltungsbereich": {
@@ -172,5 +172,24 @@
     "schwere": "fehler",
     "verbotenes_muster": "[\"']https://phtok\\.github\\.io/goeloggen/(?:design-system|assets)/|data-root\\s*=\\s*[\"']https://phtok\\.github\\.io/goeloggen/",
     "hinweis": "Quelle: Vorfall Signatur-Generator (PR #291) – Seite erschien auf werkzeuge.goetheanum.ch ungestylt. Pfadtiefe je Ort: Root design-system/…, App ../../design-system/…"
+  },
+  "barrierefreiheit": {
+    "ds_id": "DS08",
+    "regel": "Die Hausregeln B01–B05 gelten gemessen, nicht behauptet: jede Seite hält die normativen Erfolgskriterien der WCAG 2.2 auf Stufe A und AA.",
+    "schwere": "fehler",
+    "stufen": [
+      "wcag2a",
+      "wcag2aa",
+      "wcag21a",
+      "wcag21aa",
+      "wcag22a",
+      "wcag22aa"
+    ],
+    "werkzeug": "node tools/barrierefreiheit.mjs --check",
+    "pruefung": "Gemessen, nicht gelesen: Chromium lädt jede Seite des Geltungsbereichs auf 390 px (Telefon) und 1440 px (Schreibtisch), blättert sie einmal durch, damit eingeblendete Abschnitte ihre echten Farben zeigen, und lässt axe-core prüfen. Was weiterleitet, wird übersprungen statt gemessen — sonst misst der Lauf die Fehlerseite des Browsers.",
+    "stand": "Berichtend, nicht blockierend: die Erstmessung vom 8. August 2026 hat einen Rückstand ergeben, der in CHANGELOG-a11y.md steht (Abschnitt «Block D»). Erst wenn er abgetragen ist, wird DS08 zum Tor.",
+    "grenze": "Rund ein Drittel der Kriterien ist maschinell prüfbar. Ein grüner Lauf heisst «keine der prüfbaren Regeln verletzt» — nicht «zugänglich». Beschriftungen, Reihenfolge und Verständlichkeit bleiben Sache der Aufmerksamkeit.",
+    "artefakt_dateien": [],
+    "artefakt_hinweis": "Physische Farben sind keine Bildschirmflächen — eine gedruckte Karte ist weiss, weil das Papier weiss ist. Blätter, deren Farben dem Papier gehören, stehen hier; dort entfällt allein die Kontrastprüfung, alle anderen Kriterien gelten weiter. Das ist die Entsprechung zum «# ds-ok» in den Stilblättern: die Maschine schlägt vor, der Mensch ratifiziert."
   }
 }

--- a/icons.html
+++ b/icons.html
@@ -165,11 +165,11 @@
       <div class="panel">
         <h3>Als Webfont – per Taste</h3>
         <p>Eine Datei trägt alle Icons. Den <code>@font-face</code>-Block einbinden, einem Element die Icon-Schrift geben – dann sitzt jedes Piktogramm auf einer Taste.</p>
-        <div class="seg kbd-layer" role="tablist" aria-label="Tastaturebene">
+        <div class="seg kbd-layer" role="group" aria-label="Tastaturebene">
           <button type="button" data-layer="base" aria-pressed="true">Piktogramme</button>
           <button type="button" data-layer="pfeile" aria-pressed="false">Pfeile &amp; Kompass</button>
         </div>
-        <div class="seg kbd-sub" id="kbdsub" role="tablist" aria-label="Piktogramm-Ebene">
+        <div class="seg kbd-sub" id="kbdsub" role="group" aria-label="Piktogramm-Ebene">
           <button type="button" data-sub="ohne" aria-pressed="true">ohne Text</button>
           <button type="button" data-sub="mit" aria-pressed="false">mit Text</button>
         </div>

--- a/tools/barrierefreiheit.mjs
+++ b/tools/barrierefreiheit.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+// DS08 · Barrierefreiheit — was das Handbuch verspricht, wird hier gemessen.
+//
+// Die Hausregeln B01–B05 stehen seit je in CLAUDE.md: kein dunkler Text auf
+// farbigem Grund, Lesetext ≥ 4.5:1, Mindestgrössen, Fingerziele ≥ 44 px,
+// Hell/Dunkel allein aus den Tokens. Geprüft hat sie bisher niemand am
+// fertigen Blatt — ds-lint liest den Quelltext, und ob ein Kontrast trägt,
+// entscheidet sich erst im Browser. Diese Maschine schliesst die Lücke.
+//
+//   node tools/barrierefreiheit.mjs [--seite <pfad>] [--check] [--spur]
+//                                   [--alles] [--regel <id>]
+//
+// Ohne --check ist es ein Bericht, mit --check ein Tor: ein Verstoss beendet
+// den Lauf mit 1. --alles nimmt zusätzlich die Empfehlungen auf, die über die
+// Norm hinausgehen (axe nennt sie best-practice) — die zählen nie fürs Tor.
+// --regel zeigt nur eine Regelsorte, für die Arbeit an einem Fund.
+//
+// Was eine Maschine nicht sieht: ob eine Beschriftung das Richtige sagt, ob
+// die Reihenfolge dem Sinn folgt, ob eine Bewegung stört. Rund ein Drittel
+// der Kriterien ist überhaupt automatisierbar. Ein grüner Lauf heisst «keine
+// der prüfbaren Regeln verletzt» — nicht «zugänglich».
+//
+// Erwartet playwright-core und @axe-core/playwright (tools/package.json) und
+// einen Chromium unter CHROMIUM_PATH oder /opt/pw-browsers/chromium.
+
+import { chromium } from 'playwright-core'
+import axePaket from '@axe-core/playwright'
+import { readFileSync, existsSync, statSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { createServer } from 'node:http'
+import { join, extname, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Das Paket kommt als CommonJS; je nach Auflösung liegt die Klasse eine
+// Ebene tiefer. Beide Fälle abfangen, statt auf einen zu wetten.
+const AxeBuilder = axePaket?.default ?? axePaket
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const KONTRAKT = JSON.parse(readFileSync(join(ROOT, 'design-system/contract.json'), 'utf8'))
+const REGEL = KONTRAKT.barrierefreiheit ?? {}
+
+// Die normativen Kriterien, nicht die Empfehlungen. Was axe unter
+// best-practice führt, ist Rat — guter Rat, aber kein Gesetz, und ein Tor
+// darf sich nur auf Gesetz stützen.
+const NORM = REGEL.stufen ?? ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']
+const RAT = ['best-practice']
+
+// Zwei Achsen: nur zwei Kriterien der Norm hängen überhaupt an der
+// Fensterbreite — die Grösse der Fingerziele (2.5.8) und der Umbruch ohne
+// Querscrollen (1.4.10). Beide entscheiden sich zwischen Telefon und
+// Schreibtisch.
+const ACHSEN = [{ tag: 'schmal', width: 390, height: 844 },
+                { tag: 'weit', width: 1440, height: 1000 }]
+
+const TYPEN = { '.html': 'text/html; charset=utf-8', '.css': 'text/css; charset=utf-8',
+                '.js': 'text/javascript; charset=utf-8', '.mjs': 'text/javascript; charset=utf-8',
+                '.json': 'application/json; charset=utf-8', '.svg': 'image/svg+xml',
+                '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
+                '.webp': 'image/webp', '.ico': 'image/x-icon', '.woff2': 'font/woff2',
+                '.woff': 'font/woff', '.ttf': 'font/ttf', '.otf': 'font/otf',
+                '.avif': 'image/avif', '.txt': 'text/plain; charset=utf-8',
+                '.yaml': 'text/plain; charset=utf-8', '.yml': 'text/plain; charset=utf-8' }
+
+// Derselbe Geltungsbereich wie ds-lint: versionierte Seiten mit eigenem
+// Körper, ohne die ausgenommenen Pfade, ohne reine Weiterleitungen. Wer hier
+// abweicht, prüft ein anderes Haus als der Rest der Maschinen.
+function seiten () {
+  const g = KONTRAKT.geltungsbereich
+  const verzeichnet = execFileSync('git', ['ls-files', '*.html'], { cwd: ROOT, encoding: 'utf8' })
+    .split('\n').map(l => l.trim()).filter(Boolean)
+  const artefakt = REGEL.artefakt_dateien ?? []
+  const liste = []
+  for (const pfad of verzeichnet) {
+    const p = '/' + pfad.replace(/^\.?\//, '')
+    if (g.ausgenommen_substr.some(s => p.includes(s))) continue
+    if (g.ausgenommen_dateien.includes(pfad)) continue
+    const text = readFileSync(join(ROOT, pfad), 'utf8')
+    if (!text.toLowerCase().includes('<body')) continue           // kein eigener Körper
+    if (/http-equiv\s*=\s*["']?refresh/i.test(text)) continue     // reine Weiterleitung
+    liste.push({ pfad, artefakt: artefakt.some(a => pfad === a || pfad.startsWith(a)) })
+  }
+  return liste.sort((a, b) => a.pfad.localeCompare(b.pfad))
+}
+
+// Ein Server auf der Repo-Wurzel: die Seiten adressieren ihre Anhänge
+// absolut (/design-system/tokens.css), wie auf den Seiten von GitHub Pages.
+function serviere (wurzel) {
+  return new Promise(fertig => {
+    const s = createServer((req, res) => {
+      let p = decodeURIComponent(req.url.split('?')[0])
+      if (p.endsWith('/')) p += 'index.html'
+      const datei = join(wurzel, p)
+      if (!datei.startsWith(wurzel) || !existsSync(datei) || statSync(datei).isDirectory()) {
+        res.writeHead(404).end('')
+        return
+      }
+      res.writeHead(200, { 'content-type': TYPEN[extname(datei)] || 'application/octet-stream' })
+      res.end(readFileSync(datei))
+    })
+    s.listen(0, '127.0.0.1', () => fertig({ port: s.address().port, zu: () => s.close() }))
+  })
+}
+
+// Einmal durch die Seite blättern, bevor gemessen wird. Blätter, die ihre
+// Abschnitte erst beim Herankommen einblenden, zeigen sonst Schrift in
+// Grundfarbe auf Grund — und der Lauf meldet Kontrast-Verstösse, die kein
+// Mensch je zu sehen bekommt. Also wird gelesen wie von einer Leserin, dann
+// gemessen.
+async function durchblaettern (seite) {
+  await seite.evaluate(async () => {
+    const schritt = window.innerHeight * 0.8
+    const ende = document.documentElement.scrollHeight
+    for (let y = 0; y < ende; y += schritt) {
+      window.scrollTo(0, y)
+      await new Promise(r => setTimeout(r, 60))
+    }
+    window.scrollTo(0, 0)
+  })
+  await seite.waitForTimeout(700)
+}
+
+const args = process.argv.slice(2)
+const check = args.includes('--check')
+const spur = args.includes('--spur')
+const alles = args.includes('--alles')
+const nur = args.includes('--seite') ? args[args.indexOf('--seite') + 1] : null
+const nurRegel = args.includes('--regel') ? args[args.indexOf('--regel') + 1] : null
+const browserPfad = process.env.CHROMIUM_PATH || '/opt/pw-browsers/chromium'
+
+const browser = await chromium.launch(
+  existsSync(browserPfad) ? { executablePath: browserPfad } : {})
+const server = await serviere(ROOT)
+let gemessen = 0
+const alle = []
+const nachRegel = new Map()
+const fortgegangen = new Set()   // Brücken-Seiten, die sich selbst weiterschicken
+
+for (const { pfad, artefakt } of seiten()) {
+  if (nur && pfad !== nur) continue
+  if (spur) console.error(`— ${pfad}`)
+  for (const achse of ACHSEN) {
+    // Eigener Kontext statt browser.newPage(): axe legt für seine Prüfung
+    // eine zweite Seite an, und ein von newPage() erzeugter Kontext lässt
+    // genau das nicht zu.
+    const kontext = await browser.newContext(
+      { viewport: { width: achse.width, height: achse.height } })
+    const seite = await kontext.newPage()
+    seite.setDefaultTimeout(15000)
+    // Was von aussen kommt, wird abgewiesen statt abgewartet: gemessen wird
+    // das Blatt, nicht die Leitung.
+    await seite.route('**/*', r => {
+      const ziel = r.request().url()
+      return ziel.startsWith(`http://127.0.0.1:${server.port}`) || ziel.startsWith('data:')
+        ? r.continue() : r.abort()
+    })
+    try {
+      await seite.goto(`http://127.0.0.1:${server.port}/${pfad}`,
+                       { waitUntil: 'domcontentloaded', timeout: 15000 })
+      await seite.waitForTimeout(400)   // Schriften und Nachladungen setzen lassen
+
+      // Manche Blätter sind Brücken: sie lesen den Pfad und schicken weiter
+      // (die Kurzlink-404 etwa). Ihr Ziel liegt ausserhalb, wird abgewiesen,
+      // und Chromium malt an ihrer Stelle seine eigene Fehlerseite — die dann
+      // gemessen würde. Gemessen wird aber das Haus, nicht der Browser: wer
+      // fortgeht, wird gezählt und übersprungen.
+      if (!seite.url().startsWith(`http://127.0.0.1:${server.port}`)) {
+        fortgegangen.add(pfad)
+        if (spur) console.error(`  ${achse.tag}\tleitet weiter`)
+        continue
+      }
+      await durchblaettern(seite)
+
+      const bau = new AxeBuilder({ page: seite }).withTags(alles ? [...NORM, ...RAT] : NORM)
+      // Physische Farben sind keine Bildschirmflächen: eine gedruckte Karte
+      // ist weiss, weil das Papier weiss ist. Solche Blätter stehen im
+      // Kontrakt und werden von der Kontrastprüfung ausgenommen — von
+      // nichts sonst.
+      if (artefakt) bau.disableRules(['color-contrast'])
+      const ergebnis = await bau.analyze()
+      gemessen++
+
+      const funde = ergebnis.violations
+        .filter(v => !nurRegel || v.id === nurRegel)
+        .map(v => ({
+          id: v.id,
+          norm: !v.tags.includes('best-practice'),
+          schwere: v.impact || 'unbekannt',
+          was: v.help,
+          kriterien: v.tags.filter(t => /^wcag\d/.test(t)),
+          stellen: v.nodes.map(n => n.target.join(' ')),
+          probe: v.nodes[0]?.html?.replace(/\s+/g, ' ').slice(0, 72) || ''
+        }))
+        .sort((a, b) => b.stellen.length - a.stellen.length)
+
+      for (const f of funde) nachRegel.set(f.id, (nachRegel.get(f.id) || 0) + f.stellen.length)
+      if (funde.length) alle.push({ pfad, achse: achse.tag, funde })
+      if (spur) console.error(`  ${achse.tag}\t${funde.length || '·'}`)
+    } catch (e) {
+      alle.push({ pfad, achse: achse.tag,
+                  funde: [{ id: 'lädt nicht', norm: true, schwere: 'kritisch',
+                            was: e.message.split('\n')[0], kriterien: [], stellen: [], probe: '' }] })
+    } finally {
+      await kontext.close().catch(() => {})
+    }
+  }
+}
+server.zu()
+await browser.close()
+
+for (const s of alle) {
+  console.log(`!!  ${s.pfad}  (${s.achse})`)
+  for (const f of s.funde) {
+    const marke = f.norm ? f.schwere : 'rat'
+    const kr = f.kriterien.length ? `  [${f.kriterien.join(' ')}]` : ''
+    console.log(`        ${f.id}  (${marke}, ${f.stellen.length}×)${kr}`)
+    console.log(`            ${f.was}`)
+    if (f.stellen.length) console.log(`            ${f.stellen.slice(0, 3).join('  ·  ')}`)
+    if (f.probe) console.log(`            «${f.probe}»`)
+  }
+}
+
+const verstoesse = alle.reduce((s, x) => s + x.funde.filter(f => f.norm).length, 0)
+const rat = alle.reduce((s, x) => s + x.funde.filter(f => !f.norm).length, 0)
+
+if (fortgegangen.size) {
+  console.log(`\nÜbersprungen, weil sie weiterleiten: ${[...fortgegangen].join(', ')}`)
+}
+
+if (nachRegel.size) {
+  console.log('\nnach Regel:')
+  for (const [id, n] of [...nachRegel.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`        ${String(n).padStart(4)}×  ${id}`)
+  }
+}
+
+if (verstoesse) {
+  console.log(`\n${verstoesse} Verstoss/Verstösse gegen WCAG 2.2 AA` +
+              (rat ? ` (und ${rat} Empfehlung(en))` : '') +
+              ` bei ${gemessen} Messungen.`)
+  if (check) process.exit(1)
+} else {
+  console.log(`\nKein Verstoss gegen WCAG 2.2 AA` +
+              (rat ? ` (${rat} Empfehlung(en) genannt)` : '') +
+              ` bei ${gemessen} Messungen.`)
+}

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -1,0 +1,95 @@
+{
+  "name": "goeloggen-werkzeuge",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "goeloggen-werkzeuge",
+      "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
+        "axe-core": "^4.13.0",
+        "playwright": "1.62.1"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright/node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "goeloggen-werkzeuge",
+  "private": true,
+  "type": "module",
+  "description": "Werkzeuge des Hauses, die einen Browser brauchen — derzeit der Barrierefreiheits-Prüfer (DS08).",
+  "scripts": {
+    "barrierefreiheit": "node barrierefreiheit.mjs"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
+    "axe-core": "^4.13.0",
+    "playwright": "1.62.1"
+  }
+}


### PR DESCRIPTION
Die Hausregeln **B01–B05** stehen seit je in `CLAUDE.md`. Geprüft hat sie am fertigen Blatt niemand: `ds-lint` liest den Quelltext, und ob ein Kontrast trägt, entscheidet sich erst im Browser. Diese Maschine schliesst die Lücke — Schwesterwerkzeug zu dem, was im `designs`-Repo als K11 läuft.

## Was neu ist

**`tools/barrierefreiheit.mjs`** lädt jede Seite des Geltungsbereichs — **derselbe wie bei `ds-lint`**, aus `contract.json` — auf zwei Achsen (390 px Telefon, 1440 px Schreibtisch) und lässt `axe-core` die **normativen** Kriterien der WCAG 2.2 auf Stufe A und AA prüfen.

    node tools/barrierefreiheit.mjs                          # Bericht
    node tools/barrierefreiheit.mjs --check                  # als Tor
    node tools/barrierefreiheit.mjs --seite ordner.html      # nur eine Seite
    node tools/barrierefreiheit.mjs --regel select-name      # nur eine Regelsorte
    node tools/barrierefreiheit.mjs --alles                  # samt Empfehlungen
    node tools/barrierefreiheit.mjs --spur                   # Fortschritt je Seite

Der ganze Lauf dauert rund sechs Minuten — darum **nicht** im Commit-Hook, sondern als eigener Job in `pruefmaschinen.yml`. Mit `--seite` sind es Sekunden.

## Zwei Griffe, ohne die der Lauf lügt

**Durchblättern vor dem Messen** — sonst misst er bei Blättern mit Einblende-Effekt Schrift in Grundfarbe auf Grund.

**Wer weiterleitet, wird übersprungen.** `services/sommer-zaehler/kurzlink-site/404.html` ist eine Brücke: sie liest den Pfad und schickt weiter. Das Ziel liegt aussen, wird abgewiesen, und Chromium malt an ihrer Stelle **seine eigene Fehlerseite** — die dann gemessen würde. Genau daher kam der einzige `meta-viewport`-Fund der Erstmessung: nicht unsere Seite, sondern die des Browsers.

## Erstmessung: 69 Verstösse, 399 Stellen, 120 Messungen

**Sofort behoben** (unstrittig, keine Gestaltungsfrage):

| ID | Was | Datei |
|---|---|---|
| D1 | `role="tablist"` → `role="group"` auf beiden Tastatur-Umschaltern — die Knöpfe sind Umschalter mit `aria-pressed`, keine Reiter | `icons.html` |
| D2 | `role="group"` auf dem Ausgabe-Block, damit sein `aria-label` überhaupt gültig ist (`aria-label` auf einem `<pre>` ohne Rolle ist unzulässig) | `apps/bewegte-schrift/index.html` |

**Rückstand** — nach Regel und nach Seite geordnet in `CHANGELOG-a11y.md` (Block D). Er ist stark konzentriert:

| Regel | Stellen | Seiten |
|---|---:|---:|
| `color-contrast` | 145 | 14 |
| `select-name` | 106 | **2** |
| `label` | 82 | 8 |
| `target-size` | 28 | 2 |
| `link-in-text-block` | 22 | 4 |
| `scrollable-region-focusable` | 16 | 10 |

Zwei Seiten tragen ein Viertel davon: `ordner.html` (52 Stellen, ausschliesslich `select-name` — ein Muster, ein Durchgang) und `werkzeug.html` (38).

**Nicht angefasst**, weil es Gestaltungsentscheidungen sind — Farbwerte, Feldbeschriftungen, Zielgrössen, Link-Auszeichnung im Fliesstext. Die Zahlen liegen bereit, entschieden wird pro Seite.

## Warum vorerst Bericht, nicht Tor

Der Job läuft mit `--check`, aber `continue-on-error`. Ein Tor, das von Anfang an rot steht, hütet nichts. Ist der Rückstand abgetragen, verschwindet diese eine Zeile und DS08 blockiert wie `typo-check` und `ds-lint`.

`typo-check` grün (0 Fehler, 11 Hinweise wie zuvor), `ds-lint` Score **100 %**.

## Kontrakt 1.11.0

Neue Regel **DS08** samt Grenze («rund ein Drittel der Kriterien ist maschinell prüfbar — grün heisst *keine prüfbare Regel verletzt*, nicht *zugänglich*») und dem Feld `artefakt_dateien`: Blätter, deren Farben dem Papier gehören, sind keine Bildschirmflächen. Das ist die Entsprechung zum `# ds-ok` in den Stilblättern — die Maschine schlägt vor, der Mensch ratifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FmKn65CRVKgK8AsEvvMXTs

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmKn65CRVKgK8AsEvvMXTs)_