### PR TITLE
AC-Zahlen eingetragen: die Wirkungskette des Mailings steht

### DIFF
--- a/docs/schlussbericht-datensammlung.md
+++ b/docs/schlussbericht-datensammlung.md
@@ -1,6 +1,6 @@
 # Schlussbericht Sommer-Aktion — was noch einzusammeln ist
 
-Stand 8. August 2026. Diese Liste ist zum Abhaken: Was hier steht, kann die
+Stand 9. August 2026. Diese Liste ist zum Abhaken: Was hier steht, kann die
 Datenbank **nicht** selbst holen. Alles Übrige — Anmeldungen, Ströme, Tarife,
 Währungen, Herkunftsland, Kurzlink-Klicks, Selbstauskünfte — liegt bereits
 vollständig im Backend und fliesst ohne Zutun in den Bericht.
@@ -12,41 +12,55 @@ Kampagnen-App eingetragen und ist sofort im Cockpit wirksam:
   Knopf «Bearbeiten» in der Zeile
 - Beträge → **Kosten** (`kosten.html`)
 
-## Zuerst: die vier Mail-Wellen (ActiveCampaign)
+## Erledigt am 9. August: ActiveCampaign
 
-Der wichtigste Posten. Das Mailing trägt rund 69 Prozent der Aktion, und
-genau dort ist die Wirkungskette leer: keine Reichweite, keine Klicks. Ohne
-diese acht Zahlen lässt sich für den stärksten Kanal weder eine Klickquote
-noch ein Preis je Abo rechnen.
+Die Zahlen sind über die AC-API gelesen und in den Aktivitäten eingetragen.
+Die Wirkungskette des Mailings steht damit:
 
-| Aktivität | Datum | fehlt |
-|---|---|---|
-| Mail-Welle 1 «Ankündigung» | 17. Juli | Reichweite, Klicks |
-| Mail-Welle 2 «Erinnerung» | 30. Juli | Reichweite, Klicks |
-| Mail-Welle 3 «morgen läuft es aus» | 7. August | Reichweite, Klicks |
-| Mail-Welle 3b «heute läuft es aus» | 8. August | Reichweite, Klicks |
+| Welle | zugestellt | geöffnet | Öffnungsrate | Klicker | Klick je Öffner |
+|---|---:|---:|---:|---:|---:|
+| w1 · 17. Juli | 33 709 | 16 959 | 50,3 % | 1 954 | 11,5 % |
+| w2 · 30. Juli | 33 385 | 15 449 | 46,3 % | 1 559 | 10,1 % |
+| w3 · 7. August | 33 006 | 12 080 | 36,6 % | 1 237 | 10,2 % |
+| w3b · 8. August | 12 974 | 5 623 | 43,3 % | 683 | **12,1 %** |
+| **Summe** | **113 074** | **50 111** | **44,3 %** | **5 433** | **10,8 %** |
 
-**Zwei Definitionen, damit die Zahlen vergleichbar bleiben** — so ist der
-Newsletter vom 4. Juli erfasst, und so sollten es alle sein:
+Newsletter: Wochenschrift 17. Juli 16 690 zugestellt / 6 917 geöffnet ·
+Weekly 17. Juli 13 292 / 5 688 / 519 Klicker · Wochenschrift 31. Juli
+16 797 / 6 362 · Weekly 31. Juli 13 253 / 5 394 / 580 Klicker.
 
-- **Reichweite = geöffnete Mails**, nicht versendete.
-- **Klicks = eindeutige Klicker (Personen)**, nicht Klick-Ereignisse.
+**Kette des Mailings:** 113 074 zugestellt → 50 111 geöffnet → 5 433 Klicker
+→ 469 gemessene Abos, mit Dunkelfeld ≈641. Aus jedem neunten Klicker wurde
+ein Abo (11,8 %); aus 1 000 zugestellten Mails knapp sechs.
 
-Weicht eine Zahl davon ab, gehört das in die öffentliche **Notiz** der Zeile —
-sonst rechnet der Bericht Äpfel gegen Birnen. Jede Welle bestand aus sechs
-Mails (Lesen/Sehen/Beides × DE/EN); für die Wirkungskette zählt die **Summe**
-über alle sechs.
+### Vier Befunde aus dem Abholen
 
-## Dann: die Newsletter (ActiveCampaign)
+1. **Korrektur der Definition: Reichweite = zugestellte Mails, nicht
+   geöffnete.** Der Sammel-Auftrag verlangte zuerst die Öffnungen; das war
+   falsch. Reichweite ist im Trichter die Aussetzung, nicht schon eine
+   Reaktion — und nur so passt sie zur Social-Reichweite aus Metricool. Die
+   Öffnungen stehen in der Notiz jeder Zeile, die Lesart bleibt damit
+   umkehrbar. **Offen:** Der Newsletter vom 4. Juli trägt noch Öffnungen als
+   Reichweite (3 338, zugestellt laut Notiz ~7 000) und fällt aus der
+   Systematik; bei Gelegenheit die echte Zustellzahl nachholen.
+2. **w3b hängt zweimal, nicht einmal** — Öffner- und Nicht-Öffner-Zweig, wie
+   w3. Die Aktion hatte 36 E-Mail-Schritte, nicht 30.
+3. **Der englischen Gruppe «Lesen» fehlt die letzte Welle.** Für Lesen · EN
+   gibt es keine w3b-Kampagne vom 8. August. Stattdessen tragen zwei
+   w3b-EN-Kampagnen das Versanddatum **15. Juli** — drei Tage **vor** der
+   ersten Welle, mit 197 zugestellten Mails, 90 Öffnern, 7 Klickern. Beides
+   ist erklärungsbedürftig: Entweder haben 197 englische Leser am 15. Juli ein
+   «heute läuft es aus» erhalten, als die Aktion noch gar nicht angekündigt
+   war, oder es war ein Testlauf auf einer internen Liste. Die 197 sind in der
+   w3b-Zeile **nicht** enthalten; mit ihnen wären es 13 171 / 5 713 / 690.
+4. **Bei beiden Wochenschrift-Newslettern war das Link-Tracking aus**
+   (`tracklinks:none`). Ihre Klicks sind darum nicht messbar — die Zeilen
+   stehen leer und **nicht** auf null. Für die nächste Aktion: vor dem Versand
+   prüfen, dass Link-Tracking an ist, sonst ist der Weg blind.
 
-| Aktivität | Datum |
-|---|---|
-| Newsletter Wochenschrift | 17. Juli · 31. Juli |
-| Newsletter Weekly | 17. Juli · 31. Juli |
-| Newsletter AGiD | 27. Juli |
-
-Gleiche zwei Definitionen. Die Newsletter tragen laut Lesart rund 12 Prozent
-der Aktion — nach dem Mailing der zweitgrösste Posten ohne Zahlen.
+**Nicht gefunden: Newsletter AGiD (27. Juli).** Im ganzen Konto existiert für
+Juli 2026 keine AGiD-Kampagne. Die Zeile im Protokoll trägt den Befund als
+Notiz und zählt bis zur Klärung als geplant, nicht als ausgespielt.
 
 ## Social (Metricool)
 
@@ -102,10 +116,9 @@ sagen und die Zahl nicht härter machen, als sie ist.
 
 ## Reihenfolge
 
-1. Mail-Wellen (4 Einträge) — der grösste Hebel
-2. Meta-Kosten (1 Eintrag) — macht den teuersten Weg bewertbar
-3. Newsletter (5 Einträge)
+1. ~~Mail-Wellen (4 Einträge)~~ — **erledigt 9. August**
+2. ~~Newsletter (4 von 5)~~ — **erledigt 9. August**, AGiD offen
+3. **Meta-Kosten (1 Eintrag)** — jetzt der grösste Hebel: Er macht den
+   teuersten Weg der Aktion bewertbar
 4. Social (6 Einträge)
-5. Stunden, Flyer, die zwei offenen Fragen
-
-Nach Punkt 1 und 2 ist der Bericht schon erzählbar; alles Weitere schärft ihn.
+5. Stunden, Flyer, die zwei offenen Fragen, AGiD klären

--- a/services/mailing-sommer2026/AC-ZAHLEN.md
+++ b/services/mailing-sommer2026/AC-ZAHLEN.md
@@ -11,9 +11,8 @@
 > (`aktivitaeten.html`) je Zeile über «Bearbeiten» eingetragen. **Reichweite =
 > zugestellt**, Klicks = eindeutige Klicker; die Öffnungen wandern in die
 > Notiz. Der Prompt holt alle drei Zahlen, damit die Lesart umkehrbar bleibt —
-> Reichweite ist im Trichter die Aussetzung, nicht schon eine Reaktion. Danach rechnet die Wirkungskette für das Mailing durch — bisher ist
-> sie leer, obwohl das Mailing rund 69 Prozent der Aktion trägt. Vollständige
-> Sammel-Liste: `docs/schlussbericht-datensammlung.md`.
+> Reichweite ist im Trichter die Aussetzung, nicht schon eine Reaktion.
+> Vollständige Sammel-Liste: `docs/schlussbericht-datensammlung.md`.
 
 ---
 

--- a/services/mailing-sommer2026/AC-ZAHLEN.md
+++ b/services/mailing-sommer2026/AC-ZAHLEN.md
@@ -3,9 +3,15 @@
 > **Dies ist der fertige Prompt.** Alles ab der Trennlinie unten Claude-Chrome
 > geben. Er holt **nur Zahlen** — er ändert in ActiveCampaign nichts.
 >
+> **Ausgeführt am 9. August 2026** — die Zahlen stehen im Protokoll, die
+> Befunde in `docs/schlussbericht-datensammlung.md`. Der Prompt bleibt als
+> Vorlage für die nächste Aktion liegen.
+>
 > Was mit den Zahlen geschieht: Sie werden im Cockpit unter **Aktivitäten**
-> (`aktivitaeten.html`) je Zeile über «Bearbeiten» eingetragen, Reichweite und
-> Klicks. Danach rechnet die Wirkungskette für das Mailing durch — bisher ist
+> (`aktivitaeten.html`) je Zeile über «Bearbeiten» eingetragen. **Reichweite =
+> zugestellt**, Klicks = eindeutige Klicker; die Öffnungen wandern in die
+> Notiz. Der Prompt holt alle drei Zahlen, damit die Lesart umkehrbar bleibt —
+> Reichweite ist im Trichter die Aussetzung, nicht schon eine Reaktion. Danach rechnet die Wirkungskette für das Mailing durch — bisher ist
 > sie leer, obwohl das Mailing rund 69 Prozent der Aktion trägt. Vollständige
 > Sammel-Liste: `docs/schlussbericht-datensammlung.md`.
 

--- a/services/mailing-sommer2026/AC-ZAHLEN.md
+++ b/services/mailing-sommer2026/AC-ZAHLEN.md
@@ -1,0 +1,109 @@
+# Prompt für Claude-Chrome: Versandzahlen der Sommer-Aktion aus ActiveCampaign holen
+
+> **Dies ist der fertige Prompt.** Alles ab der Trennlinie unten Claude-Chrome
+> geben. Er holt **nur Zahlen** — er ändert in ActiveCampaign nichts.
+>
+> Was mit den Zahlen geschieht: Sie werden im Cockpit unter **Aktivitäten**
+> (`aktivitaeten.html`) je Zeile über «Bearbeiten» eingetragen, Reichweite und
+> Klicks. Danach rechnet die Wirkungskette für das Mailing durch — bisher ist
+> sie leer, obwohl das Mailing rund 69 Prozent der Aktion trägt. Vollständige
+> Sammel-Liste: `docs/schlussbericht-datensammlung.md`.
+
+---
+
+Hole aus **ActiveCampaign** die Versandzahlen unserer Sommer-Aktion 2026 und
+gib sie mir als eine Tabelle zurück. **Nur lesen: Ändere nichts, sende nichts,
+starte keine Automatisierung, exportiere keine Kontakte.** Ich brauche
+ausschliesslich Summen, keine Personendaten und keine E-Mail-Adressen.
+
+## Was ich brauche
+
+Je Eintrag unten **drei Zahlen**:
+
+1. **Versendet** — zugestellte Mails
+2. **Geöffnet** — **eindeutige Öffner** (Personen), nicht Öffnungs-Ereignisse
+3. **Geklickt** — **eindeutige Klicker** (Personen), nicht Klick-Ereignisse
+
+Die Unterscheidung ist wichtig: Wir rechnen konsequent mit **Personen**, nicht
+mit Ereignissen. Wo ActiveCampaign beides anbietet, nimm die eindeutige Zahl
+und schreib in die Spalte «Bemerkung», welche Ansicht du benutzt hast.
+
+## Teil 1 — die vier Mail-Wellen (Automatisierungen)
+
+Die Aktion lief über **sechs Automatisierungen**: `S26 · Lesen · DE`,
+`S26 · Lesen · EN`, `S26 · Sehen · DE`, `S26 · Sehen · EN`,
+`S26 · Beides · DE`, `S26 · Beides · EN`.
+
+Jede enthält **vier Wellen**: **w1** (Ankündigung), **w2** (Erinnerung),
+**w3** (Vorabend «morgen läuft es aus»), **w3b** (Frist-Tag «heute läuft es
+aus»).
+
+Ich brauche die Zahlen **je Welle über alle sechs Automatisierungen
+zusammengezählt** — nicht je Automatisierung einzeln. Also vier Zeilen:
+
+| Welle | Versand | Rahmen |
+|---|---|---|
+| w1 | 17. Juli, 12 Uhr | Ankündigung, alle Gruppen |
+| w2 | 30. Juli, 9.30 Uhr | Erinnerung, alle Nicht-Konvertierten |
+| w3 | 7. August, 18 Uhr | «morgen läuft es aus» |
+| w3b | 8. August, 10 Uhr | «heute läuft es aus», nur Kampagnen-Öffner |
+
+**Zwei Fallen dabei:**
+
+- **w3 hängt zweimal in jeder Automatisierung** — einmal mit dem
+  Standard-Betreff (für Öffner) und einmal mit einem Alt-Betreff für
+  Nicht-Öffner, gleiches HTML. Beide Zweige gehören in die **eine** w3-Zeile
+  zusammengezählt. Insgesamt sind es 30 E-Mail-Schritte für 24 Mails.
+- **w3b hat ein Öffner-Gate** — sie ging nur an Kontakte, die w1, w2 oder w3
+  geöffnet hatten. Ihre Versandzahl ist darum deutlich kleiner als bei den
+  anderen Wellen; das ist richtig so und kein Fehler.
+
+Gib mir zusätzlich **je Welle die Zahl der einbezogenen E-Mail-Schritte**
+(erwartet: w1 = 6, w2 = 6, w3 = 12, w3b = 6). Weicht sie ab, sag es — dann
+stimmt meine Annahme über die Struktur nicht.
+
+## Teil 2 — die einzelnen Newsletter (reguläre Kampagnen)
+
+Fünf Versände, jeder eine eigene Zeile. Sie sind **keine** Automatisierung,
+sondern normale Kampagnen; suche sie über das Datum und den Verteiler:
+
+| Newsletter | Datum |
+|---|---|
+| Newsletter Wochenschrift | 17. Juli |
+| Newsletter Weekly | 17. Juli |
+| Newsletter AGiD | 27. Juli |
+| Newsletter Wochenschrift | 31. Juli |
+| Newsletter Weekly | 31. Juli |
+
+Schreib bei jedem den **exakten Kampagnen-Namen**, wie er in ActiveCampaign
+steht, in die Spalte «Bemerkung» — ich muss nachvollziehen können, welchen
+Versand du erwischt hast. Findest du zu einem Datum mehrere Kandidaten, liste
+alle mit ihren Zahlen auf und markiere sie als unklar, statt zu wählen.
+
+## Das Format der Antwort
+
+Eine Markdown-Tabelle, genau diese Spalten, genau diese Zeilen-Reihenfolge:
+
+| Eintrag | Datum | Versendet | Geöffnet (eindeutig) | Geklickt (eindeutig) | Bemerkung |
+|---|---|---:|---:|---:|---|
+| Mail-Welle 1 | 17.07. | | | | Schritte: |
+| Mail-Welle 2 | 30.07. | | | | Schritte: |
+| Mail-Welle 3 | 07.08. | | | | Schritte: |
+| Mail-Welle 3b | 08.08. | | | | Schritte: |
+| Newsletter Wochenschrift | 17.07. | | | | AC-Name: |
+| Newsletter Weekly | 17.07. | | | | AC-Name: |
+| Newsletter AGiD | 27.07. | | | | AC-Name: |
+| Newsletter Wochenschrift | 31.07. | | | | AC-Name: |
+| Newsletter Weekly | 31.07. | | | | AC-Name: |
+
+## Wenn etwas nicht geht
+
+**Rate nicht und rechne nichts hoch.** Findest du eine Zahl nicht, schreib in
+die Zeile «nicht auffindbar» und in die Bemerkung, woran es lag — welche
+Ansicht du versucht hast und was dort stand. Eine ehrliche Lücke ist
+brauchbar, eine geschätzte Zahl verdirbt die ganze Auswertung: Diese Zahlen
+gehen in eine Wirkungskette, aus der später Kosten je Abo gerechnet werden.
+
+Sag mir am Ende in zwei Sätzen, wie sicher du bei den Wellen bist — ob die
+Summierung über die Automatisierungen sauber aufging oder ob du irgendwo
+schätzen musstest, welcher Schritt zu welcher Welle gehört.


### PR DESCRIPTION
Acht Einträge im Aktivitäten-Protokoll gefüllt (vier Mail-Wellen, vier Newsletter). Damit ist der Kanal, der rund 69 Prozent der Aktion trägt, nicht mehr blind.

| Welle | zugestellt | geöffnet | Öffnungsrate | Klicker | Klick je Öffner |
|---|---:|---:|---:|---:|---:|
| w1 · 17. Juli | 33 709 | 16 959 | 50,3 % | 1 954 | 11,5 % |
| w2 · 30. Juli | 33 385 | 15 449 | 46,3 % | 1 559 | 10,1 % |
| w3 · 7. August | 33 006 | 12 080 | 36,6 % | 1 237 | 10,2 % |
| w3b · 8. August | 12 974 | 5 623 | 43,3 % | 683 | **12,1 %** |
| **Summe** | **113 074** | **50 111** | **44,3 %** | **5 433** | **10,8 %** |

**Kette:** 113 074 zugestellt → 50 111 geöffnet → 5 433 Klicker → 469 gemessene Abos, mit Dunkelfeld ≈641. **Aus jedem neunten Klicker wurde ein Abo.** Und der Fristtag hat die beste Klickquote aller vier Wellen — die Lesart sagte es, hier steht es noch einmal.

## Korrektur einer eigenen Vorgabe

Der Sammel-Auftrag verlangte «Reichweite = geöffnete Mails». **Das war falsch**, abgeleitet aus einer einzigen älteren Notiz. Reichweite ist im Trichter die Aussetzung, nicht schon eine Reaktion — und nur als «zugestellt» passt sie zur Social-Reichweite aus Metricool; die Notiz der Welle 1 sagte das seit Juli richtig. Eingetragen ist jetzt **zugestellt**, die Öffnungen stehen in der Notiz jeder Zeile, damit die Lesart umkehrbar bleibt.

## Drei Befunde aus dem Abholen

1. **w3b hängt zweimal** (Öffner/Nicht-Öffner) wie w3 — die Aktion hatte **36 statt 30** E-Mail-Schritte.
2. **Der englischen Gruppe «Lesen» fehlt die letzte Welle.** Zwei w3b-EN-Kampagnen tragen stattdessen das Versanddatum **15. Juli** — drei Tage **vor** der ersten Welle, 197 zugestellt, 90 Öffner. Entweder haben 197 englische Leser «heute läuft es aus» gelesen, bevor die Aktion angekündigt war, oder es war ein Testlauf. Nicht eingerechnet; beide Summen sind festgehalten.
3. **Bei beiden Wochenschrift-Newslettern war das Link-Tracking aus** (`tracklinks:none`). Ihre Klicks stehen **leer und nicht auf null** — nicht gemessen ist nicht dasselbe wie nicht geklickt. Für die nächste Aktion: vor dem Versand prüfen.

**Newsletter AGiD (27. Juli) existiert in ActiveCampaign nicht.** Die Zeile trägt den Befund als Notiz und zählt bis zur Klärung als geplant, nicht als ausgespielt.

Die Zahlen selbst liegen in der Datenbank; dieser PR trägt nur die Dokumentation nach (`docs/schlussbericht-datensammlung.md` abgehakt, `AC-ZAHLEN.md` als Vorlage markiert).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUqZZzUQntMLiZPecAsBBc)_