### PR TITLE
Zwei Zahlen weg, die nichts mehr sagen: Befund-Fortschreibung und «Abos/Tag nötig»

### DIFF
--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -48,7 +48,6 @@
 
 
 
-  .stay{display:grid;grid-template-columns:1.1fr 1fr;gap:var(--s6);align-items:stretch}
   .cohort{background:var(--card,var(--paper));border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);box-shadow:var(--shadow-card)}
   .cohort .when{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted)}
   .cohort h4{margin:6px 0 var(--s4);font-family:var(--font-display);font-weight:var(--w-deutlich);font-size:var(--t-h3)}
@@ -73,10 +72,6 @@
   .szen .s-w{font-family:var(--font-display);font-weight:var(--w-strong);font-size:clamp(26px,3.4vw,36px);color:var(--ink);font-variant-numeric:tabular-nums;line-height:1.05}
   .szen .s-m{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);line-height:1.55}
   .szen .pill{margin-top:0}
-  .proj{background:var(--soft);border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6)}
-  .proj .pl{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)}
-  .proj .pv{font-family:var(--font-display);font-weight:var(--w-strong);font-size:clamp(30px,5vw,42px);color:var(--ok);font-variant-numeric:tabular-nums;line-height:1;margin-top:6px}
-  .proj .pn{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);margin-top:10px;line-height:1.55}
 
   .tablewrap{overflow-x:auto}
   .tarif{width:100%;border-collapse:collapse;font-family:var(--font-text);font-size:var(--t-small);min-width:440px}
@@ -118,17 +113,6 @@
   .kpi .k b{display:block;font-size:var(--t-body);color:var(--ink);font-variant-numeric:tabular-nums;font-weight:600}
   .kpi .k span{color:var(--muted);font-size:var(--t-micro)}
   .kpi .k.warn b{color:var(--bad)}
-  /* Befund: die Fortschreibung im Klartext – der Satz, den eine Prozentzahl
-     verschweigt. Zurückhaltend gesetzt: er soll auffallen, weil er dasteht,
-     nicht weil er laut ist (G03). Lesegrösse statt Lede, getönte Kante statt
-     Signalbalken, Fläche nur angedeutet. */
-  .befund{margin-top:var(--s4);padding:var(--s3) var(--s4);border-radius:var(--r-control);
-    background:color-mix(in srgb,var(--bad) 5%,transparent);
-    border-left:2px solid color-mix(in srgb,var(--bad) 55%,transparent)}
-  .befund p{font-family:var(--font-text);font-size:var(--t-small);
-    line-height:1.55;color:var(--ink);margin:0;max-width:var(--measure)}
-  .befund p b{font-weight:600}
-  .befund .b-meta{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);margin-top:var(--s1)}
   /* Puls: der Takt neben der Zahl, nicht als eigene Sektion. Ein Balken je
      Kalendertag seit Aktionsstart; die ganze Spalte (volle 56px) ist das
      Zeigeziel, nicht nur der gemalte Balken. Die Tageszahl erscheint als Fahne
@@ -313,7 +297,7 @@
   .jump a.is-on{color:var(--gold-ink);border-bottom-color:var(--gold)}
 
   @media (max-width:720px){
-    .board{grid-template-columns:1fr} .stay{grid-template-columns:1fr}
+    .board{grid-template-columns:1fr}
     .szen{grid-template-columns:1fr}
   }
   @media (max-width:640px){

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -331,25 +331,16 @@
       }
     }
 
-    // Befund: die Fortschreibung im Klartext. Erscheint nur, wenn die Aktion läuft.
-    var box = el('befund');
-    if (box && t.rest > 0){
-      var prognose = Math.round(total + t.tempo * t.rest);
-      box.hidden = false;
-      var txt = el('befundText'); txt.innerHTML = '';
-      txt.appendChild(document.createTextNode('Bei diesem Tempo endet die Aktion bei rund '));
-      var b1 = document.createElement('b'); b1.textContent = fmt(prognose) + ' Abos'; txt.appendChild(b1);
-      txt.appendChild(document.createTextNode('. '));
-      if (prognose < ziel){
-        txt.appendChild(document.createTextNode('Das Ziel ' + fmt(ziel) + ' ist nur erreichbar, wenn ein Impuls von der Grösse der stärksten bisherigen Welle kommt – '));
-        var b2 = document.createElement('b'); b2.textContent = 'mehrfach'; txt.appendChild(b2);
-        txt.appendChild(document.createTextNode('.'));
-      } else {
-        txt.appendChild(document.createTextNode('Das Ziel ' + fmt(ziel) + ' ist bei diesem Tempo in Reichweite.'));
-      }
-      el('befundMeta').textContent = 'Fortschreibung des Schnitts der letzten drei Tage (' +
-        t.tempo.toFixed(1).replace('.', ',') + '/Tag) auf die restlichen ' + t.rest + ' Tage. Kein Versprechen – eine Rechnung.';
-    } else if (box) { box.hidden = true; }
+    // Der Befund (Fortschreibung des Tempos auf die Resttage) ist am 8. August
+    // ENTFERNT worden, nicht abgeschaltet – er log strukturell, sobald die
+    // kommunizierte Frist vorbei war. Er schrieb den Schnitt der letzten drei
+    // Tage fort: 146,3 am Tag, gemessen im Ansturm der Fristtage, hochgerechnet
+    // auf die drei stillen Tage der Verlängerung, an denen niemand mehr
+    // angeschrieben wird. Das ergab «rund 1400 Abos» – und dazu «Das Ziel 500
+    // ist in Reichweite», obwohl es bei 186 Prozent längst übertroffen war.
+    // Eine Fortschreibung über einen Impuls hinweg ist keine Rechnung, sondern
+    // eine Behauptung. Wer sie zurückholen will, braucht ein Tempo, das den
+    // Impuls kennt – nicht einen Schnitt über drei Tage.
   }
 
   // Ströme (Produkt × Sprache × Format) – aus eigener Sektion in den Aufklapp.

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -281,8 +281,15 @@
     var pct = ziel > 0 ? Math.round(total / ziel * 100) : 0;
     el('kZiel').textContent = pct + ' %';
     el('kTempo').textContent = t.tempo.toFixed(1).replace('.', ',');
-    var noetig = t.rest > 0 ? Math.max(0, (ziel - total) / t.rest) : 0;
-    el('kNoetig').textContent = t.rest > 0 ? noetig.toFixed(1).replace('.', ',') : '–';
+    // «Abos/Tag nötig» beantwortet nur eine Frage: Was fehlt noch bis zur
+    // Zielmarke? Ist sie übertroffen oder die Aktion vorbei, fehlt nichts mehr
+    // – die Kachel stand dann auf 0,0 und sagte nichts (G03: was entbehrlich
+    // ist, entfällt). Sie erscheint darum nur, solange sie eine Antwort hat.
+    var offen = t.rest > 0 && total < ziel;
+    var noetig = offen ? (ziel - total) / t.rest : 0;
+    var kachel = el('kNoetigKachel');
+    if (kachel) kachel.hidden = !offen;
+    el('kNoetig').textContent = offen ? noetig.toFixed(1).replace('.', ',') : '–';
     // Über 100 % wird die Spur zum Ist-Stand: Gold bis zur Zielmarke,
     // die Übererfüllung dahinter in Grün (--ok).
     var ueber = el('ddBarUeber');

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -60,11 +60,6 @@
         </div>
       </div>
 
-      <div class="befund" id="befund" hidden>
-        <p id="befundText"></p>
-        <div class="b-meta" id="befundMeta"></div>
-      </div>
-
       <!-- Direkt unter der Signaturzahl: Die zweite Frage nach «wie viele» ist
            «was bringt das». Gezeigt wird die Spanne, nicht eine Zahl. -->
       <details class="zb-form">

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -52,7 +52,9 @@
           <div class="kpi">
             <div class="k"><b id="kZiel">–</b><span>vom Ziel erreicht</span></div>
             <div class="k"><b id="kTempo">–</b><span>Abos/Tag aktuell</span></div>
-            <div class="k warn"><b id="kNoetig">–</b><span>Abos/Tag nötig</span></div>
+            <!-- Verschwindet, sobald das Ziel übertroffen ist – dann ist nichts
+                 mehr nötig, und was nichts sagt, gehört weg (G03). -->
+            <div class="k warn" id="kNoetigKachel" hidden><b id="kNoetig">–</b><span>Abos/Tag nötig</span></div>
           </div>
           <div class="meter"><span id="ddBar" style="width:0"></span><span id="ddBarUeber" class="ueber" style="width:0"></span></div>
           <div class="puls" id="puls"></div>


### PR DESCRIPTION
Zwei Aufräumungen im Stand-Block, beide aus demselben Grund: **Was nichts mehr sagt, gehört weg (G03).**

## 1 · Der Befund — eine Fortschreibung über die Frist hinweg

Der Block unter der Signaturzahl schrieb den Schnitt der letzten drei Tage auf die Resttage fort. Am 8. August hiess das:

> Bei diesem Tempo endet die Aktion bei rund **1400 Abos**. Das Ziel 500 ist bei diesem Tempo in Reichweite. Fortschreibung des Schnitts der letzten drei Tage (146,3/Tag) auf die restlichen 3 Tage.

Beide Sätze sind falsch:

- Die **146,3 pro Tag** sind im Ansturm der beiden Fristtage gemessen und werden auf die **drei stillen Tage der Verlängerung** hochgerechnet — an denen niemand mehr angeschrieben wird und die Frist für die Empfänger abgelaufen ist. Das Tempo klingt sehr bald ab.
- «Das Ziel 500 ist in Reichweite», während es bei **185 Prozent** längst übertroffen ist.

**Entfernt, nicht abgeschaltet.** Eine Fortschreibung über einen Impuls hinweg ist keine Rechnung, sondern eine Behauptung. Der Grund steht als Kommentar an der Stelle, damit es niemand versehentlich wieder einbaut: Wer die Anzeige zurückholen will, braucht ein Tempo, das den Impuls kennt — nicht einen Schnitt über drei Tage.

## 2 · Die Kachel «Abos/Tag nötig»

Sie beantwortet genau eine Frage: Was fehlt noch bis zur Zielmarke? Seit dem 5. August fehlt nichts mehr — sie stand auf **0,0**. Jetzt erscheint sie nur, solange sie eine Antwort hat: Aktion läuft **und** Ziel noch nicht erreicht. Sonst ist sie nicht bloss leer, sondern weg; eine leere Kachel ist auch eine Aussage, nur eine falsche.

Beide Zustände im Browser geprüft: bei 926 Abos verschwunden, bei einem gerechneten Stand von 233 sichtbar mit 89,0 pro Tag ((500−233)/3 Tage).

**Mitgeräumt:** `.stay` und `.proj` waren seit dem Karten-Umbau (#526) tote Regeln.

## Ein Fehler beim Aufräumen, gleich mit behoben

Die zeilenweise Entfernung zerriss die **mehrzeiligen** `.befund`-Regeln und liess zwei Waisen-Zeilen stehen. Der CSS-Parser verschluckte daraufhin alles Folgende — **der Puls stand als blauer Block statt als Tageskurve**. Aufgefallen ist es nur, weil die Seite im Browser angesehen wurde (Regel aus `CLAUDE.md`); die Prüfmaschinen waren die ganze Zeit grün. Klammern jetzt ausgeglichen (227/227), Puls wieder 56 px hoch mit einem Balken je Tag und der Frist-Spitze am Ende.

## Geprüft

`typo-check` konform · `ds-lint` 0 Fehler, Score 100 % · `barrierefreiheit.mjs` ohne Verstoss · Stand-Block in beiden Zuständen im Browser nachgesehen.