### PR TITLE
Saubere Grundformen: Löcher in der Skala, Luft in den Pillen, Grün als Textfarbe (DS10)

### DIFF
--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -57,31 +57,17 @@
   .conv .txt{font-family:var(--font-text);font-size:var(--t-small);color:var(--ink);min-width:190px;flex:1}
   .conv .txt b{font-weight:600}
   .conv .txt .m{color:var(--muted);font-size:var(--t-micro)}
-  /* B02: Der Goldton mischt über --paper, NICHT über transparent. Sonst legt er
-     sich auf die jeweilige Fläche darunter und frisst den Kontrast, den
-     --gold-ink verspricht — auf der Szenario-Karte (--soft) gemessene 4.42:1
-     statt der nötigen 4.5:1, auf --paper knapp gehaltene 4.66:1. Über --paper
-     gemischt hält die Pille überall: 4.70:1 hell, 5.19:1 dunkel. */
-  .pill{display:inline-block;font-family:var(--font-text);font-size:var(--t-micro);line-height:1.45;padding:6px 13px;border-radius:var(--r-control);background:color-mix(in srgb,var(--gold) 14%,var(--paper));color:var(--gold-ink);margin-top:var(--s4);max-width:100%}
-  /* Grosse Zahlen in einer Reihe (Übersicht, Geld). Gleiche Bauart wie die
-     Szenario-Karten, nur schmaler – damit die Seite EINE Sprache für Zahlen
-     spricht und nicht zwei. Auto-fit statt fester Spaltenzahl: die Reihe bricht
-     von selbst, ohne Sonderregel je Breite. */
-  .gross{display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:var(--s4);margin-top:var(--s6)}
-  .gross .g{background:var(--soft);border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s5);display:flex;flex-direction:column;gap:6px}
-  .gross .g-n{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)}
-  .gross .g-w{font-family:var(--font-display);font-weight:var(--w-strong);font-size:clamp(24px,3vw,32px);color:var(--ink);font-variant-numeric:tabular-nums;line-height:1.05}
-  .gross .g-m{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);line-height:1.55}
+  /* Die Referenz-Marke ist ein Chip mit Ton (base.css). Hier nur ihr Sitz. */
+  .cohort .chip.ton{margin-top:var(--s4)}
+  /* Zahlenkacheln kommen aus dem Fundament (.kennzahlen/.kennzahl in base.css).
+     Hier steht nur, was diese Seite besonders macht: der Abstand nach oben. */
+  .kennzahlen{margin-top:var(--s6)}
 
   /* Drei Szenarien nebeneinander, gleiches Gewicht: die Spanne ist die Aussage.
      Die Zahl steht in --ink, nicht in --ok – Grün auf «Vorsichtig» würde
      schmeicheln. Die Referenz nennt sich per Wort (Pille), nicht per Farbe. */
   .szen{display:grid;grid-template-columns:repeat(3,1fr);gap:var(--s4);margin-top:var(--s4)}
-  .szen .s{background:var(--soft);border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s5);display:flex;flex-direction:column;gap:6px}
-  .szen .s-n{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted)}
-  .szen .s-w{font-family:var(--font-display);font-weight:var(--w-strong);font-size:clamp(26px,3.4vw,36px);color:var(--ink);font-variant-numeric:tabular-nums;line-height:1.05}
-  .szen .s-m{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);line-height:1.55}
-  .szen .pill{margin-top:0}
+  .szen .chip.ton{margin-top:var(--s2)}
 
   .tablewrap{overflow-x:auto}
   .tarif{width:100%;border-collapse:collapse;font-family:var(--font-text);font-size:var(--t-small);min-width:440px}

--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -151,12 +151,16 @@
   .geb-tief{padding:0 0 var(--s4) var(--s4);border-left:2px solid var(--line-soft);margin-bottom:var(--s3)}
   .geb-tief .qz-hint{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);padding:8px 0;line-height:1.5}
   /* Merkzeichen: ein Wort, das sagt, was die Zeile bedeutet – keine Ampel. */
+  /* Merkzeichen einer Gebiets-Zeile («trägt die Aktion», «grösstenteils
+     dunkel»). Luft aus dem Grundmass des Fundaments, nicht aus rohen Pixeln:
+     vorher 2px bei 14px Schrift – die Tinte klebte an der Rundung. */
   .zeichen{display:inline-block;font-family:var(--font-text);font-size:var(--t-micro);font-weight:600;
-    border-radius:var(--r-pill);padding:2px 10px;margin-left:var(--s2);white-space:nowrap}
-  .zeichen.traegt{color:var(--ok);background:color-mix(in srgb,var(--ok) 14%,transparent)}
-  .zeichen.leck{color:var(--bad);background:color-mix(in srgb,var(--bad) 12%,transparent)}
+    line-height:1.35;border-radius:var(--r-pill);padding:var(--pille-y) var(--pille-x);
+    margin-left:var(--s2);white-space:nowrap}
+  .zeichen.traegt{color:var(--ok-ink);background:color-mix(in srgb,var(--ok) 14%,var(--paper))}
+  .zeichen.leck{color:var(--bad);background:color-mix(in srgb,var(--bad) 12%,var(--paper))}
   .zeichen.still{color:var(--muted);background:var(--soft)}
-  .zeichen.dunkel{color:var(--gold-ink);background:color-mix(in srgb,var(--gold) 15%,transparent)}
+  .zeichen.dunkel{color:var(--gold-ink);background:color-mix(in srgb,var(--gold) 14%,var(--paper))}
 
   /* ── Nächste Züge ───────────────────────────────────────────────────────── */
   .zug{border-bottom:1px solid var(--line-soft)}
@@ -269,8 +273,8 @@
   .ev-meta{display:block;color:var(--muted);font-size:var(--t-micro);margin-top:2px}
   .ev-her{min-width:0}
   .ev-kanal{display:inline-block;font-size:var(--t-micro);font-weight:600;color:var(--gold-ink);
-    background:color-mix(in srgb,var(--gold) 15%,transparent);border-radius:var(--r-pill);
-    padding:2px 10px;margin-right:8px;white-space:nowrap}
+    background:color-mix(in srgb,var(--gold) 14%,var(--paper));border-radius:var(--r-pill);
+    padding:var(--pille-y) var(--pille-x);line-height:1.35;margin-right:8px;white-space:nowrap}
   .ev-kanal.ev-ohne{color:var(--muted);background:var(--soft)}
   .ev-spur{color:var(--muted);font-size:var(--t-micro);overflow-wrap:anywhere}
   /* Vermutete Herkunft: klar abgesetzt (gepunktete Kante), damit Indiz nie wie Messung liest. */

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -1531,14 +1531,14 @@
         card.innerHTML =
           '<div class="when"></div><h4></h4>' +
           '<div class="conv"><div class="ring"><div class="inner"></div></div>' +
-          '<div class="txt"><b></b><br><span class="m"></span><div class="pill"></div></div></div>';
+          '<div class="txt"><b></b><br><span class="m"></span><div class="chip ton"></div></div></div>';
         card.querySelector('.when').textContent = 'Kohorte ' + monat + ' · Entscheidung ab ' + dmy(kEntsch);
         card.querySelector('h4').textContent = fmt(neu) + ' Anmeldungen im Gratis-Zeitraum';
         card.querySelector('.ring').style.setProperty('--p', quote);
         card.querySelector('.ring .inner').textContent = quote + '%';
         card.querySelector('.txt b').textContent = '~' + fmt(projektiert) + ' bleiben voraussichtlich zahlend';
         card.querySelector('.txt .m').textContent = fmt(offen) + ' Entscheidungen noch offen · ' + fmt(bleibt) + ' bereits umgewandelt';
-        card.querySelector('.pill').textContent = 'Szenario ' + ref.name + ' · noch hat keine Kohorte entschieden';
+        card.querySelector('.chip').textContent = 'Szenario ' + ref.name + ' · noch hat keine Kohorte entschieden';
       }
     }
 
@@ -1550,17 +1550,17 @@
       host.innerHTML = '';
       szenarien().forEach(function(sz){
         var r = projectRevenue(stats, sz);
-        var karte = document.createElement('div'); karte.className = 's';
-        var n = document.createElement('div'); n.className = 's-n'; n.textContent = sz.name;
-        var w = document.createElement('div'); w.className = 's-w'; w.textContent = geld(r.chfGesamt);
-        var m = document.createElement('div'); m.className = 's-m';
+        var karte = document.createElement('div'); karte.className = 'kennzahl';
+        var n = document.createElement('div'); n.className = 'k-label'; n.textContent = sz.name;
+        var w = document.createElement('div'); w.className = 'k-wert'; w.textContent = geld(r.chfGesamt);
+        var m = document.createElement('div'); m.className = 'k-note';
         m.textContent = fmt(Math.round(r.bleibend)) + ' von ' + fmt(Math.round(aktiveAbos(stats))) + ' Abos bleiben · ' +
                         Math.round(bleibeQuote(sz, 'gtv') * 100) + ' % goetheanum.tv, ' +
                         Math.round(bleibeQuote(sz, 'wos') * 100) + ' % Wochenschrift · monatliche Abos ' +
                         sz.monate + ' von zwölf Monaten';
         karte.appendChild(n); karte.appendChild(w); karte.appendChild(m);
         if (sz.key === ref.key){
-          var pill = document.createElement('div'); pill.className = 'pill';
+          var pill = document.createElement('div'); pill.className = 'chip ton';
           pill.textContent = 'Referenz – diese Zahl trägt den Rückfluss';
           karte.appendChild(pill);
         }
@@ -1600,10 +1600,10 @@
     ];
     host.innerHTML = '';
     karten.forEach(function(k){
-      var d = document.createElement('div'); d.className = 'g';
-      var n = document.createElement('div'); n.className = 'g-n'; n.textContent = k.n;
-      var w = document.createElement('div'); w.className = 'g-w'; w.textContent = k.w;
-      var m = document.createElement('div'); m.className = 'g-m'; m.textContent = k.m;
+      var d = document.createElement('div'); d.className = 'kennzahl';
+      var n = document.createElement('div'); n.className = 'k-label'; n.textContent = k.n;
+      var w = document.createElement('div'); w.className = 'k-wert'; w.textContent = k.w;
+      var m = document.createElement('div'); m.className = 'k-note'; m.textContent = k.m;
       d.appendChild(n); d.appendChild(w); d.appendChild(m); host.appendChild(d);
     });
   }

--- a/apps/sommer-zaehler/index.html
+++ b/apps/sommer-zaehler/index.html
@@ -64,7 +64,7 @@
         </div>
       </div>
 
-      <div class="gross" id="kopfZahlen"><div class="empty">lädt …</div></div>
+      <div class="kennzahlen" id="kopfZahlen"><div class="empty">lädt …</div></div>
     </div>
   </section>
 
@@ -80,10 +80,10 @@
       <div class="szen" id="szenKarten"><div class="empty">lädt …</div></div>
       <p class="provisorisch" id="szenarienNote"></p>
 
-      <div class="gross" style="margin-top:var(--s6)">
-        <div class="g"><div class="g-n">Kosten erfasst</div><div class="g-w" id="costTotal">–</div><div class="g-m">alle eingetragenen Posten</div></div>
-        <div class="g"><div class="g-n">Kosten je Abo</div><div class="g-w" id="costCpa">–</div><div class="g-m">erfasste Kosten geteilt durch alle Anmeldungen</div></div>
-        <div class="g"><div class="g-n">Rückfluss</div><div class="g-w" id="costRoi">–</div><div class="g-m">Folgejahr-Umsatz je eingesetztem Franken</div></div>
+      <div class="kennzahlen">
+        <div class="kennzahl"><div class="k-label">Kosten erfasst</div><div class="k-wert" id="costTotal">–</div><div class="k-note">alle eingetragenen Posten</div></div>
+        <div class="kennzahl"><div class="k-label">Kosten je Abo</div><div class="k-wert" id="costCpa">–</div><div class="k-note">erfasste Kosten geteilt durch alle Anmeldungen</div></div>
+        <div class="kennzahl"><div class="k-label">Rückfluss</div><div class="k-wert" id="costRoi">–</div><div class="k-note">Folgejahr-Umsatz je eingesetztem Franken</div></div>
       </div>
       <p class="provisorisch" id="kostenNote"></p>
 

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -16,6 +16,36 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ---
 
+## 9. August 2026 — die Skala hatte Löcher, und CSS schwieg darüber (1.12.0)
+
+**Was.** Die Abstands-Skala ist lückenlos geworden (`--s5:20px`, `--s7:28px`),
+die fünf Schnitte tragen jetzt ihre Hausnamen als Token (`--w-klar`, `--w-laut`,
+`--w-ruhig`; die alten `--w-text`/`--w-strong` bleiben als Zweitnamen gültig),
+und zwei Grundformen kamen dazu: **`.kennzahl`/`.kennzahlen`** (eine Fläche, die
+EINE Zahl trägt: Label, Wert, Notiz — mit grosszügigem Innenabstand) und
+**`.chip.ton`** (ein Chip, der einen ganzen Satz tragen kann). Neue Regel
+**DS10**: jedes `var(--x)` muss ein definiertes Token treffen.
+
+**Warum.** Im Sommer-Bericht klebte die Schrift auf den Kartenkanten. Der Grund
+war kein Gestaltungsfehler, sondern ein Systemfehler: `--s5` existierte nicht.
+Die Skala ging 4 · 8 · 12 · 16 · — · 24 · — · 32, und **CSS löst ein unbekanntes
+Token still zu nichts auf** — aus `padding:var(--s5)` wurde `padding:0`, ohne
+Fehler, ohne Warnung. **13 Dateien im Repo** griffen nach genau diesen beiden
+fehlenden Sprossen. Wer eine Skala mit Löchern baut, baut eine Falle: Die
+fehlende Sprosse ist die, nach der gegriffen wird.
+
+Derselbe Fehlertyp eine Ebene höher: Das Haus spricht von «Klar» und «Laut», die
+Token hiessen `--w-text` und `--w-strong`. Wer das Hauswort benutzte, griff ins
+Leere — DS10 fand es sofort an drei Stellen in der Werkzeugpost, wo seit je die
+falsche Strichstärke stand. **Ein Design-System, dessen Vokabular vom
+Sprachgebrauch des Hauses abweicht, erzeugt genau solche Fehler.**
+
+**Wirkung.** `tokens.css` (Skala geschlossen, Schnitt-Namen), `base.css`
+(`.kennzahl`, `.kennzahlen`, `.chip.ton`), `contract.json` (DS10),
+`tools/ds-lint.py` (`check_tokens`). Das Cockpit gab seine zwei lokalen
+Karten-Kopien und die eigene `.pill` ab und nutzt die Grundformen. Score
+zurück auf 100 Prozent — mit einer Wache mehr.
+
 ## [1.10.0] – 2026-08-04
 
 ### Der Seitentitel wird eine Rolle des Fundaments

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -40,7 +40,28 @@ Leere — DS10 fand es sofort an drei Stellen in der Werkzeugpost, wo seit je di
 falsche Strichstärke stand. **Ein Design-System, dessen Vokabular vom
 Sprachgebrauch des Hauses abweicht, erzeugt genau solche Fehler.**
 
-**Wirkung.** `tokens.css` (Skala geschlossen, Schnitt-Namen), `base.css`
+**Und die Pillen.** Dieselbe Frage, nächste Ebene: Die pillenförmigen Rollen
+trugen zwischen **0,14 und 0,67 em** senkrechter Luft — also gar keine Regel.
+Die engsten (`.zeichen`, `.ev-kanal`: 2 px bei 14 px Schrift) klebten sichtbar
+an der Rundung. Neu gibt es dafür ein Grundmass, **in em statt in Pixeln**, damit
+die Luft mit dem Schriftgrad wächst: `--pille-y:0.4em`, `--pille-x:0.95em`.
+Waagrecht knapp ein Geviert, weil eine volle Rundung die Ecken frisst — was beim
+Rechteck noch Abstand ist, berührt im Oval schon die Kurve. Alle Pillen sitzen
+jetzt auf diesem Mass; die Marke behält ihre ratifizierte optische Verschiebung
+nach oben, nur proportional statt absolut.
+
+**Und eine fehlende Zweitfarbe.** Beim Nachmessen fiel das grüne Merkzeichen
+«trägt die Aktion» mit **4,14:1** durch. Grund: Gold hatte seit je zwei
+Gestalten — `--gold` als Fläche, `--gold-ink` als Schrift —, Grün nur eine.
+`--ok` ist als Fläche definiert («Weiss drauf»); wer es als Schrift nahm, fiel
+unter AA. Neu: **`--ok-ink`** (hell `#39703f`, dunkel `#6bac76`), gerechnet
+gegen den grünen Ton auf Papier und auf Karte. *Eine Signalfarbe braucht beide
+Gestalten, sonst wird die Fläche als Schrift missbraucht.* Die getönten Marken
+mischen jetzt zudem über `--paper` statt über `transparent` — sonst nehmen sie
+die Farbe der Fläche an, auf der sie zufällig liegen.
+
+**Wirkung.** `tokens.css` (Skala geschlossen, Schnitt-Namen, Pillen-Luft,
+`--ok-ink`), `base.css`
 (`.kennzahl`, `.kennzahlen`, `.chip.ton`), `contract.json` (DS10),
 `tools/ds-lint.py` (`check_tokens`). Das Cockpit gab seine zwei lokalen
 Karten-Kopien und die eigene `.pill` ab und nutzt die Grundformen. Score

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -92,9 +92,37 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 .card{border:1px solid var(--line);border-radius:var(--r-card);padding:var(--s6);background:var(--paper)}
 .card.soft{background:var(--soft)}
 
+/* --- Kennzahl: die Grundform für eine Fläche, die EINE Zahl trägt ----------
+   Label (was), Wert (die Zahl), Notiz (woher/wie gerechnet) – in dieser
+   Reihenfolge, weil man erst wissen muss, was man liest. Der Innenabstand ist
+   bewusst gross: Eine Zahl in 32px braucht Rand, sonst liest sie sich als
+   Etikett statt als Aussage. Rhythmus innen aus Tokens, nicht aus rohen Pixeln.
+   .kennzahlen ist das Raster dazu – auto-fit, damit die Reihe von selbst
+   umbricht und keine Sonderregel je Breite nötig wird. */
+.kennzahlen{display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:var(--s4)}
+.kennzahl{background:var(--soft);border:1px solid var(--line);border-radius:var(--r-card);
+  padding:var(--s6);display:flex;flex-direction:column;gap:var(--s2)}
+.kennzahl .k-label{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);line-height:1.4}
+.kennzahl .k-wert{font-family:var(--font-display);font-weight:var(--w-strong);
+  font-size:clamp(26px,3.2vw,34px);color:var(--ink);
+  font-variant-numeric:tabular-nums lining-nums;line-height:var(--lh-tight)}
+.kennzahl .k-note{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);line-height:1.55}
+/* Auf Papier statt auf gedämpfter Fläche – für Kennzahlen, die selbst auf
+   einer --soft-Fläche liegen (sonst verschwindet die Kante). */
+.kennzahl.auf-papier{background:var(--paper)}
+
 /* --- Chips & Marken (Lese-Grotesk, kleine Grade) --------------------------- */
 .chip{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:6px 14px}
 .chip b{color:var(--ink);font-weight:600}
+/* Chip mit Ton: benennt etwas (‹Referenz›, ‹Entwurf›) statt es nur zu zeigen.
+   Trägt darum ganze Sätze – und braucht dafür mehr Luft als der Etiketten-Chip:
+   Innenabstand aus Tokens, Zeilenhöhe wie Lesetext, Umbruch erlaubt. Der Goldton
+   mischt über --paper, NICHT über transparent, sonst nimmt er die Farbe der
+   Fläche an, auf der er liegt, und frisst den Kontrast von --gold-ink (B02;
+   auf einer --soft-Karte gemessene 4.42:1 statt der nötigen 4.5:1). */
+.chip.ton{display:inline-block;border-color:transparent;border-radius:var(--r-control);
+  padding:var(--s2) var(--s4);line-height:1.5;
+  background:color-mix(in srgb,var(--gold) 14%,var(--paper));color:var(--gold-ink);max-width:100%}
 /* Status-Marke (Live/Beta/Entwurf …) – Mikro-Pille, kleiner als .chip, nie versal (G05).
    Optischer Sitz im Oval: Statuswörter haben meist keine Unterlängen – zentriert
    man das Geviert, sitzt die Tinte zu hoch. Darum line-height:1 und ein Hauch

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -112,7 +112,7 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 .kennzahl.auf-papier{background:var(--paper)}
 
 /* --- Chips & Marken (Lese-Grotesk, kleine Grade) --------------------------- */
-.chip{font-family:var(--font-text);font-size:var(--t-small);color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:6px 14px}
+.chip{font-family:var(--font-text);font-size:var(--t-small);line-height:1.35;color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:var(--pille-y) var(--pille-x)}
 .chip b{color:var(--ink);font-weight:600}
 /* Chip mit Ton: benennt etwas (‹Referenz›, ‹Entwurf›) statt es nur zu zeigen.
    Trägt darum ganze Sätze – und braucht dafür mehr Luft als der Etiketten-Chip:
@@ -121,13 +121,14 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
    Fläche an, auf der er liegt, und frisst den Kontrast von --gold-ink (B02;
    auf einer --soft-Karte gemessene 4.42:1 statt der nötigen 4.5:1). */
 .chip.ton{display:inline-block;border-color:transparent;border-radius:var(--r-control);
-  padding:var(--s2) var(--s4);line-height:1.5;
+  padding:var(--pille-y) var(--pille-x);line-height:1.5;
   background:color-mix(in srgb,var(--gold) 14%,var(--paper));color:var(--gold-ink);max-width:100%}
 /* Status-Marke (Live/Beta/Entwurf …) – Mikro-Pille, kleiner als .chip, nie versal (G05).
    Optischer Sitz im Oval: Statuswörter haben meist keine Unterlängen – zentriert
    man das Geviert, sitzt die Tinte zu hoch. Darum line-height:1 und ein Hauch
    mehr Luft oben (nachgemessen, nicht geschätzt). */
-.badge{display:inline-flex;align-items:center;line-height:1;font-family:var(--font-text);font-size:var(--t-micro);letter-spacing:.03em;color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);padding:6px 10px 3px}
+.badge{display:inline-flex;align-items:center;line-height:1;font-family:var(--font-text);font-size:var(--t-micro);letter-spacing:.03em;color:var(--muted);border:1px solid var(--line);border-radius:var(--r-pill);
+  padding:calc(var(--pille-y) + .12em) var(--pille-x) calc(var(--pille-y) - .12em)}
 
 /* Schritt-Nummer – runde Zahl-Marke vor nummerierten Zwischentiteln. Gold ist die
    Hausfarbe für Auswahl-/Schrittmarken (wie die Auswahl-Pille); .blue nur für

--- a/design-system/contract.json
+++ b/design-system/contract.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://goetheanum/design-system/contract.schema.json",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "titel": "Goetheanum Design-System – Struktur-Vertrag",
   "zweck": "Maschinenlesbare Grundlage der GESTALT-Konformität (symmetrisch zum sprachlichen Kanon in assets/typografie/). ds-lint.py prüft jede Seite hiergegen, ds-fix.py korrigiert deterministisch, das Schaufenster bildet es ab. Eine Quelle der Wahrheit für Struktur; Werte/Farben/Schnitte bleiben in tokens.css/tokens.json.",
   "geltungsbereich": {
@@ -191,5 +191,17 @@
     "grenze": "Rund ein Drittel der Kriterien ist maschinell prüfbar. Ein grüner Lauf heisst «keine der prüfbaren Regeln verletzt» — nicht «zugänglich». Beschriftungen, Reihenfolge und Verständlichkeit bleiben Sache der Aufmerksamkeit.",
     "artefakt_dateien": [],
     "artefakt_hinweis": "Physische Farben sind keine Bildschirmflächen — eine gedruckte Karte ist weiss, weil das Papier weiss ist. Blätter, deren Farben dem Papier gehören, stehen hier; dort entfällt allein die Kontrastprüfung, alle anderen Kriterien gelten weiter. Das ist die Entsprechung zum «# ds-ok» in den Stilblättern: die Maschine schlägt vor, der Mensch ratifiziert."
+  },
+  "tokens": {
+    "ds_id": "DS10",
+    "regel": "Jedes var(--x) muss ein definiertes Token treffen.",
+    "schwere": "fehler",
+    "quellen": [
+      "design-system/tokens.css",
+      "design-system/base.css",
+      "design-system/nav.css"
+    ],
+    "ausnahme": "var(--x, rueckfall) mit Rueckfallwert ist Absicht und wird nicht geprueft.",
+    "hinweis": "CSS loest ein unbekanntes Token still zu nichts auf – aus padding:var(--s5) wird padding:0, ohne Fehlermeldung. Ein Wert, der schweigend verschwindet, ist schlimmer als einer, der bricht: niemand sucht danach."
   }
 }

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -67,7 +67,12 @@
   --line:rgba(20,24,28,.10);
   --line-soft:rgba(20,24,28,.055);
   --bad:#b3261e;         /* Fehler/Warnung */
-  --ok:#3f7d46;          /* Erfolg/Bestätigung – Weiss drauf (--on-accent) */
+  --ok:#3f7d46;          /* Erfolg/Bestätigung als FLÄCHE – Weiss drauf (--on-accent) */
+  --ok-ink:#39703f;      /* Grün als TEXT – 4.92:1 auf grünem Ton über --paper, 4.66:1 über --soft,
+                            5.89:1 auf --paper (WCAG AA). Gold hatte diese Zweitfarbe seit je
+                            (--gold-ink), Grün nicht: Wer --ok als Schrift nahm, landete bei 4.14:1
+                            (gemessen am Merkzeichen «trägt die Aktion», 9.8.2026). Eine Signalfarbe
+                            braucht beide Gestalten, sonst wird die Fläche als Schrift missbraucht. */
   --on-accent:#fff;      /* Text auf Blau/Gold-Flächen */
   --on-accent-muted:#ccdff1; /* gedämpfter Sekundärtext auf Blau (Fusszeile/Meta) – 4.7:1 auf --blue (WCAG AA); Weiss bleibt --on-accent. Nicht für Fliesstext auf Gold/Grün (dort <4.5:1). */
   --ink-print-leise:#6e6f6a; /* leises Strukturbeiwerk auf PAPIERWEISS (Druckwerke:
@@ -167,6 +172,16 @@
      Gegen das Wiederauftreten wacht DS10 (unbekanntes Token = Fehler). */
   --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s5:20px; --s6:24px; --s7:28px; --s8:32px;
 
+  /* --- Pillen-Luft --------------------------------------------------------
+     Jede Pille (Chip, Marke, Merkzeichen) bekommt ihre Luft aus DIESEN zwei
+     Werten – in em, damit sie mit dem Schriftgrad wächst statt bei kleiner
+     Schrift zu ersticken. Gemessen am 9. August 2026: Die Pillen im Repo
+     trugen zwischen 0.14 und 0.67 em senkrechter Luft, also gar keine Regel;
+     die engsten (2px bei 14px Schrift) klebten sichtbar. Waagrecht knapp ein
+     Geviert, weil eine volle Rundung (--r-pill) die Ecken frisst: Was bei
+     einem Rechteck noch Abstand ist, berührt im Oval schon die Kurve. */
+  --pille-y:0.4em; --pille-x:0.95em;
+
   /* --- Radien, Maße, Fingerziel ------------------------------------------ */
   --r-control:10px; --r-card:14px; --r-pill:999px;
   --header-h:74px; --maxw:1080px; --ds-maxw:1080px;
@@ -194,6 +209,7 @@
   --bar-bg:rgba(20,23,26,.85);
   --line:rgba(255,255,255,.14); --line-soft:rgba(255,255,255,.07);
   --bad:#e0675e; --ok:#5aa367;   /* on-accent bleibt Weiss – kein dunkler Text auf Akzentflächen */
+  --ok-ink:#6bac76;              /* Grün als Text hellt im Dunkel auf – 5.36:1 auf grünem Ton */
   /* B7: keine pauschale Gewichtsabsenkung mehr – kleiner Lese-/UI-Text (Knöpfe,
      Label, Meta, Betonung) behält im Dunkeln sein Hell-Gewicht (Beier). Die
      Halations-Absenkung greift NUR an grossen Display-Rollen (siehe base.css). */

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -129,7 +129,16 @@
   --font-mono:ui-monospace,Menlo,Consolas,monospace;
 
   /* --- Schnitte (Goetheanum Variable) ------------------------------------- */
-  --w-leise:265; --w-text:440; --w-deutlich:580; --w-strong:680;
+  /* Die fünf Schnitte tragen im Haus Namen: Leise · Ruhig · Klar · Deutlich ·
+     Laut. Genau diese Namen sind jetzt auch die Token. Vorher hiessen zwei von
+     ihnen anders (--w-text für Klar, --w-strong für Laut) – wer das Hauswort
+     benutzte und «var(--w-klar)» schrieb, griff ins Leere, und CSS schwieg
+     dazu (gefunden von DS10 in der Werkzeugpost, drei Stellen). Ein
+     Design-System, dessen Vokabular vom Sprachgebrauch des Hauses abweicht,
+     erzeugt genau solche Fehler. Die alten Namen bleiben als Zweitnamen
+     gültig, damit kein Bestand bricht. */
+  --w-leise:265; --w-ruhig:350; --w-klar:440; --w-deutlich:580; --w-laut:680;
+  --w-text:var(--w-klar); --w-strong:var(--w-laut);
 
   /* --- Typo-Skala (mobil-first, flüssig, inklusiv) ------------------------ */
   /* Grund in rem → respektiert die Browser-Schriftgröße der Nutzer (WCAG resize,
@@ -147,8 +156,16 @@
   --lh-body:1.66; --lh-tight:1.15;   /* Display-als-Fliesstext braucht Luft (Zeilenabstand) */
   --measure:62ch;        /* ~66 Zeichen in Source – lineares Lesemaß (G10) */
 
-  /* --- Abstände (4/8/12/16/24/32) ---------------------------------------- */
-  --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s6:24px; --s8:32px;
+  /* --- Abstände (4/8/12/16/20/24/28/32) -----------------------------------
+     Die Skala ist LÜCKENLOS. Sie war es nicht: --s5 und --s7 fehlten, und weil
+     CSS ein unbekanntes Token stillschweigend zu nichts auflöst, wurde aus
+     «padding:var(--s5)» ein «padding:0». Genau das war am 9. August 2026 im
+     Sommer-Bericht zu sehen — Zahlenkacheln, deren Schrift auf der Kante klebte.
+     13 Dateien im Repo griffen nach diesen beiden Sprossen. Wer eine Skala mit
+     Löchern baut, baut eine Falle: Die fehlende Sprosse ist die, nach der
+     gegriffen wird. Neue Sprossen darum nur AM STÜCK ergänzen, nie einzeln.
+     Gegen das Wiederauftreten wacht DS10 (unbekanntes Token = Fehler). */
+  --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s5:20px; --s6:24px; --s7:28px; --s8:32px;
 
   /* --- Radien, Maße, Fingerziel ------------------------------------------ */
   --r-control:10px; --r-card:14px; --r-pill:999px;

--- a/docs/schlussbericht-datensammlung.md
+++ b/docs/schlussbericht-datensammlung.md
@@ -93,6 +93,31 @@ teuerste Weg fehlt.
   Flyer Empfang» und «Auslage Flyer Buchhandlung» (10. Juli). Wo nichts
   gemessen ist: verteilte Stückzahl eintragen und das in der Notiz sagen.
 
+## Zwei Arten von Kosten — nicht vermischen (Hinweis 9. August)
+
+Bisher kennt das Cockpit **eine** Sorte Kosten: einmalige Kampagnenkosten
+(Druck, Anzeige, Stunden), verteilt über alle Abos. Das reicht nicht. Es kommt
+eine zweite Sorte dazu — **Stückkosten je Abo und Jahr**, und die sind je Strom
+verschieden:
+
+| Strom | Stückkosten | Bemerkung |
+|---|---|---|
+| Wochenschrift **Papier** | Druck + Porto je Heft | grob rechenbar; **darf nicht auf alle Abos verteilt werden** |
+| goetheanum.tv | Gebühr je Uscreen-Abo | folgt |
+| Wochenschrift **Digital** | keine | durch die laufende Infrastruktur gedeckt |
+
+Die Folge für den Bericht ist nicht kosmetisch: Aus dem Folgejahr-**Umsatz**
+wird erst mit diesen Zahlen ein **Deckungsbeitrag**. Und weil die Stückkosten
+am Papier hängen, verschiebt sich damit auch die Rangfolge der Ströme — ein
+Papier-Abo bringt mehr Umsatz und kostet mehr; ob es netto mehr trägt als ein
+digitales, ist heute unbeantwortet.
+
+Zu sammeln sind darum **je Strom zwei Zahlen**: Herstellkosten je Ausgabe und
+Portokosten je Ausgabe (Wochenschrift Papier, je Zone, wenn es sich unterscheidet)
+sowie die Uscreen-Gebühr je Abo und Monat. Sobald sie vorliegen, bekommt das
+Cockpit eine eigene Struktur dafür (`CONFIG.stueckkosten` je Strom) — vorher
+nicht: Eine leere Struktur mit Nullen darin sähe aus wie «kostet nichts».
+
 ## Zwei offene Fragen, keine Zahlen
 
 - **Inserate VaG und RSV** (13. Juli, Notiz «Bei Bruno Zweifel angefragt») —

--- a/tools/ds-lint.py
+++ b/tools/ds-lint.py
@@ -6,7 +6,7 @@ Goetheanum DS-Lint – prüft die GESTALT-Konformität jeder Seite gegen den Ver
 Symmetrisch zu tools/typo-check.py (Sprache): dieses Werkzeug erzwingt die
 Struktur des Design-Systems, statt sie hinterher von Hand nachzukontrollieren.
 
-Quelle der Wahrheit:  design-system/contract.json  (Regeln DS01–DS07).
+Quelle der Wahrheit:  design-system/contract.json  (Regeln DS01–DS10).
 Geltungsbereich:      versionierte *.html mit <body> (Werkzeug-/Schau-Seiten).
                       Reine Weiterleitungs-Stubs (meta refresh) werden übersprungen.
 Geprüft wird nur CSS: <style>-Blöcke und style="…"-Attribute; <script> bleibt aussen
@@ -161,6 +161,53 @@ def check_colors_sizes(body, base_off, full, findings, c, skip_lines):
                              f"{prop.strip()}: hartverdrahtete Farbe {lit} – var(--…) nutzen"))
 
 
+_TOKENS = None
+def bekannte_tokens():
+    """Alle im Fundament definierten Custom Properties.
+
+    Grund für DS10: CSS löst ein unbekanntes Token STILL zu nichts auf. Aus
+    »padding:var(--s5)« wird »padding:0«, ohne Fehler, ohne Warnung – am
+    9. August 2026 klebte deshalb im Sommer-Bericht die Schrift auf der
+    Kartenkante, und 13 Dateien im Repo griffen nach derselben fehlenden
+    Sprosse. Ein Wert, der schweigend verschwindet, ist schlimmer als einer,
+    der bricht: Niemand sucht danach."""
+    global _TOKENS
+    if _TOKENS is None:
+        _TOKENS = set()
+        for datei in ("design-system/tokens.css", "design-system/base.css",
+                      "design-system/nav.css"):
+            pfad = os.path.join(ROOT, datei)
+            if os.path.exists(pfad):
+                _TOKENS |= set(re.findall(r"(--[a-zA-Z0-9_-]+)\s*:", open(pfad, encoding="utf-8").read()))
+    return _TOKENS
+
+
+def check_tokens(full, findings, skip_lines, path):
+    """DS10 – jedes var(--x) muss ein definiertes Token treffen."""
+    # Was die Datei selbst definiert (eigener <style>, Inline-Stil, JS-gesetzt),
+    # zählt als bekannt – geprüft wird die Lücke zum Fundament, nicht der
+    # legitime lokale Eigenbau.
+    lokal = set(re.findall(r"(--[a-zA-Z0-9_-]+)\s*:", full))
+    # Begleitende CSS-Dateien der Seite mitlesen (<link href="x.css">).
+    for rel in re.findall(r'<link[^>]+href\s*=\s*["\']([^"\']+\.css)["\']', full):
+        kandidat = os.path.normpath(os.path.join(os.path.dirname(os.path.join(ROOT, path)), rel))
+        if os.path.exists(kandidat):
+            lokal |= set(re.findall(r"(--[a-zA-Z0-9_-]+)\s*:", open(kandidat, encoding="utf-8").read()))
+    bekannt = bekannte_tokens() | lokal
+    gemeldet = set()
+    for m in re.finditer(r"var\(\s*(--[a-zA-Z0-9_-]+)\s*([,)])", full):
+        name, weiter = m.group(1), m.group(2)
+        if name in bekannt or weiter == ",":   # mit Rückfallwert ist es Absicht
+            continue
+        ln = lineno(full, m.start())
+        if ln in skip_lines or (name, ln) in gemeldet:
+            continue
+        gemeldet.add((name, ln))
+        findings.append((ln, "DS10", "fehler",
+                         f"unbekanntes Token {name} – CSS löst es still zu nichts auf; "
+                         f"Skala in tokens.css prüfen oder Rückfallwert setzen"))
+
+
 def lint_file(path, c):
     full = open(os.path.join(ROOT, path), encoding="utf-8").read()
     if is_stub(full):
@@ -174,6 +221,9 @@ def lint_file(path, c):
         if lineno(full, m.start()) not in skip_lines:
             findings.append((lineno(full, m.start()), "DS00", "hinweis",
                              "ds-ok-Marker im falschen Format – »# ds-ok« schreiben, sonst wirkungslos"))
+
+    # DS10 – unbekannte Token (still verschwindende Werte)
+    check_tokens(full, findings, skip_lines, path)
 
     # DS01 – Pflicht-Includes
     for inc in c["includes"]["pflicht"]:


### PR DESCRIPTION
Drei Befunde, ein Muster: **Werte, die still verschwinden oder nie festgelegt wurden.**

## 1 · Die Skala hatte Löcher

Die Zahlenkacheln hatten `padding: 0`. Nicht zu wenig — gar keinen:

```
--s1:4px  --s2:8px  --s3:12px  --s4:16px  ✗  --s6:24px  ✗  --s8:32px
```

**`--s5` existierte nicht.** CSS löst ein unbekanntes Token **still zu nichts** auf. **13 Dateien im Repo** griffen nach genau diesen beiden fehlenden Sprossen. Wer eine Skala mit Löchern baut, baut eine Falle: Die fehlende Sprosse ist die, nach der gegriffen wird.

→ Skala geschlossen (`--s5:20px`, `--s7:28px`). 13 Dateien wirken jetzt wie gemeint, ohne dass eine angefasst wurde.

## 2 · Die Pillen hatten keine Regel

Nachgemessen, nicht geschätzt:

| Rolle | Grad | Luft ↕ | Luft ↔ |
|---|---:|---:|---:|
| `.zeichen` («trägt die Aktion») | 14 | **0,14** | 0,71 |
| `.ev-kanal` | 14 | **0,14** | 0,71 |
| `.badge` | 14 | 0,32 | 0,71 |
| `.chip.ton` | 16 | 0,50 | 1,00 |
| `.btn` | 15 | 0,67 | 1,07 |

Von 0,14 bis 0,67 — das ist Zufall, keine Ordnung. Die engsten hatten 2 px bei 14 px Schrift.

→ Ein Grundmass, **in em statt in Pixeln**, damit die Luft mit dem Schriftgrad wächst: `--pille-y:0.4em`, `--pille-x:0.95em`. Waagrecht knapp ein Geviert, weil eine volle Rundung die Ecken frisst — was beim Rechteck noch Abstand ist, berührt im Oval schon die Kurve. Die Marke behält ihre ratifizierte optische Verschiebung, nur proportional statt absolut.

## 3 · Grün hatte keine Textfarbe

Beim Nachmessen fiel das grüne Merkzeichen mit **4,14:1** durch. Der Grund ist strukturell: Gold hat seit je zwei Gestalten — `--gold` als Fläche, `--gold-ink` als Schrift. Grün hatte nur eine, und `--ok` ist ausdrücklich als Fläche definiert («Weiss drauf»).

→ Neu **`--ok-ink`** (hell `#39703f`, dunkel `#6bac76`), gerechnet gegen den grünen Ton auf Papier *und* auf Karte. *Eine Signalfarbe braucht beide Gestalten, sonst wird die Fläche als Schrift missbraucht.* Dazu mischen die getönten Marken jetzt über `--paper` statt über `transparent` — sonst nehmen sie die Farbe der Fläche an, auf der sie zufällig liegen.

## Dazu: Grundformen und eine Wache

- **`.kennzahl` / `.kennzahlen`** in `base.css` — die Grundform für eine Fläche, die *eine* Zahl trägt. Das Cockpit gab seine zwei Karten-Kopien und die eigene `.pill` ab.
- **DS10** — jedes `var(--x)` muss ein definiertes Token treffen; `var(--x, rückfall)` bleibt erlaubt. *Ein Wert, der schweigend verschwindet, ist schlimmer als einer, der bricht — niemand sucht danach.*
- DS10 fand sofort denselben Fehlertyp eine Ebene höher: Das Haus sagt «Klar», das Token hiess `--w-text`. **Drei Stellen in der Werkzeugpost standen seit je in der falschen Strichstärke.** Die fünf Schnitte tragen jetzt ihre Hausnamen; die alten bleiben als Zweitnamen gültig.

## Gemessen

| | vorher | jetzt |
|---|---|---|
| Kennzahl-Kachel | `padding 0px` | `24px`, Rhythmus `8px` |
| Pillen senkrecht | 0,14–0,67 em | **0,4 em**, überall |
| Merkzeichen grün | 4,14:1 | **4,92:1** (hell) · 5,37:1 (dunkel) |

`ds-lint` repo-weit 100 % · `barrierefreiheit.mjs` ohne Verstoss · Ledger und Vertrag nachgeführt (**1.12.0**).

## Nebenbei notiert

Es kommen **Stückkosten je Abo** — Druck und Porto beim Papier, Uscreen-Gebühr bei goetheanum.tv, digital gedeckt. Sie dürfen **nicht** über alle Abos verteilt werden; aus dem Umsatz wird damit erst ein Deckungsbeitrag. Steht in der Sammel-Liste; die Struktur folgt mit den Zahlen.