### PR TITLE
Alle Zahlen und Schätzungen auf den 8. August: 926 Anmeldungen, Fristtage als eigenes Fenster

### DIFF
--- a/CHANGELOG-a11y.md
+++ b/CHANGELOG-a11y.md
@@ -142,3 +142,21 @@ von Anfang an rot steht, hütet nichts.
 prüfbar. Ein grüner Lauf heisst «keine der prüfbaren Regeln verletzt» — nicht
 «zugänglich». Der Prüfhinweis oben (Tastaturrunde, Screenreader-Durchgang)
 bleibt gültig; die Maschine ersetzt ihn nicht, sie hält ihm den Rücken frei.
+
+**Zweite Grenze, am 8. August am eigenen Fall gesehen:** Der Lauf misst, was
+beim Laden dasteht. **Nicht gemessen wird, was in einer geschlossenen
+`<details>`-Klappe liegt oder erst aus dem Backend nachgeladen wird** — im
+Cockpit also der halbe Inhalt. Dort fiel eine Pille auf der Szenario-Karte mit
+**4.42:1** durch (nötig 4.5), während dieselbe Pille auf der helleren Fläche
+4.66:1 hielt: Der Goldton mischte über `transparent` und nahm die Farbe der
+Fläche an, auf der er lag (behoben in `apps/sommer-zaehler/campaign.css`, jetzt
+über `--paper` gemischt: 4.70:1 hell, 5.19:1 dunkel).
+
+Wer dynamische Oberflächen prüft, muss die Klappen also öffnen und Daten
+unterlegen — Rezept dafür steht in `CLAUDE.md` unter ‹Die Maschine prüft die
+Regel, das Auge prüft das Gewicht›. Und beim Nachrechnen von Hand: Chromium
+gibt Farben auch als `color(srgb …)` mit Werten von 0 bis 1 zurück, nicht nur
+als `rgb()` mit 0 bis 255. Wer stumpf durch 255 teilt, misst Unsinn — erst
+diese Verwechslung liess die Pille wie 4.03:1 aussehen. Sicherer ist, die
+Farben vom Browser auf ein Canvas malen und das Pixel auslesen zu lassen; dann
+stimmt auch die Alpha-Überlagerung.

--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -58,7 +58,12 @@
   .conv .txt{font-family:var(--font-text);font-size:var(--t-small);color:var(--ink);min-width:190px;flex:1}
   .conv .txt b{font-weight:600}
   .conv .txt .m{color:var(--muted);font-size:var(--t-micro)}
-  .pill{display:inline-block;font-family:var(--font-text);font-size:var(--t-micro);line-height:1.45;padding:6px 13px;border-radius:var(--r-control);background:color-mix(in srgb,var(--gold) 15%,transparent);color:var(--gold-ink);margin-top:var(--s4);max-width:100%}
+  /* B02: Der Goldton mischt über --paper, NICHT über transparent. Sonst legt er
+     sich auf die jeweilige Fläche darunter und frisst den Kontrast, den
+     --gold-ink verspricht — auf der Szenario-Karte (--soft) gemessene 4.42:1
+     statt der nötigen 4.5:1, auf --paper knapp gehaltene 4.66:1. Über --paper
+     gemischt hält die Pille überall: 4.70:1 hell, 5.19:1 dunkel. */
+  .pill{display:inline-block;font-family:var(--font-text);font-size:var(--t-micro);line-height:1.45;padding:6px 13px;border-radius:var(--r-control);background:color-mix(in srgb,var(--gold) 14%,var(--paper));color:var(--gold-ink);margin-top:var(--s4);max-width:100%}
   /* Drei Szenarien nebeneinander, gleiches Gewicht: die Spanne ist die Aussage.
      Die Zahl steht in --ink, nicht in --ok – Grün auf «Vorsichtig» würde
      schmeicheln. Die Referenz nennt sich per Wort (Pille), nicht per Farbe. */

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -31,16 +31,16 @@
     //    Wochenschrift steht höher als goetheanum.tv: Beide Angebote sind
     //    Opt-out, aber dort ist das Nein einen Klick weit weg, und die
     //    monatliche Kartenbelastung erinnert jeden Monat an die Entscheidung.
-    //    Der Frühindikator zeigt dasselbe – im Gratis-Zeitraum kündigten 21 von
-    //    440 goetheanum.tv-Abos, bei der Wochenschrift 0 von 274.
+    //    Der Frühindikator zeigt dasselbe – im Gratis-Zeitraum kündigten 24 von
+    //    573 goetheanum.tv-Abos, bei der Wochenschrift 0 von 353.
     // 2) monate – wie viele der zwölf Folgemonate ein MONATLICHES Abo im
     //    Schnitt trägt. Über 85 Prozent der Abos zahlen monatlich; wer für sie
     //    zwölf volle Monate ansetzt, rechnet mit einer Treue, die niemand
     //    zugesagt hat. Jährliche Abos zählen voll – das Jahr ist bezahlt.
-    //    Ein Monat Verweildauer ist rund CHF 4200 wert, der grösste Hebel.
-    // Herleitung und Empfindlichkeit: docs/einnahmen-perspektive-07-08.md.
+    //    Ein Monat Verweildauer ist rund CHF 5500 wert, der grösste Hebel.
+    // Herleitung und Empfindlichkeit: docs/einnahmen-perspektive-08-08.md.
     szenarien: {
-      doc:     'docs/einnahmen-perspektive-07-08.md',
+      doc:     'docs/einnahmen-perspektive-08-08.md',
       referenz:'erwartet',                 // dieses trägt die grosse Zahl und den Rückfluss
       liste: [
         { key:'vorsichtig', name:'Vorsichtig', bleibt:{ gtv:0.35, wos:0.55 }, monate:7  },
@@ -93,7 +93,7 @@
     // während die Zahlen weiterlaufen. Schätzung (±30 %), keine Messung; die
     // Messwerte in der Datenbank bleiben unangetastet. Bei neuer Auswertung:
     // stand/doc/anteile hier nachziehen, sonst nichts.
-    // Fortschreibung 7. August (löst die Lesart vom 24. Juli ab). Gerechnet aus
+    // Fortschreibung 8. August (löst die Lesart vom 7. August ab). Gerechnet aus
     // drei Ankern: (1) der Grundlinie der 14 Tage vor der ersten Mail-Welle –
     // 3,7 Anmeldungen ohne Spur je Tag, auf jedes spätere Fenster
     // fortgeschrieben; (2) den GEMESSENEN Anteilen desselben Fensters, nach
@@ -102,21 +102,26 @@
     // Zwei Änderungen im Zuschnitt: «Popup» kam am 25. Juli dazu, «Empfehlung»
     // ist im gemessenen Feld strukturell unsichtbar (dieser Weg trägt nie einen
     // Link) und stand darum bisher nirgends.
-    // Die bezahlte Anzeige bleibt bei ≈9 Abos insgesamt: sie ist seit dem
-    // 24. Juli aus (letzter Klick 26. Juli), ihr Anteil wächst nicht mehr und
-    // ist durch die Abschalt-Probe gedeckelt, nicht durch die Fensterrechnung.
+    // Neu am 8. August: Die beiden Fristtage (7./8.) sind ein eigenes Fenster
+    // und haben allein 380 Anmeldungen gebracht – mehr als der ganze Juli.
+    // Weil dort das Mailing 234 von 280 gemessenen Anmeldungen stellt, steigt
+    // sein Anteil am Dunkelfeld von 39,9 auf 49,2 Prozent.
+    // Die bezahlte Anzeige bleibt bei ≈9 Abos insgesamt und wird als FESTE
+    // Zahl geführt (6 dunkel), nicht als Anteil: sie ist seit dem 24. Juli aus
+    // (letzter Klick 26. Juli), ihr Beitrag steht absolut fest. Ein Anteil
+    // liesse ihn schrumpfen, nur weil das Mailing gewachsen ist.
     dunkel: {
-      stand: '7. August',
-      doc:   'docs/wirkungs-lesart-07-08.md',
+      stand: '8. August',
+      doc:   'docs/wirkungs-lesart-08-08.md',
       anteile: {
-        mailing:    0.399,   // die drei Mail-Wellen – jede als Sprung in der Tageskurve belegt
-        newsletter: 0.230,   // Haus-Newsletter und TV-Weekly, inkl. der beiden Eröffnungs-Mails
-        organik:    0.140,   // Direkt, Suche, Storefront, Bestandskonten
-        empfehlung: 0.112,   // persönliches Umfeld, Praxen, Schulen, Tagungen – nur aus Selbstauskunft
-        social:     0.043,   // Reels, Stories, Karussell
-        popup:      0.029,   // Webseiten-Popup seit 25. Juli
-        print:      0.025,   // Stand, Flyer, Inserate
-        bezahlt:    0.022    // Meta-Anzeige – Deckel aus der Abschalt-Probe (docs/abschaltprobe-anzeige-27-07.md)
+        mailing:    0.491,   // die drei Mail-Wellen – jede als Sprung in der Tageskurve belegt
+        newsletter: 0.196,   // Haus-Newsletter und TV-Weekly, inkl. der beiden Eröffnungs-Mails
+        organik:    0.113,   // Direkt, Suche, Storefront, Bestandskonten
+        empfehlung: 0.101,   // persönliches Umfeld, Praxen, Schulen, Tagungen – nur aus Selbstauskunft
+        social:     0.034,   // Reels, Stories, Karussell
+        popup:      0.034,   // Webseiten-Popup seit 25. Juli
+        bezahlt:    0.017,   // Meta-Anzeige – FESTE Zahl (6 Abos) aus der Abschalt-Probe, kein Anteil
+        print:      0.013    // Stand, Flyer, Inserate
       }
     },
     // Die Abschalt-Probe der bezahlten Anzeige ist gelaufen UND ausgewertet.
@@ -680,7 +685,7 @@
     // münden kaum in Abos. Darum ein Zug, der misst statt umbaut.
     // Herleitung: docs/wirkungs-lesart-24-07.md, Ergebnis der Probe in
     // docs/abschaltprobe-anzeige-27-07.md, fortgeschrieben in
-    // docs/wirkungs-lesart-07-08.md.
+    // docs/wirkungs-lesart-08-08.md.
     var leck = { kl:0, motive:[], letzter:null, bezahltKl:0, bezahltLetzter:null };
     Object.keys(grp).forEach(function(k){
       var g = grp[k], a2 = ab[k] || 0;

--- a/docs/einnahmen-perspektive-08-08.js
+++ b/docs/einnahmen-perspektive-08-08.js
@@ -1,0 +1,63 @@
+// Einnahmen-Perspektive Sommer-Aktion 2026 – Stand 8. August (letzter Fristtag)
+// Preise aus CONFIG.preise (echt, Stand 17.7.), Kurs eurChf 0.93.
+var EURCHF = 0.93;
+
+// [produkt, format, waehrung, intervall, aktive Abos, Preis je Periode]
+var SEG = [
+  ['gtv', 'stream',  'eur', 'jaehrlich',  74, 149.0],   // 73 standard + 1 ermaessigt (Fallback Standardpreis)
+  ['gtv', 'stream',  'eur', 'monatlich', 475,  14.9],
+  ['wos', 'digital', 'chf', 'jaehrlich',   1, 109.0],
+  ['wos', 'digital', 'chf', 'monatlich',  15,  10.9],
+  ['wos', 'digital', 'eur', 'jaehrlich',  21,  99.0],
+  ['wos', 'digital', 'eur', 'monatlich', 210,   9.9],
+  ['wos', 'papier',  'chf', 'jaehrlich',   8, 149.0],
+  ['wos', 'papier',  'chf', 'monatlich',  12,  14.9],
+  ['wos', 'papier',  'eur', 'jaehrlich',  16, 139.0],
+  ['wos', 'papier',  'eur', 'monatlich',  70,  13.9]
+];
+
+var SZENARIEN = [
+  { name: 'Vorsichtig', gtv: 0.35, wos: 0.55, monate: 7  },
+  { name: 'Erwartet',   gtv: 0.50, wos: 0.70, monate: 9  },
+  { name: 'Gut',        gtv: 0.65, wos: 0.85, monate: 11 }
+];
+
+function chf(eur, waehrung){ return waehrung === 'eur' ? eur * EURCHF : eur; }
+function f(n){ return Math.round(n).toLocaleString('de-CH'); }
+
+// Decke: alle bleiben, monatliche zahlen volle 12 Monate.
+var decke = 0, decken = 0;
+SEG.forEach(function(s){
+  var jahr = s[3] === 'jaehrlich' ? s[5] : s[5] * 12;
+  decke += chf(jahr * s[4], s[2]); decken += s[4];
+});
+console.log('Decke (100 %, volle 12 Monate): CHF ' + f(decke) + ' aus ' + decken + ' Abos\n');
+
+SZENARIEN.forEach(function(sz){
+  var sum = 0, bleiben = 0, jeProdukt = { gtv: 0, wos: 0 };
+  SEG.forEach(function(s){
+    var quote = s[0] === 'gtv' ? sz.gtv : sz.wos;
+    var n = s[4] * quote;
+    var jahr = s[3] === 'jaehrlich' ? s[5] : s[5] * sz.monate;
+    var betrag = chf(jahr * n, s[2]);
+    sum += betrag; bleiben += n; jeProdukt[s[0]] += betrag;
+  });
+  console.log(sz.name.padEnd(11) +
+    ' | bleiben ' + String(Math.round(bleiben)).padStart(3) +
+    ' | CHF ' + f(sum).padStart(7) +
+    ' | gtv ' + f(jeProdukt.gtv).padStart(6) +
+    ' | wos ' + f(jeProdukt.wos).padStart(6) +
+    ' | je Abo ' + f(sum / bleiben));
+});
+
+// Empfindlichkeit: nur der Monats-Faktor, Quoten des Erwartet-Falls.
+console.log('\nEmpfindlichkeit (Quoten wie «Erwartet», nur Monate variiert):');
+[6, 8, 9, 10, 12].forEach(function(m){
+  var sum = 0;
+  SEG.forEach(function(s){
+    var quote = s[0] === 'gtv' ? 0.50 : 0.70;
+    var jahr = s[3] === 'jaehrlich' ? s[5] : s[5] * m;
+    sum += chf(jahr * s[4] * quote, s[2]);
+  });
+  console.log('  ' + m + ' Monate: CHF ' + f(sum));
+});

--- a/docs/einnahmen-perspektive-08-08.md
+++ b/docs/einnahmen-perspektive-08-08.md
@@ -1,14 +1,16 @@
-# Einnahmen-Perspektive der Sommer-Aktion — drei Szenarien, Stand 7. August 2026
-
-> **Abgelöst am 8. August 2026 durch `einnahmen-perspektive-08-08.md`.** Diese Fassung
-> bleibt als Historie stehen — die Zahlen darin sind der Stand vom 7. August.
+# Einnahmen-Perspektive der Sommer-Aktion — drei Szenarien, Stand 8. August 2026
 
 Was die Aktion im **Folgejahr** einbringt, wenn die Gratis-Zeit vorbei ist.
-Gerechnet auf dem Stand vom 7. August: **714 Anmeldungen, davon 693 aktiv**
-(21 bereits gekündigt). Die Aktion läuft noch bis zum 11. August — die Zahlen
-wachsen also weiter, die Verhältnisse voraussichtlich nicht.
+Gerechnet auf dem Stand vom 8. August, dem letzten Fristtag: **926
+Anmeldungen, davon 902 aktiv** (24 bereits gekündigt). Die Aktion läuft still
+bis zum 11. August weiter — die Zahlen wachsen also noch, die Verhältnisse
+voraussichtlich nicht mehr.
 
-Nachrechenbar: `node docs/einnahmen-perspektive-07-08.js` — dort stehen die
+Diese Fassung löst den Stand vom 7. August ab (693 aktive Abos, erwartet
+CHF 45 115). Geändert haben sich allein die Mengen: Die beiden Fristtage
+brachten 380 Anmeldungen. Quoten, Monats-Faktoren und Methode sind unverändert.
+
+Nachrechenbar: `node docs/einnahmen-perspektive-08-08.js` — dort stehen die
 Segmente, die Preise und die Szenario-Annahmen als Code, damit die Tabellen
 unten nicht von Hand gepflegt werden müssen.
 
@@ -19,9 +21,9 @@ Annahmen.
 
 ## Die Decke
 
-Blieben **alle** 693 und zahlten die monatlichen zwölf volle Monate:
+Blieben **alle** 902 und zahlten die monatlichen zwölf volle Monate:
 
-**CHF 101 904 im Folgejahr.**
+**CHF 132 710 im Folgejahr.**
 
 Diese Zahl ist keine Erwartung, sondern die Obergrenze. Sie zu nennen lohnt
 trotzdem: Sie sagt, worüber wir reden — die Aktion hat einen Gegenwert im
@@ -31,9 +33,9 @@ sechsstelligen Bereich aufgebaut, nicht im fünfstelligen Zehner.
 
 | | bleiben | **Folgejahr CHF** | davon goetheanum.tv | davon Wochenschrift | je bleibendem Abo |
 |---|---:|---:|---:|---:|---:|
-| **Vorsichtig** | 297 | **26 995** | 15 083 | 11 911 | 91 |
-| **Erwartet** | 401 | **45 115** | 26 536 | 18 578 | 112 |
-| **Gut** | 505 | **67 693** | 40 982 | 26 711 | 134 |
+| **Vorsichtig** | 386 | **34 877** | 19 715 | 15 162 | 90 |
+| **Erwartet** | 522 | **58 497** | 34 746 | 23 750 | 112 |
+| **Gut** | 657 | **87 974** | 53 727 | 34 247 | 134 |
 
 Die Spanne ist gross — Faktor 2,5 zwischen vorsichtig und gut. Das ist keine
 Rechenschwäche, sondern der ehrliche Zustand: **Noch keine einzige Kohorte
@@ -62,12 +64,21 @@ aus den eigenen Daten und Texten:
   Konto», eigene Formulierung), bei der Wochenschrift nicht. Und die
   monatliche Kartenbelastung erinnert dort jeden Monat an die Entscheidung.
 - **Der Frühindikator zeigt genau das:** Schon im Gratis-Zeitraum haben
-  **21 von 440** goetheanum.tv-Abos gekündigt (4,8 %) — bei der Wochenschrift
-  **0 von 274**.
+  **24 von 573** goetheanum.tv-Abos gekündigt (4,2 %) — bei der Wochenschrift
+  **0 von 353**.
+
+**Neu am 8. August und gegen alle drei Szenarien:** 380 der 926 Anmeldungen —
+gut 40 Prozent — kamen an den beiden Fristtagen herein, unter Zeitdruck und
+grösstenteils aus einer Erinnerungs-Mail. Wer unter einer ablaufenden Frist
+zusagt, hat kürzer überlegt als wer im Juli aus eigenem Antrieb zugesagt hat;
+für die Bleibe-Entscheidung im Herbst ist das eher ein Nach- als ein Vorteil.
+Die Quoten sind hier **nicht** gesenkt worden — dafür fehlt jede Messung —,
+aber es ist der stärkste vorliegende Grund, «Vorsichtig» einzuplanen und nicht
+«Erwartet».
 
 ### 2 · Wie lange die monatlichen zahlen
 
-**595 der 693 Abos zahlen monatlich, nur 98 jährlich.** Ein Folgejahr-Umsatz,
+**782 der 902 Abos zahlen monatlich, nur 120 jährlich.** Ein Folgejahr-Umsatz,
 der bei jedem monatlichen Abo zwölf volle Monate ansetzt, rechnet mit einer
 Treue, die niemand zugesagt hat. Darum trägt jedes Szenario einen
 Monats-Faktor: **7 · 9 · 11** von zwölf Monaten. Jährliche Abos zählen voll —
@@ -79,13 +90,13 @@ Nur der Monats-Faktor bewegt, die Quoten bleiben auf «Erwartet»:
 
 | Monate | Folgejahr CHF |
 |---:|---:|
-| 6 | 32 504 |
-| 8 | 40 911 |
-| 9 | **45 115** |
-| 10 | 49 318 |
-| 12 | 57 725 |
+| 6 | 41 944 |
+| 8 | 52 979 |
+| 9 | **58 497** |
+| 10 | 64 014 |
+| 12 | 75 049 |
 
-**Ein Monat durchschnittlicher Verweildauer ist rund CHF 4 200 wert.** Das
+**Ein Monat durchschnittlicher Verweildauer ist rund CHF 5 500 wert.** Das
 ist der grösste einzelne Hebel in dieser Rechnung — grösser als jede
 plausible Verschiebung der Bleibe-Quote allein.
 
@@ -103,7 +114,7 @@ plausible Verschiebung der Bleibe-Quote allein.
   ohne weiteres Zutun ein, sobald sie im Kosten-Formular stehen.
 - **Keine Aussage über Papier.** Die Wochenschrift auf Papier trägt
   Herstellungs- und Versandkosten je Exemplar, die hier nicht abgezogen sind.
-  Von den 274 WoS-Abos sind 87 Papier-Abos.
+  Von den 353 WoS-Abos sind 106 Papier-Abos.
 
 ## Was den Rat durch Messung ersetzt
 

--- a/docs/wirkungs-lesart-07-08.md
+++ b/docs/wirkungs-lesart-07-08.md
@@ -1,5 +1,8 @@
 # Wirkungs-Lesart der Sommer-Aktion — Stand 7. August 2026
 
+> **Abgelöst am 8. August 2026 durch `wirkungs-lesart-08-08.md`.** Diese Fassung
+> bleibt als Historie stehen — die Zahlen darin sind der Stand vom 7. August.
+
 Dieses Dokument ordnet die Anmeldungen **ohne UTM-Spur** («ohne UTM» im
 Cockpit) den Aktivitäten der Kampagne zu. Es ist eine **Lesart, keine
 Messung**: Alle mit ≈ markierten Zahlen sind Schätzungen (±30 %). Die

--- a/docs/wirkungs-lesart-08-08.js
+++ b/docs/wirkungs-lesart-08-08.js
@@ -1,0 +1,119 @@
+// Wirkungs-Lesart der Sommer-Aktion – Stand 8. August 2026, letzter Fristtag.
+// Verteilt die Anmeldungen OHNE UTM-Spur (352 von 926) auf die Gebiete.
+// Methode wie am 7. August, nur mit einem Fenster mehr (die Fristtage):
+//   1) Grundlinie – die Tage vor der ersten Mail-Welle geben die Rate der
+//      spurlosen Anmeldungen je Tag; sie wird auf jedes Fenster fortgeschrieben.
+//   2) Ueberschuss eines Fensters -> nach den GEMESSENEN Anteilen desselben
+//      Fensters verteilt (was im Hellen dominiert, dominiert auch im Dunkeln).
+//   3) Grundlinien-Block -> nach der Selbstauskunft verteilt (61 Antworten).
+// Aufruf: node docs/wirkungs-lesart-08-08.js
+
+// Fenster: Tage, Anmeldungen ohne Spur, gemessene Anteile im selben Fenster.
+const FENSTER = [
+  { name:'Grundlinie · 3.–16. Juli',   tage:14, dunkel: 52, anzeigeLief:false,
+    gemessen:{ social:7, mailing:4, organik:2 } },
+  { name:'Welle 1 · 17.–23. Juli',     tage: 7, dunkel: 69, anzeigeLief:true,
+    gemessen:{ mailing:80, newsletter:4, organik:2, social:2, bezahlt:1 } },
+  { name:'Zwischenfeld · 24.–29. Juli',tage: 6, dunkel: 42, anzeigeLief:true,
+    gemessen:{ mailing:13, newsletter:6, social:1, organik:1 } },
+  { name:'Welle 2 · 30. Juli–6. Aug.', tage: 8, dunkel: 89, anzeigeLief:false,
+    gemessen:{ mailing:138, popup:18, newsletter:8, social:4, bezahlt:2, organik:1 } },
+  { name:'Fristtage · 7.–8. Aug.',     tage: 2, dunkel:100, anzeigeLief:false,
+    gemessen:{ mailing:234, newsletter:20, popup:17, social:5, organik:4 } }
+];
+
+// Selbstauskunft der dunklen Anmeldungen (61 Antworten, 58 einordenbar).
+// Traegt den Grundlinien-Block; «mail» heisst dort Newsletter, denn in der
+// Grundlinie lief kein Mailer – nur die beiden Eroeffnungs-Newsletter.
+const SELBST = { newsletter:22, organik:14, empfehlung:15, social:3, print:2, bezahlt:2 };
+
+// Die bezahlte Anzeige wird NICHT als Anteil gerechnet, sondern als feste Zahl.
+// Grund: Sie ist seit dem 24. Juli aus (letzter Klick 26. Juli). Ihr Beitrag
+// steht damit absolut fest und darf nicht schrumpfen, nur weil das Dunkelfeld
+// durch die Mail-Wellen gewachsen ist – ein Anteil taete genau das. Die Zahl
+// stammt aus der Abschalt-Probe: rund 8–12 Abos insgesamt, davon 3 gemessen
+// (docs/abschaltprobe-anzeige-27-07.md).
+const BEZAHLT_DUNKEL = 6;
+
+const summe = o => Object.values(o).reduce((a, b) => a + b, 0);
+const rate  = FENSTER[0].dunkel / FENSTER[0].tage;
+
+const out = {};
+const add = (k, v) => { out[k] = (out[k] || 0) + v; };
+
+// Selbstauskunft-Schluessel, einmal ohne «bezahlt» (fuer Fenster ohne Anzeige).
+const selbstAnteile = (mitBezahlt) => {
+  const s = { ...SELBST };
+  if (!mitBezahlt){ s.organik += s.bezahlt; s.bezahlt = 0; }
+  const g = summe(s);
+  return Object.fromEntries(Object.entries(s).map(([k, v]) => [k, v / g]));
+};
+
+for (const f of FENSTER){
+  const grund = Math.min(f.dunkel, rate * f.tage);
+  const ueber = f.dunkel - grund;
+
+  const sa = selbstAnteile(f.anzeigeLief);
+  for (const [k, a] of Object.entries(sa)) add(k, grund * a);
+
+  const g = summe(f.gemessen);
+  if (ueber > 0 && g > 0){
+    for (const [k, n] of Object.entries(f.gemessen)) add(k, ueber * n / g);
+  }
+}
+
+// Anzeige auf die feste Zahl setzen; die Differenz traegt das groesste Gebiet.
+{
+  const diff = (out.bezahlt || 0) - BEZAHLT_DUNKEL;
+  out.bezahlt = BEZAHLT_DUNKEL;
+  const groesstes = Object.keys(out).filter(k => k !== 'bezahlt')
+    .sort((a, b) => out[b] - out[a])[0];
+  out[groesstes] += diff;
+}
+
+const DUNKEL = FENSTER.reduce((s, f) => s + f.dunkel, 0);
+
+// Dieselbe Rundung wie dunkelVerteilen() im Cockpit: je Gebiet kaufmaennisch
+// runden, den Rest dem groessten Gebiet geben. Ohne diese Angleichung stuenden
+// im Dokument andere Zahlen als auf der Seite – genau die Drift, die eine
+// datierte Lesart verhindern soll.
+const ANTEILE_ROH = {};
+{
+  const anteile = Object.fromEntries(Object.entries(out).map(([k, v]) => [k, v / DUNKEL]));
+  for (const [k, a] of Object.entries(anteile)) ANTEILE_ROH[k] = Math.round(a * 1000) / 1000;
+  let verteilt = 0, groesstes = null, max = -1;
+  for (const [k, a] of Object.entries(anteile)){
+    const n = Math.round(DUNKEL * Math.round(a * 1000) / 1000);
+    out[k] = n; verteilt += n;
+    if (a > max){ max = a; groesstes = k; }
+  }
+  if (groesstes && verteilt !== DUNKEL) out[groesstes] += (DUNKEL - verteilt);
+}
+// Gemessenes Feld ueber alle Fenster – fuer die Spalte «dazu gemessen».
+const GEMESSEN = {};
+FENSTER.forEach(f => Object.entries(f.gemessen).forEach(([k, n]) => GEMESSEN[k] = (GEMESSEN[k] || 0) + n));
+
+console.log('Grundlinie:', rate.toFixed(2), 'Anmeldungen ohne Spur je Tag');
+console.log('Dunkelfeld gesamt:', DUNKEL, '· gemessen:', summe(GEMESSEN),
+            '· Aktion:', DUNKEL + summe(GEMESSEN), '\n');
+
+const zeilen = Object.entries(out).sort((a, b) => b[1] - a[1]);
+let anteilSumme = 0, dunkelSumme = 0;
+console.log('Gebiet          dunkel  Anteil   gemessen   gesamt');
+for (const [k, v] of zeilen){
+  const anteil = v / DUNKEL;
+  const d = Math.round(v);
+  anteilSumme += Math.round(anteil * 1000) / 1000; dunkelSumme += d;
+  console.log(k.padEnd(14),
+    String(d).padStart(6),
+    (anteil * 100).toFixed(1).padStart(7) + ' %',
+    String(GEMESSEN[k] || 0).padStart(8),
+    String(d + (GEMESSEN[k] || 0)).padStart(8));
+}
+console.log('\nProbe · Anteile:', anteilSumme.toFixed(3), '· verteilt:', dunkelSumme, 'von', DUNKEL);
+// Diese Anteile stehen in CONFIG.dunkel.anteile im Cockpit. Die Restzuteilung
+// oben laesst die gerundeten Stueckzahlen exakt aufgehen – deshalb ergeben die
+// Anteile hier nicht in jedem Fall wieder genau die Zeilen der Tabelle.
+console.log('\nAnteile fuer CONFIG.dunkel.anteile (Summe ' +
+  Object.values(ANTEILE_ROH).reduce((a, b) => a + b, 0).toFixed(3) + '):');
+console.log(ANTEILE_ROH);

--- a/docs/wirkungs-lesart-08-08.md
+++ b/docs/wirkungs-lesart-08-08.md
@@ -1,0 +1,102 @@
+# Wirkungs-Lesart der Sommer-Aktion — Stand 8. August 2026
+
+Diese Fassung löst `wirkungs-lesart-07-08.md` ab (die bleibt als Historie
+liegen). Sie widerspricht ihr nicht — sie rechnet dieselbe Methode auf einem
+Feld, das sich in einem Tag um **fast die Hälfte vergrössert** hat.
+
+Grundlage: **926 Anmeldungen**, davon **574 mit UTM** und **352 ohne**.
+Am 7. August waren es 636. Die beiden Fristtage (7. und 8. August, Mail-Wellen
+3 und 3b) haben allein **380 Anmeldungen** gebracht — mehr als der ganze Juli.
+
+Nachrechenbar: `node docs/wirkungs-lesart-08-08.js`. Dort stehen Fenster,
+gemessene Anteile und Selbstauskunft als Code; die Tabellen unten sind seine
+Ausgabe.
+
+## Was sich gegenüber gestern ändert
+
+**Nichts an der Methode, alles an der Grössenordnung.** Die Fristtage sind ein
+eigenes Fenster geworden, und weil in ihnen das Mailing 234 von 280 gemessenen
+Anmeldungen stellt, wandert auch der grösste Teil ihres Dunkelfeldes dorthin.
+Der Mailing-Anteil am Dunkelfeld steigt damit von 39,9 auf **48,9 Prozent**.
+
+Das Dunkelfeld selbst ist **anteilig gesunken**: von 44 auf **38 Prozent** aller
+Anmeldungen. Der Grund ist gut: Was in den Schlusstagen hereinkam, kam
+überwiegend mit sauberer Spur.
+
+## Das Ergebnis
+
+Die 352 Anmeldungen ohne Spur, verteilt:
+
+| Gebiet | ≈ dunkel | Anteil | dazu gemessen | ≈ gesamt |
+|---|---:|---:|---:|---:|
+| Mailing | 172 | 48,9 % | 469 | **641** |
+| Newsletter | 69 | 19,6 % | 38 | 107 |
+| Organik · Direkt · Bestand | 40 | 11,4 % | 10 | 50 |
+| Empfehlung | 36 | 10,2 % | 0 | 36 |
+| Social organisch | 12 | 3,4 % | 19 | 31 |
+| Popup | 12 | 3,4 % | 35 | 47 |
+| Bezahlt · Anzeige | 6 | 1,7 % | 3 | **9** |
+| Print · Stand · Inserat | 5 | 1,4 % | 0 | 5 |
+| **Summe** | **352** | **100 %** | **574** | **926** |
+
+**Die eine Aussage, schärfer als gestern:** **69 Prozent der ganzen Aktion**
+(641 von 926) gehen auf die drei Mail-Wellen an den eigenen Verteiler zurück,
+weitere 12 Prozent auf die Newsletter. Vier von fünf Abos stammen damit aus
+Adressen, die das Haus schon hatte.
+
+## Die Fristtage — was sie zeigen
+
+380 Anmeldungen in zwei Tagen, gegen einen Schnitt von 25 in den zwei Wochen
+davor. Das ist **kein neues Publikum**, sondern dasselbe, das früher schon
+angeschrieben wurde und erst unter der Frist entschieden hat: 234 der 280
+gemessenen Fristtag-Anmeldungen tragen die Mailing-Spur, also Wellen an
+denselben Verteiler.
+
+Für die nächste Aktion ist das die brauchbarste Zahl des ganzen Sommers: **Die
+Frist wirkt stärker als jeder einzelne Kanal.** Wer sie früher setzt oder
+zweimal setzt, hebt mehr als wer einen weiteren Kanal bespielt.
+
+## Die bezahlte Anzeige — als feste Zahl, nicht als Anteil
+
+Die Anzeige steht mit **≈9 Abos** (6 dunkel, 3 gemessen) unverändert da wie am
+24. Juli. Das ist eine bewusste Rechenentscheidung: Sie ist seit dem 24. Juli
+aus, ihr Beitrag steht damit **absolut** fest. Ein Anteil würde ihn schrumpfen
+lassen, nur weil das Mailing gewachsen ist — und würde eine Genauigkeit
+vortäuschen, die die Abschalt-Probe gar nicht hergibt.
+
+## Die Selbstauskunft hat sich bestätigt
+
+61 der 352 dunklen Anmeldungen beantworten «Wie sind Sie auf uns aufmerksam
+geworden?», 58 davon einordenbar. Die Verteilung ist gegenüber gestern (42
+Antworten) **fast unverändert** — ein gutes Zeichen für die Belastbarkeit:
+
+| Antwort-Gruppe | 7. August | 8. August |
+|---|---:|---:|
+| E-Mail, Newsletter, Verteiler | 37,5 % | 37,9 % |
+| Direkt, Suche, Bestand | 25,0 % | 24,1 % |
+| Empfehlung, Praxis, Schule, Tagung | 22,5 % | 25,9 % |
+| Social | 5,0 % | 5,2 % |
+| Print, Stand | 5,0 % | 3,4 % |
+| Anzeige, Werbung | 5,0 % | 3,4 % |
+
+## Wo diese Lesart schwach ist
+
+- **Die Grundlinie trägt die Fristtage nicht.** Sie unterstellt für den 7./8.
+  August dieselben 3,7 spurlosen Anmeldungen je Tag wie im Juli. Unter einer
+  Frist entsteht aber zusätzlicher Direktverkehr — Leute, die die Mail vor
+  Tagen sahen und jetzt selbst auf die Seite gehen. Dieser Teil wird hier dem
+  Mailing zugeschlagen. **Der Mailing-Anteil ist darum eine Obergrenze**; die
+  Wahrheit liegt vermutlich einige Prozentpunkte tiefer, zugunsten von Organik.
+- **Newsletter gegen Mailing** bleibt die unsicherste Trennung: Beide fallen
+  auf dieselben Tage, und die Selbstauskunft kann sie nicht auseinanderhalten
+  («eine Mail»).
+- **Empfehlung** steht weiter allein auf Selbstauskünften (jetzt 15 statt 9).
+  Die Grössenordnung ist belegt, die Zahl nicht.
+
+## Die Aktion läuft noch
+
+Sie ist still bis zum **11. August** verlängert (Beschluss 7. August, keine
+Ankündigung). Die kommunizierte Frist war der 8. August — die Tage 9. bis 11.
+sind darum ein **Nachzügler-Fenster ohne eigenen Impuls** und gehören in einer
+Schluss-Lesart in der Grundlinie gerechnet, nicht im Schlussspurt. Wer sie in
+den Fristtagen mitzählt, verdünnt deren Befund.

--- a/services/sommer-zaehler/README.md
+++ b/services/sommer-zaehler/README.md
@@ -197,7 +197,7 @@ drei Monate gratis, die erste Kohorte entscheidet frühestens Anfang Oktober
 
 Die **Dunkelfeld-Anteile** (`CONFIG.dunkel`) sind eine datierte Lesart und
 gehören bei jeder neuen Auswertung nachgezogen (stand / doc / anteile), zuletzt
-`docs/wirkungs-lesart-07-08.md` vom 7. August. Sie verteilt die Anmeldungen ohne Spur aus drei Ankern: Grundlinie
+`docs/wirkungs-lesart-08-08.md` vom 8. August (nachrechenbar: das gleichnamige `.js` daneben). Sie verteilt die Anmeldungen ohne Spur aus drei Ankern: Grundlinie
 der Tageskurve vor der ersten Mail-Welle, gemessene Anteile desselben Fensters,
-Selbstauskunft. Historie: `wirkungs-lesart-18-07.md`, `-22-07`, `-24-07` und
+Selbstauskunft. Historie: `wirkungs-lesart-18-07.md`, `-22-07`, `-24-07`, `-07-08` und
 die Abschalt-Probe der bezahlten Anzeige (`abschaltprobe-anzeige-27-07.md`).


### PR DESCRIPTION
Aus 636 sind **926** geworden. Die beiden Fristtage (7. und 8. August, Mail-Wellen 3 und 3b) brachten allein **380 Anmeldungen** — mehr als der ganze Juli. Beide datierten Lesarten mussten darum neu gerechnet werden, nicht nur fortgeschrieben.

## Wirkung · `docs/wirkungs-lesart-08-08.md`

Dunkelfeld 352 von 926 — anteilig **gesunken** von 44 auf 38 Prozent. Der Grund ist gut: Was in den Schlusstagen hereinkam, kam überwiegend mit sauberer Spur.

| Gebiet | ≈ dunkel | Anteil | dazu gemessen | ≈ gesamt |
|---|---:|---:|---:|---:|
| Mailing | 172 | 48,9 % | 469 | **641** |
| Newsletter | 69 | 19,6 % | 38 | 107 |
| Organik · Direkt · Bestand | 40 | 11,4 % | 10 | 50 |
| Empfehlung | 36 | 10,2 % | 0 | 36 |
| Social organisch | 12 | 3,4 % | 19 | 31 |
| Popup | 12 | 3,4 % | 35 | 47 |
| Bezahlt · Anzeige | 6 | 1,7 % | 3 | **9** |
| Print · Stand · Inserat | 5 | 1,4 % | 0 | 5 |

**Die eine Aussage, schärfer als gestern:** 69 Prozent der ganzen Aktion (641 von 926) gehen auf die drei Mail-Wellen an den eigenen Verteiler zurück, weitere 12 Prozent auf die Newsletter. Vier von fünf Abos stammen aus Adressen, die das Haus schon hatte — und **die Frist wirkt stärker als jeder einzelne Kanal**.

**Eine Rechenentscheidung:** Die bezahlte Anzeige wird als **feste Zahl** geführt (6 dunkel + 3 gemessen = 9), nicht als Anteil. Sie ist seit dem 24. Juli aus, ihr Beitrag steht absolut fest — ein Anteil liesse ihn schrumpfen, nur weil das Mailing gewachsen ist.

## Einnahmen · `docs/einnahmen-perspektive-08-08.md`

902 aktive Abos (24 gekündigt):

| | bleiben | Folgejahr CHF |
|---|---:|---:|
| Vorsichtig | 386 | **34 877** |
| Erwartet | 522 | **58 497** |
| Gut | 657 | **87 974** |
| Decke | 902 | 132 710 |

Ein Monat durchschnittlicher Verweildauer ist jetzt rund **CHF 5 500** wert. Neu vermerkt und **gegen alle drei Szenarien**: 40 Prozent der Anmeldungen kamen unter Zeitdruck herein; wer unter ablaufender Frist zusagt, hat kürzer überlegt als wer im Juli aus eigenem Antrieb zusagte. Die Quoten sind deshalb **nicht** gesenkt — dafür fehlt jede Messung —, aber es ist der stärkste vorliegende Grund, «Vorsichtig» einzuplanen.

## Gegen die Drift

Beide Lesarten sind jetzt als Skript nachrechenbar (`…-08-08.js`). Das Wirkungs-Skript trägt **dieselbe Rundungsregel wie `dunkelVerteilen()` im Cockpit** — sonst stünden im Dokument andere Stückzahlen als auf der Seite. Nachgeprüft: beide liefern 172/69/40/36/12/12/6/5.

Im Browser mit den heutigen Daten gegengeprüft (Regel aus `CLAUDE.md`): die drei Karten zeigen 34 877 / 58 497 / 87 974, die Decke 132 710.

Die abgelösten Fassungen vom 7. August bleiben als Historie liegen und tragen oben einen Verweis auf die neuen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUqZZzUQntMLiZPecAsBBc)_