### PR TITLE
Verlängerungen zählen nicht mehr mit: goetheanum.tv 636 statt 665

### DIFF
--- a/docs/schlussbericht-datensammlung.md
+++ b/docs/schlussbericht-datensammlung.md
@@ -90,10 +90,17 @@ keine Kontaktdaten:
    bisher nirgends verbucht — es gehört auf die Kostenseite, auch ohne
    Frankenbetrag.
 
-**Nicht holen:** Kontaktlisten auf Personenebene. Sie liessen sich ohne
-E-Mail-Adressen nicht gegen Uscreen legen, und die Frage ‹wer hat geklickt und
-doch nicht abgeschlossen› ist über Uscreen bereits beantwortet (227 abgebrochene
-Kassengänge mit Mailing-Spur).
+Dazu die AC-Kosten selbst (Tarif, Kontingent, Gebühr) — sie sind bisher
+nirgends verbucht. Fertiger Auftrag: `services/mailing-sommer2026/AC-NENNER.md`.
+
+**Nicht holen: Kontaktlisten auf Personenebene.** Sie *würden* etwas sagen —
+mit den Adressen liesse sich Klick gegen Abschluss legen, und das Dunkelfeld
+wäre gemessen statt geschätzt. Dagegen stehen zwei Dinge: Personendaten aus
+zwei Systemen zusammenzuführen ist ein eigener Vorgang mit eigener
+Rechtsgrundlage, und die Frage ‹wer hat geklickt und doch nicht abgeschlossen›
+ist über Uscreen bereits beantwortet (227 abgebrochene Kassengänge mit
+Mailing-Spur). Die Nenner je Gruppe bringen fast dieselbe Erkenntnis ohne eine
+einzige Adresse.
 
 ## Traffic der Aktionsseiten — was wir haben und was fehlt (Frage vom 10. August)
 

--- a/docs/uscreen-abgleich-10-08.md
+++ b/docs/uscreen-abgleich-10-08.md
@@ -115,14 +115,29 @@ noch nichts über den Oktober, aber sie ist keine Schätzung.
 547 monatlich, 79 jährlich (12,6 %). Die Einnahmen-Perspektive rechnet mit
 dieser Mischung; sie ist damit belegt statt angenommen.
 
-## Was zu tun ist
+## Umgesetzt am 10. August
 
-1. **Ingest-Regel schärfen:** Verlängerungen nicht als Neuzugang zählen
-   (Bedingung auf `Subscription Created at`).
-2. **Die 40 markieren, nicht löschen** — sie sind ein Beleg dafür, wie viele
-   Bestandsabos in der Kampagnenzeit turnusmässig verlängert wurden.
-3. **Die 11 aus dem Juli nachtragen.**
-4. **Aktionsangebot gegen Bestandsabos sperren**, damit niemand geschenkt
-   bekommt, wofür er schon zahlt.
-5. **Angebote 84317 und 84322 am 12. August zurücksetzen** — steht
-   unverändert offen.
+1. **Neue Spalte `art`** in `sommer2026_signups`: `neu` oder `verlaengerung`.
+   Die 40 sind markiert, nicht gelöscht — sie bleiben als Beleg sichtbar, wie
+   viele Bestandsabos in der Aktionszeit turnusmässig weiterliefen.
+2. **Eine View für die Regel:** `sommer2026_neuabos` zeigt nur `art = 'neu'`.
+   Alle neun öffentlichen Auswertungen lesen sie — ein Ort statt neun.
+3. **Die 11 aus dem Juli sind nachgetragen** (`source = 'manual'`, damit die
+   Herkunft der Zeile sichtbar bleibt). Zwei davon hatten schon gekündigt.
+4. **Der Webhook erkennt es künftig selbst.** Uscreens Payload unterscheidet
+   Abschluss und Verlängerung nicht — aber ein Abo mit drei Gratismonaten kann
+   in den ersten 90 Tagen keine wiederkehrende Zahlung haben. Liegt für
+   dieselbe Person schon ein `success_recurring` im Rohprotokoll, ist es eine
+   Verlängerung. Gegen die 655 bekannten Zeilen geprüft: **kein Fehlgriff auf
+   ein echtes Neuabo** (der Test findet 33 der 40 — was er findet, stimmt).
+
+**Stand danach:** goetheanum.tv **636** statt 665. Davon sind 626 gegen Uscreen
+belegt; die restlichen 10 tragen keine `ext_id` und lassen sich nicht prüfen.
+
+## Was offen bleibt
+
+- **Aktionsangebot gegen Bestandsabos sperren**, damit niemand geschenkt
+  bekommt, wofür er schon zahlt.
+- **Angebote 84317 und 84322 am 12. August zurücksetzen** — steht unverändert
+  offen und ist die einzige offene Sache mit einer Frist.
+- **Die 10 Zeilen ohne `ext_id`** — nicht prüfbar, bleiben in der Zählung.

--- a/services/mailing-sommer2026/AC-NENNER.md
+++ b/services/mailing-sommer2026/AC-NENNER.md
@@ -1,0 +1,85 @@
+# Prompt für Claude-Chrome: die Nenner je Gruppe und die Kosten der Aktion
+
+> **Dies ist der fertige Prompt.** Alles ab der Trennlinie unten Claude-Chrome
+> geben. Er holt **nur Zahlen** — er ändert in ActiveCampaign nichts.
+>
+> **Zweiter Lauf.** Der erste (`AC-ZAHLEN.md`, ausgeführt am 9. August) hat die
+> Wellen als Summe geholt. Damit wissen wir, wie viele geklickt haben — aber
+> nicht, **wie viele je Gruppe angeschrieben** wurden. Ohne diesen Nenner ist
+> jede Aussage über die Wirkung einer Gruppe eine absolute Zahl statt einer
+> Quote, und Quoten sind das, womit die nächste Aktion geplant wird.
+>
+> Dazu zwei Dinge, die bisher nirgends verbucht sind: was die Aktion an
+> **Verteilerqualität** gekostet hat (Abmeldungen, Bounces) und was sie an
+> **Franken** gekostet hat (der AC-Anteil).
+
+---
+
+Hole aus **ActiveCampaign** drei Sorten Zahlen zur Sommer-Aktion 2026 und gib
+sie als Tabellen zurück. **Nur lesen: Ändere nichts, sende nichts, starte keine
+Automatisierung, exportiere keine Kontakte.** Ich brauche ausschliesslich
+Summen — keine Personendaten, keine E-Mail-Adressen, keine Namen.
+
+## Teil 1 — die Wellen je Automatisierung einzeln
+
+Die Aktion lief über **sechs Automatisierungen**: `S26 · Lesen · DE`,
+`S26 · Lesen · EN`, `S26 · Sehen · DE`, `S26 · Sehen · EN`,
+`S26 · Beides · DE`, `S26 · Beides · EN`.
+
+Jede enthält vier Wellen: **w1** (17. Juli), **w2** (30. Juli),
+**w3** (7. August, hängt zweimal — Öffner- und Nicht-Öffner-Zweig, beide in
+eine Zeile zusammenzählen), **w3b** (8. August).
+
+Beim letzten Mal habe ich die Wellen **über alle sechs zusammengezählt**
+bekommen. Diesmal brauche ich sie **einzeln je Automatisierung** — also
+**24 Zeilen** (6 Automatisierungen × 4 Wellen):
+
+| Automatisierung | Welle | Versendet | Geöffnet (eindeutig) | Geklickt (eindeutig) | Bemerkung |
+|---|---|---:|---:|---:|---|
+
+**Versendet** heisst zugestellt. **Geöffnet** und **geklickt** heissen
+eindeutige Personen, nicht Ereignisse — wo ActiveCampaign beides anbietet, nimm
+die eindeutige Zahl und schreib in die Bemerkung, welche Ansicht du benutzt hast.
+
+Findest du eine Welle in einer Automatisierung nicht, schreib «nicht vorhanden»
+und sag es. Für `S26 · Lesen · EN` erwarte ich genau das bei **w3b** — dort
+fehlte sie im letzten Lauf.
+
+## Teil 2 — was der Versand den Verteiler gekostet hat
+
+Vier Wellen auf rund 33 000 Adressen sind nicht gratis. Je Welle **über alle
+sechs Automatisierungen zusammen** (also vier Zeilen, wie beim ersten Lauf):
+
+| Welle | Abmeldungen | Hard Bounces | Soft Bounces | Spam-Beschwerden |
+|---|---:|---:|---:|---:|
+
+Dieselben vier Spalten zusätzlich für die vier Newsletter vom 17. und
+31. Juli (Wochenschrift und Weekly, je Datum eine Zeile).
+
+Findest du «Spam-Beschwerden» nicht als eigene Zahl, lass die Spalte leer und
+sag es — **rate nicht**.
+
+## Teil 3 — was ActiveCampaign selbst kostet
+
+Unter **Einstellungen → Konto/Abrechnung** (oder wo dein Konto es zeigt):
+
+1. **Welcher Tarif** läuft (Name des Plans)?
+2. **Wie viele Kontakte** umfasst er, und wie viele sind belegt?
+3. **Wie hoch ist die laufende Gebühr** je Monat oder Jahr, in welcher Währung?
+4. Wird **monatlich oder jährlich** abgerechnet?
+
+**Nur diese vier Angaben.** Keine Zahlungsmittel, keine Kartendaten, keine
+Rechnungsadressen, keine Rechnungs-PDFs — wenn eine Seite so etwas zeigt, lies
+es nicht mit und gib es nicht wieder.
+
+## Wenn etwas nicht geht
+
+**Rate nicht und rechne nichts hoch.** Findest du eine Zahl nicht, schreib
+«nicht auffindbar» und in die Bemerkung, woran es lag — welche Ansicht du
+versucht hast und was dort stand. Eine ehrliche Lücke ist brauchbar, eine
+geschätzte Zahl verdirbt die Auswertung: Aus diesen Zahlen werden Quoten je
+Zielgruppe und Kosten je Abo gerechnet.
+
+Sag mir am Ende in zwei Sätzen, wie sicher du bei der Zuordnung der Wellen zu
+den Automatisierungen bist — ob jeder E-Mail-Schritt eindeutig einer Welle
+zuzuordnen war oder ob du irgendwo raten musstest.

--- a/services/sommer-zaehler/ingest-uscreen/index.ts
+++ b/services/sommer-zaehler/ingest-uscreen/index.ts
@@ -6,9 +6,16 @@
 //
 // Aktions-Isolierung: jede Neuanmeldung im Aktionszeitraum → status 'neu' (jeder
 // Trial hinterlegt eine Karte, darum ist transaction_id KEIN Unterscheidungsmerkmal).
-// Verlängerungen legen nichts an. Zahlungen setzen (noch) KEIN 'bleibt' – die
-// Umwandlung wird erst nach der 3-Monats-Frist bestimmt. Kündigung → 'gekuendigt'.
+// Zahlungen setzen (noch) KEIN 'bleibt' – die Umwandlung wird erst nach der
+// 3-Monats-Frist bestimmt. Kündigung → 'gekuendigt'.
 // Optional schärfer via aktion_coupon / aktion_plan.
+//
+// Verlängerung ≠ Abschluss (Beschluss 10. August 2026): Uscreen feuert
+// `subscription_assigned` auch für laufende Bestandsabos und unterscheidet die
+// beiden Fälle im Payload nicht. Erkannt wird es an einer früheren
+// `success_recurring` derselben Person – ein Abo mit drei Gratismonaten kann
+// keine haben. Solche Zeilen bekommen `art: 'verlaengerung'` und fallen aus
+// allen Auswertungen (die lesen die View `sommer2026_neuabos`).
 //
 // Attribution: volles UTM-Tupel (source/medium/campaign/content) + Landingpage-Pfad
 // + offene Selbstauskunft (E-Mail-redigiert) werden je Anmeldung mitgeschrieben; der
@@ -274,6 +281,30 @@ Deno.serve(async (req) => {
 
   if (!isNew) return json({ ok: true, skipped: "event ignoriert" });
 
+  // Verlängerung oder Abschluss? Uscreen sagt es nicht: `subscription_assigned`
+  // trägt nur user_id, subscription_id und den Plantitel – dieselben Felder für
+  // beides. 40 laufende Bestandsabos standen darum als Anmeldung in der Zählung
+  // (belegt am 10.8. über den Uscreen-Vollexport: ihre nächste Rechnung fällt
+  // genau einen Monat bzw. ein Jahr nach unserem Anmeldedatum).
+  //
+  // Der Test, der trägt: Ein Abo mit drei Gratismonaten kann in den ersten 90
+  // Tagen KEINE wiederkehrende Zahlung haben. Liegt für dieselbe Person schon
+  // ein `success_recurring` VOR diesem Ereignis, läuft ihr Abo bereits. Gegen
+  // die 655 bekannten Zeilen geprüft: kein einziger Fehlgriff auf ein echtes
+  // Neuabo. Die Zeile wird trotzdem geschrieben – als `art: 'verlaengerung'`,
+  // sichtbar, aber ausserhalb der Zählung (View sommer2026_neuabos).
+  let art = "neu";
+  if (ext) {
+    try {
+      const frueher = await fetch(
+        `${SB}/rest/v1/sommer2026_ingest_raw?source=eq.uscreen&event=eq.success_recurring` +
+        `&payload->>user_id=eq.${encodeURIComponent(ext)}&limit=1&select=id`,
+        { headers: H },
+      ).then((r) => (r.ok ? r.json() : []));
+      if (Array.isArray(frueher) && frueher.length) art = "verlaengerung";
+    } catch { /* im Zweifel als Abschluss zählen – der Abgleich korrigiert */ }
+  }
+
   // Aktion = jede Neuanmeldung im Aktionszeitraum (aktion_start begrenzt es zeitlich).
   // Optional schärfer über aktion_coupon / aktion_plan.
   const coupon = (pick(data, ["coupon_code", "coupon", "discount_code", "code"]) || "").toString().toLowerCase();
@@ -337,7 +368,7 @@ Deno.serve(async (req) => {
     signed_up_at: when, produkt: "gtv", sprache, format: "stream",
     // Der Store rechnet ausschliesslich in EUR (Uscreen-Währung des Shops).
     waehrung: "eur",
-    tarif, intervall, status: "neu", kanal, source: "uscreen", ext_id: ext, dedup_key: dedupKey,
+    tarif, intervall, status: "neu", art, kanal, source: "uscreen", ext_id: ext, dedup_key: dedupKey,
     kampagne: (camp ? String(camp) : "summer26_trial"),
     utm_source: src ? String(src) : null, utm_medium: med ? String(med) : null,
     utm_campaign: camp ? String(camp) : null, utm_content: cont ? String(cont) : null,


### PR DESCRIPTION
Uscreen feuert `subscription_assigned` auch für **laufende Bestandsabos** und unterscheidet die beiden Fälle im Payload nicht — nur `user_id`, `subscription_id` und Plantitel, für Abschluss wie Verlängerung dieselben Felder. 40 solcher Ereignisse standen als Anmeldung in der Zählung.

## Was sich ändert

- Neue Spalte `art` (`neu` | `verlaengerung`); die 40 sind **markiert, nicht gelöscht** — sie bleiben als Beleg sichtbar, wie viele Bestandsabos in der Aktionszeit turnusmässig weiterliefen.
- View `sommer2026_neuabos` zeigt nur `art = 'neu'`. Alle **neun** öffentlichen Auswertungen lesen sie: ein Ort für die Regel statt neun.
- Die **11 echten Abos vom 3.–6. Juli** sind nachgetragen (Webhook-Lücke der ersten Tage), zwei davon mit Status `gekuendigt`.
- Der Webhook erkennt es künftig selbst: Ein Abo mit drei Gratismonaten kann in den ersten 90 Tagen **keine wiederkehrende Zahlung** haben. Liegt für dieselbe Person schon ein `success_recurring` im Rohprotokoll, ist es eine Verlängerung. Gegen die 655 bekannten Zeilen geprüft: **kein Fehlgriff auf ein echtes Neuabo**.

**Stand danach:** gtv **636** (626 gegen Uscreen belegt, 10 ohne `ext_id` nicht prüfbar), wos 406, gesamt **1042**.

## Dazu

`services/mailing-sommer2026/AC-NENNER.md` — der zweite AC-Auftrag: Nenner je Automatisierung und Welle (24 Zeilen), Abmeldungen und Bounces, und der AC-Tarif, damit die Kosten nicht geschätzt werden müssen. Summen, keine Listen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUqZZzUQntMLiZPecAsBBc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUqZZzUQntMLiZPecAsBBc)_