### PR TITLE
G-Logo-Anwendungskonzept aus vodojo hierher verpflanzen

### DIFF
--- a/docs/g-logo-anwendung/Konzept-Anwendungshinweise.md
+++ b/docs/g-logo-anwendung/Konzept-Anwendungshinweise.md
@@ -1,0 +1,276 @@
+# G‑Logo – Hinweise zur Anwendung
+
+### Ein Anwendungskonzept aus der Sicht der Sekretariate und wissenschaftlichen Mitarbeitenden
+
+*Arbeitsstand · Review der bisher zusammengetragenen Hinweise und Vorschlag für ein einfacheres, alltagstaugliches Konzept.*
+
+---
+
+## 0 · Worum es geht
+
+Seit 2020 wird am Goetheanum ein gemeinsames Zeichen eingeführt, seit 2023 in der heutigen
+Form. Auf **grafik.goetheanum.ch** ist dazu inzwischen ein umfangreicher Apparat
+zusammengekommen: Logos und Logo‑Generator, Zeichen, Schriften, Icons, Farben, dazu
+Anwendungen von Social Media über PowerPoint, Leitsystem und Briefpapier bis zum
+Signatur‑Generator, schliesslich die Druckaufträge. Das ist viel – und vieles davon ist gut.
+
+Dieses Papier macht einen Schritt zurück und liest das Zusammengetragene **mit den Augen
+derer, die es täglich brauchen**: der Sektionssekretariate und der wissenschaftlichen
+Mitarbeitenden. Die Leitfrage ist nicht «Ist die Systematik vollständig?», sondern
+«Ist diesen Menschen damit wirklich geholfen – und der Sache?»
+
+> Das Hochschulzeichen «trägt sein Zentrum ausser sich. Es ist ganz bezogen auf das, dem es
+> schützend Umraum schenkt.» (*Anthroposophie weltweit* 9/20)
+
+Dieser Satz über Rudolf Steiners Zeichen ist zugleich der Massstab für ein gutes
+Anwendungskonzept: **Das System soll der Arbeit und den Menschen dienen, nicht sich selbst.**
+Ein Hinweis, den man lesen muss, ist schon fast ein Mangel; am besten hilft eine Vorlage, in
+der das Zeichen bereits richtig sitzt.
+
+---
+
+## 1 · Review: Was von den bisherigen Hinweisen trägt – und was nicht
+
+**Was trägt.** Die inhaltliche und gestalterische Arbeit in der Werkstatt ist stark und
+belastbar. Die Diagnose stimmt (rund 35 gewachsene Logos, «unbefriedigende
+Kombinierbarkeit»), die Herleitung der neuen Bildmarke aus dem Bau ist tragfähig, und die
+Unterscheidung zwischen Steiners *eröffnenden* Zeichen und einer heutigen, frei platzierbaren
+*Bildmarke* ist der eigentliche konzeptionelle Gewinn. Auch die Materialfülle ist ein Schatz:
+Es gibt zu fast jeder Frage eine Antwort.
+
+**Was nicht trägt – aus Nutzersicht.** Genau diese Fülle ist das Problem. Vier Beobachtungen:
+
+1. **Geordnet nach Gestalter‑Logik, nicht nach Aufgaben.** Die Seite gliedert nach *Logos →
+   Elemente → Anwendungen → Druckauftrag*. Eine Sekretärin denkt aber nicht in «Elementen»,
+   sondern in **Aufgaben**: «Ich mache eine Einladung», «Ich brauche meine Mail‑Signatur»,
+   «Ich baue Folien», «Ich gebe ein Programmheft in den Druck». Wer in Aufgaben denkt, muss
+   sich die Antwort heute aus mehreren Rubriken zusammensuchen.
+
+2. **Zu viele Entscheidungen.** Logo‑Generator, Varianten (flächig/linear/farbig), vier
+   Sprachen, Lang‑ und Kurzformen, Formate – das ist mächtig, verlangt aber an der falschen
+   Stelle eine Designentscheidung. Die meisten Mitarbeitenden wollen **nicht generieren,
+   sondern nehmen**: das fertige, richtige File für *ihre* Sektion, in *ihrer* Sprache, im
+   *gebrauchten* Format.
+
+3. **Reibung beim Beschaffen und beim Format.** Welche Datei für Word/PowerPoint (PNG mit
+   Transparenz), welche für den Druck (SVG/PDF/EPS)? Wo genau liegt sie? Diese Hürde führt im
+   Alltag zu genau dem, was wir vermeiden wollten: Man nimmt das alte Logo aus dem letzten
+   Dokument, weil es schneller geht.
+
+4. **Offene Stellen, die im Alltag wehtun.** Auf der Übersetzungsseite steht bei der Sektion
+   für Bildende Künste «SBK???». Solche Lücken im **Vier‑Sprachen‑ und Kürzel‑System** sind
+   keine Detailfrage – sie sind genau die Stelle, an der ein Sekretariat hängenbleibt und
+   improvisiert.
+
+**Fazit des Reviews:** Nicht *mehr* Hinweise sind nötig, sondern **weniger Entscheidungen,
+nach Aufgaben sortiert, mit fertigen Paketen und geschlossenen Lücken.**
+
+---
+
+## 2 · Wer braucht die Hinweise wirklich? Der Betriebsalltag
+
+Die Zielgruppe sind nicht Designer, sondern:
+
+- **Sektionssekretariate** – sie tragen die laufende Kommunikation: Einladungen, Programme,
+  Tagungsunterlagen, Namensschilder, Bescheinigungen, Rundbriefe, Mail‑Signaturen, die
+  Website‑Pflege.
+- **Wissenschaftliche Mitarbeitende** – sie schreiben und gestalten nebenbei: Folien für
+  Vorträge, Tagungsbeiträge, Aufsätze, Poster, gelegentlich ein Buch‑ oder Heft‑Layout.
+
+Ihr Werkzeug ist **Word, PowerPoint, das Mailprogramm, ein Browser, manchmal InDesign, oft
+die Hausdruckerei.** Ihr Ziel ist nicht das Logo, sondern **die Sache** – dass der Inhalt
+würdig und klar nach aussen kommt. Gestaltung ist Mittel, nicht Zweck; sie geschieht meist
+unter Zeitdruck und zwischen zehn anderen Aufgaben. Hinzu kommt der **Vier‑Sprachen‑Alltag**
+(DE / EN / FR / ES) und die Tatsache, dass jede Sektion eine eigene, gewachsene Kultur und
+oft eine eigene Website hat (medicalsection.goetheanum.ch, youthsection.org …).
+
+**Die fünf Fragen, die im Alltag immer wieder auftauchen:**
+
+1. *Welches* Zeichen nehme ich hier – das «G», die Wortmarke, das Steiner‑Zeichen?
+2. *Wo* bekomme ich es und in *welchem Format*?
+3. Wie heisst meine Sektion korrekt in dieser *Sprache* – lang und kurz?
+4. Darf / muss ich *unser altes Signet* aufgeben?
+5. Wie sieht es richtig aus, ohne dass ich Layout lernen muss?
+
+Ein Konzept, das diese fünf Fragen schnell und verbindlich beantwortet, hilft tatsächlich.
+Alles andere ist Kür.
+
+---
+
+## 3 · Die Grundordnung: drei Ebenen, ein Haus
+
+Die ganze Vielfalt lässt sich auf **drei klar benannte Ebenen** zurückführen. Wer diese drei
+auseinanderhält, hat 90 % der Alltagsfragen beantwortet.
+
+### A · Steiners Zeichen — das *festliche / inspirative* Gesicht
+*Hochschulzeichen (1924), Gesellschaftszeichen, Zeichen der Bau‑Administration; dazu das
+historische Erbe (Planetensiegel u. a.).*
+
+Diese Zeichen **eröffnen** – sie schenken dem Folgenden Umraum. Sie gehören dorthin, wo das
+Goetheanum als geistige Institution *spricht*: auf den **Briefkopf aller Sektionen**, auf
+Mitgliederkarten, zur Generalversammlung, in die inspirative und festliche Arbeit. Sie werden
+**würdig und nur in geeigneten Formaten** eingesetzt – nie gequetscht, verzerrt, klein
+gerechnet oder als Allzweck‑Icon zweckentfremdet.
+
+→ *Das ist die Antwort auf «Was ist mit den alten Signets?» – sie werden nicht abgeschafft,
+sie bekommen ihren würdigen Ort zurück. Siehe Abschnitt 4.3.*
+
+### B · Die Bildmarke Goetheanum — das *gemeinsame öffentliche* Gesicht
+*Das «G» aus dem Bau (2020 / 2023): der aufstrebende Fassadenrhythmus, der Dreischritt.*
+
+Dieses Zeichen ist für die **heutige Welt der Berührungspunkte** gemacht: Social‑Media‑Icon,
+Website, Folien, Plakate, Kooperationslogos – winzig bis gross, frei platzierbar, neben
+beliebigen anderen Elementen. Es ist mit dem Hochschulzeichen verwandt, aber **in sich
+ruhend** und damit robust für den Alltag. Es ist das verbindende Familienmerkmal: Wo es
+erscheint, erkennt man «Goetheanum».
+
+### C · Die Wortmarke & das Logo‑System — die *Zuordnung*
+*Wortmarke «Goetheanum» + Sektions-/Bereichsname, in vier Sprachen, lang und kurz.*
+
+Hier wird konkret, *wer* spricht: «Goetheanum · Medizinische Sektion», «… Pädagogische
+Sektion» usw. Das System hält die Familie zusammen (gleiche Schrift, gleiche Logik) und lässt
+zugleich die einzelne Sektion erkennbar sein. **Hier – und nur hier – lebt die «Vielfalt»;
+aber als geordnete Variation eines Themas, nicht als 35 Fremdkörper.**
+
+> **Merksatz für den Aushang:** **A** unterschreibt (festlich), **B** grüsst (öffentlich),
+> **C** sagt, wer spricht (Zuordnung).
+
+---
+
+## 4 · Antworten auf die Leitfragen
+
+### 4.1 · Was sollen sie wann und wo verwenden?
+
+Die ehrliche Hilfe ist *eine Tabelle*, nicht ein Handbuch. Der ausführliche, ausdruckbare
+**Spickzettel** liegt als eigenes Blatt bei (`Spickzettel-Logo-Anwendung.md`). Im Kern:
+
+| Aufgabe im Alltag | Was verwenden | Format |
+|---|---|---|
+| **Briefkopf, offizieller Brief** | **A** Steiner‑Zeichen (Sektion) + Wortmarke **C** | Vorlage (Word) |
+| **Mitgliederkarte, Generalversammlung, festlich/inspirativ** | **A** Steiner‑Zeichen | Druck (PDF/EPS) |
+| **Website, Newsletter, Social Media** | **B** Bildmarke + **C** Sektionsname | SVG / PNG |
+| **PowerPoint / Vortragsfolien** | **B** Bildmarke (+ **C** auf Titel-/Schlussfolie) | PNG (transparent) / PPT‑Vorlage |
+| **Plakat, Programmheft, Flyer** | **B** + **C**, ggf. **A** als festliches Eröffnungszeichen | Druck (SVG/PDF/EPS) |
+| **E‑Mail‑Signatur** | **C** Wortmarke + Sektion (Text/Logo schlank) | Signatur‑Vorlage |
+| **Kooperations-/Partnerlogo, sehr klein** | **B** Bildmarke allein | SVG / PNG |
+| **Namensschild, Bescheinigung, Urkunde** | Vorlage mit **C** (festlich ggf. **A**) | Word-/InDesign‑Vorlage |
+
+**Faustregeln:**
+- **Nach aussen, alltäglich → B (das «G»).** **Offiziell/festlich, im Namen der Institution
+  → A (Steiner‑Zeichen).** **Wer genau? → immer C dazustellen.**
+- **Im Zweifel B.** Die Bildmarke ist für den ungenauen Alltagseinsatz gebaut; das
+  Steiner‑Zeichen ist es ausdrücklich nicht.
+- **Nie improvisieren am Steiner‑Zeichen** (nicht stauchen, einfärben, freistellen, als Icon
+  missbrauchen). Wenn es eng wird: B nehmen.
+
+### 4.2 · Warum so viele verschiedene Logos?
+
+Weil das Goetheanum **wirklich vielfältig** ist – Hochschule, Bau, Gesellschaft, Campus,
+zwölf Sektionen, dazu Bereiche, Abteilungen, Gremien, Medien, Initiativen. Bis in die
+1980er‑Jahre war es selbstverständlich, im Gestus Steiners ein eigenes Zeichen zu entwerfen,
+um das eigene Projekt als anthroposophisch auszuweisen. So wuchsen rund 35 Logos – «eine
+unserer kulturschaffenden Arbeit innewohnende Qualität», zugleich ein Problem: «das Erzählen
+von vielen Geschichten lässt die grosse Geschichte leicht untergehen.»
+
+**Die Antwort des Konzepts ist nicht «weniger Vielfalt», sondern «Vielfalt als Familie».**
+Die Vielheit darf bleiben – aber sie soll *aus einem Prinzip* kommen (Ebene C: ein
+Wortmarken‑System, eine Schrift‑Logik, ein verbindendes Zeichen B). Was wirklich reduziert
+gehört, ist nicht die kulturelle Vielfalt, sondern die **operative Vielfalt**: das
+Datei‑Chaos, die Sonderwege, die widersprüchlichen Schreibweisen. Aus *35 Geschichten* wird
+*eine Familie mit zwölf Stimmen*.
+
+### 4.3 · Was ist mit den alten Signets?
+
+Sie bleiben – mit Würde. Die wichtigste Botschaft an die Sektionen ist eine *beruhigende*:
+**Niemand muss sein geliebtes Zeichen wegwerfen.** Aber wir geben ihm einen klaren Ort:
+
+- **Steiners drei Zeichen** (Hochschule, Gesellschaft, Bau‑Administration) sind die **Ebene
+  A**: Briefkopf, festliche und inspirative Anlässe. Sie werden *aufgewertet*, indem sie
+  *nicht mehr* für jeden Alltagszweck herhalten müssen. Genau das war ihr Schaden: «seine
+  Geste ist zur Erinnerung verkümmert», weil man es quetschte und verzerrte.
+- **Gewachsene Sektions-Signets** (eigene, oft liebgewonnene Zeichen) bekommen einen
+  definierten Status:
+  - als **historisches/erzählendes Element** auf der eigenen Website, im Archiv, im
+    Jubiläumskontext – ja;
+  - als **Allzweck‑Logo neben oder anstelle der Bildmarke** – nein, dafür ist B da.
+- **Klärungsbedarf, ehrlich benannt:** Für jedes gewachsene Signet braucht es eine kurze,
+  gemeinsame Entscheidung «Erbe / Übergang / Ablösung». Das ist Beziehungsarbeit mit den
+  Sektionen, kein Dekret. Vorschlag: ein einseitiges «Signet‑Gespräch» pro Sektion.
+
+So wird aus der scheinbaren Konkurrenz «alt gegen neu» eine **Schichtung**: das Inspirative
+(A) trägt, das Verbindende (B) grüsst, die Zuordnung (C) benennt.
+
+### 4.4 · Die stille Tagesfalle: vier Sprachen und Kürzel
+
+Das **Vier‑Sprachen‑/Kürzel‑System** muss *vollständig und verbindlich* sein, sonst
+improvisiert jedes Sekretariat anders. Konkret:
+
+- Eine **abgeschlossene Tabelle** je Sektion/Bereich: Langform und offizielle Kurzform in
+  DE / EN / FR / ES. Die heutige Lücke «SBK???» wird geschlossen, ebenso alle anderen.
+- **Eine** verbindliche Schreibweise pro Sprache (Gross-/Kleinschreibung, Akzente, Reihenfolge
+  Goetheanum ↔ Sektionsname). Diese Tabelle ist die Quelle für Logo‑Generator, Signaturen,
+  Briefköpfe und Übersetzungen gleichermassen.
+
+→ Entwurf dieser Tabelle siehe `Spickzettel-Logo-Anwendung.md`, Teil 3 (mit markierten
+offenen Stellen, die das Grafik‑Team / die Sektionen bestätigen).
+
+---
+
+## 5 · Das Konzept: Womit ihnen tatsächlich geholfen ist
+
+Sieben Massnahmen, vom grössten Hebel zum kleinsten. Keine verlangt eine neue Gestaltung –
+sie ordnen und *liefern* das Vorhandene so, dass es im Alltag ankommt.
+
+1. **Fertige Logo‑Pakete statt Generator‑Zwang.** Für jede Sektion/jeden Bereich ein
+   herunterladbares ZIP: Bildmarke (B) + Wortmarken‑Logo (C), je in DE/EN/FR/ES, je in den
+   *real gebrauchten* Formaten – **PNG (transparent) für Word/PowerPoint/Web**, **SVG/PDF/EPS
+   für Druck**. Der Generator bleibt für Sonderfälle; der Normalfall ist «herunterladen, nicht
+   bauen».
+2. **Ein aufgabenorientierter Einstieg.** Auf grafik.goetheanum.ch eine Startfrage «**Was
+   möchten Sie gestalten?**» mit den acht, neun echten Alltagsaufgaben (Brief, Folien,
+   Einladung, Signatur, Plakat, Social Post …), die direkt zur richtigen Datei + Vorlage
+   führen. Die heutige Gliederung nach Elementen bleibt darunter für Profis.
+3. **Vorlagen statt Regeln.** Word‑, PowerPoint‑, E‑Mail‑Signatur‑ und InDesign‑Vorlagen, in
+   denen das Logo bereits korrekt sitzt (Position, Grösse, Schutzraum, Sprache). Die beste
+   Anwendungs­hinweis ist die, die man nie lesen muss, weil die Vorlage sie erfüllt.
+4. **Der eine Spickzettel.** Ein **A4‑Blatt** (beiliegend), das die Ebenen A/B/C, die
+   Aufgaben‑Tabelle und die Vier‑Sprachen‑Kürzel auf einer Seite zeigt. Ausdruckbar, am
+   Sekretariats­pinnwand‑tauglich. Das ist das eigentliche tägliche Werkzeug.
+5. **Vier‑Sprachen‑Tabelle schliessen** (siehe 4.4) – die unsichtbarste, aber häufigste
+   Reibung beseitigen.
+6. **Signet‑Gespräche mit den Sektionen** (siehe 4.3) – jedem gewachsenen Zeichen einen
+   klaren Status geben, im Dialog, nicht per Erlass.
+7. **Eine Ansprechstelle und ein Versprechen.** Eine Mailadresse/Person, die innert kurzer
+   Frist «das richtige File» liefert, wenn jemand nicht weiterkommt. Das nimmt der ganzen
+   Systematik den Druck: Niemand muss alles wissen, es gibt einen sicheren Hafen.
+
+**Prüfstein für jede künftige Ergänzung:** *Spart sie der Sekretärin eine Entscheidung oder
+einen Klick – oder fügt sie eine hinzu?* Nur das Erste gehört ins Konzept.
+
+---
+
+## 6 · Offene Punkte / nächste Schritte
+
+- **Bestätigen:** Stimmt die Drei‑Ebenen‑Ordnung (A/B/C) mit der Haltung der
+  Goetheanum‑Leitung überein? Insbesondere die Rolle der Steiner‑Zeichen als reine Ebene A.
+- **Liefern:** Kürzel‑/Sprachtabelle vervollständigen (offene Stellen markiert).
+- **Bauen:** Logo‑Pakete (ZIP je Sektion) und die vier Kern‑Vorlagen
+  (Word / PPT / Signatur / InDesign).
+- **Sortieren:** Aufgabenorientierten Einstieg «Was möchten Sie gestalten?» auf
+  grafik.goetheanum.ch ergänzen.
+- **Sprechen:** Reihenfolge der Signet‑Gespräche mit den Sektionen festlegen.
+
+---
+
+### Quellen / gelesenes Material
+
+- *Anthroposophie weltweit* 9/2020, «Gemeinsamer Auftritt» (Bildmarke) – S. Hasler /
+  Ph. Tok. Grundlagentext zur neuen Bildmarke, zum Wesen des Hochschulzeichens und zur
+  künftigen Verwendung der Steiner‑Zeichen.
+- grafik.goetheanum.ch – Werkstatt-Studien, u. a. «Logo‑Perspektiven» (2019),
+  «Formale und öffentliche Identitäten» (2018), «Knochen und Fleisch» (2018),
+  «Geschichte der Wortmarke» (2019), «Zeichen, Bild‑ und Wortmarken» (2019),
+  «Logo weltweit» (2020).
+- grafik.goetheanum.ch – Seiten *Logos*, *Zeichen*, *Übersetzungen*, *Werkstatt*; Logo‑Generator.
+- goetheanum.ch – Sektionsübersicht der Freien Hochschule für Geisteswissenschaft
+  (zwölf Sektionen) und deren eigenständige Webauftritte.

--- a/docs/g-logo-anwendung/README.md
+++ b/docs/g-logo-anwendung/README.md
@@ -1,0 +1,47 @@
+# G-Logo – Hinweise zur Anwendung
+
+Konzeptarbeit zur **Anwendung des Goetheanum-Logos im Betriebsalltag** der
+Sektionen, Sekretariate und wissenschaftlichen Mitarbeitenden. Sie liest das
+auf grafik.goetheanum.ch zusammengetragene Material (Bildmarke 2020/2023,
+Logo-Generator, Werkstatt-Studien) aus der Sicht der täglichen Nutzer und
+schlägt eine einfachere Ordnung vor.
+
+## Kerngedanke
+
+**A unterschreibt · B grüsst · C sagt, wer spricht.**
+
+Steiners Zeichen (**A**) für das Festliche und Inspirative, die Bildmarke «G»
+(**B**) für den öffentlichen Alltag, Wortmarke + Sektion (**C**) für die
+Zuordnung. Die Vielfalt der Sektionen bleibt – aber als *eine Familie mit
+zwölf Stimmen* statt fünfunddreissig Einzelgeschichten.
+
+> Massstab ist das Hochschulzeichen selbst, das ‹sein Zentrum ausser sich
+> trägt›: Das System soll der Arbeit und den Menschen dienen, nicht sich
+> selbst.
+
+## Inhalt
+
+| Datei | Zweck |
+|---|---|
+| [`Konzept-Anwendungshinweise.md`](./Konzept-Anwendungshinweise.md) | Das ausführliche Konzept: Review der bisherigen Hinweise, Betriebsalltag, die Drei-Ebenen-Ordnung A/B/C, Antworten auf die Leitfragen, sieben konkrete Massnahmen |
+| [`Spickzettel-Logo-Anwendung.md`](./Spickzettel-Logo-Anwendung.md) | Welche Aufgabe → welches Zeichen → welches Format, plus Vier-Sprachen-Tabelle und die drei No-Gos |
+
+## Herkunft und was noch fehlt
+
+Die Arbeit entstand im Juni 2026 und lag bis zum 9. August im Repo `vodojo`
+– einer Vokabel-PWA ohne jeden Logo-Bezug. Sie ist hierher verpflanzt
+worden, weil hier ihr Gegenstand wohnt: `assets/logos/`, `apps/logos/` und
+die Logo-Studien. Der ursprüngliche Pull Request (`phtok/vodojo#26`) ist
+damit erledigt.
+
+**Der A4-Bogen kam bewusst nicht mit.** Die dortige HTML-Fassung verlinkte
+Titillium Web als Platzhalter und trug weder die Hausschrift noch die
+Haustokens; das PDF zeigt entsprechend eine fremde Schrift. Wer den Bogen
+braucht, setzt ihn hier neu auf – aus `design-system/starter.html`, mit
+`tokens.css` und `base.css` eingebunden. Dann greifen `typo-check`,
+`ds-lint` und die Barrierefreiheitsmessung, und der Bogen sieht aus wie das
+Haus, das er erklärt.
+
+Beide Texte sind beim Verpflanzen an die Hausregeln angeglichen worden:
+Anführung auf ‹…› (G16), mehrgliedrige Abkürzungen mit schmalem geschütztem
+Spatium (G20). `typo-check` läuft sauber durch.

--- a/docs/g-logo-anwendung/Spickzettel-Logo-Anwendung.md
+++ b/docs/g-logo-anwendung/Spickzettel-Logo-Anwendung.md
@@ -1,0 +1,71 @@
+# Spickzettel · Logo richtig anwenden
+
+*Eine Seite zum Ausdrucken und Aufhängen. Im Zweifel gilt: nach aussen/alltäglich → das «G»;
+offiziell/festlich → Steiner‑Zeichen; und immer dazu, **wer** spricht.*
+
+---
+
+## Teil 1 · Die drei Zeichen – was ist was?
+
+| | **A · Steiner‑Zeichen** | **B · Bildmarke «G»** | **C · Wortmarke + Sektion** |
+|---|---|---|---|
+| **Was** | Hochschul‑, Gesellschafts‑, Bau‑Zeichen (R. Steiner) | Das «G» aus dem Bau (2020/23) | «Goetheanum · *deine Sektion*» |
+| **Charakter** | eröffnend, festlich, inspirativ | verbindend, robust, überall | benennend, zuordnend |
+| **Wofür** | Briefkopf, Mitgliederkarte, GV, Festliches | Web, Social, Folien, Plakat, klein bis gross | sagt, **wer** spricht – zu A oder B |
+| **Regel** | nur würdig & in geeignetem Format, **nie** quetschen/einfärben | freie Platzierung erlaubt | feste Schreibweise, 4 Sprachen |
+
+> **A unterschreibt · B grüsst · C sagt, wer spricht.**
+
+---
+
+## Teil 2 · Welche Aufgabe → was nehmen → welches Format
+
+| Ich mache … | Zeichen | Datei‑Format | Am besten |
+|---|---|---|---|
+| **Offiziellen Brief / Briefkopf** | A + C | – | **Word‑Vorlage** nehmen |
+| **Mitgliederkarte · Generalversammlung · Festliches** | A | PDF / EPS | Druckvorlage |
+| **Website · Newsletter** | B + C | SVG, sonst PNG | – |
+| **Social‑Media‑Post / ‑Icon** | B (+ C) | PNG (transparent) | Social‑Vorlage |
+| **PowerPoint / Vortragsfolien** | B (Titel/Schluss + C) | PNG transparent | **PPT‑Vorlage** |
+| **Plakat · Programmheft · Flyer** | B + C (A festlich möglich) | SVG / PDF / EPS | in den Druck |
+| **E‑Mail‑Signatur** | C (schlank) | – | **Signatur‑Vorlage** |
+| **Kooperations‑/Partnerlogo, sehr klein** | B allein | SVG / PNG | – |
+| **Namensschild · Bescheinigung · Urkunde** | C (festlich: A) | – | Word‑/InDesign‑Vorlage |
+
+**Format‑Eselsbrücke:** **PNG** = für Bildschirm/Word/PowerPoint (mit transparentem Hintergrund) ·
+**SVG/PDF/EPS** = für den Druck (scharf in jeder Grösse). Im Zweifel **PNG** für Office, **PDF** für die Druckerei.
+
+**Drei No‑Gos:**
+1. Steiner‑Zeichen **nie** stauchen, verzerren, neu einfärben, freistellen oder als Mini‑Icon nehmen → dann **B**.
+2. **Kein** Logo aus einem alten Dokument oder dem Web ‹herauskopieren› → immer das offizielle File laden.
+3. **Nicht** selbst Wortmarke + Sektionsname zusammenbasteln → fertiges **C**-Logo nehmen (Generator/Paket).
+
+---
+
+## Teil 3 · Sektionsnamen in vier Sprachen (Quelle für Logo, Signatur, Briefkopf)
+
+> **Wichtig:** Diese Tabelle ist der Entwurf, der das heutige «SBK???» schliessen soll.
+> ⟨…⟩ = **vom Grafik‑Team / der Sektion noch zu bestätigen**, bevor sie verbindlich wird.
+
+| Sektion (DE) | EN | FR ⟨zu bestätigen⟩ | ES ⟨zu bestätigen⟩ | Kurz |
+|---|---|---|---|---|
+| Allgemeine Anthroposophische Sektion | General Anthroposophical Section | Section générale | Sección General | ⟨offen⟩ |
+| Naturwissenschaftliche Sektion | Natural Science Section | Section des sciences naturelles | Sección de Ciencias Naturales | ⟨offen⟩ |
+| Pädagogische Sektion | Pedagogical Section | Section pédagogique | Sección Pedagógica | ⟨offen⟩ |
+| Sektion für Schöne Wissenschaften | Section for the Literary Arts and Humanities | Section des belles‑lettres | Sección de Bellas Letras | SSW ⟨üblich, bestätigen⟩ |
+| Medizinische Sektion | Medical Section | Section médicale | Sección Médica | ⟨offen⟩ |
+| Sektion für Landwirtschaft | Section for Agriculture | Section d’agriculture | Sección de Agricultura | ⟨offen⟩ |
+| Sektion für Bildende Künste | Visual Arts Section | Section des arts plastiques | Sección de Artes Plásticas | SBK ⟨üblich, bestätigen⟩ |
+| Sektion für Redende und Musizierende Künste | Performing Arts Section | Section des arts de la parole et de la musique | Sección de Artes de la Palabra y la Música | SRMK ⟨üblich, bestätigen⟩ |
+| Sektion für Sozialwissenschaften | Social Sciences Section | Section des sciences sociales | Sección de Ciencias Sociales | ⟨offen⟩ |
+| Mathematisch‑Astronomische Sektion | Mathematical‑Astronomical Section | Section mathématique et astronomique | Sección Matemático‑Astronómica | MAS ⟨üblich, bestätigen⟩ |
+| Jugendsektion | Youth Section | Section des jeunes | Sección de la Juventud | ⟨offen⟩ |
+| Sektion für inklusive soziale Entwicklung | Section for Inclusive Social Development | Section pour le développement social inclusif | Sección de Desarrollo Social Inclusivo | ⟨offen⟩ |
+
+**Schreibregel (Vorschlag):** immer «**Goetheanum**» voran, dann der Sektionsname in der jeweiligen
+Sprache; Kurzform nur dort, wo der Platz es verlangt (Icon, Fussnote, Social‑Handle).
+
+---
+
+*Hilfe nötig? Eine kurze Mail ans Grafik‑/Sekretariats‑Anlaufteam genügt – sie liefern das richtige File.
+Niemand muss alles auswendig wissen.*


### PR DESCRIPTION
Bergung aus `phtok/vodojo#26`, offen seit dem 28. Juni.

## Warum verpflanzen statt mergen

Die Konzeptarbeit lag in `vodojo` — einer Vokabel-PWA aus vierzehn Einträgen (`index.html`, `sw.js`, `api/cron.js`) **ohne jeden Logo-Bezug**. Dort hatte sie kein Publikum, keine Prüfmaschinen und keinen Zusammenhang. Hier wohnt ihr Gegenstand: `assets/logos/`, `apps/logos/` und die Logo-Studien. Sie ist auch nicht doppelt — `assets/logo-usage-config.js` sind vier Zeilen Telemetrie-Endpoint, kein Regelmodell.

## Was mitkommt

| Datei | |
|---|---|
| `docs/g-logo-anwendung/Konzept-Anwendungshinweise.md` | 276 Zeilen: Review der bisherigen Hinweise, Betriebsalltag, Drei-Ebenen-Ordnung A/B/C, sieben Massnahmen |
| `docs/g-logo-anwendung/Spickzettel-Logo-Anwendung.md` | Aufgabe → Zeichen → Format, Vier-Sprachen-Tabelle, drei No-Gos |
| `docs/g-logo-anwendung/README.md` | neu geschrieben: Kerngedanke, Herkunft, und was noch fehlt |

Der Kerngedanke, den es zu retten lohnte: **A unterschreibt · B grüsst · C sagt, wer spricht.** Steiners Zeichen fürs Festliche, die Bildmarke «G» für den öffentlichen Alltag, Wortmarke + Sektion für die Zuordnung — die Sektionen bleiben vielfältig, aber als eine Familie mit zwölf Stimmen statt fünfunddreissig Einzelgeschichten.

## Was bewusst nicht mitkommt

**Der A4-Bogen** (`G-Logo-A4.html` + `.pdf`). Er ist nach eigener Auskunft unfertig — die HTML-Fassung verlinkt **Titillium Web** als Platzhalter und trägt weder die Hausschrift noch die Tokens; das PDF zeigt entsprechend eine fremde Schrift. Ein Bogen, der die Hausmarke erklärt und dabei nach einem anderen Haus aussieht, ist schlimmer als keiner.

Der README sagt, wie er hier neu entsteht: aus `design-system/starter.html`, mit `tokens.css` und `base.css` eingebunden — dann greifen `typo-check`, `ds-lint` und die Barrierefreiheitsmessung, statt dass jemand nachträglich prüfen muss.

## Regelbezug

Beim Verpflanzen an die Hausregeln angeglichen, mit Regel-IDs:

- **G16** Anführung: `„herauskopieren"` → `‹herauskopieren›` (Spickzettel Z40)
- **G20** mehrgliedrige Abkürzungen: `u. a.` mit schmalem geschütztem Spatium (Konzept Z107, Z270)

`python3 tools/typo-check.py docs/g-logo-anwendung/*.md` → **✓ Typografie konform**. `ds-lint`: keine HTML-Fläche berührt, Score 100 %.

Nach dem Merge kann `phtok/vodojo#26` ungemergt geschlossen werden.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jz7jsbBGAxWF9vFZBRKLNm)_