### PR TITLE
Cockpit wird Schlussbericht: fünf Abschnitte, grosse Zahlen zuerst

### DIFF
--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -63,6 +63,16 @@
      statt der nötigen 4.5:1, auf --paper knapp gehaltene 4.66:1. Über --paper
      gemischt hält die Pille überall: 4.70:1 hell, 5.19:1 dunkel. */
   .pill{display:inline-block;font-family:var(--font-text);font-size:var(--t-micro);line-height:1.45;padding:6px 13px;border-radius:var(--r-control);background:color-mix(in srgb,var(--gold) 14%,var(--paper));color:var(--gold-ink);margin-top:var(--s4);max-width:100%}
+  /* Grosse Zahlen in einer Reihe (Übersicht, Geld). Gleiche Bauart wie die
+     Szenario-Karten, nur schmaler – damit die Seite EINE Sprache für Zahlen
+     spricht und nicht zwei. Auto-fit statt fester Spaltenzahl: die Reihe bricht
+     von selbst, ohne Sonderregel je Breite. */
+  .gross{display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:var(--s4);margin-top:var(--s6)}
+  .gross .g{background:var(--soft);border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s5);display:flex;flex-direction:column;gap:6px}
+  .gross .g-n{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)}
+  .gross .g-w{font-family:var(--font-display);font-weight:var(--w-strong);font-size:clamp(24px,3vw,32px);color:var(--ink);font-variant-numeric:tabular-nums;line-height:1.05}
+  .gross .g-m{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);line-height:1.55}
+
   /* Drei Szenarien nebeneinander, gleiches Gewicht: die Spanne ist die Aussage.
      Die Zahl steht in --ink, nicht in --ok – Grün auf «Vorsichtig» würde
      schmeicheln. Die Referenz nennt sich per Wort (Pille), nicht per Farbe. */

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -142,6 +142,14 @@
     // Aktion hier auf true stellen; die Sektion und ihre Logik bleiben
     // vollständig erhalten.
     zuegeZeigen: false,
+    // Sind die Kosten vollständig erfasst? Solange NEIN, zeigt der Bericht
+    // «Kosten je Abo» und «Rückfluss» NICHT an. Mit CHF 310 erfassten Kosten
+    // stünde dort ein Rückfluss von 215-fach und ein Preis je Abo von 0 Franken
+    // — beides technisch richtig gerechnet und trotzdem gelogen, weil der
+    // teuerste Weg der Aktion (die bezahlte Anzeige) noch fehlt. Sobald die
+    // Beträge eingetragen sind: hier auf true stellen.
+    // Was fehlt, steht in docs/schlussbericht-datensammlung.md.
+    kostenVollstaendig: false,
     // Zeigt an, was im Cockpit noch Annahme ist und nicht gemessen. Preise und
     // Zielmarken sind es seit dem 17. Juli nicht mehr (echte Formular- und
     // Uscreen-Preise, ratifizierte GF-Vorgabe) – allein die Bleibe-Quote bleibt
@@ -485,19 +493,21 @@
       motive[g][key] = motive[g][key] || { label:label, quelle:l.utm_source || '', ab:0, kl:0 };
       motive[g][key].kl += k;
     });
+    var ko = {};
     (massnahmen || []).forEach(function(m){
       var g = gebietVonMassnahme(m);
-      var r = Number(m.reichweite) || 0, k = Number(m.klicks) || 0;
+      var r = Number(m.reichweite) || 0, k = Number(m.klicks) || 0, c = Number(m.kosten) || 0;
       if (r) add(rw, g, r);
       if (k) add(kl, g, k);
-      if (r || k) (akte[g] = akte[g] || []).push({ name:m.massnahme || '—', tag:m.tag, reichweite:r, klicks:k });
+      if (c) add(ko, g, c);
+      if (r || k || c) (akte[g] = akte[g] || []).push({ name:m.massnahme || '—', tag:m.tag, reichweite:r, klicks:k, kosten:c });
     });
 
     var dunkel = dunkelVerteilen(ohne);
     var total = ohne; Object.keys(ab).forEach(function(k){ total += ab[k]; });
     var keys = {}; [ab, kl, rw, dunkel, linkN].forEach(function(o){ Object.keys(o).forEach(function(k){ keys[k] = true; }); });
     var items = Object.keys(keys).map(function(g){
-      return { g:g, ab:ab[g] || 0, kl:kl[g] || 0, rw:rw[g] || 0, du:dunkel[g] || 0,
+      return { g:g, ab:ab[g] || 0, kl:kl[g] || 0, rw:rw[g] || 0, du:dunkel[g] || 0, ko:ko[g] || 0,
                links:linkN[g] || 0, gesamt:(ab[g] || 0) + (dunkel[g] || 0) };
     }).filter(function(x){ return x.gesamt > 0 || x.rw > 0 || x.kl >= 3 || (x.links >= 2 && x.g !== 'andere'); })
       .sort(function(a, b){ return b.gesamt - a.gesamt || b.kl - a.kl; });
@@ -532,6 +542,12 @@
       teil('Klicks', x.kl ? fmt(x.kl) : '–');
       teil('Abschlüsse', fmt(x.ab));
       if (x.rw && x.kl) teil('Klickquote', (x.kl / x.rw * 100).toFixed(1).replace('.', ',') + ' %');
+      // Aufwand nur zeigen, wo er erfasst ist. Eine 0 wäre hier keine Sparsamkeit,
+      // sondern eine Lücke – und würde das Gebiet gratis aussehen lassen.
+      if (x.ko){
+        teil('Aufwand', geld(x.ko));
+        if (x.gesamt) teil('je Abo', geld(x.ko / x.gesamt));
+      }
       var track = document.createElement('div'); track.className = 'track';
       var tb = document.createElement('span'); tb.style.width = Math.max(3, Math.round(x.gesamt / max * 100)) + '%';
       track.appendChild(tb);
@@ -1323,9 +1339,24 @@
     var jeKat = {}; var summe = 0;
     posten.forEach(function(k){ var b = Number(k.betrag) || 0; summe += b; jeKat[k.kategorie] = (jeKat[k.kategorie] || 0) + b; });
     el('costTotal').textContent = geld(summe);
-    el('costCpa').textContent   = (summe > 0 && total > 0) ? geld(summe / total) : '–';
     var revChf = revenue && revenue.chfGesamt || 0;
-    el('costRoi').textContent   = summe > 0 ? (revChf / summe).toFixed(1) + '×' : '–';
+    var voll = CONFIG.kostenVollstaendig !== false;
+    if (voll){
+      // Beträge unter zehn Franken auf Rappen genau – ein «CHF 0» wäre keine
+      // Sparsamkeit, sondern eine gerundete Unwahrheit.
+      var cpa = (summe > 0 && total > 0) ? summe / total : 0;
+      el('costCpa').textContent = cpa > 0
+        ? (cpa < 10 ? CONFIG.waehrung + ' ' + cpa.toFixed(2).replace('.', ',') : geld(cpa))
+        : '–';
+      el('costRoi').textContent = summe > 0 ? (revChf / summe).toFixed(1) + '×' : '–';
+    } else {
+      el('costCpa').textContent = '–';
+      el('costRoi').textContent = '–';
+    }
+    if (el('kostenNote')) el('kostenNote').textContent = voll
+      ? 'Alle bekannten Kosten sind erfasst; Kosten je Abo und Rückfluss rechnen darauf.'
+      : 'Kosten je Abo und Rückfluss bleiben leer, solange die Kosten unvollständig sind — vor allem der Betrag der bezahlten Anzeige fehlt. '
+        + 'Gerechnet würden daraus sonst Zahlen, die technisch stimmen und trotzdem täuschen. Was fehlt, steht in docs/schlussbericht-datensammlung.md; eingetragen wird es unter Kosten.';
 
     var body = el('costBody'); body.innerHTML = '';
     Object.keys(KAT_LABEL).forEach(function(kat){
@@ -1549,6 +1580,98 @@
       'Herleitung, Begründung der Quoten und Empfindlichkeit: ' + ((CONFIG.szenarien && CONFIG.szenarien.doc) || '') + '.';
   }
 
+  // ── Kopfzahlen: die grossen Zahlen zuerst ─────────────────────────────────
+  // Der Bericht beginnt mit dem, was jeder wissen will, und nicht mit dem Weg
+  // dorthin. Alles Kleinere steht darunter in Klappen.
+  function renderKopf(stats, revenue, posten){
+    var host = el('kopfZahlen'); if (!host) return;
+    var je = function(produkt){
+      return (stats || []).reduce(function(s, r){ return r.produkt === produkt ? s + Number(r.n || 0) : s; }, 0);
+    };
+    var kosten = (posten || []).reduce(function(s, k){ return s + (Number(k.betrag) || 0); }, 0);
+    var ref = (revenue && revenue.szenario) || referenzSzenario();
+    var karten = [
+      { n:'Wochenschrift', w:fmt(je('wos')), m:'Papier und Digital, Deutsch und Englisch' },
+      { n:'goetheanum.tv', w:fmt(je('gtv')), m:'ein Strom, Sprache dort nicht gemessen' },
+      { n:'Folgejahr-Umsatz', w:geld(revenue ? revenue.chfGesamt : 0),
+        m:'Szenario ' + ref.name + ' – eine Rechnung, keine Messung' },
+      { n:'Kosten erfasst', w:geld(kosten),
+        m:kosten > 0 ? 'Stand der Kosten-Seite' : 'noch nichts erfasst' }
+    ];
+    host.innerHTML = '';
+    karten.forEach(function(k){
+      var d = document.createElement('div'); d.className = 'g';
+      var n = document.createElement('div'); n.className = 'g-n'; n.textContent = k.n;
+      var w = document.createElement('div'); w.className = 'g-w'; w.textContent = k.w;
+      var m = document.createElement('div'); m.className = 'g-m'; m.textContent = k.m;
+      d.appendChild(n); d.appendChild(w); d.appendChild(m); host.appendChild(d);
+    });
+  }
+
+  // ── Wen wir erreicht haben: die drei Zielgruppen des Mailings ─────────────
+  // Die Wellen tragen die Gruppe im utm_content (w1_noabo, w2_nurws …). Damit
+  // ist «welche Gruppe haben wir wie erreicht» gemessen, nicht geraten – der
+  // einzige Ort der Aktion, an dem das geht.
+  var SEGMENTE = [
+    { key:'noabo', name:'Ohne Abo',
+      was:'bekam beide Angebote – Wochenschrift und goetheanum.tv' },
+    { key:'nurws', name:'Wochenschrift-Abonnenten',
+      was:'Quer-Angebot: goetheanum.tv' },
+    { key:'nurtv', name:'goetheanum.tv-Abonnenten',
+      was:'Quer-Angebot: Wochenschrift' }
+  ];
+  function renderSegmente(attribution){
+    var host = el('segmente'); if (!host) return;
+    var je = {}, wellen = {};
+    (attribution || []).forEach(function(r){
+      var t = /^(w\d+b?)_(nurtv|nurws|noabo)(_share)?$/.exec(r.utm_content || '');
+      if (!t) return;
+      var n = Number(r.n) || 0;
+      je[t[2]] = (je[t[2]] || 0) + n;
+      (wellen[t[2]] = wellen[t[2]] || {});
+      wellen[t[2]][t[1]] = (wellen[t[2]][t[1]] || 0) + n;
+    });
+    var summe = Object.keys(je).reduce(function(s, k){ return s + je[k]; }, 0);
+    if (!summe){ host.innerHTML = '<div class="empty">Keine Zielgruppen-Spur in den Anmeldungen.</div>'; return; }
+    host.innerHTML = '';
+    SEGMENTE.forEach(function(sg){
+      var n = je[sg.key] || 0;
+      var det = document.createElement('details'); det.className = 'geb';
+      var sum = document.createElement('summary');
+      var kopf = document.createElement('div'); kopf.className = 'geb-kopf';
+      var nm = document.createElement('span'); nm.className = 'geb-name';
+      var car = document.createElement('span'); car.className = 'car'; car.setAttribute('aria-hidden', 'true');
+      nm.appendChild(car); nm.appendChild(document.createTextNode(sg.name));
+      var wert = document.createElement('span'); wert.className = 'geb-wert';
+      wert.appendChild(document.createTextNode(fmt(n)));
+      var an = document.createElement('span'); an.className = 'du';
+      an.textContent = ' · ' + Math.round(n / summe * 100) + ' % der Mailing-Abos';
+      wert.appendChild(an);
+      kopf.appendChild(nm); kopf.appendChild(wert);
+      var kette = document.createElement('div'); kette.className = 'geb-kette';
+      var s2 = document.createElement('span'); s2.textContent = sg.was; kette.appendChild(s2);
+      var track = document.createElement('div'); track.className = 'track';
+      var tb = document.createElement('span'); tb.style.width = Math.max(3, Math.round(n / summe * 100)) + '%';
+      track.appendChild(tb);
+      sum.appendChild(kopf); sum.appendChild(kette); sum.appendChild(track);
+      det.appendChild(sum);
+      var tief = document.createElement('div'); tief.className = 'geb-tief';
+      ['w1', 'w2', 'w3', 'w3b'].forEach(function(w){
+        var v = (wellen[sg.key] || {})[w] || 0;
+        var row = document.createElement('div'); row.className = 'motrow';
+        var mc = document.createElement('span'); mc.className = 'mc'; mc.textContent = 'Welle ' + w.slice(1);
+        var mn = document.createElement('span'); mn.className = 'mn'; mn.textContent = fmt(v) + ' Abos';
+        row.appendChild(mc); row.appendChild(mn); tief.appendChild(row);
+      });
+      det.appendChild(tief);
+      host.appendChild(det);
+    });
+    if (el('segmenteNote')) el('segmenteNote').textContent =
+      'Gemessen an ' + fmt(summe) + ' Anmeldungen, die eine Mailing-Spur tragen: Die Wellen führten je Zielgruppe ' +
+      'einen eigenen Link (utm_content), darum ist die Gruppe hier keine Vermutung. ' +
+      'Anmeldungen ohne Spur sind nicht enthalten – sie lassen sich keiner Gruppe zuordnen.';
+  }
+
   // ── Ereignis-Protokoll: die einzelnen Abos («Was ist passiert?») ────────────
   // RPC sommer2026_ereignisse: Einzel-Anmeldungen der letzten 14 Tage, stunden-
   // genau gerundet, ohne Personendaten. Beantwortet «woher kamen heute welche
@@ -1672,7 +1795,9 @@
         var revenue = projectRevenue(stats);
         // 1 Stand · 2 Gebiete · 3 Züge · 4 Belege – in dieser Reihenfolge gelesen.
         renderStand(total, timeline);
+        renderKopf(stats, revenue, kostenPosten);
         renderStroeme(stats, total);
+        renderSegmente(attribution);
         renderGebiete(attribution, links, massnahmen, kanaele);
         renderZuege(links, massnahmen, attribution, timeline, total);
         renderDunkelfeld(kanaele, attribution);

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Sommer-Aktion · Cockpit · Goetheanum</title>
-<meta name="description" content="Aktions-Cockpit der Sommer-Aktion 2026 – Stand, Gebiete und nächste Züge auf einen Blick." />
+<meta name="description" content="Sommer-Aktion 2026 – Ergebnis, Wirkung je Kanal, Herkunft der Abos und Schlüsse, live aus dem Backend." />
 <meta name="robots" content="noindex" />
 <link rel="icon" type="image/svg+xml" href="../../assets/logos/goetheanum-mark-blue.svg" />
 <link rel="stylesheet" href="../../design-system/tokens.css" />
@@ -39,9 +39,11 @@
   </section>
 
 
-  <!-- ══ 1 · STAND ═══════════════════════════════════════════════════════ -->
+  <!-- ══ 1 · ÜBERSICHT ═══════════════════════════════════════════════════
+       Grosse Zahlen zuerst, alles Kleinere in Klappen darunter. Wer nur den
+       Ausgang wissen will, liest die erste Bildschirmhöhe und hört auf. -->
   <section id="stand">
-    <div class="shead"><h2>Stand</h2></div>
+    <div class="shead"><h2>Übersicht</h2></div>
     <div class="panel">
       <div class="stand">
         <div>
@@ -62,17 +64,97 @@
         </div>
       </div>
 
-      <!-- Direkt unter der Signaturzahl: Die zweite Frage nach «wie viele» ist
-           «was bringt das». Gezeigt wird die Spanne, nicht eine Zahl. -->
+      <div class="gross" id="kopfZahlen"><div class="empty">lädt …</div></div>
+    </div>
+  </section>
+
+
+  <!-- ══ 2 · ERGEBNIS UND GELD ═══════════════════════════════════════════ -->
+  <section id="ergebnis">
+    <div class="shead"><h2>Ergebnis und Geld</h2><p>Was die Aktion eingebracht hat und was sie gekostet hat – nebeneinander. Der Umsatz ist bis November eine Rechnung in drei Szenarien; dann entscheiden die ersten Kohorten, und aus der Spanne wird eine Zahl.</p></div>
+    <div class="panel">
+
+      <!-- Drei gleichwertige Karten: Die Spanne IST die Aussage, darum trägt
+           keine der drei mehr Gewicht als die andere. Die Referenz nennt sich
+           mit einem Wort, nicht mit Farbe oder Grösse (G01, G03). -->
+      <div class="szen" id="szenKarten"><div class="empty">lädt …</div></div>
+      <p class="provisorisch" id="szenarienNote"></p>
+
+      <div class="gross" style="margin-top:var(--s6)">
+        <div class="g"><div class="g-n">Kosten erfasst</div><div class="g-w" id="costTotal">–</div><div class="g-m">alle eingetragenen Posten</div></div>
+        <div class="g"><div class="g-n">Kosten je Abo</div><div class="g-w" id="costCpa">–</div><div class="g-m">erfasste Kosten geteilt durch alle Anmeldungen</div></div>
+        <div class="g"><div class="g-n">Rückfluss</div><div class="g-w" id="costRoi">–</div><div class="g-m">Folgejahr-Umsatz je eingesetztem Franken</div></div>
+      </div>
+      <p class="provisorisch" id="kostenNote"></p>
+
       <details class="zb-form">
-        <summary>Wer bleibt, und was bringt das? – drei Szenarien</summary>
-        <!-- Drei gleichwertige Karten: Die Spanne IST die Aussage, darum trägt
-             keine der drei mehr Gewicht als die andere. Die Referenz nennt sich
-             mit einem Wort, nicht mit Farbe oder Grösse (G01, G03). -->
-        <div class="szen" id="szenKarten"><div class="empty">lädt …</div></div>
-        <div class="cohort" id="cohortCard" style="margin-top:var(--s6)"><div class="empty">lädt …</div></div>
-        <p class="provisorisch" id="szenarienNote"></p>
+        <summary>Wer bleibt? – die Kohorte und der Drei-Monats-Moment</summary>
+        <div class="cohort" id="cohortCard" style="margin-top:var(--s4)"><div class="empty">lädt …</div></div>
       </details>
+
+      <details class="zb-form">
+        <summary>Kosten im Einzelnen</summary>
+        <div class="tablewrap" style="margin-top:var(--s4)">
+          <table class="tarif">
+            <thead><tr><th>Kategorie</th><th class="num">Betrag</th></tr></thead>
+            <tbody id="costBody"><tr><td class="empty" colspan="2">lädt …</td></tr></tbody>
+            <tfoot id="costFoot"></tfoot>
+          </table>
+        </div>
+        <div class="tablewrap" style="margin-top:var(--s6)">
+          <table class="tarif">
+            <thead><tr><th>Datum</th><th>Posten</th><th>Kategorie</th><th class="num">Betrag</th></tr></thead>
+            <tbody id="kostenPostenBody"><tr><td class="empty" colspan="4">lädt …</td></tr></tbody>
+          </table>
+        </div>
+      </details>
+
+      <details class="zb-form">
+        <summary>Nach Tarif und Zahlungsweise</summary>
+        <div class="tablewrap" style="margin-top:var(--s4)">
+          <table class="tarif">
+            <thead><tr><th>Tarif</th><th class="num">Monatlich</th><th class="num">Jährlich</th><th class="num">Summe</th></tr></thead>
+            <tbody id="tarifBody"><tr><td class="empty" colspan="4">lädt …</td></tr></tbody>
+            <tfoot id="tarifFoot"></tfoot>
+          </table>
+        </div>
+        <p class="provisorisch" id="provisorisch"></p>
+      </details>
+    </div>
+  </section>
+
+
+  <!-- ══ 3 · WAS HAT FUNKTIONIERT ════════════════════════════════════════ -->
+  <section id="gebiete">
+    <div class="shead"><h2>Was hat funktioniert</h2><p>Jede Zeile ist ein Wirkungsfeld und trägt die ganze Kette: Reichweite, Klicks, Abschlüsse – und den Aufwand, wo er erfasst ist. Aufklappen zeigt die einzelnen Motive und Aktivitäten dahinter.</p></div>
+    <div class="panel">
+      <div id="gebieteListe"><div class="empty">lädt …</div></div>
+    </div>
+    <p class="provisorisch" id="gebieteNote"></p>
+  </section>
+
+
+  <!-- Ausgeblendet, seit die Frist vorbei ist: Ein Zug, den niemand mehr tun
+       kann, ist kein Zug. Der Schalter ist CONFIG.zuegeZeigen – für die nächste
+       Aktion ein Wort, nicht ein Wiederaufbau. Die Sektion bleibt darum im
+       Markup stehen, auch wenn der Bericht sie nicht braucht. -->
+  <section id="zuege" hidden>
+    <div class="shead"><h2>Nächste Züge</h2><p>Was jetzt noch möglich ist – aus den Daten gelesen, nach Hebel sortiert.</p></div>
+    <div class="panel">
+      <div id="zuegeListe"><div class="empty">lädt …</div></div>
+    </div>
+    <p class="provisorisch">Die Erwartungen sind grob und aus der bisherigen Wirkung derselben Kanäle abgeleitet – sie sortieren die Reihenfolge, sie versprechen nichts.</p>
+  </section>
+
+
+  <!-- ══ 4 · WER SIND DIE NEUEN ══════════════════════════════════════════ -->
+  <section id="wer">
+    <div class="shead"><h2>Wer sind die Neuen</h2><p>Woher sie kommen, was sie gewählt haben – und welche Zielgruppe wie geantwortet hat.</p></div>
+    <div class="panel">
+
+      <div class="mh">Welche Gruppe wir wie erreicht haben</div>
+      <div id="segmente"><div class="empty">lädt …</div></div>
+      <p class="provisorisch" id="segmenteNote"></p>
 
       <details class="zb-form">
         <summary id="stroemeKopf">Woraus sich die Abos zusammensetzen</summary>
@@ -101,32 +183,35 @@
   </section>
 
 
-  <!-- ══ 2 · GEBIETE ═════════════════════════════════════════════════════ -->
-  <section id="gebiete">
-    <div class="shead"><h2>Gebiete</h2></div>
+  <!-- ══ 5 · SCHLÜSSE ════════════════════════════════════════════════════
+       Der einzige Abschnitt, der nicht gerechnet, sondern geschrieben ist.
+       Er steht bewusst NACH den Zahlen: Wer die Schlüsse zuerst liest, liest
+       die Zahlen nur noch als Beleg. -->
+  <section id="schluesse">
+    <div class="shead"><h2>Schlüsse und Perspektiven</h2><p>Geschrieben, nicht gerechnet – gestützt auf die datierten Lesarten im Repo. Was hier steht, ist eine Auslegung und darf widersprochen werden.</p></div>
     <div class="panel">
-      <div id="gebieteListe"><div class="empty">lädt …</div></div>
+
+      <div class="mh">Was diese Aktion gezeigt hat</div>
+      <div class="prose">
+        <p><b>Die Aktion war eine Aktivierung des eigenen Umfelds, keine Gewinnung neuer Öffentlichkeit.</b> Rund vier von fünf Abos stammen aus Adressen, die das Haus schon hatte – Mailing und Newsletter zusammen. Das ist kein Makel, aber es beantwortet die Frage nach Wachstum nicht: Wer neue Kreise erreichen will, kann das aus dem eigenen Verteiler nicht lernen.</p>
+        <p><b>Die Frist wirkt stärker als jeder einzelne Kanal.</b> Die beiden Fristtage brachten mehr Anmeldungen als der ganze Juli, und die letzte Welle hatte die höchste Klickquote aller vier. Wer beim nächsten Mal mehr will, setzt eher eine zweite Frist als einen weiteren Kanal.</p>
+        <p><b>Bezahlte Reichweite hat hier nicht getragen.</b> Rund 131 000 erreichte Personen und 965 Klicks ergaben etwa neun Abos – dreifach belegt durch Placebo-Probe, Abschalt-Probe und Fensterrechnung. Für eine nächste bezahlte Runde gilt: erst hart messbar machen, dann buchen.</p>
+        <p><b>Das Quer-Angebot funktioniert asymmetrisch.</b> Wochenschrift-Abonnenten nahmen goetheanum.tv rund dreimal so oft an wie umgekehrt. Wer beide Häuser verbinden will, geht offenbar leichter vom Lesen zum Sehen als vom Sehen zum Lesen.</p>
+      </div>
+
+      <div class="mh" style="margin-top:var(--s6)">Was jetzt noch aussteht</div>
+      <div class="prose">
+        <p>Der Bericht ist erst vollständig, wenn die Kosten drinstehen – vor allem der Betrag der bezahlten Anzeige. Bis dahin bleiben «Kosten je Abo» und «Rückfluss» oben leer: Mit den bisher erfassten CHF 310 ergäben sie einen Rückfluss von rund 215-fach und einen Preis von null Franken je Abo – technisch richtig gerechnet und trotzdem gelogen.</p>
+        <p><b>Anfang November</b> entscheiden die ersten Kohorten über das Bleiben. Dann ersetzt eine Messung die drei Szenarien, und aus der Spanne wird eine Zahl. Erst danach lässt sich sagen, was die Aktion wirklich eingebracht hat.</p>
+        <p>Offen sind ausserdem: die Social-Zahlen aus Metricool, der Abgleich der Wochenschrift-Anmeldungen gegen Zoho, und zwei Ungereimtheiten aus dem Mailing – der englischen Gruppe «Lesen» fehlt die letzte Welle, und bei beiden Wochenschrift-Newslettern war das Link-Tracking aus. Alles einzeln in <code>docs/schlussbericht-datensammlung.md</code>.</p>
+      </div>
     </div>
-    <p class="provisorisch" id="gebieteNote"></p>
   </section>
 
 
-  <!-- ══ 3 · NÄCHSTE ZÜGE ════════════════════════════════════════════════ -->
-  <!-- Ausgeblendet, seit die Frist vorbei ist: Ein Zug, den niemand mehr tun
-       kann, ist kein Zug. Der Schalter ist CONFIG.zuegeZeigen – für die nächste
-       Aktion ein Wort, nicht ein Wiederaufbau. -->
-  <section id="zuege" hidden>
-    <div class="shead"><h2>Nächste Züge</h2><p>Was jetzt noch möglich ist – aus den Daten gelesen, nach Hebel sortiert. Der Plan steht schon im Link-Register und im Aktivitäten-Protokoll; hier steht, was davon noch nicht gezündet hat.</p></div>
-    <div class="panel">
-      <div id="zuegeListe"><div class="empty">lädt …</div></div>
-    </div>
-    <p class="provisorisch">Die Erwartungen sind grob und aus der bisherigen Wirkung derselben Kanäle abgeleitet – sie sortieren die Reihenfolge, sie versprechen nichts.</p>
-  </section>
-
-
-  <!-- ══ 4 · BELEGE ══════════════════════════════════════════════════════ -->
+  <!-- ══ 6 · BELEGE ══════════════════════════════════════════════════════ -->
   <section id="belege">
-    <div class="shead"><h2>Belege</h2><p>Alles, was man selten braucht, aber jederzeit nachschlagen können muss.</p></div>
+    <div class="shead"><h2>Belege und Methode</h2><p>Alles, was man selten braucht, aber jederzeit nachschlagen können muss.</p></div>
     <div class="panel">
 
       <details class="zb-form">
@@ -146,7 +231,7 @@
         <p class="provisorisch" id="dunkelNote"></p>
         <div id="vermutetKopf" class="mh" style="margin-top:var(--s6)"></div>
         <div id="vermutetList"><div class="empty">lädt …</div></div>
-        <p class="provisorisch">Live aus den Ereignissen: je Anmeldung ohne UTM der zeitlich nächste Kurzlink-Klick (bis 90 Min. davor) auf einen passenden Kampagnen-Link. Ein Indiz, keine Messung – gezählt wird es nirgends, es ordnet nur ein. Das Indiz trägt nur bei spärlichen Klicks: Solange die bezahlte Anzeige lief, stellte sie über die Hälfte aller Klicks und stand darum zufällig bei fast jeder Anmeldung daneben – nachgerechnet in <code>docs/wirkungs-lesart-24-07.md</code>. Seit ihrem Stopp am 24. Juli beherrscht kein Weg mehr das Klick-Log; das Indiz ist damit brauchbarer geworden, bleibt aber ein Indiz. Die geltende Zuordnung des Dunkelfeldes rechnet nicht damit, sondern aus Tageskurve, gemessenen Fenster-Anteilen und Selbstauskunft: <code>docs/wirkungs-lesart-07-08.md</code>.</p>
+        <p class="provisorisch">Live aus den Ereignissen: je Anmeldung ohne UTM der zeitlich nächste Kurzlink-Klick (bis 90 Min. davor) auf einen passenden Kampagnen-Link. Ein Indiz, keine Messung – gezählt wird es nirgends, es ordnet nur ein. Das Indiz trägt nur bei spärlichen Klicks: Solange die bezahlte Anzeige lief, stellte sie über die Hälfte aller Klicks und stand darum zufällig bei fast jeder Anmeldung daneben – nachgerechnet in <code>docs/wirkungs-lesart-24-07.md</code>. Seit ihrem Stopp am 24. Juli beherrscht kein Weg mehr das Klick-Log; das Indiz ist damit brauchbarer geworden, bleibt aber ein Indiz. Die geltende Zuordnung des Dunkelfeldes rechnet nicht damit, sondern aus Tageskurve, gemessenen Fenster-Anteilen und Selbstauskunft: <code>docs/wirkungs-lesart-08-08.md</code>.</p>
       </details>
 
       <details class="zb-form">
@@ -157,21 +242,9 @@
       </details>
 
       <details class="zb-form">
-        <summary>Nach Tarif und Zahlungsweise</summary>
-        <div class="tablewrap" style="margin-top:var(--s4)">
-          <table class="tarif">
-            <thead><tr><th>Tarif</th><th class="num">Monatlich</th><th class="num">Jährlich</th><th class="num">Summe</th></tr></thead>
-            <tbody id="tarifBody"><tr><td class="empty" colspan="4">lädt …</td></tr></tbody>
-            <tfoot id="tarifFoot"></tfoot>
-          </table>
-        </div>
-        <p class="provisorisch" id="provisorisch"></p>
-      </details>
-
-      <details class="zb-form">
         <summary>Methode und Quellen</summary>
         <div style="margin-top:var(--s4)">
-          <p class="provisorisch">Abschlüsse und «Geblieben» zählt das Cockpit live aus den Anmeldungen (nur Summen, keine Personendaten). Reichweite und die je Aktivität erfassten Klicks kommen aus dem <a href="aktivitaeten.html">Aktivitäten-Protokoll</a>, die Kurzlink-Klicks automatisch aus dem <a href="../utm-generator/">Link-Register</a>. Alles mit ≈ ist eine datierte Lesart, keine Messung.</p>
+          <p class="provisorisch">Abschlüsse und «Geblieben» zählt das Cockpit live aus den Anmeldungen (nur Summen, keine Personendaten). Reichweite und die je Aktivität erfassten Klicks kommen aus dem <a href="aktivitaeten.html">Aktivitäten-Protokoll</a>, die Kurzlink-Klicks automatisch aus dem <a href="../utm-generator/">Link-Register</a>. Reichweite heisst bei Mails <b>zugestellt</b>, Klicks heissen <b>eindeutige Klicker</b> – die Öffnungen stehen je Zeile in der Notiz. Alles mit ≈ ist eine datierte Lesart, keine Messung.</p>
           <div id="quelleSocial"></div>
         </div>
       </details>


### PR DESCRIPTION
**Der Bericht *ist* das Cockpit** — eine Seite, eine Wahrheit, live aus dem Backend. Eine zweite Seite hätte dieselben Zahlen ein zweites Mal behauptet.

## Die neue Ordnung

1. **Übersicht** — Signaturzahl, dazu vier grosse Zahlen: Wochenschrift 399 · goetheanum.tv 658 · Folgejahr-Umsatz CHF 66 473 · Kosten CHF 310. Wer nur den Ausgang wissen will, liest die erste Bildschirmhöhe und hört auf.
2. **Ergebnis und Geld** — die drei Szenarien und die Kosten nebeneinander; Kohorte, Einzelposten und Tarife in Klappen.
3. **Was hat funktioniert** — die Gebiete-Liste, jetzt zusätzlich mit **Aufwand je Gebiet** und **Kosten je Abo**, wo Kosten erfasst sind.
4. **Wer sind die Neuen** — neu: die **drei Zielgruppen des Mailings**, gemessen am `utm_content` der Wellen. Dazu Ströme und Herkunftsland.
5. **Schlüsse und Perspektiven** — der einzige geschriebene Abschnitt, bewusst **nach** den Zahlen: Wer die Schlüsse zuerst liest, liest die Zahlen nur noch als Beleg.
6. **Belege und Methode** — unverändert.

## Was Abschnitt 4 jetzt beantwortet

| Zielgruppe | Abos | Anteil |
|---|---:|---:|
| Ohne Abo (bekam beide Angebote) | 397 | 74 % |
| Wochenschrift-Abonnenten → goetheanum.tv | 102 | 19 % |
| goetheanum.tv-Abonnenten → Wochenschrift | 34 | 6 % |

**Das Quer-Angebot wirkt asymmetrisch:** vom Lesen zum Sehen rund dreimal so oft wie umgekehrt. Aufklappen zeigt die Verteilung über die vier Wellen.

## Ein Befund beim Bauen

Mit den bisher erfassten CHF 310 zeigte der neue Geld-Block **«Kosten je Abo: CHF 0»** und **«Rückfluss: 214,6×»**. Beides technisch richtig gerechnet und trotzdem gelogen, weil der teuerste Weg der Aktion fehlt — derselbe Fehler wie bei der Tempo-Fortschreibung.

Beide Zahlen bleiben jetzt **leer**, solange `CONFIG.kostenVollstaendig` auf `false` steht, und die Notiz sagt warum. Ist der Anzeigen-Betrag eingetragen: Schalter auf `true`, dann rechnen sie — mit Rappen-Genauigkeit unter zehn Franken, damit nie wieder ein gerundetes «CHF 0» dasteht.

Die ausgeblendete Züge-Sektion bleibt im Markup — das Versprechen war, sie sei mit einem Wort zurückholbar.

## Geprüft

Im Browser mit den **echten** RPC-Antworten, 1280 und 420 px: alle Abschnitte da, Kacheln brechen sauber um, Mailing-Kette 113 074 → 5 506 → 533. Kontraste der neuen Kacheln, Segmente und des Schluss-Textes in hell und dunkel gemessen (4,65:1 bis 15:1). `typo-check` konform · `ds-lint` 100 % · `barrierefreiheit.mjs` ohne Verstoss.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUqZZzUQntMLiZPecAsBBc)_