### PR TITLE
«Nächste Züge» ausgeblendet – ein Zug, den niemand mehr tun kann, ist kein Zug

### DIFF
--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -135,6 +135,13 @@
                 'die goetheanum.tv-Anmeldungen fielen um 0,8 am Tag. Über die ganze Laufzeit rund 8 bis 12 Abos ' +
                 'aus 965 Klicks und 131 000 erreichten Personen. Damit ist sie der teuerste und der schwächste Weg der Aktion.'
     },
+    // «Nächste Züge» liest aus den Daten, was noch nicht gezündet hat. Das
+    // trägt, solange die Aktion läuft – seit die Frist am 8. August um
+    // Mitternacht ablief, schlägt es Handlungen vor, die niemand mehr tun
+    // kann. Darum ausgeblendet (Beschluss 8. August). Für die nächste
+    // Aktion hier auf true stellen; die Sektion und ihre Logik bleiben
+    // vollständig erhalten.
+    zuegeZeigen: false,
     // Zeigt an, was im Cockpit noch Annahme ist und nicht gemessen. Preise und
     // Zielmarken sind es seit dem 17. Juli nicht mehr (echte Formular- und
     // Uscreen-Preise, ratifizierte GF-Vorgabe) – allein die Bleibe-Quote bleibt
@@ -619,6 +626,11 @@
   ];
   function renderZuege(links, massnahmen, attribution, timeline, total){
     if (!el('zuegeListe')) return;
+    // Der Schalter entscheidet, die Seite trägt nur das Vorzeichen: So gibt es
+    // eine Wahrheit, nicht zwei (HTML-Attribut UND Konfiguration).
+    var sektion = el('zuege');
+    if (sektion) sektion.hidden = !CONFIG.zuegeZeigen;
+    if (!CONFIG.zuegeZeigen) return;
     var host = el('zuegeListe'); host.innerHTML = '';
     var zuege = [], ohneSpur = 0;
     (attribution || []).forEach(function(r){ if (!r.utm_source && !r.utm_content) ohneSpur += Number(r.n) || 0; });

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -112,7 +112,10 @@
 
 
   <!-- ══ 3 · NÄCHSTE ZÜGE ════════════════════════════════════════════════ -->
-  <section id="zuege">
+  <!-- Ausgeblendet, seit die Frist vorbei ist: Ein Zug, den niemand mehr tun
+       kann, ist kein Zug. Der Schalter ist CONFIG.zuegeZeigen – für die nächste
+       Aktion ein Wort, nicht ein Wiederaufbau. -->
+  <section id="zuege" hidden>
     <div class="shead"><h2>Nächste Züge</h2><p>Was jetzt noch möglich ist – aus den Daten gelesen, nach Hebel sortiert. Der Plan steht schon im Link-Register und im Aktivitäten-Protokoll; hier steht, was davon noch nicht gezündet hat.</p></div>
     <div class="panel">
       <div id="zuegeListe"><div class="empty">lädt …</div></div>


### PR DESCRIPTION
Die Sektion liest aus den Daten, was vorbereitet ist und noch nicht gezündet hat. Das trägt, solange die Aktion läuft. Seit die Frist heute um Mitternacht abläuft, schlägt sie Handlungen für eine Aktion vor, die vorbei ist — «Newsletter-Phasen ausspielen», «Popup scharf schalten» — und liest sich wie eine Aufgabenliste, die niemand mehr abarbeiten kann.

## Ausgeblendet, nicht entfernt

Schalter: **`CONFIG.zuegeZeigen`**. Sektion und Logik bleiben vollständig erhalten; für die nächste Aktion genügt ein Wort statt eines Wiederaufbaus.

Der Schalter ist dabei die **einzige Wahrheit**. Das `hidden`-Attribut im Markup ist nur das Vorzeichen — gesetzt wird es beim Rendern aus der Konfiguration. So können HTML und Konfiguration nicht auseinanderlaufen, und niemand sucht später an zwei Stellen.

## Geprüft

Beide Zustände im Browser:

| | Sektion | sichtbare Sektionen |
|---|---|---|
| `false` | verschwunden | Lead · Stand · Gebiete · Belege |
| `true` | vollständig da | zusätzlich Nächste Züge |

`typo-check` konform · `ds-lint` 0 Fehler, Score 100 % · `barrierefreiheit.mjs` ohne Verstoss.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUqZZzUQntMLiZPecAsBBc)_