### PR TITLE
Frist als Instrument + Uscreen-Vollabgleich: 626 statt 665

### DIFF
--- a/apps/sommer-zaehler/campaign.css
+++ b/apps/sommer-zaehler/campaign.css
@@ -75,6 +75,9 @@
   .tarif thead th{color:var(--muted);font-weight:600;font-size:var(--t-micro)}
   .tarif td.num,.tarif th.num{text-align:right;font-variant-numeric:tabular-nums lining-nums}
   .tarif tfoot td{font-weight:600;border-top:2px solid var(--line);border-bottom:0}
+  /* Zwei Spalten brauchen die Mindestbreite nicht. Mit ihr schob sich auf dem
+     Handy ausgerechnet die Summe hinter den rechten Rand. */
+  .tarif.schmal{min-width:0}
   .tarif .prod-h td{background:var(--soft);color:var(--gold-ink);font-weight:600}
 
   .provisorisch{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);margin-top:var(--s4);line-height:1.55}
@@ -248,6 +251,10 @@
   @media (max-width:720px){ .mvform{grid-template-columns:1fr 1fr} }
   .medit{font-family:var(--font-text);font-size:var(--t-micro);color:var(--muted);background:none;border:0;cursor:pointer;padding:4px 6px;min-height:var(--tap)}
   .medit:hover{color:var(--blue)} td.act{text-align:right;white-space:nowrap}
+  /* Löschen ist erreichbar, aber nicht die erste Farbe im Blatt: gedämpft, bis
+     der Finger darauf liegt. Rot erst beim Zeigen (--bad trägt als Schrift). */
+  .medit.weg:hover,.medit.weg:focus-visible{color:var(--bad)}
+  .medit[disabled]{opacity:.5;pointer-events:none}
   .zb-form{margin-top:var(--s5)}
   .zb-form summary{cursor:pointer;font-family:var(--font-text);font-weight:600;color:var(--ink);min-height:var(--tap);display:flex;align-items:center}
   .zb-form .grid{display:grid;grid-template-columns:repeat(3,1fr);gap:var(--s4);margin-top:var(--s4)}

--- a/apps/sommer-zaehler/campaign.js
+++ b/apps/sommer-zaehler/campaign.js
@@ -1074,10 +1074,14 @@
   // erscheint sofort überall. Bearbeiten lädt die Zeile über den Knopf im Protokoll.
   if (el('mfTag')) el('mfTag').value = new Date().toISOString().slice(0, 10);
   if (el('mfBtn')) el('mfBtn').addEventListener('click', function(){
-    var sagen = function(msg, bad){ var s = el('mfSaid'); s.textContent = msg; s.style.color = bad ? 'var(--bad)' : 'var(--ok)'; };
+    var sagen = function(msg, bad){ meldung('mfSaid', msg, bad); };
     var titel = (el('mfTitel').value || '').trim();
     var wer = (el('mfWer').value || '').trim();
     if (!el('mfTag').value || !titel || !wer){ sagen('Datum, Aktivität und Kürzel sind Pflicht.', true); return; }
+    // Wie bei den Kosten: kein zweiter Klick, solange der erste schreibt.
+    var mfB = el('mfBtn'), mfText = mfB.textContent;
+    mfB.disabled = true; mfB.textContent = 'Wird gespeichert …';
+    var mfFrei = function(){ mfB.disabled = false; mfB.textContent = mfText; };
     var zahl = function(id){ var e = el(id); return (e && e.value !== '') ? Math.max(0, Math.round(Number(e.value) || 0)) : null; };
     var istEdit = mfEditId != null;
     var notiz = el('mfNotiz') ? (el('mfNotiz').value || '').trim() : '';
@@ -1095,6 +1099,7 @@
       body: JSON.stringify(params)
     }).then(function(r){ if(!r.ok) throw new Error(r.status); return r.json(); })
       .then(function(ergebnis){
+        mfFrei();
         if (ergebnis === 'ok'){
           sagen(istEdit ? 'Geändert.' : 'Eingetragen – erscheint im Zeitband, im Protokoll und in der Reichweite.');
           mfZuruecksetzen();
@@ -1110,7 +1115,7 @@
             .catch(function(){});
         } else { sagen('Datum und Aktivität prüfen.', true); }
       })
-      .catch(function(){ sagen(istEdit ? 'Ändern nicht erreichbar.' : 'Eintragen nicht erreichbar.', true); });
+      .catch(function(){ mfFrei(); sagen(istEdit ? 'Ändern nicht erreichbar.' : 'Eintragen nicht erreichbar.', true); });
   });
 
   function renderMassnahmen(rows){
@@ -1355,7 +1360,7 @@
     }
     if (el('kostenNote')) el('kostenNote').textContent = voll
       ? 'Alle bekannten Kosten sind erfasst; Kosten je Abo und Rückfluss rechnen darauf.'
-      : 'Kosten je Abo und Rückfluss bleiben leer, solange die Kosten unvollständig sind — vor allem der Betrag der bezahlten Anzeige fehlt. '
+      : 'Kosten je Abo und Rückfluss bleiben leer, solange die Kosten unvollständig sind — die bezahlten Anzeigen stehen seit dem 10. August drin, die internen Stunden fehlen noch. '
         + 'Gerechnet würden daraus sonst Zahlen, die technisch stimmen und trotzdem täuschen. Was fehlt, steht in docs/schlussbericht-datensammlung.md; eingetragen wird es unter Kosten.';
 
     var body = el('costBody'); body.innerHTML = '';
@@ -1373,42 +1378,185 @@
 
     var pb = el('kostenPostenBody'); pb.innerHTML = '';
     if (!posten.length){
-      pb.innerHTML = '<tr><td class="empty" colspan="4">Noch keine Einzelposten erfasst.</td></tr>';
+      pb.innerHTML = '<tr><td class="empty" colspan="5">Noch keine Einzelposten erfasst.</td></tr>';
     } else {
       posten.forEach(function(k){
         var tr = document.createElement('tr');
-        tr.innerHTML = '<td></td><td></td><td></td><td class="num"></td>';
+        tr.innerHTML = '<td></td><td></td><td></td><td class="num"></td><td class="act"></td>';
         tr.children[0].textContent = k.tag ? new Date(k.tag + 'T00:00:00').toLocaleDateString('de-CH', { day:'numeric', month:'numeric' }) : '–';
         tr.children[1].textContent = (k.posten || '') + (k.ersteller ? ' · ' + k.ersteller : '');
+        // Stunden bleiben sichtbar, nicht nur ihr Franken-Wert: «8 h × CHF 80»
+        // sagt im Bericht mehr als «CHF 640».
+        if (k.stunden != null){
+          var sn = document.createElement('span'); sn.className = 'mnote';
+          sn.textContent = zahlKurz(k.stunden) + ' h' + (k.ansatz != null ? ' × ' + geld(k.ansatz) : '');
+          tr.children[1].appendChild(sn);
+        }
         tr.children[2].textContent = KAT_LABEL[k.kategorie] || k.kategorie || '';
         tr.children[3].textContent = geld(k.betrag);
+        if (el('kfBtn')){   // Löschen nur dort, wo auch eingetragen wird
+          var weg = document.createElement('button');
+          weg.type = 'button'; weg.className = 'medit weg';
+          weg.textContent = 'Löschen';
+          weg.setAttribute('aria-label', 'Posten ' + (k.posten || '') + ' löschen');
+          weg.addEventListener('click', function(){ kostenLoeschen(k, weg); });
+          tr.children[4].appendChild(weg);
+        }
         pb.appendChild(tr);
       });
     }
   }
 
-  // Kosten eintragen: offener Schreibweg mit Pflicht-Kuerzel.
-  if (el('kfTag')) el('kfTag').value = new Date().toISOString().slice(0, 10);
-  if (el('kfBtn')) el('kfBtn').addEventListener('click', function(){
-    var sagen = function(msg, bad){ var s = el('kfSaid'); s.textContent = msg; s.style.color = bad ? 'var(--bad)' : 'var(--ok)'; };
-    var posten = (el('kfPosten').value || '').trim();
-    var wer = (el('kfWer').value || '').trim();
-    var betrag = el('kfBetrag').value;
-    if (!el('kfTag').value || !posten || !wer || betrag === '' || Number(betrag) < 0){ sagen('Datum, Posten, Betrag und Kürzel sind Pflicht.', true); return; }
-    fetch(SB + '/rest/v1/rpc/sommer2026_kosten_eintragen', {
+  // Zahl ohne unnötige Nullen: 8 statt 8.00, 2,5 statt 2.50.
+  function zahlKurz(n){
+    var z = Number(n) || 0;
+    return (Math.round(z * 100) / 100).toString().replace('.', ',');
+  }
+
+  // Löschen ist so offen wie Eintragen – wer einen Posten anlegen darf, muss
+  // den eigenen Fehler wegnehmen können, ohne jemanden zu fragen. Genau das
+  // hat am 10. August gefehlt: Ein Doppelklick landete zweimal in der Summe
+  // und musste von Hand aus der Datenbank geholt werden.
+  function kostenLoeschen(k, btn){
+    var sagen = function(msg, bad){ meldung('kfSaid', msg, bad); };
+    var wer = kfKuerzel();
+    if (!wer){ sagen('Zuerst das eigene Kürzel oben eintragen – dann löschen.', true); if (el('kfWer')) el('kfWer').focus(); return; }
+    if (!window.confirm('Posten «' + (k.posten || '') + '» über ' + geld(k.betrag) + ' wirklich löschen?')) return;
+    btn.disabled = true;
+    fetch(SB + '/rest/v1/rpc/sommer2026_kosten_loeschen', {
       method: 'POST',
       headers: { 'Content-Type':'application/json', 'apikey':KEY, 'Authorization':'Bearer ' + KEY },
-      body: JSON.stringify({ p_tag: el('kfTag').value, p_posten: posten, p_kategorie: el('kfKategorie').value, p_betrag: Number(betrag), p_ersteller: wer })
+      body: JSON.stringify({ p_id: k.id, p_ersteller: wer })
     }).then(function(r){ if(!r.ok) throw new Error(r.status); return r.json(); })
       .then(function(ergebnis){
         if (ergebnis === 'ok'){
-          sagen('Eingetragen – Summe, Kosten je Abo und Rückfluss sind aktualisiert.');
-          el('kfPosten').value = ''; el('kfBetrag').value = '';
-          rpc('sommer2026_kosten_public').then(function(rows){ renderKosten(lastTotal, lastRevenue, rows); }).catch(function(){});
-        } else { sagen('Angaben prüfen.', true); }
+          sagen('Gelöscht: ' + (k.posten || '') + ' · ' + geld(k.betrag) + '.');
+          kostenNeuLaden();
+        } else { btn.disabled = false; sagen('Der Posten war schon weg.', true); }
       })
-      .catch(function(){ sagen('Eintragen nicht erreichbar.', true); });
-  });
+      .catch(function(){ btn.disabled = false; sagen('Löschen nicht erreichbar.', true); });
+  }
+
+  function kostenNeuLaden(){
+    return rpc('sommer2026_kosten_public')
+      .then(function(rows){ renderKosten(lastTotal, lastRevenue, rows); })
+      .catch(function(){});
+  }
+
+  // Rückmeldung: Farbe über die Klasse, nicht über style – sonst bleibt Grün
+  // im Dunkelmodus stehen und fällt unter den Kontrast (B05).
+  function meldung(id, text, schlecht){
+    var s = el(id); if (!s) return;
+    s.textContent = text;
+    s.className = 'said ' + (schlecht ? 'schlecht' : 'gut');
+  }
+
+  // ── Kosten eintragen ───────────────────────────────────────────────────────
+  // Offener Schreibweg mit Pflicht-Kürzel. Die Maske sagt je Kostenart, was
+  // hineingehört: Bei ‹Stunden intern› fragte sie bisher nach einem «Betrag in
+  // Franken» – und niemand wusste, ob Stunden oder Franken gemeint sind
+  // (Rückmeldung Team, 10. August). Jetzt fragt sie nach Stunden und rechnet.
+  var KAT_HINWEIS = {
+    stunden:        'Eigene Arbeitszeit. Stunden und Ansatz eintragen – die Franken rechnet das Werkzeug.',
+    social:         'Bezahlte Anzeigen und was ihre Gestaltung gekostet hat: Meta, YouTube, Instagram.',
+    druck:          'Druck, Papier, Porto, Versand, Material am Stand.',
+    infrastruktur:  'Dienste, die die Aktion getragen haben: Aktionsseiten, Mailversand, Video-Plattform.',
+    andere:         'Was in keine der anderen Arten passt – im Posten sagen, was es ist.'
+  };
+  var KAT_BEISPIEL = {
+    stunden:        'z. B. Redaktion Mailtexte',
+    social:         'z. B. Meta-Anzeige Juli',
+    druck:          'z. B. Flyer DE 1000 Stück',
+    infrastruktur:  'z. B. Landingpage Hosting Juli',
+    andere:         'z. B. Inserat BZ Basel, halbe Seite'
+  };
+  var KF_KUERZEL = 'sommer2026:kuerzel';
+
+  function kfKuerzel(){ return el('kfWer') ? (el('kfWer').value || '').trim() : ''; }
+  function kfStundenModus(){ return el('kfKategorie') && el('kfKategorie').value === 'stunden'; }
+
+  // Was am Ende in der Datenbank steht, ist immer ein Franken-Betrag. Im
+  // Stunden-Modus entsteht er aus Stunden × Ansatz – und wird vor dem Klick
+  // ausgeschrieben, damit niemand eine Zahl abschickt, die er nicht gesehen hat.
+  function kfBetragJetzt(){
+    if (!kfStundenModus()) return el('kfBetrag').value === '' ? null : Number(el('kfBetrag').value);
+    var h = Number(el('kfStunden').value), a = Number(el('kfAnsatz').value);
+    if (!(h > 0) || !(a >= 0)) return null;
+    return Math.round(h * a * 100) / 100;
+  }
+
+  function kfMaskeStellen(){
+    if (!el('kfKategorie')) return;
+    var kat = el('kfKategorie').value, stunden = kat === 'stunden';
+    el('kfBetragFeld').hidden = stunden;
+    el('kfStundenFeld').hidden = !stunden;
+    el('kfAnsatzFeld').hidden = !stunden;
+    el('kfKatHint').textContent = KAT_HINWEIS[kat] || '';
+    el('kfPosten').placeholder = KAT_BEISPIEL[kat] || '';
+    var r = el('kfRechnung'), b = kfBetragJetzt();
+    if (stunden && b != null){
+      r.hidden = false;
+      r.textContent = 'Das ergibt ' + geld(b) + ' – so steht es nachher in der Summe.';
+    } else { r.hidden = true; r.textContent = ''; }
+  }
+
+  if (el('kfBtn')){
+    el('kfTag').value = new Date().toISOString().slice(0, 10);
+    try { var gemerkt = localStorage.getItem(KF_KUERZEL); if (gemerkt) el('kfWer').value = gemerkt; } catch(e){}
+    el('kfKategorie').addEventListener('change', kfMaskeStellen);
+    ['kfStunden','kfAnsatz'].forEach(function(id){ el(id).addEventListener('input', kfMaskeStellen); });
+    kfMaskeStellen();
+
+    el('kfBtn').addEventListener('click', function(){
+      var sagen = function(msg, bad){ meldung('kfSaid', msg, bad); };
+      var btn = el('kfBtn');
+      var posten = (el('kfPosten').value || '').trim();
+      var wer = kfKuerzel();
+      var betrag = kfBetragJetzt();
+
+      // Fehlt etwas, sagen wir welches Feld – und springen hin.
+      var fehlt = null;
+      if (!posten) fehlt = ['Wofür ist das Geld gegangen?', 'kfPosten'];
+      else if (betrag == null || betrag < 0) fehlt = kfStundenModus()
+        ? ['Wie viele Stunden waren es?', 'kfStunden']
+        : ['Wie viel hat es gekostet?', 'kfBetrag'];
+      else if (!el('kfTag').value) fehlt = ['Welches Datum?', 'kfTag'];
+      else if (!wer) fehlt = ['Noch das eigene Kürzel – dann ist klar, wer eingetragen hat.', 'kfWer'];
+      if (fehlt){ sagen(fehlt[0], true); el(fehlt[1]).focus(); return; }
+
+      // Der Knopf nimmt keinen zweiten Klick an, solange er schreibt.
+      btn.disabled = true;
+      var beschriftung = btn.textContent;
+      btn.textContent = 'Wird eingetragen …';
+      var frei = function(){ btn.disabled = false; btn.textContent = beschriftung; };
+
+      try { localStorage.setItem(KF_KUERZEL, wer); } catch(e){}
+      fetch(SB + '/rest/v1/rpc/sommer2026_kosten_eintragen', {
+        method: 'POST',
+        headers: { 'Content-Type':'application/json', 'apikey':KEY, 'Authorization':'Bearer ' + KEY },
+        body: JSON.stringify({
+          p_tag: el('kfTag').value, p_posten: posten, p_kategorie: el('kfKategorie').value,
+          p_betrag: betrag, p_ersteller: wer,
+          p_stunden: kfStundenModus() ? Number(el('kfStunden').value) : null,
+          p_ansatz:  kfStundenModus() ? Number(el('kfAnsatz').value)  : null
+        })
+      }).then(function(r){ if(!r.ok) throw new Error(r.status); return r.json(); })
+        .then(function(ergebnis){
+          frei();
+          if (ergebnis === 'ok'){
+            sagen('Eingetragen: ' + posten + ' · ' + geld(betrag) + '. Summe, Kosten je Abo und Rückfluss sind aktualisiert.');
+            el('kfPosten').value = ''; el('kfBetrag').value = ''; el('kfStunden').value = '';
+            kfMaskeStellen();
+            el('kfPosten').focus();
+            kostenNeuLaden();
+          } else if (ergebnis === 'doppelt'){
+            sagen('Dieser Posten steht mit demselben Betrag schon in der Liste – nichts doppelt eingetragen.', true);
+            kostenNeuLaden();
+          } else { sagen('Angaben prüfen.', true); }
+        })
+        .catch(function(){ frei(); sagen('Eintragen nicht erreichbar – bitte gleich noch einmal.', true); });
+    });
+  }
 
   // ── Tarif-Tabelle ──────────────────────────────────────────────────────────
   function renderTarif(rows){

--- a/apps/sommer-zaehler/kosten.html
+++ b/apps/sommer-zaehler/kosten.html
@@ -74,8 +74,8 @@
 
         <label class="field" id="kfAnsatzFeld" hidden>
           <span class="lab">Ansatz je Stunde</span>
-          <input type="number" id="kfAnsatz" min="0" step="5" inputmode="decimal" value="80" />
-          <span class="hint">Interner Vollkosten-Ansatz in Franken. Vorschlag: 80.</span>
+          <input type="number" id="kfAnsatz" min="0" step="5" inputmode="decimal" value="60" />
+          <span class="hint">Interner Ansatz in Franken, Hausvorgabe 60. Nur ändern, wenn es für diesen Posten anders gilt.</span>
         </label>
 
         <label class="field">

--- a/apps/sommer-zaehler/kosten.html
+++ b/apps/sommer-zaehler/kosten.html
@@ -28,65 +28,104 @@
     <p class="kampagne">Was die Aktion kostet – und was voraussichtlich zurückkommt. Eintragen erscheint sofort im Cockpit.</p>
   </section>
 
+  <!-- Eintragen steht oben und offen: Es ist die Handlung, für die man diese
+       Seite aufruft. Die Auswertung darunter ist das Ergebnis, nicht der Weg. -->
+  <section id="eintragen">
+    <div class="shead">
+      <h2>Kosten eintragen</h2>
+      <p>Ein Posten je Ausgabe. Alles zählt sofort in Summe, Kosten je Abo und Rückfluss – und lässt sich unten wieder löschen.</p>
+    </div>
+
+    <div class="card soft">
+      <div class="formgrid">
+
+        <label class="field span2">
+          <span class="lab">Wofür? <b>Pflicht</b></span>
+          <input type="text" id="kfPosten" placeholder="z. B. Meta-Anzeige Juli" autocomplete="off" />
+          <span class="hint" id="kfPostenHint">Kurz und wiedererkennbar – so steht es später im Bericht.</span>
+        </label>
+
+        <label class="field">
+          <span class="lab">Was für eine Kosten­art? <b>Pflicht</b></span>
+          <select id="kfKategorie">
+            <option value="stunden">Stunden intern</option>
+            <option value="social">Social Media</option>
+            <option value="druck">Druck &amp; Versand</option>
+            <option value="infrastruktur">Infrastruktur</option>
+            <option value="andere">Andere</option>
+          </select>
+          <span class="hint" id="kfKatHint"></span>
+        </label>
+
+        <!-- Franken-Feld: der Normalfall. Bei Stunden intern tritt das
+             Stunden-Paar an seine Stelle, damit niemand raten muss, was in
+             ein Feld ‹Betrag in CHF› gehört. -->
+        <label class="field" id="kfBetragFeld">
+          <span class="lab">Wie viel in Franken? <b>Pflicht</b></span>
+          <input type="number" id="kfBetrag" min="0" step="0.05" inputmode="decimal" placeholder="0.00" />
+          <span class="hint">Ganze Rechnung, ohne Währungszeichen.</span>
+        </label>
+
+        <label class="field" id="kfStundenFeld" hidden>
+          <span class="lab">Wie viele Stunden? <b>Pflicht</b></span>
+          <input type="number" id="kfStunden" min="0" step="0.25" inputmode="decimal" placeholder="z. B. 8" />
+          <span class="hint">Grobe Schätzung genügt – Viertelstunden möglich.</span>
+        </label>
+
+        <label class="field" id="kfAnsatzFeld" hidden>
+          <span class="lab">Ansatz je Stunde</span>
+          <input type="number" id="kfAnsatz" min="0" step="5" inputmode="decimal" value="80" />
+          <span class="hint">Interner Vollkosten-Ansatz in Franken. Vorschlag: 80.</span>
+        </label>
+
+        <label class="field">
+          <span class="lab">Wann?</span>
+          <input type="date" id="kfTag" />
+          <span class="hint">Datum der Rechnung oder der Arbeit. Heute ist voreingestellt.</span>
+        </label>
+
+        <label class="field">
+          <span class="lab">Dein Kürzel <b>Pflicht</b></span>
+          <input type="text" id="kfWer" placeholder="z. B. hao" autocomplete="off" maxlength="8" />
+          <span class="hint">Zwei bis vier Buchstaben. Wird für das nächste Mal gemerkt.</span>
+        </label>
+
+        <p class="hint span3" id="kfRechnung" hidden></p>
+      </div>
+
+      <div class="cfoot" style="align-items:center">
+        <button class="btn primary" type="button" id="kfBtn">Eintragen</button>
+        <span class="said" id="kfSaid" role="status" aria-live="polite"></span>
+      </div>
+    </div>
+  </section>
 
   <section id="kosten">
     <div class="shead"><h2>Kosten und Wirkung</h2><p>Summe, Kosten je Abo und Rückfluss – sobald Posten erfasst sind.</p></div>
-    <div class="tiles">
-      <div class="tile"><div class="n gold" id="costTotal">–</div><div class="l">Kosten gesamt</div><div class="s" id="costSub">Stunden, Social Media, Druck & Versand, Infrastruktur</div></div>
-      <div class="tile"><div class="n blue" id="costCpa">–</div><div class="l">Kosten je Abo</div><div class="s">sobald Kosten erfasst</div></div>
-      <div class="tile"><div class="n ok" id="costRoi">–</div><div class="l">Rückfluss je eingesetztem Franken</div><div class="s">projizierter Folgejahr-Umsatz</div></div>
+    <!-- Hausrolle .kennzahlen – die alten .tile-Klassen gab es seit dem Umbau
+         des Cockpits nicht mehr, die Zahlen standen hier unformatiert
+         untereinander. Gefunden beim Anschauen der Seite, nicht beim Rechnen. -->
+    <div class="kennzahlen">
+      <div class="kennzahl"><div class="k-label">Kosten erfasst</div><div class="k-wert" id="costTotal">–</div><div class="k-note" id="costSub">alle eingetragenen Posten</div></div>
+      <div class="kennzahl"><div class="k-label">Kosten je Abo</div><div class="k-wert" id="costCpa">–</div><div class="k-note">erfasste Kosten geteilt durch alle Anmeldungen</div></div>
+      <div class="kennzahl"><div class="k-label">Rückfluss</div><div class="k-wert" id="costRoi">–</div><div class="k-note">Folgejahr-Umsatz je eingesetztem Franken</div></div>
     </div>
+    <p class="hint" id="kostenNote" style="margin-top:var(--s4)"></p>
     <div class="tablewrap" style="margin-top:var(--s5)">
-      <table class="tarif">
+      <table class="tarif schmal">
         <thead><tr><th>Kostenart</th><th class="num">Betrag</th></tr></thead>
         <tbody id="costBody"><tr><td class="empty" colspan="2">lädt …</td></tr></tbody>
         <tfoot id="costFoot"></tfoot>
       </table>
     </div>
-    <details class="zb-form" open>
-      <summary>Einzelposten anzeigen und eintragen</summary>
-      <div class="tablewrap" style="margin-top:var(--s4)">
-        <table class="tarif">
-          <thead><tr><th>Datum</th><th>Posten</th><th>Kostenart</th><th class="num">Betrag</th></tr></thead>
-          <tbody id="kostenPostenBody"><tr><td class="empty" colspan="4">Noch keine Einzelposten erfasst.</td></tr></tbody>
-        </table>
-      </div>
-      <div class="card soft" style="margin-top:var(--s4)">
-        <div class="grid">
-          <label class="field">
-            <span class="lab">Datum</span>
-            <input type="date" id="kfTag" />
-          </label>
-          <label class="field">
-            <span class="lab">Kostenart</span>
-            <select id="kfKategorie">
-              <option value="stunden">Stunden intern</option>
-              <option value="social">Social Media</option>
-              <option value="druck">Druck &amp; Versand</option>
-              <option value="infrastruktur">Infrastruktur</option>
-              <option value="andere">Andere</option>
-            </select>
-          </label>
-          <label class="field">
-            <span class="lab">Betrag in Franken</span>
-            <input type="number" id="kfBetrag" min="0" step="0.01" placeholder="0.00" />
-          </label>
-          <label class="field span3">
-            <span class="lab">Posten</span>
-            <input type="text" id="kfPosten" placeholder="z. B. Inserat BZ Basel, halbe Seite" />
-          </label>
-          <label class="field">
-            <span class="lab">Kürzel – wer trägt ein?</span>
-            <input type="text" id="kfWer" placeholder="z. B. hao" autocomplete="off" />
-          </label>
-        </div>
-        <div style="display:flex;gap:var(--s3);align-items:center;flex-wrap:wrap;margin-top:var(--s4)">
-          <button class="btn primary" type="button" id="kfBtn">Eintragen</button>
-          <span class="said" id="kfSaid"></span>
-        </div>
-      </div>
-    </details>
-    <p class="provisorisch">Jeder Posten zählt sofort in Summe, Kosten je Abo und Rückfluss. Eintragen dürfen alle Beteiligten – das Kürzel sagt, wer.</p>
+    <div class="shead" style="margin-top:var(--s7)"><h3>Einzelposten</h3><p>Jede Zeile eine Ausgabe. Falsch eingetragenes hier löschen.</p></div>
+    <div class="tablewrap">
+      <table class="tarif">
+        <thead><tr><th>Datum</th><th>Posten</th><th>Kostenart</th><th class="num">Betrag</th><th><span class="sr-only">Löschen</span></th></tr></thead>
+        <tbody id="kostenPostenBody"><tr><td class="empty" colspan="5">Noch keine Einzelposten erfasst.</td></tr></tbody>
+      </table>
+    </div>
+    <p class="provisorisch">Eintragen und Löschen dürfen alle Beteiligten – das Kürzel sagt, wer es war.</p>
   </section>
 
 

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -16,6 +16,47 @@ Schema je Eintrag: *was · warum · Wirkung (welche Regel/Token/Komponente)*.
 
 ---
 
+## 10. August 2026 — eine Maske, die sagt, was sie will (1.13.0)
+
+**Was.** Vier Grundformen für Eingabemasken kommen ins Fundament:
+**`.formgrid`** (drei Spalten, auf schmalem Blatt eine, mit `.span2`/`.span3`),
+**`.said`** als Rückmelde-Zeile mit `.gut`/`.schlecht`, **`.field>.hint`** als
+Beisatz direkt am Feld — und **`.btn[disabled]`**, damit ein Knopf keinen
+zweiten Klick annimmt, solange der erste noch schreibt. Dazu eine Zeile, die
+lange gefehlt hat: **`[hidden]{display:none !important}`**.
+
+**Warum.** Das Team hat die Kosten-Maske benutzt und drei Dinge gemeldet, die
+alle dasselbe Muster haben — *die Maske erklärt sich nicht*:
+
+1. «Wo sollen die internen Stunden eingetragen sein? Was machen wir unter
+   Betrag in CHF?» Die Maske fragte bei der Kostenart «Stunden intern» nach
+   einem Franken-Betrag und liess den Menschen die Umrechnung machen. **Eine
+   Maske, die nach dem Ergebnis fragt statt nach dem, was man weiss, ist eine
+   Rechenaufgabe.** Jetzt fragt sie nach Stunden und Ansatz und schreibt das
+   Ergebnis hin, bevor geklickt wird.
+2. Ein Doppelklick auf «Eintragen» hat den Posten **zweimal** angelegt — die
+   Zeile musste von Hand aus der Datenbank geholt werden. Der Knopf war nie
+   gesperrt; keine Maske im Haus hatte dafür eine Form.
+3. Es gab **keinen Weg zurück**. Wer sich vertippt, muss jemanden bitten. Ein
+   offener Schreibweg ohne offenen Löschweg macht aus jedem Tippfehler eine
+   Anfrage.
+
+**`[hidden]` war die stille Falle.** Das Franken-Feld sollte im Stunden-Modus
+verschwinden, blieb aber stehen: `.field{display:grid}` schlägt das schwache
+`[hidden]` des Browsers. Derselbe Fehlertyp wie die Löcher in der Skala vom
+Vortag — das Fundament setzt `display` auf Klassen und muss darum auch sagen,
+wie Verstecken gewinnt. **Gefunden beim Anschauen der Seite, nicht beim
+Rechnen**; im selben Blick fiel auf, dass die Kosten-Seite seit dem Cockpit-Umbau
+noch `.tile` benutzte — eine Klasse, die es nicht mehr gab. Ihre drei Zahlen
+standen seither unformatiert untereinander, und keine Maschine hat es gesehen.
+
+**Wirkung.** `base.css` (`.formgrid`, `.said`, `.field>.hint`,
+`.btn[disabled]`, `[hidden]`), `contract.json` (Version). Die Kosten-Seite
+nutzt die Grundformen und die Hausrolle `.kennzahl`; die Aktivitäten-Maske
+bekam dieselbe Klick-Sperre. Backend: Stunden bleiben als Stunden erhalten
+(`stunden`, `ansatz`), eine Zwei-Minuten-Sperre gegen den doppelten Klick und
+ein Löschweg, der so offen ist wie der Schreibweg.
+
 ## 9. August 2026 — die Skala hatte Löcher, und CSS schwieg darüber (1.12.0)
 
 **Was.** Die Abstands-Skala ist lückenlos geworden (`--s5:20px`, `--s7:28px`),

--- a/design-system/base.css
+++ b/design-system/base.css
@@ -161,6 +161,12 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 .btn.primary:hover{filter:brightness(1.08)}
 .btn.ghost{color:var(--muted);background:none}
 .btn.ok{background:var(--ok);border-color:var(--ok);color:var(--on-accent)}
+/* Ausgeschaltet, solange eine Handlung läuft: Der Knopf nimmt keinen zweiten
+   Klick mehr an. Ohne das entstehen doppelte Einträge – einmal passiert und
+   von Hand aus der Datenbank geholt (Kosten, 10. August 2026). Kontrast ist
+   hier ausgenommen (WCAG 1.4.3 nimmt inaktive Bedienelemente aus); dass der
+   Knopf wartet, sagt zusätzlich seine Beschriftung. */
+.btn[disabled]{cursor:default;pointer-events:none;opacity:.6}
 
 /* --- Segmentierte Auswahl (Pillen) = WAHL ---------------------------------- */
 /* Anwahl = Gold/Weiss – der Hausfarbklang für Auswahl. Kapselform, kein Pfeil. */
@@ -184,6 +190,12 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 
 /* --- Formularfelder -------------------------------------------------------- */
 /* 16px+ verhindert das automatische Zoomen beim Fokus auf iOS. Lesetext-Schrift. */
+/* [hidden] muss stärker sein als jede display-Regel des Hauses. Sonst blieb ein
+   ausgeblendetes Feld stehen, weil .field{display:grid} das schwache
+   UA-[hidden] überschreibt – genau so stand ‹Betrag in Franken› neben den
+   Stunden, die es ersetzen sollte (gefunden 10. August 2026). */
+[hidden]{display:none !important}
+
 .field{display:grid;gap:var(--s1)}
 .field>.lab{font-size:var(--t-small);color:var(--muted);letter-spacing:.01em}
 .field input,.field textarea,.field select{
@@ -212,6 +224,26 @@ section{padding:var(--s8) 0;border-top:1px solid var(--line-soft)}
 .field input::placeholder,.field textarea::placeholder{color:var(--muted);opacity:.7}
 .field input:focus,.field textarea:focus,.field select:focus{border-color:var(--blue);box-shadow:0 0 0 3px color-mix(in srgb,var(--blue) 22%,transparent)}
 .field input.invalid{border-color:var(--bad);box-shadow:0 0 0 3px color-mix(in srgb,var(--bad) 20%,transparent)}
+/* Beisatz unter einem Feld: sagt in einem Satz, was hineingehört. Wo eine
+   Maske erklärt werden muss, gehört die Erklärung ans Feld – nicht in eine
+   Legende weiter unten, die niemand liest. */
+.field>.hint{margin:2px 0 0}
+
+/* --- Eingabe-Raster -------------------------------------------------------- */
+/* Drei Spalten auf breitem Blatt, eine auf schmalem. Jede Eingabemaske im Haus
+   benutzt dieses Raster – vorher hatte jede Seite ihr eigenes. */
+.formgrid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--s4)}
+.formgrid>.span2{grid-column:span 2}
+.formgrid>.span3{grid-column:1 / -1}
+@media(max-width:640px){
+  .formgrid{grid-template-columns:1fr}
+  .formgrid>.span2,.formgrid>.span3{grid-column:auto}
+}
+/* Zeile unter dem Knopf: Ist die Handlung angekommen? Die Farbe kommt aus der
+   Klasse, nicht aus dem Skript – sonst bleibt sie im Dunkelmodus stehen. */
+.said{font-family:var(--font-text);font-size:var(--t-small);line-height:1.5;color:var(--muted)}
+.said.gut{color:var(--ok-ink)}
+.said.schlecht{color:var(--bad)}
 
 /* --- Fusszeile ------------------------------------------------------------- */
 .ds-footer{border-top:1px solid var(--line);padding:var(--s8) 0 60px;color:var(--muted);font-size:var(--t-small);margin-top:var(--s8)}

--- a/design-system/contract.json
+++ b/design-system/contract.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://goetheanum/design-system/contract.schema.json",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "titel": "Goetheanum Design-System – Struktur-Vertrag",
   "zweck": "Maschinenlesbare Grundlage der GESTALT-Konformität (symmetrisch zum sprachlichen Kanon in assets/typografie/). ds-lint.py prüft jede Seite hiergegen, ds-fix.py korrigiert deterministisch, das Schaufenster bildet es ab. Eine Quelle der Wahrheit für Struktur; Werte/Farben/Schnitte bleiben in tokens.css/tokens.json.",
   "geltungsbereich": {

--- a/docs/kampagnen-drehbuch.md
+++ b/docs/kampagnen-drehbuch.md
@@ -13,6 +13,120 @@ geerbt.
 erst unterwegs nachziehen mussten: der **Wahrheit des Angebots** und der
 **Messkette**. Beides war teurer nachzurüsten als alles Redaktionelle.
 
+## Die Frist ist das Instrument — und sie verbraucht sich
+
+**Eine Frist gewinnt keine Aufmerksamkeit. Sie erntet Unentschiedene.** Das ist
+der brauchbarste Befund des Sommers 2026 und er bestimmt den Zuschnitt der
+nächsten Kampagne mehr als jeder Kanal.
+
+Belegt: Die beiden Fristtage (7./8. August) brachten **380 von 1057
+Anmeldungen** — in zwei von vierzig Tagen. Es war aber **kein neues Publikum**:
+234 der 280 messbaren Fristtag-Anmeldungen trugen die Mailing-Spur, waren also
+Leute, die im Juli schon zweimal angeschrieben worden waren. Die Frist hat
+geerntet, was die Wellen vorher gesät hatten.
+
+Daraus folgen drei verschiedene Fragen, die man nicht verwechseln darf.
+
+### 1 · Mehrere Fristen INNERHALB einer Kampagne — der eigentliche Hebel
+
+Nicht mehr Erinnerungsmails an dieselbe Frist, sondern **mehrere echte Fristen**.
+Das Kriterium, an dem sich jede Form messen lassen muss:
+
+> **Eine Frist muss etwas kosten, wenn man sie verpasst.** Sonst ist sie
+> Dekoration, und der Empfänger merkt es beim zweiten Mal.
+
+Vier Formen, die dieses Kriterium erfüllen — geordnet nach Aufwand:
+
+**(a) Eigene Frist je Zielgruppe.** Die Kampagne lief 2026 ohnehin in sechs
+Automatisierungen (drei Gruppen × zwei Sprachen). Gibt man jeder Gruppe ein
+eigenes Enddatum — Lesen endet am 20., Sehen am 27., Beides am 3. —, hat das
+**Haus drei Ernte-Momente, der einzelne Empfänger aber genau eine Frist**. Kein
+Glaubwürdigkeits-Verlust, weil niemand zwei Daten sieht. Kostet nichts ausser
+drei Zeilen Konfiguration; die Fabrik kann es heute schon.
+
+Zwei Zugaben: Die Last verteilt sich (2026 kamen 380 Anmeldungen an zwei Tagen
+durch dieselbe Kette), und **man lernt an der ersten Gruppe für die zweite** —
+2026 hätte man nach der Lesen-Gruppe gewusst, dass das Quer-Angebot an
+TV-Abonnenten kaum trägt (34 Abos gegen 102 in der Gegenrichtung), und die
+verbleibenden Wellen anders bestückt.
+
+Der einzige Haken: Wer weiterleitet, sieht ein anderes Datum. Selten, und
+harmlos, solange die Mails kein «für alle» behaupten.
+
+**(b) Gestaffeltes Angebot — die Frist verliert Substanz, nicht Gültigkeit.**
+Bis zum 20. drei Monate gratis, bis zum 31. zwei, bis zum 8. einer. Jede Stufe
+ist eine echte Frist, weil man wirklich etwas verliert. Drei Ernten aus einem
+Vorrat, der sich dazwischen neu bildet.
+
+Der Preis dafür steht in Phase 0: **Die Mechanik muss in EINEM Satz sagbar
+bleiben.** 2026 sagten die Kleinzeilen schon bei einem einzigen Angebot
+dreierlei. Eine Staffel verdoppelt diese Gefahr — nur machen, wenn der eine
+Satz vorher steht.
+
+**(c) Kontingent statt Datum.** «Die ersten 300 zum vollen Angebot.» Der Zähler
+läuft im Cockpit ohnehin live und liesse sich öffentlich zeigen — Knappheit,
+die man sieht, wirkt stärker als eine, die behauptet wird. **Aber nur, wenn man
+wirklich schliesst.** Wer bei 400 Interessierten die 301. Anmeldung trotzdem
+nimmt, hat das Instrument verbrannt. Sauberer darum als Stufe, nicht als Stopp:
+die ersten 300 bekommen drei Monate, danach zwei.
+
+**(d) Anlass-Fristen.** An ein wirkliches Ereignis gebunden — «nur während des
+Faust-Festivals», «endet mit der Tagung». Sie sind von Natur aus wahr, weil das
+Ereignis wirklich endet, und sie geben der Frist einen Grund. 2026 lagen drei
+Festival-Wochenenden in der Kampagne, ungenutzt als Frist.
+
+**Empfehlung für die nächste Kampagne:** **(a) je Gruppe eine eigene Frist**,
+weil es nichts kostet, nichts riskiert und sofort geht — kombiniert mit **(d)**,
+wo ein Anlass da ist. **(b)** nur, wenn der eine Satz steht. **(c)** nur mit der
+Bereitschaft, wirklich zu schliessen.
+
+**Unabhängig davon:** die letzte Frist mit **drei** Schlussmomenten in 48 Stunden
+statt zwei. 2026 erreichte die vorletzte Mail 12 080 Öffner und 1 237 Klicker,
+die letzte nur noch 5 623 Öffner — aber mit **12,1 % der höchsten Klickquote
+aller vier Wellen**. Der Vorrat war nach der ersten Schlussmail also nicht
+erschöpft. Wo die vierte läge, hat 2026 nicht ausgetestet.
+
+### 2 · Kürzere Kampagne, Frist früher — ja
+
+Die Mitte war schwach: **24. bis 29. Juli 10,5 Anmeldungen am Tag** gegen 26 im
+Schnitt. Fünf Wochen waren rund zwei zu lang; die Zeit hat den Vorrat nicht
+vergrössert, nur das Vergessen.
+
+→ **Drei Wochen statt fünf**, gleiche Zahl Wellen, dichter gestellt.
+
+### 3 · Mehrere Frist-Kampagnen im Jahr — nur mit eigenem Anlass
+
+Zwei Gründe zur Vorsicht, beide gemessen:
+
+- **Der Verteiler ist endlich.** 69 % der Aktion kamen aus einer Liste von rund
+  33 000 Adressen und ergaben etwa 640 Abos — knapp **2 %**. Eine zweite
+  Frist-Kampagne spricht dieselben Menschen an, und zwar die 98 %, die schon
+  einmal nicht wollten.
+- **Die Ermüdung ist schon INNERHALB einer Kampagne messbar:** Öffnungsrate
+  **50,3 → 46,3 → 36,6 %** über die drei offenen Wellen. Das ist der Verschleiss
+  in fünf Wochen.
+
+→ **Höchstens zwei solcher Kampagnen im Jahr, jede mit eigenem Anlass**
+(Jahreswechsel, Jubiläum, Michaeli) — nicht zweimal dasselbe «3 Monate gratis».
+Eine Frist ohne Anlass ist eine Behauptung; mit Anlass ist sie ein Ereignis.
+
+### Der Punkt, der über alles entscheidet: Glaubwürdigkeit
+
+**Eine Frist wirkt, weil man ihr glaubt.** Die Aktion 2026 wurde nach dem
+kommunizierten Fristtag **still** um drei Tage verlängert. Das kostete nichts —
+*weil* es still war. Angekündigt hätte es die Frist entwertet.
+
+Wer «nur bis» zweimal im Jahr sagt und beide Male weiterlaufen lässt, hat beim
+dritten Mal ein Datum ohne Wirkung. **Der Mechanismus lebt von Kredit, und
+Kredit wird verbraucht.** Verlängern also nie ankündigen — besser gar nicht
+verlängern.
+
+### Was 2026 nicht beantwortet hat
+
+Ob eine zweite Kampagne im selben Jahr nochmals 2 % bringt oder nur 0,5 %.
+Billig herauszufinden: **beim nächsten Mal die Liste teilen** und eine Hälfte
+auslassen — dann steht die Antwort in den Zahlen statt in einer Vermutung.
+
 ## Phase 0 — Angebots-Wahrheit (bevor irgendjemand gestaltet)
 
 1. **Mechanik schriftlich festzurren, in einem Satz:** Was genau bekommt man,
@@ -125,7 +239,13 @@ erst unterwegs nachziehen mussten: der **Wahrheit des Angebots** und der
 
 ## Phase 6 — Nach der Frist (der grösste Hebel liegt HIER)
 
-1. Frist durchsetzen (Trial zurück, Formulare schliessen) — am Tag danach.
+1. **Frist durchsetzen** (Trial zurück, Formulare schliessen) — am Tag danach,
+   und zwar als Termin mit Namen, nicht als guter Vorsatz. 2026 war das eine
+   Falle: Die Uscreen-Checkout-Angebote waren die **regulären** Abos, deren
+   Gratis-Testphase nur auf 90 Tage gestellt war — «nur bis 8. August» stand
+   allein im Beschreibungstext, nicht im System. Ohne manuelles Zurückstellen
+   bekommt **jeder** spätere Abonnent weiter drei Gratismonate; die Frist wäre
+   im Nachhinein unwahr. Vor der Kampagne notieren, welcher Wert vorher galt.
 2. Zählung: Paperform/Backend direkt; TV per uscreen-People-CSV
    (`utm_campaign` × `utm_content`), App-Zugänge als bekannte Lücke.
 3. **Onboarding-Strecke für die Gratis-Monate** (Willkommen mit

--- a/docs/schlussbericht-datensammlung.md
+++ b/docs/schlussbericht-datensammlung.md
@@ -147,7 +147,10 @@ fehlt, hält Kosten je Abo und Rückfluss weiterhin leer.
 - **Interne Stunden** — Kategorie **Stunden intern**, grobe Schätzung genügt.
   Ohne sie liest sich die Aktion billiger, als sie war. Die Maske fragt jetzt
   nach **Stunden und Ansatz** und rechnet die Franken selbst; eingetragen
-  werden also 8 h zu 80, nicht 640.
+  werden also 8 Stunden zu 60, nicht 480. **Der Hausansatz ist CHF 60 je
+  Stunde** (festgelegt am 10. August 2026) und steht in der Maske
+  voreingestellt — er ist damit über alle Posten hinweg derselbe, sonst
+  vergleicht der Bericht Stunden, die verschieden viel wert sind.
 - **Flyer und Stand** — Druck ist erfasst; fehlen noch Reichweite für «Auslage
   Flyer Empfang» und «Auslage Flyer Buchhandlung» (10. Juli). Wo nichts
   gemessen ist: verteilte Stückzahl eintragen und das in der Notiz sagen.

--- a/docs/schlussbericht-datensammlung.md
+++ b/docs/schlussbericht-datensammlung.md
@@ -95,6 +95,32 @@ E-Mail-Adressen nicht gegen Uscreen legen, und die Frage ‹wer hat geklickt und
 doch nicht abgeschlossen› ist über Uscreen bereits beantwortet (227 abgebrochene
 Kassengänge mit Mailing-Spur).
 
+## Traffic der Aktionsseiten — was wir haben und was fehlt (Frage vom 10. August)
+
+**Die Aktionsseiten selbst zählen nicht mit.** Auf
+`global-sommer2026.goetheanum.online`, `ws-sommer2026.dasgoetheanum.com` und
+`tv-sommer2026.goetheanum.tv` läuft keine Reichweiten-Messung — es gibt also
+keine Seitenaufrufe, keine Verweildauer, keine Absprungrate. Das ist die
+grösste blinde Stelle der Auswertung.
+
+**Der Weg dorthin ist trotzdem gemessen**, an der Quelle statt am Ziel:
+
+| Was | Zahl | Woher |
+|---|---:|---|
+| Klicks auf Aktionslinks, alle Aktivitäten zusammen | 10 589 | Aktivitäten-Protokoll (AC, Meta, YouTube) |
+| davon Klicker der vier Mail-Wellen | 5 433 | ActiveCampaign |
+| Klicks auf die Kurzlinks (Print, QR, Social) | 2 333 | eigene Weiterleitung |
+| neue Konten auf goetheanum.tv | 874 | Uscreen |
+| abgeschlossene Abos goetheanum.tv | 626 | Uscreen |
+
+Aus 10 589 Klicks wurden 874 Konten und 626 Abos. Die Kurzlink-Klicks je Ziel:
+Übersicht 1 529 · goetheanum.tv 401 · Wochenschrift 363.
+
+**Für die nächste Aktion:** ein leichtgewichtiger Zähler auf den Aktionsseiten
+(dieselbe Weiterleitung, die die Kurzlinks zählt, kann das) — damit die Lücke
+zwischen ‹Klick im Mail› und ‹Konto angelegt› sichtbar wird. Heute ist sie eine
+Differenz, die wir ausrechnen, statt einer Zahl, die wir messen.
+
 ## Social (Metricool)
 
 Sechs Einträge, alle ohne vollständige Zahlen. Die Kampagnen-Auswertung liegt
@@ -112,16 +138,16 @@ und Quellen».
 
 ## Geld (Meta Ads Manager und eigene Aufzeichnung)
 
-In der Datenbank stehen bisher **nur CHF 309.70 Druck**. Damit sind Kosten je
-Abo und Rückfluss auf der Kosten-Seite zu günstig — und ausgerechnet der
-teuerste Weg fehlt.
+Stand 10. August: **CHF 769.70** erfasst — Druck 309.70, Meta-Anzeige 423,
+YouTube-Anzeige 37. Damit ist der teuerste Weg endlich bewertbar. Was noch
+fehlt, hält Kosten je Abo und Rückfluss weiterhin leer.
 
-- **Meta-Anzeige** — Betrag aus dem Ads Manager (Rechnung Juli), Kategorie
-  **Social Media**. DE und EN dürfen zusammengefasst werden. Reichweite und
-  Klicks der Anzeige stehen bereits (62 812 / 353 und 68 343 / 612). Ist die
-  Zahl da, steht neben dem Befund «≈9 Abos» endlich ein Preis.
+- ~~**Meta-Anzeige**~~ — **erledigt 10. August** (CHF 423). Reichweite und
+  Klicks standen bereits (62 812 / 353 und 68 343 / 612).
 - **Interne Stunden** — Kategorie **Stunden intern**, grobe Schätzung genügt.
-  Ohne sie liest sich die Aktion billiger, als sie war.
+  Ohne sie liest sich die Aktion billiger, als sie war. Die Maske fragt jetzt
+  nach **Stunden und Ansatz** und rechnet die Franken selbst; eingetragen
+  werden also 8 h zu 80, nicht 640.
 - **Flyer und Stand** — Druck ist erfasst; fehlen noch Reichweite für «Auslage
   Flyer Empfang» und «Auslage Flyer Buchhandlung» (10. Juli). Wo nichts
   gemessen ist: verteilte Stückzahl eintragen und das in der Notiz sagen.

--- a/docs/schlussbericht-datensammlung.md
+++ b/docs/schlussbericht-datensammlung.md
@@ -62,6 +62,39 @@ ein Abo (11,8 %); aus 1 000 zugestellten Mails knapp sechs.
 Juli 2026 keine AGiD-Kampagne. Die Zeile im Protokoll trägt den Befund als
 Notiz und zählt bis zur Klärung als geplant, nicht als ausgespielt.
 
+## Erledigt am 10. August: Abgleich goetheanum.tv gegen Uscreen
+
+Vollexport aller Konten, zeilenweise gejoint. Befund und Folgen stehen in
+`docs/uscreen-abgleich-10-08.md`. Kurz: Uscreen kennt **626** neue Abos im
+Fenster, wir zählen 665 — 40 unserer Zeilen sind Verlängerungen, 11 echte
+Abos aus dem Juli fehlen uns. Die Gratismonate sind bei 620 von 626 gebucht;
+der Verlust liegt nicht bei der Frist, sondern an der Kasse (268 Abbrüche
+ohne Rückkehr).
+
+## Noch einmal ActiveCampaign — zwei Sorten Zahlen, die nur dort liegen
+
+Der erste Lauf hat Summen je Welle geholt. Für den Bericht fehlen zwei Dinge,
+die keine andere Quelle hat. Beides sind **Summen, keine Listen** — es braucht
+keine Kontaktdaten:
+
+1. **Die Nenner je Gruppe.** Bisher haben wir jede Welle über alle sechs
+   Automatisierungen zusammengezählt. Gebraucht wird die Aufschlüsselung
+   **je Automatisierung** (`Lesen`, `Sehen`, `Beides` × DE/EN) mal **je Welle**
+   — 24 Zeilen mit zugestellt, geöffnet, geklickt. Erst damit lässt sich
+   rechnen, welche **Gruppe** wie gut konvertiert hat: Unsere Abschlüsse
+   tragen die Gruppe im `utm_content` (`_noabo`, `_nurws`, `_nurtv`), aber
+   ohne den Nenner ist das nur eine absolute Zahl. Die Quote je Gruppe ist die
+   Zahl, mit der die nächste Aktion geplant wird.
+2. **Abmeldungen und Bounces je Welle.** Vier Wellen auf rund 33 000 Adressen
+   sind nicht gratis. Was die Aktion an Verteilerqualität gekostet hat, ist
+   bisher nirgends verbucht — es gehört auf die Kostenseite, auch ohne
+   Frankenbetrag.
+
+**Nicht holen:** Kontaktlisten auf Personenebene. Sie liessen sich ohne
+E-Mail-Adressen nicht gegen Uscreen legen, und die Frage ‹wer hat geklickt und
+doch nicht abgeschlossen› ist über Uscreen bereits beantwortet (227 abgebrochene
+Kassengänge mit Mailing-Spur).
+
 ## Social (Metricool)
 
 Sechs Einträge, alle ohne vollständige Zahlen. Die Kampagnen-Auswertung liegt

--- a/docs/uscreen-abgleich-10-08.md
+++ b/docs/uscreen-abgleich-10-08.md
@@ -1,0 +1,128 @@
+# Totaler Abgleich goetheanum.tv gegen Uscreen — 10. August 2026
+
+Grundlage: Vollexport aller Uscreen-Konten (11 867 Zeilen, ohne Datumsfilter,
+alle Status), zeilenweise gegen `sommer2026_signups` gejoint über
+`ext_id` = Uscreen `User ID`. Der Export enthält Personendaten; ausgewertet
+wurde ausschliesslich aggregiert, nichts davon steht in diesem Dokument oder
+im Repository.
+
+Dieses Dokument löst die aggregierte Vorprüfung vom 9. August ab.
+
+## Das Ergebnis in einem Satz
+
+Wir zählen für goetheanum.tv **665 Anmeldungen**, Uscreen kennt im
+Kampagnenfenster **626 neue Abonnements**. Die Differenz ist erklärt, nicht
+geschätzt: **40 unserer Zeilen sind gar keine neuen Abos**, dafür fehlen uns
+**11 echte** aus den ersten Julitagen.
+
+| | Zeilen |
+|---|---:|
+| unsere gtv-Anmeldungen | 665 |
+| davon mit `ext_id` | 655 |
+| **belegt: auch bei Uscreen ein neues Abo im Fenster** | **615** |
+| bei uns, bei Uscreen aber kein neues Abo | 40 |
+| ohne `ext_id`, nicht zuordenbar | 10 |
+| bei Uscreen im Fenster, bei uns nicht | 11 |
+| **Uscreen: neue Abos 3. Juli bis 10. August** | **626** |
+
+## Woher die 40 kommen — Verlängerungen als Neuzugang gezählt
+
+Die 40 Zeilen tragen bei Uscreen Abo-Daten aus 2022 bis 2025. Der Beweis
+liegt in der Folgerechnung: Bei fast allen liegt `Next invoice date` **genau
+einen Monat** (oder bei Jahresabos genau ein Jahr) nach dem Tag, an dem
+unsere Datenbank sie als Anmeldung führt. Das ist kein Abschluss — das ist
+die turnusmässige Rechnung eines laufenden Abos.
+
+| Sorte | Zeilen |
+|---|---:|
+| reine Monatsrechnung eines Bestandsabos | 19 |
+| reine Jahresrechnung eines Bestandsabos | 7 |
+| Kündigung eines alten Abos, keine Folgerechnung | 11 |
+| **Gratismonate auf ein bereits zahlendes Abo gebucht** | **2** |
+| anderes | 1 |
+
+**Ursache:** Der Uscreen-Webhook feuert auf Abo-Ereignisse allgemein, nicht
+nur auf Neuabschlüsse. Wir haben Verlängerung und Neuabschluss nicht
+unterschieden. Für die nächste Aktion gehört in die Ingest-Regel eine
+Bedingung: nur zählen, wenn `Subscription Created at` im Kampagnenfenster
+liegt.
+
+**Die zwei mit Gratismonaten sind ein eigener Befund.** Zwei Menschen, die
+bereits zahlten, haben über die Aktionsseite drei Monate geschenkt bekommen.
+Klein in der Zahl, eindeutig in der Richtung: Das Angebot war nicht gegen
+Bestandsabos gesperrt. Es kostet Geld, statt welches zu bringen.
+
+## Die 11 fehlenden — Webhook-Lücke am Anfang
+
+Alle 11 stammen vom **3. bis 6. Juli**, den ersten vier Kampagnentagen. Der
+Webhook lief noch nicht sauber. Sie sind echte Abos und fehlen uns.
+
+## Wer die Gratismonate nicht bekommt
+
+Kaum jemand. Von 626 Abos im Fenster tragen **596** eine Folgerechnung
+89 oder 90 Tage nach Abschluss — die drei Monate sind gebucht. Weitere 24
+haben die Frist erhalten und **während** ihr gekündigt, darum steht bei ihnen
+keine Folgerechnung mehr.
+
+Wirklich ohne die drei Monate sind **sechs**:
+
+| Fall | Zahl | Grund |
+|---|---:|---|
+| Institutionelles Abo über Team-Einladung | 2 | eigener Vertrag, wird separat verrechnet |
+| App-Abo und ermässigtes Abo | 2 | anderer Plan, nur 6 Tage Probezeit |
+| Herabstufung eines App-Abos | 1 | 42 Tage Restlaufzeit, kein Neuabschluss |
+| Migration | 1 | Jahresabo, direkt verrechnet |
+
+Die Aktion hat also **technisch getan, was sie sollte**. Die Unschärfe liegt
+nicht bei der Frist, sondern beim Zählen und beim Bezahlen.
+
+## Der eigentliche Verlust: die Kasse
+
+Im Kampagnenfenster entstanden **874 neue Konten**. 460 davon haben ein Abo
+abgeschlossen. **341 sind an der Kasse stehengeblieben** (Uscreen:
+‹Abandoned checkout›), 227 davon mit Mailing-Spur. 73 sind später
+zurückgekommen und haben doch abgeschlossen — **268 nicht**.
+
+Das ist die grösste einzelne Zahl der ganzen Auswertung: 268 Menschen waren
+entschlossen genug, bis zur Kasse zu gehen, und sind dort verloren gegangen.
+Gemessen an 626 Abschlüssen wären sie **43 % mehr** gewesen. Für die nächste
+Aktion ist der Kassenweg der Hebel, nicht die Reichweite.
+
+## Ein Viertel kam aus dem eigenen Haus
+
+Von den 626 Abos stammen **166 aus Konten, die es vorher schon gab** — 63
+davon seit 2022. Sie tragen **keine** UTM-Spur, weil die beim Anlegen des
+Kontos gesetzt wird und nicht beim Abschluss.
+
+Das korrigiert die Dunkelfeld-Lesart an einer wichtigen Stelle: Ein guter
+Teil des Dunkelfelds ist kein ungemessener Kanal, sondern **die Rückkehr
+alter Konten**. Wer schon einmal da war, ist über die Aktion wiedergekommen.
+
+Und diese Gruppe ist die bessere: Sie kündigt bisher mit **1,8 %** halb so
+oft wie die Neukonten (**4,6 %**) und wählt etwas häufiger das Jahresabo
+(15 % gegen 12 %). Ein erster, früher Hinweis für die Bleibe-Quote — mehr
+noch nicht.
+
+## Erste Kündigungen: 24 von 626
+
+24 Abos sind bereits gekündigt oder ausgelaufen, gleichmässig über die
+Laufzeit verteilt, mit leichter Häufung in den letzten Tagen. Das sind
+**3,8 %** — die erste gemessene Zahl zur Bleibe-Quote überhaupt. Sie sagt
+noch nichts über den Oktober, aber sie ist keine Schätzung.
+
+## Tarifmischung im Fenster
+
+547 monatlich, 79 jährlich (12,6 %). Die Einnahmen-Perspektive rechnet mit
+dieser Mischung; sie ist damit belegt statt angenommen.
+
+## Was zu tun ist
+
+1. **Ingest-Regel schärfen:** Verlängerungen nicht als Neuzugang zählen
+   (Bedingung auf `Subscription Created at`).
+2. **Die 40 markieren, nicht löschen** — sie sind ein Beleg dafür, wie viele
+   Bestandsabos in der Kampagnenzeit turnusmässig verlängert wurden.
+3. **Die 11 aus dem Juli nachtragen.**
+4. **Aktionsangebot gegen Bestandsabos sperren**, damit niemand geschenkt
+   bekommt, wofür er schon zahlt.
+5. **Angebote 84317 und 84322 am 12. August zurücksetzen** — steht
+   unverändert offen.


### PR DESCRIPTION
Zwei Dinge auf einem Zweig.

## 1. Drehbuch: die Frist als Instrument

Neuer Abschnitt zu mehreren echten Fristen **innerhalb einer** Kampagne — mit
Kriterium und vier Formen: Frist je Gruppe, gestaffeltes Angebot, Kontingent,
anlassgebundene Frist. Phase 6.1 um die Uscreen-Falle geschärft (Probezeit
zurücksetzen, sonst läuft das Angebot still weiter).

## 2. Totaler Abgleich goetheanum.tv gegen Uscreen

`docs/uscreen-abgleich-10-08.md` — Vollexport aller Uscreen-Konten,
zeilenweise gegen `sommer2026_signups` gejoint. Aggregiert ausgewertet, keine
Personendaten im Repository.

- **626 neue Abos** im Fenster laut Uscreen, wir zählen 665. Die Differenz ist
  erklärt: **40 unserer Zeilen sind Verlängerungen** laufender Abos — der
  Beweis liegt in der Folgerechnung, die genau einen Monat bzw. ein Jahr nach
  unserem Anmeldedatum fällig wird. Dazu fehlen uns **11 echte Abos** vom
  3.–6. Juli (Webhook-Lücke).
- **Gratismonate**: 596 mit 89/90 Tagen gebucht, 24 während der Frist
  gekündigt, nur 6 wirklich ohne — und **2 versehentlich an bereits Zahlende**
  vergeben.
- **Grösster Verlust ist die Kasse**: 341 Abbrüche, 73 kamen zurück, 268 nicht.
- **166 der 626 Abos** stammen aus Bestandskonten ohne UTM-Spur; sie kündigen
  bisher halb so oft (1,8 % gegen 4,6 %).

Dazu in der Sammelliste der nächste AC-Auftrag: Nenner je Automatisierung und
Welle sowie Abmeldungen/Bounces — Summen, keine Listen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUqZZzUQntMLiZPecAsBBc